### PR TITLE
Fix handling unix SIGTERM signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix searching record by timestamp, [PR-266](https://github.com/reductstore/reductstore/pull/266)
 - Graceful shutdown, [PR-267](https://github.com/reductstore/reductstore/pull/267)
 - Access to a block descriptor from several threads, [PR-268](https://github.com/reductstore/reductstore/pull/268)
+- Handling unix SIGTERM signal, [PR-269](https://github.com/reductstore/reductstore/pull/269)
 
 ## [1.3.2] - 2023-03-10
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Graceful shutdown was fixed only for Ctr-C, it is a cross platform solution, but docker sends the SIGTERM signal to stop a container.

### What is the new behavior?

An additional handler for SIGTERM was added.

### Does this PR introduce a breaking change?

No

### Other information:
