### PR TITLE
Begin time 0 is valid for a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Install snap as daemon, [PR-240](https://github.com/reductstore/reductstore/pull/240)
 
 
+### Fixed
+
+- Begin time 0 is valid for a block, [PR-242](https://github.com/reductstore/reductstore/pull/242)
+
 ## [1.3.1] - 2023-02-03
 
 ### Fixed

--- a/src/reduct/storage/block_manager.cc
+++ b/src/reduct/storage/block_manager.cc
@@ -162,9 +162,7 @@ class BlockManager : public IBlockManager {
           }
 
           blk->mutable_records(index)->set_state(state);
-          if (state == proto::Record::kInvalid) {
-            blk->set_invalid(true);
-          }
+          blk->set_invalid(state == proto::Record::kInvalid);
 
           if (auto err = SaveBlock(blk)) {
             LOG_ERROR("{}", err.ToString());

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -53,7 +53,7 @@ class Entry : public IEntry {
             auto ts = TimeUtil::MicrosecondsToTimestamp(std::stoull(path.stem().c_str()));
             auto [block, err] = block_manager_->LoadBlock(ts);
 
-            if (err || block->begin_time().seconds() == 0 || block->invalid()) {
+            if (err || block->invalid()) {
               LOG_WARNING("Block {} looks broken. Remove it.", path.string());
               std::error_code ec;
               if (!fs::remove(path, ec)) {

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -53,7 +53,7 @@ class Entry : public IEntry {
             auto ts = TimeUtil::MicrosecondsToTimestamp(std::stoull(path.stem().c_str()));
             auto [block, err] = block_manager_->LoadBlock(ts);
 
-            if (err || block->invalid()) {
+            if (err || !block->has_begin_time() || block->invalid()) {
               LOG_WARNING("Block {} looks broken. Remove it.", path.string());
               std::error_code ec;
               if (!fs::remove(path, ec)) {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

If the begin time of a block is 0 in seconds we remove this block as invalid at the start. This is wrong because we can use timestamp as ID and ID can be 0.

### What is the new behavior?

We check if `begin_time` is initialized at the validation.

### Does this PR introduce a breaking change?

No

### Other information:
