### PR TITLE
Fix token validation for anonymous access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,7 +319,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/reductstore/reductstore/compare/v1.2.1...HEAD
 
-[1.1.1]: https://github.com/reductstore/reductstore/compare/v1.2.0...v1.2.1
+[1.2.1]: https://github.com/reductstore/reductstore/compare/v1.2.0...v1.2.1
 
 [1.2.0]: https://github.com/reductstore/reductstore/compare/v1.1.1...v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix token validation for anonymous access, [PR-217](https://github.com/reductstore/reductstore/pull/217)
+
 ## [1.2.1] - 2021-12-19
 
 ### Fixed

--- a/src/reduct/auth/token_auth.cc
+++ b/src/reduct/auth/token_auth.cc
@@ -44,15 +44,15 @@ class BearerTokenAuthentication : public ITokenAuthorization {
               const IAuthorizationPolicy& policy) const override {
     auto [token_value, parse_err] = ParseBearerToken(authorization_header);
     if (parse_err) {
-      return parse_err;
+      return policy.Validate(parse_err);
     }
 
     auto [token, error] = repository.ValidateToken(token_value);
     if (error) {
-      return error;
+      return policy.Validate(error);
     }
 
-    return policy.Validate({token.permissions(), Error::kOk});
+    return policy.Validate(token.permissions());
   }
 };
 

--- a/unit_tests/reduct/auth/token_auth_test.cc
+++ b/unit_tests/reduct/auth/token_auth_test.cc
@@ -6,6 +6,7 @@
 #include "reduct/auth/token_repository.h"
 #include "reduct/helpers.h"
 
+using reduct::auth::Anonymous;
 using reduct::auth::Authenticated;
 using reduct::auth::ITokenAuthorization;
 using reduct::core::Error;
@@ -27,4 +28,14 @@ TEST_CASE("auth::TokenAuthorization should use API token to check") {
   REQUIRE(err == Error::kOk);
 
   REQUIRE(auth->Check("Bearer " + token.value(), *repo, Authenticated()) == Error::kOk);
+}
+
+TEST_CASE("auth::TokenAuthorization should allow an invalid token for anonymous access") {
+  auto auth = ITokenAuthorization::Build("we have init api token");
+  REQUIRE(auth->Check("Bearer invalid-token",
+                      *reduct::auth::ITokenRepository::Build({.data_path = BuildTmpDirectory()}),
+                      Anonymous()) == Error::kOk);
+  REQUIRE(auth->Check("",
+                      *reduct::auth::ITokenRepository::Build({.data_path = BuildTmpDirectory()}),
+                      Anonymous()) == Error::kOk);
 }


### PR DESCRIPTION
Closes #216 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior

We check if an API token is valid before checking its permissions. It is wrong for anonymous access where we should allow empty or invalid tokens.

### What is the new behavior?

We check permissions for invalid tokens as well. 

### Does this PR introduce a breaking change?

No

### Other information:
