### PR TITLE
Implement include/exclude filters for data quering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Labels for  `POST|GET /api/v1/:bucket/:entry` as headers with
   prefix `x-reduct-label-`, [PR-224](https://github.com/reductstore/reductstore/pull/224)
+- `include-<label>` and `exclude-<label>` query parameters for query endpoint
+  `GET /api/v1/:bucket/:entry/q`, [PR-226](https://github.com/reductstore/reductstore/pull/226)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ more [here](https://docs.reduct.store/).
 * Optimized for small files
 * Real-time FIFO quota for buckets
 * Token authorization
-* Labeling
+* Labeling and searching
 * Embedded Web Console
 * Support Linux, MacOS and Windows on AMD64
 

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -31,7 +31,7 @@ A UNIX timestamp in microseconds
 Content-length is required to start an asynchronous write operation
 {% endswagger-parameter %}
 
-{% swagger-parameter in="header" name="x-reduct-label-<name>" %}
+{% swagger-parameter in="header" name="x-reduct-label-<name>" required="false" %}
 A value of a label assigned to the record
 {% endswagger-parameter %}
 
@@ -175,6 +175,18 @@ The method responds with a JSON document containing an ID which should be used t
 The time interval is \[start, stop).
 
 If authentication is enabled, the method needs a valid API token with read access to the bucket of the entry.
+
+Since version 1.3, the method also provides the `include-<label>` and `exclude-<label>` query parameters to filter records based on the values of certain labels. For example:
+
+**GET /api/v1/:bucket/:entry/q?include-\<label1>=foo\&exclude-\<label2>=bar**
+
+This would find all records that have `label1` equal to "foo" and excludes those that have `label2` equal to "bar".
+
+A user can specify multiple `include` and `exclude` labels, which will be connected with an AND operator. For example:
+
+GET /api/v1/:bucket/:entry/q?include-\<label1>=foo\&include-\<label2>=bar
+
+This would query records that have both `label1` equal to "foo" and `label2` equal to "bar".
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name=":bucket_name" required="true" %}
@@ -195,6 +207,14 @@ Name of entry
 
 {% swagger-parameter in="query" name="ttl" type="Integer" required="false" %}
 Time To Live of the query in seconds. If a client haven't read any record for this time interval, the server removes the query and the query ID becomes invalid. Default value 5 seconds.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="query" name="include-<label name>" %}
+Query records that have a certain value of a label.
+{% endswagger-parameter %}
+
+{% swagger-parameter in="query" name="exclude-<label name>" %}
+Query records that don't have a certain value of a label.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ add_custom_command(OUTPUT ${PROTOBUF_FILES}
 
 set(SRC_FILES
         reduct/api/bucket_api.cc
+        reduct/api/common.cc
         reduct/api/console.cc
         reduct/api/entry_api.cc
         reduct/api/http_server.cc

--- a/src/reduct/api/common.cc
+++ b/src/reduct/api/common.cc
@@ -1,0 +1,38 @@
+// Copyright 2023 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#include "reduct/api/common.h"
+
+namespace reduct::api {
+
+std::map<std::string, std::string> ParseQueryString(std::string_view query) {
+  std::map<std::string, std::string> result;
+  std::string key;
+  std::string value;
+  bool is_key = true;
+  for (auto c : query) {
+    if (c == '=') {
+      is_key = false;
+    } else if (c == '&') {
+      result[key] = value;
+      key.clear();
+      value.clear();
+      is_key = true;
+    } else {
+      if (is_key) {
+        key += c;
+      } else {
+        value += c;
+      }
+    }
+  }
+
+  if (!key.empty()) {
+    result[key] = value;
+  }
+
+  return result;
+}
+
+}  // namespace reduct::api

--- a/src/reduct/api/common.h
+++ b/src/reduct/api/common.h
@@ -180,6 +180,12 @@ static core::Result<HttpRequestReceiver> ReceiveAndSendJson(std::function<core::
   };
 }
 
+/**
+ * @brief HTTP request handler
+ * This function is called by uWS engine when it receives a request. It returns a function to send a response.
+ */
+std::map<std::string, std::string> ParseQueryString(std::string_view query);
+
 }  // namespace reduct::api
 
 #endif  // REDUCT_STORAGE_COMMON_H

--- a/src/reduct/api/entry_api.cc
+++ b/src/reduct/api/entry_api.cc
@@ -144,7 +144,6 @@ Result<HttpRequestReceiver> EntryApi::Read(IStorage* storage, std::string_view b
     }
 
     RESULT_OR_RETURN_ERROR(reader, entry->BeginRead(ts));
-
   } else {
     size_t id;
     RESULT_OR_RETURN_ERROR(id, ParseUInt(query_id, "id"));

--- a/src/reduct/api/entry_api.cc
+++ b/src/reduct/api/entry_api.cc
@@ -27,6 +27,7 @@ inline Result<Time> ParseTimestamp(std::string_view timestamp, std::string_view 
   if (timestamp.empty()) {
     return Error::UnprocessableEntity(fmt::format("'{}' parameter can't be empty", param_name));
   }
+
   try {
     auto ts_as_umber = std::stoll(timestamp.data());
     if (ts_as_umber < 0) {
@@ -47,6 +48,7 @@ inline core::Result<uint64_t> ParseUInt(std::string_view timestamp, std::string_
   if (timestamp.empty()) {
     return Error::UnprocessableEntity(fmt::format("'{}' parameter can't be empty", param_name));
   }
+
   try {
     return std::stoul(std::string{timestamp});
   } catch (...) {
@@ -58,9 +60,7 @@ inline core::Result<uint64_t> ParseUInt(std::string_view timestamp, std::string_
 inline core::Result<IEntry::SPtr> GetOrCreateEntry(IStorage* storage, const std::string& bucket_name,
                                                    const std::string& entry_name, bool must_exist = false) {
   auto [bucket_it, err] = storage->GetBucket(bucket_name);
-  if (err) {
-    return err;
-  }
+  RETURN_ERROR(err);
 
   auto bucket = bucket_it.lock();
 
@@ -69,10 +69,8 @@ inline core::Result<IEntry::SPtr> GetOrCreateEntry(IStorage* storage, const std:
     return Error::NotFound(fmt::format("Entry '{}' is not found", entry_name));
   }
 
-  auto [entry, ref_error] = bucket->GetOrCreateEntry(entry_name);
-  if (ref_error) {
-    return ref_error;
-  }
+  IEntry::WPtr entry;
+  RESULT_OR_RETURN_ERROR(entry, bucket->GetOrCreateEntry(entry_name));
 
   auto entry_ptr = entry.lock();
   assert(bucket && "Failed to reach entry");
@@ -87,15 +85,11 @@ inline core::Result<IEntry::SPtr> GetOrCreateEntry(IStorage* storage, const std:
 core::Result<HttpRequestReceiver> EntryApi::Write(storage::IStorage* storage, std::string_view bucket_name,
                                                   std::string_view entry_name, std::string_view timestamp,
                                                   std::string_view content_length, const IEntry::LabelMap& labels) {
-  auto [entry, create_err] = GetOrCreateEntry(storage, std::string(bucket_name), std::string(entry_name));
-  if (create_err) {
-    return create_err;
-  }
+  IEntry::SPtr entry;
+  RESULT_OR_RETURN_ERROR(entry, GetOrCreateEntry(storage, std::string{bucket_name}, std::string{entry_name}));
 
-  auto [ts, parse_err] = ParseTimestamp(timestamp);
-  if (parse_err) {
-    return parse_err;
-  }
+  Time ts;
+  RESULT_OR_RETURN_ERROR(ts, ParseTimestamp(timestamp));
 
   int64_t size;
   try {
@@ -108,9 +102,7 @@ core::Result<HttpRequestReceiver> EntryApi::Write(storage::IStorage* storage, st
   }
 
   auto [writer, writer_err] = entry->BeginWrite(ts, size, labels);
-  if (writer_err) {
-    return writer_err;
-  }
+  RETURN_ERROR(writer_err);
 
   auto [bucket, _] = storage->GetBucket(std::string(bucket_name));
   auto quota_error = bucket.lock()->KeepQuota();
@@ -137,10 +129,8 @@ core::Result<HttpRequestReceiver> EntryApi::Write(storage::IStorage* storage, st
 
 Result<HttpRequestReceiver> EntryApi::Read(IStorage* storage, std::string_view bucket_name, std::string_view entry_name,
                                            std::string_view timestamp, std::string_view query_id) {
-  auto [entry, create_err] = GetOrCreateEntry(storage, std::string(bucket_name), std::string(entry_name), true);
-  if (create_err) {
-    return create_err;
-  }
+  IEntry::SPtr entry;
+  RESULT_OR_RETURN_ERROR(entry, GetOrCreateEntry(storage, std::string{bucket_name}, std::string{entry_name}, true));
 
   bool last = true;
   async::IAsyncReader::SPtr reader;
@@ -148,31 +138,20 @@ Result<HttpRequestReceiver> EntryApi::Read(IStorage* storage, std::string_view b
   if (query_id.empty()) {
     Time ts;
     if (!timestamp.empty()) {
-      auto [parsed_ts, parse_err] = ParseTimestamp(timestamp);
-      if (parse_err) {
-        return parse_err;
-      }
-
-      ts = parsed_ts;
+      RESULT_OR_RETURN_ERROR(ts, ParseTimestamp(timestamp));
     } else {
       ts = Time() + std::chrono::microseconds(entry->GetInfo().latest_record());
     }
 
-    auto [next, start_err] = entry->BeginRead(ts);
-    if (start_err) {
-      return start_err;
-    }
-    reader = next;
+    RESULT_OR_RETURN_ERROR(reader, entry->BeginRead(ts));
+
   } else {
-    auto [id, parse_err] = ParseUInt(query_id, "id");
-    if (parse_err) {
-      return parse_err;
-    }
+    size_t id;
+    RESULT_OR_RETURN_ERROR(id, ParseUInt(query_id, "id"));
 
     auto [next, start_err] = entry->Next(id);
-    if (start_err) {
-      return start_err;
-    } else if (start_err.code == Error::kNoContent) {
+    RETURN_ERROR(start_err);
+    if (start_err.code == Error::kNoContent) {
       return DefaultReceiver(std::move(start_err));
     }
 
@@ -183,7 +162,7 @@ Result<HttpRequestReceiver> EntryApi::Read(IStorage* storage, std::string_view b
 
   assert(reader && "Failed to reach reader");
   return {
-      [reader, last, error = std::move(error)](std::string_view chunk, bool) -> Result<HttpResponse> {
+      [reader, last](std::string_view chunk, bool) -> Result<HttpResponse> {
         StringMap headers = {{"x-reduct-time", std::to_string(core::ToMicroseconds(reader->timestamp()))},
                              {"x-reduct-last", std::to_string(static_cast<int>(last))},
                              {"content-type", "application/octet-stream"}};
@@ -205,51 +184,40 @@ Result<HttpRequestReceiver> EntryApi::Read(IStorage* storage, std::string_view b
             Error::kOk,
         };
       },
-
       error,
   };
 }
 
 core::Result<HttpRequestReceiver> EntryApi::Query(storage::IStorage* storage, std::string_view bucket_name,
                                                   std::string_view entry_name, std::string_view start_timestamp,
-                                                  std::string_view stop_timestamp, std::string_view ttl_interval) {
+                                                  std::string_view stop_timestamp, const QueryOptions& options) {
   auto [entry, err] = GetOrCreateEntry(storage, std::string(bucket_name), std::string(entry_name), true);
-  if (err) {
-    return err;
-  }
+  RETURN_ERROR(err);
 
   std::optional<Time> start_ts;
   if (!start_timestamp.empty()) {
-    auto [ts, parse_err] = ParseTimestamp(start_timestamp, "start_timestamp");
-    if (parse_err) {
-      return parse_err;
-    }
-    start_ts = ts;
+    RESULT_OR_RETURN_ERROR(start_ts, ParseTimestamp(start_timestamp, "start_timestamp"));
   }
 
   std::optional<Time> stop_ts;
   if (!stop_timestamp.empty()) {
-    auto [ts, parse_err] = ParseTimestamp(stop_timestamp, "stop_timestamp");
-    if (parse_err) {
-      return parse_err;
-    }
-    stop_ts = ts;
+    RESULT_OR_RETURN_ERROR(stop_ts, ParseTimestamp(stop_timestamp, "stop_timestamp"));
   }
 
   std::chrono::seconds ttl{5};
-  if (!ttl_interval.empty()) {
-    auto [val, parse_err] = ParseUInt(ttl_interval, "ttl");
-    if (parse_err) {
-      return parse_err;
-    }
-
+  if (!options.ttl.empty()) {
+    auto [val, parse_err] = ParseUInt(options.ttl, "ttl");
+    RETURN_ERROR(parse_err);
     ttl = std::chrono::seconds(val);
   }
 
-  auto [id, query_err] = entry->Query(start_ts, stop_ts, IQuery::Options{.ttl = ttl});
-  if (query_err) {
-    return query_err;
-  }
+  size_t id;
+  RESULT_OR_RETURN_ERROR(id, entry->Query(start_ts, stop_ts,
+                                          IQuery::Options{
+                                              .ttl = ttl,
+                                              .include = options.include,
+                                              .exclude = options.exclude,
+                                          }));
 
   QueryInfo info;
   info.set_id(id);

--- a/src/reduct/api/entry_api.h
+++ b/src/reduct/api/entry_api.h
@@ -15,6 +15,11 @@ namespace reduct::api {
 class EntryApi {
  public:
   constexpr static std::string_view kLabelHeaderPrefix = "x-reduct-label-";
+  struct QueryOptions {
+    std::string_view ttl;
+    std::map<std::string, std::string> include;
+    std::map<std::string, std::string> exclude;
+  };
   /**
    * POST /b/:bucket_name/:entry
    */
@@ -35,7 +40,8 @@ class EntryApi {
    */
   static core::Result<HttpRequestReceiver> Query(storage::IStorage* storage, std::string_view bucket_name,
                                                  std::string_view entry_name, std::string_view start_timestamp,
-                                                 std::string_view stop_timestamp, std::string_view ttl_interval);
+                                                 std::string_view stop_timestamp,
+                                                 const QueryOptions& options);
 };
 
 }  // namespace reduct::api

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -337,7 +337,7 @@ class HttpServer : public IHttpServer {
                    ReadAccess(bucket_name), HttpContext<SSL>{res, req, running}, [this, req, bucket_name]() {
                      return EntryApi::Query(storage_.get(), bucket_name, std::string(req->getParameter(1)),
                                             std::string(req->getQuery("start")), std::string(req->getQuery("stop")),
-                                            std::string(req->getQuery("ttl")));
+                                            {.ttl = req->getQuery("ttl")});
                    });
              })
         // Token API

--- a/src/reduct/core/error.h
+++ b/src/reduct/core/error.h
@@ -82,5 +82,12 @@ struct [[nodiscard]] Error {  // NOLINT
   static Error InternalError(std::string msg = "Internal Error") { return Error{kInternalError, std::move(msg)}; }
 };
 
+#define RETURN_ERROR(err) \
+  {                       \
+    if (err) {            \
+      return err;         \
+    }                     \
+  }
+
 }  // namespace reduct::core
 #endif  // REDUCT_CORE_ERROR_H

--- a/src/reduct/core/result.h
+++ b/src/reduct/core/result.h
@@ -38,6 +38,14 @@ struct [[nodiscard]] UPtrResult {  // NOLINT
   operator const Error&() const noexcept { return error; }
 };
 
+#define RESULT_OR_RETURN_ERROR(val, expr) \
+  {                                       \
+    auto result = (expr);                 \
+    if (result.error) {                   \
+      return result.error;                \
+    }                                     \
+    val = std::move(result.result);       \
+  }
 }  // namespace reduct::core
 
 #endif  // REDUCT_CORE_RESULT_H

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -324,7 +324,7 @@ class Entry : public IEntry {
           record.timestamp() >= start_ts && record.timestamp() < stop_ts && record.state() == proto::Record::kFinished;
       if (!in_time_interval) continue;
 
-      // check if a record has value of labels that match the query
+      // check if a record has value of labels that match include
       if (!query_info.options.include.empty()) {
         auto include = query_info.options.include;
         for (const auto& label : record.labels()) {
@@ -334,6 +334,18 @@ class Entry : public IEntry {
         }
 
         if (!include.empty()) continue;
+      }
+
+      // check if a record has value of labels that does not match exclude
+      if (!query_info.options.exclude.empty()) {
+        auto exclude = query_info.options.exclude;
+        for (const auto& label : record.labels()) {
+          if (exclude.contains(label.name()) && label.value() == exclude[label.name()]) {
+            exclude.erase(label.name());
+          }
+        }
+
+        if (exclude.empty()) continue;
       }
 
       records.push_back(record_index);

--- a/src/reduct/storage/query/quiery.h
+++ b/src/reduct/storage/query/quiery.h
@@ -21,7 +21,9 @@ class IQuery {
    * Query Options
    */
   struct Options {
-    std::chrono::seconds ttl{5};  // TTL of query in entries cache (time from last request)
+    std::chrono::seconds ttl{5};                 // TTL of query in entries cache (time from last request)
+    std::map<std::string, std::string> include;  // include labels with certain values
+    std::map<std::string, std::string> exclude;  // exclude labels with certain values
   };
 
   /**

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(SRC_FILES
         reduct/api/bucket_api_test.cc
+        reduct/api/common_test.cc
         reduct/api/entry_api_test.cc
         reduct/api/server_api_test.cc
         reduct/api/token_api_test.cc

--- a/unit_tests/reduct/api/bucket_api_test.cc
+++ b/unit_tests/reduct/api/bucket_api_test.cc
@@ -14,7 +14,7 @@ using reduct::auth::ITokenRepository;
 using reduct::core::Error;
 using reduct::storage::IStorage;
 
-TEST_CASE("BucketApi::CreateBucket should create a bucket") {
+TEST_CASE("BucketApi::CreateBucket should create a bucket", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   SECTION("default settings") {
     auto [receiver, err] = BucketApi::CreateBucket(storage.get(), "bucket");
@@ -57,7 +57,7 @@ TEST_CASE("BucketApi::CreateBucket should create a bucket") {
   }
 }
 
-TEST_CASE("BucketApi::GetBucket should get a bucket") {
+TEST_CASE("BucketApi::GetBucket should get a bucket", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
 
   SECTION("ok") {
@@ -80,7 +80,7 @@ TEST_CASE("BucketApi::GetBucket should get a bucket") {
   }
 }
 
-TEST_CASE("BucketApi::HeadBucket should get a bucket") {
+TEST_CASE("BucketApi::HeadBucket should get a bucket", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
 
   SECTION("ok") {
@@ -100,7 +100,7 @@ TEST_CASE("BucketApi::HeadBucket should get a bucket") {
   }
 }
 
-TEST_CASE("BucketApi::UpdateBucket should update a bucket") {
+TEST_CASE("BucketApi::UpdateBucket should update a bucket", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
 
   SECTION("ok") {
@@ -128,7 +128,7 @@ TEST_CASE("BucketApi::UpdateBucket should update a bucket") {
   }
 }
 
-TEST_CASE("BucketApi::RemoveBucket should remove a bucket") {
+TEST_CASE("BucketApi::RemoveBucket should remove a bucket", "[api]") {
   const auto path = BuildTmpDirectory();
   auto storage = IStorage::Build({.data_path = path});
   auto repo = ITokenRepository::Build({.data_path = path});

--- a/unit_tests/reduct/api/common_test.cc
+++ b/unit_tests/reduct/api/common_test.cc
@@ -1,0 +1,28 @@
+// Copyright 2023 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "reduct/api/common.h"
+
+#include <catch2/catch.hpp>
+
+using reduct::api::ParseQueryString;
+
+TEST_CASE("ParseQueryString parse query") {
+  SECTION("empty") { REQUIRE(ParseQueryString("").empty()); }
+  SECTION("one") { REQUIRE(ParseQueryString("a=b") == std::map<std::string, std::string>({{"a", "b"}})); }
+  SECTION("two") {
+    REQUIRE(ParseQueryString("a=b&c=d") == std::map<std::string, std::string>({{"a", "b"}, {"c", "d"}}));
+  }
+  SECTION("three") {
+    REQUIRE(ParseQueryString("a=b&c=d&e=f") ==
+            std::map<std::string, std::string>({{"a", "b"}, {"c", "d"}, {"e", "f"}}));
+  }
+  SECTION("three with empty") {
+    REQUIRE(ParseQueryString("a=b&c=d&e=") == std::map<std::string, std::string>({{"a", "b"}, {"c", "d"}, {"e", ""}}));
+  }
+  SECTION("three with empty key") {
+    REQUIRE(ParseQueryString("a=b&=d&e=f") == std::map<std::string, std::string>({{"a", "b"}, {"", "d"}, {"e", "f"}}));
+  }
+}

--- a/unit_tests/reduct/api/entry_api_test.cc
+++ b/unit_tests/reduct/api/entry_api_test.cc
@@ -303,7 +303,7 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
   }
 
   SECTION("ok ttl") {
-    auto [resp, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", "1000003", "1000004", "1");
+    auto [resp, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", "1000003", "1000004", {.ttl = "1"});
     REQUIRE(err == Error::kOk);
 
     std::this_thread::sleep_for(us(1'000'000));
@@ -327,9 +327,7 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
     REQUIRE(
         EntryApi::Query(storage.get(), "bucket", "entry-1", {}, "XXX", {}).error ==
         Error::UnprocessableEntity("Failed to parse 'stop_timestamp' parameter: XXX must unix times in microseconds"));
-    REQUIRE(EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {}, "XXX").error ==
-            Error::UnprocessableEntity("Failed to parse 'ttl' parameter: XXX must be unsigned integer"));
-    REQUIRE(EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {}, "XXX").error ==
+    REQUIRE(EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {}, {.ttl = "XXX"}).error ==
             Error::UnprocessableEntity("Failed to parse 'ttl' parameter: XXX must be unsigned integer"));
   }
 }

--- a/unit_tests/reduct/api/entry_api_test.cc
+++ b/unit_tests/reduct/api/entry_api_test.cc
@@ -25,7 +25,7 @@ using google::protobuf::util::JsonStringToMessage;
 
 using us = std::chrono::microseconds;
 
-TEST_CASE("EntryApi::Write should write data in chunks") {
+TEST_CASE("EntryApi::Write should write data in chunks", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
@@ -107,7 +107,7 @@ TEST_CASE("EntryApi::Write should write data in chunks") {
   }
 }
 
-TEST_CASE("EntryAPI::Write should write data with labels") {
+TEST_CASE("EntryAPI::Write should write data with labels", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
@@ -131,7 +131,7 @@ TEST_CASE("EntryAPI::Write should write data with labels") {
   REQUIRE(entry->BeginRead(reduct::core::Time() + us(1000001)).result->labels() == labels);
 }
 
-TEST_CASE("EntryApi::Read should read data in chunks with time") {
+TEST_CASE("EntryApi::Read should read data in chunks with time", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
@@ -177,7 +177,7 @@ TEST_CASE("EntryApi::Read should read data in chunks with time") {
   }
 }
 
-TEST_CASE("EntryApi::Read should read data in chunks with query id") {
+TEST_CASE("EntryApi::Read should read data in chunks with query id", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
@@ -238,13 +238,13 @@ TEST_CASE("EntryApi::Read should read data in chunks with query id") {
   }
 }
 
-TEST_CASE("EntryApi::Query should query data for time interval") {
+TEST_CASE("EntryApi::Query should query data for time interval", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
   auto entry = storage->GetBucket("bucket").result.lock()->GetOrCreateEntry("entry-1").result.lock();
-  REQUIRE(WriteOne(*entry, "1234567890", Time() + us(1000001)) == Error::kOk);
-  REQUIRE(WriteOne(*entry, "abcd", Time() + us(2000001)) == Error::kOk);
+  REQUIRE(WriteOne(*entry, "1234567890", Time() + us(1000001), {{"label1", "value1"}}) == Error::kOk);
+  REQUIRE(WriteOne(*entry, "abcd", Time() + us(2000001), {{"label1", "value2"}}) == Error::kOk);
 
   QueryInfo info;
   SECTION("ok all") {
@@ -307,6 +307,34 @@ TEST_CASE("EntryApi::Query should query data for time interval") {
     REQUIRE(err == Error::kOk);
 
     std::this_thread::sleep_for(us(1'000'000));
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
+  }
+
+  SECTION("ok include") {
+    auto [receiver, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {},
+                                           EntryApi::QueryOptions{.include = {{"label1", "value1"}}});
+    REQUIRE(err == Error::kOk);
+
+    auto [resp, recv_err] = receiver("", true);
+    REQUIRE(recv_err == Error::kOk);
+
+    JsonStringToMessage(resp.SendData().result, &info);
+
+    REQUIRE(entry->Next(info.id()).result.reader->timestamp() == Time() + us(1000001));
+    REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
+  }
+
+  SECTION("ok exclude") {
+    auto [receiver, err] = EntryApi::Query(storage.get(), "bucket", "entry-1", {}, {},
+                                           EntryApi::QueryOptions{.exclude = {{"label1", "value1"}}});
+    REQUIRE(err == Error::kOk);
+
+    auto [resp, recv_err] = receiver("", true);
+    REQUIRE(recv_err == Error::kOk);
+
+    JsonStringToMessage(resp.SendData().result, &info);
+
+    REQUIRE(entry->Next(info.id()).result.reader->timestamp() == Time() + us(2000001));
     REQUIRE(entry->Next(info.id()).error.code == Error::kNotFound);
   }
 

--- a/unit_tests/reduct/api/server_api_test.cc
+++ b/unit_tests/reduct/api/server_api_test.cc
@@ -14,7 +14,7 @@ using reduct::auth::ITokenRepository;
 using reduct::core::Error;
 using reduct::storage::IStorage;
 
-TEST_CASE("ServerApi::Alive should return empty body") {
+TEST_CASE("ServerApi::Alive should return empty body", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
 
   auto [receiver, err] = ServerApi::Alive(storage.get());
@@ -28,7 +28,7 @@ TEST_CASE("ServerApi::Alive should return empty body") {
   REQUIRE(output.result.empty());
 }
 
-TEST_CASE("ServerApi::Info should return JSON") {
+TEST_CASE("ServerApi::Info should return JSON", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
 
   auto [receiver, err] = ServerApi::Info(storage.get());
@@ -45,7 +45,7 @@ TEST_CASE("ServerApi::Info should return JSON") {
   REQUIRE(info.version() == storage->GetInfo().result.version());
 }
 
-TEST_CASE("ServerApi::List should return JSON") {
+TEST_CASE("ServerApi::List should return JSON", "[api]") {
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
 
   auto [receiver, err] = ServerApi::List(storage.get());
@@ -64,7 +64,7 @@ TEST_CASE("ServerApi::List should return JSON") {
   REQUIRE(list.buckets().empty());
 }
 
-TEST_CASE("ServerAPI::Me should return current permissions") {
+TEST_CASE("ServerAPI::Me should return current permissions", "[api]") {
   auto repo = ITokenRepository::Build({.data_path = BuildTmpDirectory()});
 
   ITokenRepository::TokenPermissions permissions;

--- a/unit_tests/reduct/api/token_api_test.cc
+++ b/unit_tests/reduct/api/token_api_test.cc
@@ -22,7 +22,7 @@ using reduct::proto::api::TokenCreateResponse;
 using reduct::proto::api::TokenRepo;
 using Storage = reduct::storage::IStorage;  // fix windows build
 
-TEST_CASE("TokenApi::CreateToken should create a token and return its value") {
+TEST_CASE("TokenApi::CreateToken should create a token and return its value", "[api]") {
   const auto path = BuildTmpDirectory();
   auto repo = ITokenRepository::Build({.data_path = path});
   auto storage = Storage::Build({.data_path = path});
@@ -70,7 +70,7 @@ TEST_CASE("TokenApi::CreateToken should create a token and return its value") {
   }
 }
 
-TEST_CASE("TokenApi::ListTokens should list tokens") {
+TEST_CASE("TokenApi::ListTokens should list tokens", "[api]") {
   const auto path = BuildTmpDirectory();
   auto repo = ITokenRepository::Build({.data_path = path});
 
@@ -90,7 +90,7 @@ TEST_CASE("TokenApi::ListTokens should list tokens") {
   REQUIRE(proto_message.tokens(0) == repo->GetTokenList().result[0]);
 }
 
-TEST_CASE("TokenApi::GetToken should show a token") {
+TEST_CASE("TokenApi::GetToken should show a token", "[api]") {
   const auto path = BuildTmpDirectory();
   auto repo = ITokenRepository::Build({.data_path = path});
 
@@ -120,7 +120,7 @@ TEST_CASE("TokenApi::GetToken should show a token") {
   }
 }
 
-TEST_CASE("TokenApi::RemoveToken should delete a token") {
+TEST_CASE("TokenApi::RemoveToken should delete a token", "[api]") {
   const auto path = BuildTmpDirectory();
   auto repo = ITokenRepository::Build({.data_path = path});
 


### PR DESCRIPTION
Closes #225 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #225 

### What is the new behavior?

I implement the `include` and `exclude` filter for `GET /api/v1/:bucket/:entry/q`.


### Does this PR introduce a breaking change?

No

### Other information:
