### PR TITLE
Store the content-type received in the header into the record metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefix `x-reduct-label-`, [PR-224](https://github.com/reductstore/reductstore/pull/224)
 - `include-<label>` and `exclude-<label>` query parameters for query endpoint
   `GET /api/v1/:bucket/:entry/q`, [PR-226](https://github.com/reductstore/reductstore/pull/226)
+- Store the `Content-Type` header received for a record while writing it, so that the record may be returned with the same header, [PR-231](https://github.com/reductstore/reductstore/pull/231)
 
 ### Changed
 

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -327,3 +327,19 @@ def test__query_with_read_token(base_url, session, bucket, token_without_permiss
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/q', headers=auth_headers(token_write_bucket))
     assert resp.status_code == 403
+
+
+def test_write_with_content_type_header(base_url, session, bucket):
+    ts = 1000
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={1000}', data='{"data": "some data"}',
+                        headers={'content-type': 'application/json'})
+    assert resp.status_code == 200
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}')
+    assert resp.status_code == 200
+    query_id = int(json.loads(resp.content)["id"])
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    assert resp.status_code == 200
+    assert resp.content == b"{\"data\": \"some data\"}"
+    assert resp.headers['content-type'] == 'application/json'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SRC_FILES
         reduct/core/env_variable.cc
         reduct/core/logger.cc
         reduct/core/error.cc
+        reduct/core/common.h
 
         reduct/storage/io/async_reader.cc
         reduct/storage/io/async_writer.cc

--- a/src/reduct/api/entry_api.cc
+++ b/src/reduct/api/entry_api.cc
@@ -84,7 +84,8 @@ inline core::Result<IEntry::SPtr> GetOrCreateEntry(IStorage* storage, const std:
 
 core::Result<HttpRequestReceiver> EntryApi::Write(storage::IStorage* storage, std::string_view bucket_name,
                                                   std::string_view entry_name, std::string_view timestamp,
-                                                  std::string_view content_length, const IEntry::LabelMap& labels) {
+                                                  std::string_view content_length, const std::string_view& content_type,
+                                                  const IEntry::LabelMap& labels) {
   IEntry::SPtr entry;
   RESULT_OR_RETURN_ERROR(entry, GetOrCreateEntry(storage, std::string{bucket_name}, std::string{entry_name}));
 
@@ -101,7 +102,7 @@ core::Result<HttpRequestReceiver> EntryApi::Write(storage::IStorage* storage, st
     return Error::ContentLengthRequired("Bad or empty content-length");
   }
 
-  auto [writer, writer_err] = entry->BeginWrite(ts, size, labels);
+  auto [writer, writer_err] = entry->BeginWrite(ts, size, content_type, labels);
   RETURN_ERROR(writer_err);
 
   auto [bucket, _] = storage->GetBucket(std::string(bucket_name));
@@ -164,7 +165,7 @@ Result<HttpRequestReceiver> EntryApi::Read(IStorage* storage, std::string_view b
       [reader, last](std::string_view chunk, bool) -> Result<HttpResponse> {
         StringMap headers = {{"x-reduct-time", std::to_string(core::ToMicroseconds(reader->timestamp()))},
                              {"x-reduct-last", std::to_string(static_cast<int>(last))},
-                             {"content-type", "application/octet-stream"}};
+                             {"content-type", reader->content_type()}};
 
         for (const auto& [key, value] : reader->labels()) {
           headers.insert({fmt::format("{}{}", kLabelHeaderPrefix, key), value});

--- a/src/reduct/api/entry_api.h
+++ b/src/reduct/api/entry_api.h
@@ -7,6 +7,7 @@
 #define REDUCT_STORAGE_ENTRY_API_H
 
 #include "common.h"
+#include "reduct/core/common.h"
 #include "reduct/core/result.h"
 #include "reduct/storage/storage.h"
 
@@ -26,6 +27,7 @@ class EntryApi {
   static core::Result<HttpRequestReceiver> Write(storage::IStorage* storage, std::string_view bucket_name,
                                                  std::string_view entry_name, std::string_view timestamp,
                                                  std::string_view content_length,
+                                                 const std::string_view& content_type = core::kContentTypeOctetStream,
                                                  const storage::IEntry::LabelMap& labels = {});
 
   /**

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -318,7 +318,7 @@ class HttpServer : public IHttpServer {
                         }
                       }
                       return EntryApi::Write(storage_.get(), bucket_name, req->getParameter(1), req->getQuery("ts"),
-                                             req->getHeader("content-length"), labels);
+                                             req->getHeader("content-length"), req->getHeader("content-type"), labels);
                     });
               })
         .get(api_path + "b/:bucket_name/:entry_name",

--- a/src/reduct/async/io.h
+++ b/src/reduct/async/io.h
@@ -55,6 +55,7 @@ class IAsyncReader {
   [[nodiscard]] virtual core::Time timestamp() const noexcept = 0;
   [[nodiscard]] virtual size_t size() const noexcept = 0;
   [[nodiscard]] virtual const std::map<std::string, std::string>& labels() const noexcept = 0;
+  [[nodiscard]] virtual const std::string& content_type() const noexcept = 0;
 };
 
 }  // namespace reduct::async

--- a/src/reduct/core/common.h
+++ b/src/reduct/core/common.h
@@ -1,0 +1,15 @@
+// Copyright 2023 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef REDUCTSTORE_COMMON_H
+#define REDUCTSTORE_COMMON_H
+
+#include <string>
+
+namespace reduct::core {
+constexpr static std::string_view kContentTypeOctetStream = "application/octet-stream";
+}  // namespace reduct::core
+
+#endif  // REDUCTSTORE_COMMON_H

--- a/src/reduct/proto/storage/entry.proto
+++ b/src/reduct/proto/storage/entry.proto
@@ -19,7 +19,7 @@ message Record {
   }
 
   message Label {
-    string name =1;
+    string name = 1;
     string value = 2;
   }
 
@@ -28,6 +28,7 @@ message Record {
   uint64 end = 3;                           // end position of a blob in a block
   State state = 4;                          // state of record
   repeated Label labels = 5;                // labels
+  optional string content_type = 6;         // Content type of the record
 }
 
 // Represents a block of records.

--- a/src/reduct/proto/storage/entry.proto
+++ b/src/reduct/proto/storage/entry.proto
@@ -28,7 +28,7 @@ message Record {
   uint64 end = 3;                           // end position of a blob in a block
   State state = 4;                          // state of record
   repeated Label labels = 5;                // labels
-  optional string content_type = 6;         // Content type of the record
+  string content_type = 6;                  // Content type of the record
 }
 
 // Represents a block of records.

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -79,6 +79,7 @@ class Entry : public IEntry {
   }
 
   [[nodiscard]] Result<async::IAsyncWriter::SPtr> BeginWrite(const Time& time, size_t content_size,
+                                                             const std::string_view& content_type,
                                                              const LabelMap& labels) override {
     enum class RecordType { kLatest, kBelated, kBelatedFirst };
     RecordType type = RecordType::kLatest;
@@ -158,12 +159,13 @@ class Entry : public IEntry {
       block = std::move(ret.result);
     }
 
-    // Finally we have found a proper blog. Update it and write the record
+    // Finally we have found a proper block. Update it and write the record
     auto record = block->add_records();
     record->set_state(proto::Record::kStarted);
     record->mutable_timestamp()->CopyFrom(proto_ts);
     record->set_begin(block->size());
     record->set_end(block->size() + content_size);
+    record->set_content_type(std::string(content_type));
 
     for (const auto& [key, value] : labels) {
       auto label = record->add_labels();

--- a/src/reduct/storage/io/async_io.h
+++ b/src/reduct/storage/io/async_io.h
@@ -10,6 +10,7 @@
 #include <map>
 
 #include "reduct/async/io.h"
+#include "reduct/core/common.h"
 #include "reduct/core/time.h"
 
 namespace reduct::storage::io {
@@ -24,8 +25,9 @@ class IAsyncIO {
    * @param time timestamp of the data
    * @return async writer or error
    */
-  [[nodiscard]] virtual core::Result<async::IAsyncWriter::SPtr> BeginWrite(const core::Time& time, size_t size,
-                                                                           const LabelMap& labels = {}) = 0;
+  [[nodiscard]] virtual core::Result<async::IAsyncWriter::SPtr> BeginWrite(
+      const core::Time& time, size_t size, const std::string_view& content_type = core::kContentTypeOctetStream,
+      const LabelMap& labels = {}) = 0;
 
   /**
    * @brief Finds the record for the timestamp and read the blob

--- a/src/reduct/storage/io/async_reader.cc
+++ b/src/reduct/storage/io/async_reader.cc
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <fstream>
 
+#include "reduct/core/common.h"
 #include "reduct/core/logger.h"
 
 namespace reduct::storage::io {
@@ -29,6 +30,10 @@ class AsyncReader : public async::IAsyncReader {
 
     for (const auto& label : record.labels()) {
       labels_.insert({label.name(), label.value()});
+    }
+    content_type_ = record.content_type();
+    if (content_type_ == "") {
+      content_type_ = core::kContentTypeOctetStream;
     }
   }
 
@@ -57,12 +62,15 @@ class AsyncReader : public async::IAsyncReader {
 
   const std::map<std::string, std::string>& labels() const noexcept override { return labels_; }
 
+  const std::string& content_type() const noexcept override { return content_type_; }
+
  private:
   AsyncReaderParameters parameters_;
   size_t size_;
   size_t read_bytes_;
   std::ifstream file_;
   std::map<std::string, std::string> labels_;
+  std::string content_type_;
 };
 
 async::IAsyncReader::UPtr BuildAsyncReader(const proto::Block& block, AsyncReaderParameters parameters) {

--- a/src/reduct/storage/io/async_reader.cc
+++ b/src/reduct/storage/io/async_reader.cc
@@ -32,7 +32,7 @@ class AsyncReader : public async::IAsyncReader {
       labels_.insert({label.name(), label.value()});
     }
     content_type_ = record.content_type();
-    if (content_type_ == "") {
+    if (content_type_.empty()) {
       content_type_ = core::kContentTypeOctetStream;
     }
   }

--- a/unit_tests/reduct/api/entry_api_test.cc
+++ b/unit_tests/reduct/api/entry_api_test.cc
@@ -142,6 +142,8 @@ TEST_CASE("EntryAPI::Write should respect the passed in content-type header", "[
 
     auto [resp, resp_err] = receiver(R"({"name": "random"})", true);
     REQUIRE(resp_err == Error::kOk);
+
+    auto entry = storage->GetBucket("bucket").result.lock()->GetOrCreateEntry("entry-1").result.lock();
   }
 
   SECTION("check headers after reading") {

--- a/unit_tests/reduct/api/entry_api_test.cc
+++ b/unit_tests/reduct/api/entry_api_test.cc
@@ -136,11 +136,11 @@ TEST_CASE("EntryAPI::Write should respect the passed in content-type header", "[
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
-  auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "10", "application/json", {});
+  auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "18", "application/json", {});
   REQUIRE(err == Error::kOk);
 
-  auto [resp, recv_err] = receiver("", true);
-  REQUIRE(recv_err == Error::kOk);
+  auto [resp, resp_err] = receiver(R"({"name": "random"})", true);
+  REQUIRE(resp_err == Error::kOk);
   REQUIRE(resp.headers["content-type"] == "application/json");
 }
 

--- a/unit_tests/reduct/api/entry_api_test.cc
+++ b/unit_tests/reduct/api/entry_api_test.cc
@@ -136,24 +136,21 @@ TEST_CASE("EntryAPI::Write should respect the passed in content-type header", "[
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
-  SECTION("write dummy record") {
-    auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "18", "application/json", {});
-    REQUIRE(err == Error::kOk);
+  auto [writeRecvr, writeErr] =
+      EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "18", "application/json", {});
+  REQUIRE(writeErr == Error::kOk);
 
-    auto [resp, resp_err] = receiver(R"({"name": "random"})", true);
-    REQUIRE(resp_err == Error::kOk);
+  auto [_, writeRespErr] = writeRecvr(R"({"name": "random"})", true);
+  REQUIRE(writeRespErr == Error::kOk);
 
-    auto entry = storage->GetBucket("bucket").result.lock()->GetOrCreateEntry("entry-1").result.lock();
-  }
+  auto entry = storage->GetBucket("bucket").result.lock()->GetOrCreateEntry("entry-1").result.lock();
 
-  SECTION("check headers after reading") {
-    auto [receiver, err] = EntryApi::Read(storage.get(), "bucket", "entry-1", "1000001", {});
-    REQUIRE(err == Error::kOk);
+  auto [readRecvr, readErr] = EntryApi::Read(storage.get(), "bucket", "entry-1", "1000001", {});
+  REQUIRE(readErr == Error::kOk);
 
-    auto [resp, resp_err] = receiver("", true);
-    REQUIRE(resp.headers["content-type"] == "application/json");
-    REQUIRE(resp_err == Error::kOk);
-  }
+  auto [readResp, readRespErr] = readRecvr("", true);
+  REQUIRE(readResp.headers["content-type"] == "application/json");
+  REQUIRE(readRespErr == Error::kOk);
 }
 
 TEST_CASE("EntryApi::Read should read data in chunks with time", "[api]") {

--- a/unit_tests/reduct/api/entry_api_test.cc
+++ b/unit_tests/reduct/api/entry_api_test.cc
@@ -136,12 +136,22 @@ TEST_CASE("EntryAPI::Write should respect the passed in content-type header", "[
   auto storage = IStorage::Build({.data_path = BuildTmpDirectory()});
   REQUIRE(storage->CreateBucket("bucket", {}) == Error::kOk);
 
-  auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "18", "application/json", {});
-  REQUIRE(err == Error::kOk);
+  SECTION("write dummy record") {
+    auto [receiver, err] = EntryApi::Write(storage.get(), "bucket", "entry-1", "1000001", "18", "application/json", {});
+    REQUIRE(err == Error::kOk);
 
-  auto [resp, resp_err] = receiver(R"({"name": "random"})", true);
-  REQUIRE(resp_err == Error::kOk);
-  REQUIRE(resp.headers["content-type"] == "application/json");
+    auto [resp, resp_err] = receiver(R"({"name": "random"})", true);
+    REQUIRE(resp_err == Error::kOk);
+  }
+
+  SECTION("check headers after reading") {
+    auto [receiver, err] = EntryApi::Read(storage.get(), "bucket", "entry-1", "1000001", {});
+    REQUIRE(err == Error::kOk);
+
+    auto [resp, resp_err] = receiver("", true);
+    REQUIRE(resp.headers["content-type"] == "application/json");
+    REQUIRE(resp_err == Error::kOk);
+  }
 }
 
 TEST_CASE("EntryApi::Read should read data in chunks with time", "[api]") {

--- a/unit_tests/reduct/helpers.h
+++ b/unit_tests/reduct/helpers.h
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <random>
 
+#include "reduct/core/common.h"
 #include "reduct/proto/api/bucket.pb.h"
 #include "reduct/storage/entry.h"
 #include "reduct/storage/storage.h"
@@ -66,7 +67,7 @@ static proto::api::BucketSettings MakeDefaultBucketSettings() {
  */
 inline auto WriteOne(storage::IEntry& entry, std::string_view blob, core::Time ts,  // NOLINT
                      const storage::IEntry::LabelMap& labels = {}) {
-  auto [ret, err] = entry.BeginWrite(ts, blob.size(), labels);
+  auto [ret, err] = entry.BeginWrite(ts, blob.size(), core::kContentTypeOctetStream, labels);
   if (err) {
     return err;
   }


### PR DESCRIPTION
Closes #219 

### Please check if the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

If a record is written with the `Content-Type` header, this should be preserved so that the record can be returned with the same header later.

### What is the current behavior?

All records are returned using the `Content-Type: application/octet-stream` header.

### What is the new behavior?

Stores the `Content-Type` header in the record metadata.


### Does this PR introduce a breaking change?

No, this does not introduce a breaking change.
