### PR TITLE
Fix encoding non-text assets of Web Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Graceful shutdown, [PR-267](https://github.com/reductstore/reductstore/pull/267)
 - Access to a block descriptor from several threads, [PR-268](https://github.com/reductstore/reductstore/pull/268)
 - Handling unix SIGTERM signal, [PR-269](https://github.com/reductstore/reductstore/pull/269)
+- Encoding non-text assets of Web Console, [PR-270](https://github.com/reductstore/reductstore/pull/270)
 
 ## [1.3.2] - 2023-03-10
 

--- a/src/asset/asset_manager.rs
+++ b/src/asset/asset_manager.rs
@@ -3,7 +3,8 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use log::{debug, trace};
+use bytes::Bytes;
+use log::{debug, info, trace};
 use std::fs::File;
 use std::io::{Cursor, Read};
 use tempfile::{tempdir, TempDir};
@@ -76,7 +77,7 @@ impl ZipAssetManager {
     /// # Returns
     ///
     /// The file content as string.
-    pub fn read(&self, relative_path: &str) -> Result<String, HttpError> {
+    pub fn read(&self, relative_path: &str) -> Result<Bytes, HttpError> {
         if self.path.is_none() {
             // TODO: When C++ is gone, use trait and emtpy implementation
             return Err(HttpError::not_found("No static files supported"));
@@ -94,10 +95,10 @@ impl ZipAssetManager {
 
         // read file
         let mut file = File::open(path)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
+        let mut content = Vec::new();
+        file.read_to_end(&mut content)?;
 
-        Ok(contents)
+        Ok(Bytes::from(content))
     }
 }
 

--- a/src/asset/asset_manager.rs
+++ b/src/asset/asset_manager.rs
@@ -4,7 +4,7 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use bytes::Bytes;
-use log::{debug, info, trace};
+use log::{debug, trace};
 use std::fs::File;
 use std::io::{Cursor, Read};
 use tempfile::{tempdir, TempDir};

--- a/src/http_frontend/ui_api.rs
+++ b/src/http_frontend/ui_api.rs
@@ -82,14 +82,14 @@ mod tests {
     use crate::auth::token_repository::TokenRepository;
     use crate::storage::storage::Storage;
     use axum::body::HttpBody;
-    use hyper::header::CONTENT_LENGTH;
+
     use std::path::PathBuf;
 
     #[tokio::test]
     async fn test_img_decoding() {
         let components = setup();
         let request = Request::get("/ui/favicon.png").body(Body::empty()).unwrap();
-        let mut response = UiApi::show_ui(State(components), request)
+        let response = UiApi::show_ui(State(components), request)
             .await
             .unwrap()
             .into_response();
@@ -100,7 +100,7 @@ mod tests {
     fn setup() -> Arc<RwLock<HttpServerComponents>> {
         let data_path = tempfile::tempdir().unwrap().into_path();
 
-        let mut components = HttpServerComponents {
+        let components = HttpServerComponents {
             storage: Storage::new(PathBuf::from(data_path.clone())),
             auth: TokenAuthorization::new(""),
             token_repo: TokenRepository::new(PathBuf::from(data_path), ""),


### PR DESCRIPTION
Closes #262 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

`AssetManager` returns an asset as a string, what caused an UTF-8 encoding error when it tries to decode non-text content.

### What is the new behavior?

`AssetManager` returns `Bytes` and HTTP API level checks the mime type before encoding.

### Does this PR introduce a breaking change?

No

### Other information:
