### PR TITLE
Allow null quota type in bucket settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GET /api/v1/me endpoint for disabled authentication, [PR-245](https://github.com/reductstore/reductstore/pull/245)
 - Error handling when a client closes a connection, [PR-263](https://github.com/reductstore/reductstore/pull/263)
+- Allow null quota type in bucket settings, [PR-264](https://github.com/reductstore/reductstore/pull/264)
 
 ## [1.3.2] - 2023-03-10
 

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -19,6 +19,17 @@ def test__create_bucket_ok(base_url, session, bucket_name):
 
     assert resp.headers['Content-Type'] == "application/json"
 
+def test__create_bucket_quota_type_null(base_url, session, bucket_name):
+    """Should create a bucket if quota_type is null"""
+    resp = session.post(f'{base_url}/b/{bucket_name}', json={"quota_type": None})
+    assert resp.status_code == 200
+
+    resp = session.get(f'{base_url}/b/{bucket_name}')
+    assert resp.status_code == 200
+
+    data = json.loads(resp.content)
+    assert data['settings']['quota_type'] == "NONE"
+
 
 @requires_env("API_TOKEN")
 def test__create_bucket_with_full_access_token(base_url, session, bucket_name, token_without_permissions):

--- a/src/http_frontend/bucket_api.rs
+++ b/src/http_frontend/bucket_api.rs
@@ -78,10 +78,12 @@ where
                 serde_json::from_slice(&bytes).map_err(|e| HttpError::from(e).into_response())?;
             match json.get_mut("quota_type") {
                 Some(quota_type) => {
-                    let val = QuotaType::from_str_name(quota_type.as_str().unwrap()).ok_or(
-                        HttpError::unprocessable_entity("Invalid quota type").into_response(),
-                    )? as i32;
-                    *quota_type = json!(val);
+                    if !quota_type.is_null() {
+                        let val = QuotaType::from_str_name(quota_type.as_str().unwrap()).ok_or(
+                            HttpError::unprocessable_entity("Invalid quota type").into_response(),
+                        )? as i32;
+                        *quota_type = json!(val);
+                    }
                 }
                 None => {}
             }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Some serializers can send null value for optional fields. However, the HTTP layer doesn't support it for the quota type field.

### What is the new behavior?

I added a manual check for this.

### Does this PR introduce a breaking change?

No

### Other information:
