### PR TITLE
Update Web Console to v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Console
-        run: wget https://github.com/reductstore/web-console/releases/download/v1.1.1/web-console.build.tar.gz
+        run: wget https://github.com/reductstore/web-console/releases/download/v1.2.0/web-console.build.tar.gz
       - name: Extract
         run: mkdir web-console && tar xf web-console.build.tar.gz -C ./web-console
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefix `x-reduct-label-`, [PR-224](https://github.com/reductstore/reductstore/pull/224)
 - `include-<label>` and `exclude-<label>` query parameters for query endpoint
   `GET /api/v1/:bucket/:entry/q`, [PR-226](https://github.com/reductstore/reductstore/pull/226)
-- Store the `Content-Type` header received for a record while writing it, so that the record may be returned with the same header, [PR-231](https://github.com/reductstore/reductstore/pull/231)
+- Store the `Content-Type` header received for a record while writing it, so that the record may be returned with the
+  same header, [PR-231](https://github.com/reductstore/reductstore/pull/231)
 
 ### Changed
 
 - Project license AGPLv3 to MPL-2.0, [PR-221](https://github.com/reductstore/reductstore/pull/221)
-- Rename error header `-x-reduct-error` to `x-reduct-error`, [PR-230](https://github.com/reductstore/reductstore/pull/230)
+- Rename error header `-x-reduct-error`
+  to `x-reduct-error`, [PR-230](https://github.com/reductstore/reductstore/pull/230)
+- Update Web Console to v1.2.0, [PR-232](https://github.com/reductstore/reductstore/pull/232)
 
 ## [1.2.3] - 2023-01-02
 

--- a/api_tests/server_api_test.py
+++ b/api_tests/server_api_test.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from conftest import requires_env, auth_headers
 
@@ -9,7 +10,7 @@ def test__get_info(base_url, session):
 
     assert resp.status_code == 200
     data = json.loads(resp.content)
-    assert data['version'] >= '1.0.0'
+    assert data['version'] >= '1.3.0'
     assert int(data['bucket_count']) > 0
     assert int(data['uptime']) >= 0
     assert int(data['latest_record']) >= 0
@@ -17,7 +18,7 @@ def test__get_info(base_url, session):
 
     assert data['defaults']['bucket'] == {'max_block_records': '1024', 'max_block_size': '64000000', 'quota_size': '0',
                                           'quota_type': 'NONE'}
-    assert resp.headers['server'] == "ReductStorage"
+    assert re.match(r"ReductStore 1\.\d+\.\d+", resp.headers['server'])
     assert resp.headers['Content-Type'] == "application/json"
 
 

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -140,7 +140,7 @@ class HttpServer : public IHttpServer {
       }
 
       ctx.res->writeHeader("connection", ctx.running ? "keep-alive" : "close");
-      ctx.res->writeHeader("server", "ReductStore " + kVersion);
+      ctx.res->writeHeader("server", fmt::format("ReductStore {}", kVersion));
     };
 
     auto SendError = [ctx, &method, &url, CommonHeaders](const core::Error &err) {

--- a/src/reduct/api/http_server.cc
+++ b/src/reduct/api/http_server.cc
@@ -18,6 +18,7 @@
 #include "reduct/api/server_api.h"
 #include "reduct/api/token_api.h"
 #include "reduct/async/sleep.h"
+#include "reduct/config.h"
 #include "reduct/core/logger.h"
 
 namespace reduct::api {
@@ -139,7 +140,7 @@ class HttpServer : public IHttpServer {
       }
 
       ctx.res->writeHeader("connection", ctx.running ? "keep-alive" : "close");
-      ctx.res->writeHeader("server", "ReductStorage");
+      ctx.res->writeHeader("server", "ReductStore " + kVersion);
     };
 
     auto SendError = [ctx, &method, &url, CommonHeaders](const core::Error &err) {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

The database has Web Console v1.1.1

### What is the new behavior?

Now it is [v1.2.0](https://github.com/reductstore/web-console/releases/tag/v1.2.0)

### Does this PR introduce a breaking change?

No

### Other information:
