### PR TITLE
Fix access to a block descriptor from several threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow null quota type in bucket settings, [PR-264](https://github.com/reductstore/reductstore/pull/264)
 - Writing belated data, [PR-265](https://github.com/reductstore/reductstore/pull/265)
 - Fix searching record by timestamp, [PR-266](https://github.com/reductstore/reductstore/pull/266)
+- Graceful shutdown, [PR-267](https://github.com/reductstore/reductstore/pull/267)
 
 ## [1.3.2] - 2023-03-10
 

--- a/src/storage/block_manager.rs
+++ b/src/storage/block_manager.rs
@@ -7,12 +7,11 @@ use prost::bytes::{Bytes, BytesMut};
 use prost::Message;
 use prost_wkt_types::Timestamp;
 
-use log::{debug, info};
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::sync::{Arc, RwLock, Weak};
 
 use crate::core::status::HttpError;
 use crate::storage::proto::*;
@@ -384,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_start_writing() {
-        let mut bm = setup();
+        let bm = setup();
 
         let block_id = 1;
         let mut block = bm.start(block_id, 1024).unwrap().clone();
@@ -417,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_remove_with_writers() {
-        let mut bm = setup();
+        let bm = setup();
         let block_id = 1;
 
         {

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -424,7 +424,8 @@ mod tests {
         write_stub_record(&mut entry, 1).unwrap();
         write_stub_record(&mut entry, 2000010).unwrap();
 
-        let records = entry.block_manager.load(1).unwrap().records.clone();
+        let bm = entry.block_manager.read().unwrap();
+        let records = bm.load(1).unwrap().records.clone();
         assert_eq!(records.len(), 2);
         assert_eq!(
             records[0],
@@ -467,8 +468,10 @@ mod tests {
         write_stub_record(&mut entry, 1).unwrap();
         write_stub_record(&mut entry, 2000010).unwrap();
 
+        let bm = entry.block_manager.read().unwrap();
+
         assert_eq!(
-            entry.block_manager.load(1).unwrap().records[0],
+            bm.load(1).unwrap().records[0],
             Record {
                 timestamp: Some(us_to_ts(&1)),
                 begin: 0,
@@ -480,7 +483,7 @@ mod tests {
         );
 
         assert_eq!(
-            entry.block_manager.load(2000010).unwrap().records[0],
+            bm.load(2000010).unwrap().records[0],
             Record {
                 timestamp: Some(us_to_ts(&2000010)),
                 begin: 0,
@@ -503,8 +506,9 @@ mod tests {
         write_stub_record(&mut entry, 2).unwrap();
         write_stub_record(&mut entry, 2000010).unwrap();
 
+        let bm = entry.block_manager.read().unwrap();
         assert_eq!(
-            entry.block_manager.load(1).unwrap().records[0],
+            bm.load(1).unwrap().records[0],
             Record {
                 timestamp: Some(us_to_ts(&1)),
                 begin: 0,
@@ -516,7 +520,7 @@ mod tests {
         );
 
         assert_eq!(
-            entry.block_manager.load(2000010).unwrap().records[0],
+            bm.load(2000010).unwrap().records[0],
             Record {
                 timestamp: Some(us_to_ts(&2000010)),
                 begin: 0,
@@ -536,7 +540,8 @@ mod tests {
         write_stub_record(&mut entry, 3000000).unwrap();
         write_stub_record(&mut entry, 2000000).unwrap();
 
-        let records = entry.block_manager.load(1000000).unwrap().records.clone();
+        let bm = entry.block_manager.read().unwrap();
+        let records = bm.load(1000000).unwrap().records.clone();
         assert_eq!(records.len(), 3);
         assert_eq!(records[0].timestamp, Some(us_to_ts(&1000000)));
         assert_eq!(records[1].timestamp, Some(us_to_ts(&3000000)));
@@ -550,7 +555,8 @@ mod tests {
         write_stub_record(&mut entry, 3000000).unwrap();
         write_stub_record(&mut entry, 1000000).unwrap();
 
-        let records = entry.block_manager.load(1000000).unwrap().records.clone();
+        let bm = entry.block_manager.read().unwrap();
+        let records = bm.load(1000000).unwrap().records.clone();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].timestamp, Some(us_to_ts(&1000000)));
     }

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -30,7 +30,7 @@ pub struct Entry {
     name: String,
     settings: EntrySettings,
     block_index: BTreeSet<u64>,
-    block_manager: BlockManager,
+    block_manager: Arc<RwLock<BlockManager>>,
     record_count: u64,
     size: u64,
     queries: HashMap<u64, Box<dyn Query + Send + Sync>>,
@@ -50,7 +50,7 @@ impl Entry {
             name: name.to_string(),
             settings,
             block_index: BTreeSet::new(),
-            block_manager: BlockManager::new(path.join(name)),
+            block_manager: Arc::new(RwLock::new(BlockManager::new(path.join(name)))),
             record_count: 0,
             size: 0,
             queries: HashMap::new(),
@@ -92,7 +92,7 @@ impl Entry {
             name: path.file_name().unwrap().to_str().unwrap().to_string(),
             settings: options,
             block_index,
-            block_manager: BlockManager::new(path),
+            block_manager: Arc::new(RwLock::new(BlockManager::new(path))),
             record_count,
             size,
             queries: HashMap::new(),
@@ -131,7 +131,8 @@ impl Entry {
         let block = if self.block_index.is_empty() {
             self.start_new_block(time)?
         } else {
-            self.block_manager.load(*self.block_index.last().unwrap())?
+            let bm = self.block_manager.read().unwrap();
+            bm.load(*self.block_index.last().unwrap())?
         };
 
         let (block, record_type) = if block.latest_record_time.is_some()
@@ -146,7 +147,8 @@ impl Entry {
                 (self.start_new_block(time)?, RecordType::BelatedFirst)
             } else {
                 let block_id = find_first_block(&self.block_index, &time);
-                let block = self.block_manager.load(block_id)?;
+                let bm = self.block_manager.read().unwrap();
+                let block = bm.load(block_id)?;
                 // check if the record already exists
                 let proto_time = Some(us_to_ts(&time));
                 if block
@@ -175,7 +177,7 @@ impl Entry {
         {
             // We need to create a new block.
             debug!("Creating a new block");
-            self.block_manager.finish(&block)?;
+            self.block_manager.write().unwrap().finish(&block)?;
             self.start_new_block(time)?
         } else {
             // We can just append to the latest block.
@@ -203,9 +205,12 @@ impl Entry {
             block.latest_record_time = Some(us_to_ts(&time));
         }
 
-        self.block_manager.save(&block)?;
-        self.block_manager
-            .begin_write(&block, block.records.len() - 1)
+        self.block_manager.write().unwrap().save(&block)?;
+        BlockManager::begin_write(
+            Arc::clone(&self.block_manager),
+            &block,
+            block.records.len() - 1,
+        )
     }
 
     /// Starts a new record read.
@@ -236,7 +241,10 @@ impl Entry {
         let _block_id = self.block_index.range(time..).next();
         let block_id = find_first_block(&self.block_index, &time);
 
-        let block = self.block_manager.load(block_id)?;
+        let block = {
+            let bm = self.block_manager.read().unwrap();
+            bm.load(block_id)?
+        };
 
         let record_index = block
             .records
@@ -262,7 +270,10 @@ impl Entry {
             )));
         }
 
-        self.block_manager.begin_read(&block, record_index.unwrap())
+        self.block_manager
+            .write()
+            .unwrap()
+            .begin_read(&block, record_index.unwrap())
     }
 
     /// Query records for a time range.
@@ -303,7 +314,7 @@ impl Entry {
             .queries
             .get_mut(&query_id)
             .ok_or_else(|| HttpError::not_found(&format!("Query {} not found", query_id)))?;
-        query.next(&self.block_index, &mut self.block_manager)
+        query.next(&self.block_index, &mut self.block_manager.write().unwrap())
     }
 
     /// Returns stats about the entry.
@@ -311,7 +322,11 @@ impl Entry {
         let (oldest_record, latest_record) = if self.block_index.is_empty() {
             (0, 0)
         } else {
-            let latest_block = self.block_manager.load(*self.block_index.last().unwrap())?;
+            let latest_block = self
+                .block_manager
+                .read()
+                .unwrap()
+                .load(*self.block_index.last().unwrap())?;
             let latest_record = if latest_block.records.is_empty() {
                 0
             } else {
@@ -351,11 +366,14 @@ impl Entry {
 
         let oldest_block_id = *self.block_index.first().unwrap();
 
-        let block = self.block_manager.load(oldest_block_id)?;
+        let block = self.block_manager.read().unwrap().load(oldest_block_id)?;
         self.size -= block.size;
         self.record_count -= block.records.len() as u64;
 
-        self.block_manager.remove(oldest_block_id)?;
+        self.block_manager
+            .write()
+            .unwrap()
+            .remove(oldest_block_id)?;
         self.block_index.remove(&oldest_block_id);
 
         Ok(())
@@ -376,6 +394,8 @@ impl Entry {
     fn start_new_block(&mut self, time: u64) -> Result<Block, HttpError> {
         let block = self
             .block_manager
+            .write()
+            .unwrap()
             .start(time, self.settings.max_block_size)?;
         self.block_index
             .insert(ts_to_us(&block.begin_time.as_ref().unwrap()));

--- a/src/storage/query/continuous.rs
+++ b/src/storage/query/continuous.rs
@@ -68,7 +68,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use prost_wkt_types::Timestamp;
-    use std::ops::Deref;
+
     use std::thread::sleep;
     use tempfile::tempdir;
 
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_query() {
-        let (mut block_manager, block_indexes) = setup();
+        let (block_manager, block_indexes) = setup();
         let mut block_manager = block_manager.write().unwrap();
 
         let mut query = ContinuousQuery::new(
@@ -116,7 +116,7 @@ mod tests {
 
     fn setup() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
         let dir = tempdir().unwrap().into_path();
-        let mut block_manager = BlockManager::new(dir);
+        let block_manager = BlockManager::new(dir);
         let mut block = block_manager.start(0, 10).unwrap();
 
         block.records.push(Record {

--- a/src/storage/query/continuous.rs
+++ b/src/storage/query/continuous.rs
@@ -68,6 +68,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use prost_wkt_types::Timestamp;
+    use std::ops::Deref;
     use std::thread::sleep;
     use tempfile::tempdir;
 
@@ -79,6 +80,7 @@ mod tests {
     #[test]
     fn test_query() {
         let (mut block_manager, block_indexes) = setup();
+        let mut block_manager = block_manager.write().unwrap();
 
         let mut query = ContinuousQuery::new(
             0,
@@ -112,7 +114,7 @@ mod tests {
         assert_eq!(query.state(), &QueryState::Expired);
     }
 
-    fn setup() -> (BlockManager, BTreeSet<u64>) {
+    fn setup() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
         let dir = tempdir().unwrap().into_path();
         let mut block_manager = BlockManager::new(dir);
         let mut block = block_manager.start(0, 10).unwrap();
@@ -136,8 +138,9 @@ mod tests {
         block.size = 10;
         block_manager.save(&block).unwrap();
 
+        let bm_ref = Arc::new(RwLock::new(block_manager));
         {
-            let writer = block_manager.begin_write(&block, 0).unwrap();
+            let writer = BlockManager::begin_write(Arc::clone(&bm_ref), &block, 0).unwrap();
             writer
                 .write()
                 .unwrap()
@@ -145,7 +148,7 @@ mod tests {
                 .unwrap();
         }
 
-        block_manager.finish(&block).unwrap();
-        (block_manager, BTreeSet::from([0]))
+        bm_ref.write().unwrap().finish(&block).unwrap();
+        (Arc::clone(&bm_ref), BTreeSet::from([0]))
     }
 }

--- a/src/storage/query/historical.rs
+++ b/src/storage/query/historical.rs
@@ -178,7 +178,7 @@ mod tests {
     fn test_query_ok_1_rec() {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
 
-        let (mut block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = setup_2_blocks();
         let mut block_manager = block_manager.write().unwrap();
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
@@ -200,7 +200,7 @@ mod tests {
     fn test_query_ok_2_recs() {
         let mut query = HistoricalQuery::new(0, 1000, QueryOptions::default());
 
-        let (mut block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = setup_2_blocks();
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -236,7 +236,7 @@ mod tests {
     fn test_query_ok_3_recs() {
         let mut query = HistoricalQuery::new(0, 1001, QueryOptions::default());
 
-        let (mut block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = setup_2_blocks();
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -287,7 +287,7 @@ mod tests {
                 ..QueryOptions::default()
             },
         );
-        let (mut block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = setup_2_blocks();
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -325,7 +325,7 @@ mod tests {
             },
         );
 
-        let (mut block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = setup_2_blocks();
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -363,7 +363,7 @@ mod tests {
     fn test_ignoring_errored_records() {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
 
-        let (mut block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = setup_2_blocks();
         let mut block_manager = block_manager.write().unwrap();
 
         let mut block = block_manager.load(*index.get(&0u64).unwrap()).unwrap();
@@ -381,7 +381,7 @@ mod tests {
 
     fn setup_2_blocks() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
         let dir = tempdir().unwrap().into_path();
-        let mut block_manager = BlockManager::new(dir);
+        let block_manager = BlockManager::new(dir);
         let mut block = block_manager.start(0, 10).unwrap();
 
         block.records.push(Record {

--- a/src/storage/query/historical.rs
+++ b/src/storage/query/historical.rs
@@ -179,6 +179,7 @@ mod tests {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
 
         let (mut block_manager, index) = setup_2_blocks();
+        let mut block_manager = block_manager.write().unwrap();
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
@@ -200,6 +201,8 @@ mod tests {
         let mut query = HistoricalQuery::new(0, 1000, QueryOptions::default());
 
         let (mut block_manager, index) = setup_2_blocks();
+        let mut block_manager = block_manager.write().unwrap();
+
         {
             {
                 let (reader, _) = query.next(&index, &mut block_manager).unwrap();
@@ -234,8 +237,11 @@ mod tests {
         let mut query = HistoricalQuery::new(0, 1001, QueryOptions::default());
 
         let (mut block_manager, index) = setup_2_blocks();
+        let mut block_manager = block_manager.write().unwrap();
+
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
+
             assert_eq!(
                 reader.write().unwrap().read().unwrap(),
                 Some(Bytes::from("0123456789"))
@@ -282,6 +288,8 @@ mod tests {
             },
         );
         let (mut block_manager, index) = setup_2_blocks();
+        let mut block_manager = block_manager.write().unwrap();
+
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
@@ -316,7 +324,10 @@ mod tests {
                 ..QueryOptions::default()
             },
         );
+
         let (mut block_manager, index) = setup_2_blocks();
+        let mut block_manager = block_manager.write().unwrap();
+
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
             assert_eq!(
@@ -353,6 +364,8 @@ mod tests {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
 
         let (mut block_manager, index) = setup_2_blocks();
+        let mut block_manager = block_manager.write().unwrap();
+
         let mut block = block_manager.load(*index.get(&0u64).unwrap()).unwrap();
         block.records[0].state = record::State::Errored as i32;
         block_manager.save(&block).unwrap();
@@ -366,7 +379,7 @@ mod tests {
         );
     }
 
-    fn setup_2_blocks() -> (BlockManager, BTreeSet<u64>) {
+    fn setup_2_blocks() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
         let dir = tempdir().unwrap().into_path();
         let mut block_manager = BlockManager::new(dir);
         let mut block = block_manager.start(0, 10).unwrap();
@@ -420,9 +433,9 @@ mod tests {
         block.size = 20;
         block_manager.save(&block).unwrap();
 
+        let block_manager = Arc::new(RwLock::new(block_manager));
         {
-            let writer = block_manager.begin_write(&block, 0).unwrap();
-
+            let writer = BlockManager::begin_write(Arc::clone(&block_manager), &block, 0).unwrap();
             writer
                 .write()
                 .unwrap()
@@ -431,7 +444,7 @@ mod tests {
         }
 
         {
-            let writer = block_manager.begin_write(&block, 1).unwrap();
+            let writer = BlockManager::begin_write(Arc::clone(&block_manager), &block, 1).unwrap();
             writer
                 .write()
                 .unwrap()
@@ -439,9 +452,9 @@ mod tests {
                 .unwrap();
         }
 
-        block_manager.finish(&block).unwrap();
+        block_manager.write().unwrap().finish(&block).unwrap();
 
-        let mut block = block_manager.start(1000, 10).unwrap();
+        let mut block = block_manager.write().unwrap().start(1000, 10).unwrap();
 
         block.records.push(Record {
             timestamp: Some(Timestamp {
@@ -469,10 +482,10 @@ mod tests {
             nanos: 1000_000,
         });
         block.size = 10;
-        block_manager.save(&block).unwrap();
+        block_manager.write().unwrap().save(&block).unwrap();
 
         {
-            let writer = block_manager.begin_write(&block, 0).unwrap();
+            let writer = BlockManager::begin_write(Arc::clone(&block_manager), &block, 0).unwrap();
             writer
                 .write()
                 .unwrap()
@@ -480,7 +493,7 @@ mod tests {
                 .unwrap();
         }
 
-        block_manager.finish(&block).unwrap();
+        block_manager.write().unwrap().finish(&block).unwrap();
         (block_manager, BTreeSet::from([0, 1000]))
     }
 }

--- a/src/storage/writer.rs
+++ b/src/storage/writer.rs
@@ -179,7 +179,8 @@ mod tests {
             .times(1)
             .returning(move |_| Ok(same_block.clone()));
 
-        let mut writer = RecordWriter::new(path, &block, 0, 10, Box::new(block_manager)).unwrap();
+        let bm_ref = Arc::new(RwLock::new(block_manager));
+        let mut writer = RecordWriter::new(path, &block, 0, 10, bm_ref).unwrap();
         writer.write(Chunk::Data(Bytes::from("67890"))).unwrap();
         writer.write(Chunk::Last(Bytes::from("12345"))).unwrap();
     }
@@ -200,7 +201,8 @@ mod tests {
             .times(1)
             .returning(move |_| Ok(same_block.clone()));
 
-        let mut writer = RecordWriter::new(path, &block, 0, 10, Box::new(block_manager)).unwrap();
+        let bm_ref = Arc::new(RwLock::new(block_manager));
+        let mut writer = RecordWriter::new(path, &block, 0, 10, bm_ref).unwrap();
         writer.write(Chunk::Data(Bytes::from("67890"))).unwrap();
 
         assert_eq!(
@@ -227,7 +229,8 @@ mod tests {
             .times(1)
             .returning(move |_| Ok(same_block.clone()));
 
-        let mut writer = RecordWriter::new(path, &block, 0, 10, Box::new(block_manager)).unwrap();
+        let bm_ref = Arc::new(RwLock::new(block_manager));
+        let mut writer = RecordWriter::new(path, &block, 0, 10, bm_ref).unwrap();
         writer.write(Chunk::Data(Bytes::from("67890"))).unwrap();
 
         assert_eq!(
@@ -254,7 +257,8 @@ mod tests {
             .times(1)
             .returning(move |_| Ok(same_block.clone()));
 
-        let mut writer = RecordWriter::new(path, &block, 0, 10, Box::new(block_manager)).unwrap();
+        let bm_ref = Arc::new(RwLock::new(block_manager));
+        let mut writer = RecordWriter::new(path, &block, 0, 10, bm_ref).unwrap();
         writer.write(Chunk::Error).unwrap();
     }
 

--- a/src/storage/writer.rs
+++ b/src/storage/writer.rs
@@ -4,7 +4,6 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use bytes::Bytes;
-use futures_util::TryFutureExt;
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::path::PathBuf;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

A block descriptor can be read and written from several tokio threads. This causes data corruption.

### What is the new behavior?

BlockManager is responsible for working with block descriptors. We use it only as Arc<RwLock<BlockManager>> pointer.

### Does this PR introduce a breaking change?

No

### Other information:
