### PR TITLE
Speed up loading entries at start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Continuous query `GET /api/v1/:bucket/:entry/q?continuous=true|false`,
   [PR-248](https://github.com/reductstore/reductstore/pull/248)
-
+- Build ARM64 Docker image
+-
 ### Changed
 
 - New public Docker repository `reduct/store`, [PR-246](https://github.com/reductstore/reductstore/pull/246)
-- Build ARM64 Docker image
+- Speed up loading entries at start, [PR-250](https://github.com/reductstore/reductstore/pull/250)
 
 ### Fixed
 

--- a/benchmarks/reduct/storage/entry_benchmarks.cc
+++ b/benchmarks/reduct/storage/entry_benchmarks.cc
@@ -22,7 +22,7 @@ using reduct::storage::IEntry;
 
 using google::protobuf::util::TimeUtil;
 
-TEST_CASE("storage::IEntry write operation") {
+TEST_CASE("storage::IEntry benchmarks", "[storage][entry][benchmarks]") {
   auto dir_path = fs::temp_directory_path() / "reduct" / "bucket";
   fs::remove_all(dir_path);
 
@@ -38,5 +38,9 @@ TEST_CASE("storage::IEntry write operation") {
   BENCHMARK("Write forward") {
     auto [writer, err] = entry->BeginWrite(Time::clock::now(), 10, {});
     [[maybe_unused]] auto ret = writer->Write("1234567890");
+  };
+
+  BENCHMARK("Load records") {
+    IBucket::Restore(dir_path);
   };
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,6 @@ if (WITH_WEB_CONSOLE)
             web_console
             URL https://github.com/reductstore/web-console/releases/download/v1.2.0/web-console.build.tar.gz
             URL_HASH MD5=5b48f33d8bbd0679e11eca2a1c71c0c9
-            DOWNLOAD_EXTRACT_TIMESTAMP ON
     )
     FetchContent_MakeAvailable(web_console)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,8 @@ if (WITH_WEB_CONSOLE)
     FetchContent_Declare(
             web_console
             URL https://github.com/reductstore/web-console/releases/download/v1.2.0/web-console.build.tar.gz
+            URL_HASH MD5=5b48f33d8bbd0679e11eca2a1c71c0c9
+            DOWNLOAD_EXTRACT_TIMESTAMP ON
     )
     FetchContent_MakeAvailable(web_console)
 

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -19,7 +19,6 @@
 #include "reduct/proto/storage/entry.pb.h"
 #include "reduct/storage/block_manager.h"
 #include "reduct/storage/io/async_reader.h"
-#include "reduct/storage/io/async_writer.h"
 
 namespace reduct::storage {
 

--- a/src/reduct/storage/entry.cc
+++ b/src/reduct/storage/entry.cc
@@ -9,6 +9,7 @@
 #include <google/protobuf/util/time_util.h>
 
 #include <filesystem>
+#include <fstream>
 #include <ranges>
 
 #include "reduct/async/io.h"
@@ -31,7 +32,6 @@ using query::IQuery;
 
 using google::protobuf::Timestamp;
 using google::protobuf::util::TimeUtil;
-auto to_time_t = core::Time::clock::to_time_t;
 
 namespace fs = std::filesystem;
 
@@ -50,10 +50,16 @@ class Entry : public IEntry {
         auto path = file.path();
         if (fs::is_regular_file(file) && path.extension() == kMetaExt) {
           try {
-            auto ts = TimeUtil::MicrosecondsToTimestamp(std::stoull(path.stem().c_str()));
-            auto [block, err] = block_manager_->LoadBlock(ts);
+            google::protobuf::Arena arena;
+            auto block = google::protobuf::Arena::CreateMessage<proto::Block>(&arena);
 
-            if (err || !block->has_begin_time() || block->invalid()) {
+            std::ifstream block_descriptor(path, std::ios::binary);
+            if (!block_descriptor) {
+              LOG_ERROR("Failed to open file {}: {}", path.string(), std::strerror(errno));
+              continue;
+            }
+
+            if (!block->ParseFromIstream(&block_descriptor) || !block->has_begin_time() || block->invalid()) {
               LOG_WARNING("Block {} looks broken. Remove it.", path.string());
               std::error_code ec;
               if (!fs::remove(path, ec)) {
@@ -67,7 +73,7 @@ class Entry : public IEntry {
               continue;
             }
 
-            block_set_.insert(ts);
+            block_set_.insert(block->begin_time());
             size_counter_ += block->size();
             record_counter_ += block->records_size();
           } catch (std::exception& err) {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

The database parse all descriptors to calculate the number of records and size of stored data. It takes some time.
For example, it takes 4 seconds for 4e9 records on modern hardware. 

### What is the new behavior?

For parsing blocks, we use Protobuf arenas which increased the performance twice.


### Does this PR introduce a breaking change?

No

### Other information:
