### PR TITLE
Fix error header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GET /api/v1/me` endpoint to get current
   permissions, [PR-202](https://github.com/reductstore/reductstore/pull/208)
-- Send error message in `-x-reduct-error`header [PR-213](https://github.com/reductstore/reductstore/pull/213)
+- Send error message in `x-reduct-error`header [PR-213](https://github.com/reductstore/reductstore/pull/213)
 
 ### Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GET /api/v1/me` endpoint to get current
   permissions, [PR-202](https://github.com/reductstore/reductstore/pull/208)
-- Send error message in `x-reduct-error`header [PR-213](https://github.com/reductstore/reductstore/pull/213)
+- Send error message in `-x-reduct-error`header [PR-213](https://github.com/reductstore/reductstore/pull/213)
 
 ### Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Project license AGPLv3 to MPL-2.0, [PR-221](https://github.com/reductstore/reductstore/pull/221)
+- Rename error header `-x-reduct-error` to `x-reduct-error`, [PR-230](https://github.com/reductstore/reductstore/pull/230)
 
 ## [1.2.3] - 2023-01-02
 

--- a/api_tests/auth_test.py
+++ b/api_tests/auth_test.py
@@ -14,7 +14,7 @@ def test__compare_api_token(base_url, session):
     """should compare token"""
     resp = session.get(f'{base_url}/info', headers=auth_headers('ABCB0001'))
     assert resp.status_code == 401
-    assert resp.headers["-x-reduct-error"] == "Invalid token"
+    assert resp.headers["x-reduct-error"] == "Invalid token"
 
 
 @requires_env("API_TOKEN")
@@ -22,4 +22,4 @@ def test__empty_token(base_url, session):
     """should use Bearer token"""
     resp = session.get(f'{base_url}/info', headers={'Authorization': ''})
     assert resp.status_code == 401
-    assert resp.headers["-x-reduct-error"] == "No bearer token in request header"
+    assert resp.headers["x-reduct-error"] == "No bearer token in request header"

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -59,14 +59,14 @@ def test__create_twice_bucket(base_url, session, bucket_name):
     resp = session.post(f'{base_url}/b/{bucket_name}')
 
     assert resp.status_code == 409
-    assert "already exists" in resp.headers["-x-reduct-error"]
+    assert "already exists" in resp.headers["x-reduct-error"]
 
 
 def test__get_bucket_not_exist(base_url, session, bucket_name):
     """Should return error if the bucket is not found"""
     resp = session.get(f'{base_url}/b/{bucket_name}')
     assert resp.status_code == 404
-    assert "is not found" in resp.headers["-x-reduct-error"]
+    assert "is not found" in resp.headers["x-reduct-error"]
 
 
 @requires_env("API_TOKEN")
@@ -182,7 +182,7 @@ def test__remove_bucket_not_exist(base_url, session, bucket_name):
     """Should return an error if  bucket doesn't exist"""
     resp = session.delete(f'{base_url}/b/{bucket_name}')
     assert resp.status_code == 404
-    assert "is not found" in resp.headers["-x-reduct-error"]
+    assert "is not found" in resp.headers["x-reduct-error"]
 
 
 @requires_env("API_TOKEN")

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -59,7 +59,7 @@ def test_read_no_bucket(base_url, session):
     """Should return 404 if no bucket found"""
     resp = session.get(f'{base_url}/b/xxx/entry?ts=100')
     assert resp.status_code == 404
-    assert 'xxx' in resp.headers["-x-reduct-error"]
+    assert 'xxx' in resp.headers["x-reduct-error"]
 
 
 def test_read_no_data(base_url, session, bucket):
@@ -74,14 +74,14 @@ def test_read_bad_ts(base_url, session, bucket):
     resp = session.get(f'{base_url}/b/{bucket}/entry?ts=XXXX')
 
     assert resp.status_code == 422
-    assert 'XXX' in resp.headers["-x-reduct-error"]
+    assert 'XXX' in resp.headers["x-reduct-error"]
 
 
 def test_read_bad_no_entry(base_url, session, bucket):
     """Should return 400 if ts is bad"""
     resp = session.get(f'{base_url}/b/{bucket}/entry')
     assert resp.status_code == 404
-    assert 'entry' in resp.headers["-x-reduct-error"]
+    assert 'entry' in resp.headers["x-reduct-error"]
 
 
 @requires_env("API_TOKEN")
@@ -105,14 +105,14 @@ def test_write_no_bucket(base_url, session):
     """Should return 404 if no bucket found"""
     resp = session.post(f'{base_url}/b/xxx/entry?ts=100')
     assert resp.status_code == 404
-    assert 'xxx' in resp.headers["-x-reduct-error"]
+    assert 'xxx' in resp.headers["x-reduct-error"]
 
 
 def test_write_bad_ts(base_url, session, bucket):
     """Should return 422 if ts is bad"""
     resp = session.post(f'{base_url}/b/{bucket}/entry?ts=XXXX')
     assert resp.status_code == 422
-    assert 'XXX' in resp.headers["-x-reduct-error"]
+    assert 'XXX' in resp.headers["x-reduct-error"]
 
 
 def test_get_record_ok(base_url, session, bucket):

--- a/api_tests/token_api_test.py
+++ b/api_tests/token_api_test.py
@@ -28,7 +28,7 @@ def test__create_token_exist(base_url, session, token_name):
     assert resp.status_code == 200
     resp = session.post(f'{base_url}/tokens/{token_name}')
     assert resp.status_code == 409
-    assert resp.headers["-x-reduct-error"] == f"Token '{token_name}' already exists"
+    assert resp.headers["x-reduct-error"] == f"Token '{token_name}' already exists"
 
 
 @requires_env("API_TOKEN")
@@ -42,7 +42,7 @@ def test__creat_token_with_full_access(base_url, session, token_name, token_with
     resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions,
                         headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"
+    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
 
 
 def test__list_tokens(base_url, session, token_name):
@@ -66,7 +66,7 @@ def test__list_token_with_full_access(base_url, session, token_without_permissio
 
     resp = session.get(f'{base_url}/tokens', headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"
+    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
 
 
 def test__get_token(base_url, session, bucket_name, token_name):
@@ -99,7 +99,7 @@ def test__get_token_not_found(base_url, session):
     """Should return 404 if a token does not exist"""
     resp = session.get(f'{base_url}/tokens/token-not-found')
     assert resp.status_code == 404
-    assert resp.headers["-x-reduct-error"] == "Token 'token-not-found' doesn't exist"
+    assert resp.headers["x-reduct-error"] == "Token 'token-not-found' doesn't exist"
 
 
 @requires_env("API_TOKEN")
@@ -110,7 +110,7 @@ def test__get_token_with_full_access(base_url, session, token_without_permission
 
     resp = session.get(f'{base_url}/tokens/token-name', headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"
+    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
 
 
 def test__delete_token(base_url, session, token_name):
@@ -132,7 +132,7 @@ def test__delete_token_not_found(base_url, session):
     """Should return 404 if a token does not exist"""
     resp = session.delete(f'{base_url}/tokens/token-not-found')
     assert resp.status_code == 404
-    assert resp.headers["-x-reduct-error"] == "Token 'token-not-found' doesn't exist"
+    assert resp.headers["x-reduct-error"] == "Token 'token-not-found' doesn't exist"
 
 
 @requires_env("API_TOKEN")
@@ -143,4 +143,4 @@ def test__delete_token_with_full_access(base_url, session, token_without_permiss
 
     resp = session.delete(f'{base_url}/tokens/token-name', headers=auth_headers(token_without_permissions))
     assert resp.status_code == 403
-    assert resp.headers["-x-reduct-error"] == "Token doesn't have full access"
+    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"

--- a/docs/http-api/README.md
+++ b/docs/http-api/README.md
@@ -22,4 +22,4 @@ The storage engine uses the token authentication when the`RS_API_TOKEN` envirnom
 
 If a request to ReductStore fails, the API  returns an HTTP status code indicating the type of error that occurred. For example, a `404 Not Found` status code indicates that the requested resource could not be found.
 
-Since version 1.2.0, the HTTP API also includes an error message in the `-x-reduct-error` header of the response. This error message provides more detailed information about the error, which can be useful for debugging and troubleshooting.
+Since version 1.2.0, the HTTP API also includes an error message in the `x-reduct-error` header of the response. This error message provides more detailed information about the error, which can be useful for debugging and troubleshooting.

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -152,7 +152,7 @@ class HttpServer : public IHttpServer {
       ctx.res->writeStatus(std::to_string(err.code));
       CommonHeaders();
       ctx.res->writeHeader("content-type", "application/json");
-      ctx.res->writeHeader("-x-reduct-error", err.message);
+      ctx.res->writeHeader("x-reduct-error", err.message);
       if (method == "HEAD") {
         ctx.res->end({});
       } else {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

We send a header "-x-reduct-error" additionally to the HTTP status code. It should be "x-reduct-error" like other specific headers

### What is the new behavior?

I changed the name and fix documentation

### Does this PR introduce a breaking change?

Partitionally, this is header haven"t been used in the client SDKs. 

### Other information:
