### PR TITLE
Fix crashing when post request is aborted by client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Crashing when post request is aborted by client, [PR-223](https://github.com/reductstore/reductstore/pull/223)
+
 ## [1.2.2] - 2022-12-20
 
 ### Fixed
 
-- Fix token validation for anonymous access, [PR-217](https://github.com/reductstore/reductstore/pull/217)
+- Token validation for anonymous access, [PR-217](https://github.com/reductstore/reductstore/pull/217)
 
 ## [1.2.1] - 2022-12-19
 

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -88,7 +88,7 @@ class HttpServer : public IHttpServer {
 
       res->onAborted([this] {
         LOG_ERROR("Aborted write operation");
-        error_ = core::Error{.code = 400};
+        error_ = core::Error::BadRequest("Aborted write operation");
       });
     }
 
@@ -96,7 +96,6 @@ class HttpServer : public IHttpServer {
 
     void await_suspend(std::coroutine_handle<> h) const noexcept {
       if (finish_ || error_) {
-        res_->onData([](auto, bool) {});
         h.resume();
       } else {
         async::ILoop::loop().Defer([this, h] { await_suspend(h); });
@@ -140,7 +139,7 @@ class HttpServer : public IHttpServer {
     };
 
     auto SendError = [ctx, &method, &url, CommonHeaders](const core::Error &err) {
-      if (err.code >= 500) {
+      if (err.code >= Error::kInternalError) {
         LOG_ERROR("{} {}: {}", method, url, err.ToString());
       } else {
         LOG_DEBUG("{} {}: {}", method, url, err.ToString());


### PR DESCRIPTION
Closes #222 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Buf fix

### What is the current behavior?

I replace `onAbort` callback with a stub function if the client cancels a write operation. It is wrong because the structure with the callback is already removed.

### What is the new behavior?

The stub isnt needed after refactoring of HTTP layer. I removed it.

### Does this PR introduce a breaking change?

No

### Other information:
