### PR TITLE
Fix error when a client aborts streaming data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - GET /api/v1/me endpoint for disabled authentication, [PR-245](https://github.com/reductstore/reductstore/pull/245)
+- Error handling when a client closes a connection, [PR-263](https://github.com/reductstore/reductstore/pull/263)
 
 ## [1.3.2] - 2023-03-10
 

--- a/build.rs
+++ b/build.rs
@@ -24,9 +24,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .expect("Failed to download Web Console");
     if resp.status_code() != 200.into() {
         if resp.status_code() == 302.into() {
-            let resp =
-                http_req::request::get(&resp.headers().get("location").unwrap(), &mut writer)
-                    .expect("Failed to download Web Console");
+            http_req::request::get(&resp.headers().get("location").unwrap(), &mut writer)
+                .expect("Failed to download Web Console");
         } else {
             panic!("Failed to download Web Console: {}", resp.reason());
         }

--- a/src/http_frontend.rs
+++ b/src/http_frontend.rs
@@ -60,3 +60,9 @@ impl StdError for HttpError {
         None
     }
 }
+
+impl From<axum::Error> for HttpError {
+    fn from(err: axum::Error) -> Self {
+        HttpError::internal_server_error(&format!("Internal server error: {}", err))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use crate::core::logger::Logger;
 
 use crate::http_frontend::bucket_api::BucketApi;
 use crate::http_frontend::entry_api::EntryApi;
-use crate::http_frontend::middleware::default_headers;
+use crate::http_frontend::middleware::{default_headers, print_statuses};
 use crate::http_frontend::server_api::ServerApi;
 use crate::http_frontend::token_api::TokenApi;
 use crate::http_frontend::ui_api::UiApi;
@@ -50,7 +50,7 @@ async fn main() {
 
     let mut env = Env::new();
 
-    let log_level = env.get::<String>("LOG_LEVEL", "INFO".to_string(), false);
+    let log_level = env.get::<String>("RS_LOG_LEVEL", "INFO".to_string(), false);
     let host = env.get::<String>("RS_HOST", "0.0.0.0".to_string(), false);
     let port = env.get::<i32>("RS_PORT", 8383, false);
     let api_base_path = env.get::<String>("RS_API_BASE_PATH", "/".to_string(), false);
@@ -156,6 +156,7 @@ async fn main() {
         .route(&format!("{}", api_base_path), get(UiApi::redirect_to_index))
         .fallback(get(UiApi::show_ui))
         .layer(middleware::from_fn(default_headers))
+        .layer(middleware::from_fn(print_statuses))
         .with_state(Arc::new(RwLock::new(components)));
 
     if cert_path.is_empty() {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,4 +10,4 @@ pub mod storage;
 mod block_manager;
 pub mod query;
 pub mod reader;
-mod writer;
+pub mod writer;

--- a/src/storage/block_manager.rs
+++ b/src/storage/block_manager.rs
@@ -270,6 +270,7 @@ impl ManageBlock for BlockManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::writer::Chunk;
     use tempfile::tempdir;
 
     #[test]
@@ -365,7 +366,7 @@ mod tests {
             writer
                 .write()
                 .unwrap()
-                .write("hello".as_bytes(), true)
+                .write(Chunk::Last(Bytes::from("hello")))
                 .unwrap();
         }
 

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -399,7 +399,7 @@ mod tests {
     use super::*;
     use crate::storage::block_manager::DEFAULT_MAX_READ_CHUNK;
     use crate::storage::writer::Chunk;
-    use crate::storage::writer::Chunk::Data;
+
     use std::thread::sleep;
     use std::time::Duration;
     use tempfile;

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -134,7 +134,7 @@ impl Entry {
 
         let (block, record_type) =
             if block.begin_time.is_some() && ts_to_us(block.begin_time.as_ref().unwrap()) >= time {
-                debug!("Timestamp {} is belated. Finding proper block", time);
+                debug!("Timestamp {} is belated. Looking for a block", time);
                 // The timestamp is belated. We need to find the proper block to write to.
 
                 if *self.block_index.first().unwrap() > time {
@@ -142,11 +142,6 @@ impl Entry {
                     debug!("Timestamp {} is the earliest. Creating a new block", time);
                     (self.start_new_block(time)?, RecordType::BelatedFirst)
                 } else {
-                    // The timestamp is in the middle. We need to find the proper block.
-                    debug!(
-                        "Timestamp {} is in the middle. Finding the proper block",
-                        time
-                    );
                     let block_id = self.block_index.range(time..).next().unwrap();
                     let block = self.block_manager.load(*block_id)?;
                     // check if the record already exists

--- a/src/storage/query/continuous.rs
+++ b/src/storage/query/continuous.rs
@@ -66,6 +66,7 @@ impl Query for ContinuousQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
     use prost_wkt_types::Timestamp;
     use std::thread::sleep;
     use tempfile::tempdir;
@@ -73,6 +74,7 @@ mod tests {
     use crate::core::status::HttpStatus;
     use crate::storage::block_manager::ManageBlock;
     use crate::storage::proto::{record::State as RecordState, Record};
+    use crate::storage::writer::Chunk;
 
     #[test]
     fn test_query() {
@@ -136,7 +138,11 @@ mod tests {
 
         {
             let writer = block_manager.begin_write(&block, 0).unwrap();
-            writer.write().unwrap().write(b"0123456789", true).unwrap();
+            writer
+                .write()
+                .unwrap()
+                .write(Chunk::Last(Bytes::from("0123456789")))
+                .unwrap();
         }
 
         block_manager.finish(&block).unwrap();

--- a/src/storage/query/historical.rs
+++ b/src/storage/query/historical.rs
@@ -176,7 +176,7 @@ mod tests {
     use bytes::Bytes;
     use prost_wkt_types::Timestamp;
     use std::collections::HashMap;
-    use std::process::id;
+
     use std::time::Duration;
     use tempfile::tempdir;
 

--- a/src/storage/query/historical.rs
+++ b/src/storage/query/historical.rs
@@ -171,7 +171,8 @@ mod tests {
     use super::*;
     use crate::core::status::HttpStatus;
     use crate::storage::proto::record::Label;
-    use crate::storage::reader::DataChunk;
+    use crate::storage::writer::Chunk;
+    use bytes::Bytes;
     use prost_wkt_types::Timestamp;
     use std::collections::HashMap;
     use std::time::Duration;
@@ -194,11 +195,9 @@ mod tests {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
                 reader.write().unwrap().read().unwrap(),
-                DataChunk {
-                    data: Vec::from("0123456789"),
-                    last: true,
-                }
+                Some(Bytes::from("0123456789"))
             );
+            assert!(reader.write().unwrap().read().unwrap().is_none())
         }
         {
             let res = query.next(&index, &mut block_manager);
@@ -214,24 +213,22 @@ mod tests {
 
         let (mut block_manager, index) = setup_2_blocks();
         {
-            let (reader, _) = query.next(&index, &mut block_manager).unwrap();
-            assert_eq!(
-                reader.write().unwrap().read().unwrap(),
-                DataChunk {
-                    data: Vec::from("0123456789"),
-                    last: true,
-                }
-            );
+            {
+                let (reader, _) = query.next(&index, &mut block_manager).unwrap();
+                assert_eq!(
+                    reader.write().unwrap().read().unwrap(),
+                    Some(Bytes::from("0123456789"))
+                );
+                assert!(reader.write().unwrap().read().unwrap().is_none())
+            }
         }
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
                 reader.write().unwrap().read().unwrap(),
-                DataChunk {
-                    data: Vec::from("0123456789"),
-                    last: true,
-                }
+                Some(Bytes::from("0123456789"))
             );
+            assert!(reader.write().unwrap().read().unwrap().is_none())
         }
 
         assert_eq!(
@@ -253,31 +250,25 @@ mod tests {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
                 reader.write().unwrap().read().unwrap(),
-                DataChunk {
-                    data: Vec::from("0123456789"),
-                    last: true,
-                }
+                Some(Bytes::from("0123456789"))
             );
+            assert!(reader.write().unwrap().read().unwrap().is_none())
         }
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
                 reader.write().unwrap().read().unwrap(),
-                DataChunk {
-                    data: Vec::from("0123456789"),
-                    last: true,
-                }
+                Some(Bytes::from("0123456789"))
             );
+            assert!(reader.write().unwrap().read().unwrap().is_none())
         }
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
                 reader.write().unwrap().read().unwrap(),
-                DataChunk {
-                    data: Vec::from("0123456789"),
-                    last: true,
-                }
+                Some(Bytes::from("0123456789"))
             );
+            assert!(reader.write().unwrap().read().unwrap().is_none())
         }
         assert_eq!(
             query.next(&index, &mut block_manager).err(),
@@ -426,12 +417,20 @@ mod tests {
         {
             let writer = block_manager.begin_write(&block, 0).unwrap();
 
-            writer.write().unwrap().write(b"0123456789", true).unwrap();
+            writer
+                .write()
+                .unwrap()
+                .write(Chunk::Last(Bytes::from("0123456789")))
+                .unwrap();
         }
 
         {
             let writer = block_manager.begin_write(&block, 1).unwrap();
-            writer.write().unwrap().write(b"0123456789", true).unwrap();
+            writer
+                .write()
+                .unwrap()
+                .write(Chunk::Last(Bytes::from("0123456789")))
+                .unwrap();
         }
 
         block_manager.finish(&block).unwrap();
@@ -468,7 +467,11 @@ mod tests {
 
         {
             let writer = block_manager.begin_write(&block, 0).unwrap();
-            writer.write().unwrap().write(b"0123456789", true).unwrap();
+            writer
+                .write()
+                .unwrap()
+                .write(Chunk::Last(Bytes::from("0123456789")))
+                .unwrap();
         }
 
         block_manager.finish(&block).unwrap();

--- a/src/storage/storage.rs
+++ b/src/storage/storage.rs
@@ -159,6 +159,8 @@ mod tests {
     use super::*;
     use crate::storage::entry::Labels;
     use crate::storage::proto::bucket_settings::QuotaType;
+    use crate::storage::writer::Chunk;
+    use bytes::Bytes;
     use std::thread::sleep;
     use std::time::Duration;
     use tempfile::tempdir;
@@ -206,21 +208,33 @@ mod tests {
             let writer = entry
                 .begin_write(1000, 10, "text/plain".to_string(), Labels::new())
                 .unwrap();
-            writer.write().unwrap().write(b"0123456789", true).unwrap();
+            writer
+                .write()
+                .unwrap()
+                .write(Chunk::Last(Bytes::from("0123456789")))
+                .unwrap();
         }
         {
             let entry = bucket.get_or_create_entry("entry-2").unwrap();
             let writer = entry
                 .begin_write(2000, 10, "text/plain".to_string(), Labels::new())
                 .unwrap();
-            writer.write().unwrap().write(b"0123456789", true).unwrap();
+            writer
+                .write()
+                .unwrap()
+                .write(Chunk::Last(Bytes::from("0123456789")))
+                .unwrap();
         }
         {
             let entry = bucket.get_or_create_entry("entry-2").unwrap();
             let writer = entry
                 .begin_write(5000, 10, "text/plain".to_string(), Labels::new())
                 .unwrap();
-            writer.write().unwrap().write(b"0123456789", true).unwrap();
+            writer
+                .write()
+                .unwrap()
+                .write(Chunk::Last(Bytes::from("0123456789")))
+                .unwrap();
         }
 
         let mut storage = Storage::new(path);


### PR DESCRIPTION
Closes #260 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #260 

### What is the new behavior?

The HTTP layer handles the error and mark the record, which was written, with error flag.

### Does this PR introduce a breaking change?

No

### Other information:
