### PR TITLE
Return `init-token` to token list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Return `init-token` to token list, [PR-280](https://github.com/reductstore/reductstore/pull/280)
+
 ## [1.4.0-alpha.2] - 2023-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.4.0-alpha.1"
+version = "1.4.0-alpha.2"
 dependencies = [
  "axum",
  "axum-server",

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -304,6 +304,10 @@ impl ManageTokens for TokenRepository {
     }
 
     fn remove_token(&mut self, name: &str) -> Result<(), HttpError> {
+        if name == INIT_TOKEN_NAME {
+            return Err(HttpError::bad_request("Cannot remove init token"));
+        }
+
         if self.repo.remove(name).is_none() {
             Err(HttpError::not_found(
                 format!("Token '{}' doesn't exist", name).as_str(),
@@ -755,6 +759,17 @@ mod tests {
         let token = repo.remove_token("test").unwrap();
 
         assert_eq!(token, ());
+    }
+
+    #[test]
+    pub fn test_remove_init_token() {
+        let mut repo = setup("init-token");
+        let token = repo.remove_token("init-token");
+
+        assert_eq!(
+            token,
+            Err(HttpError::bad_request("Cannot remove init token"))
+        );
     }
 
     #[test]

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use log::{debug, warn};
+use log::debug;
 use prost::bytes::Bytes;
 use prost::Message;
 use prost_wkt_types::Timestamp;

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -20,11 +20,71 @@ use crate::core::status::HttpError;
 const TOKEN_REPO_FILE_NAME: &str = ".auth";
 const INIT_TOKEN_NAME: &str = "init-token";
 
+pub trait ManageTokens {
+    /// Create a new token
+    ///
+    /// # Arguments
+    ///
+    /// `name` - The name of the token
+    /// `permissions` - The permissions of the token
+    ///
+    /// # Returns
+    ///
+    /// token value and creation time
+    fn create_token(
+        &mut self,
+        name: &str,
+        permissions: Permissions,
+    ) -> Result<TokenCreateResponse, HttpError>;
+
+    /// Update a token
+    ///
+    /// # Arguments
+    ///
+    /// `name` - The name of the token
+    /// `permissions` - The permissions of the token
+    fn update_token(&mut self, name: &str, permissions: Permissions) -> Result<(), HttpError>;
+
+    /// Find a token by name
+    ///
+    /// # Arguments
+    ///
+    /// `name` - The name of the token
+    ///
+    /// # Returns
+    /// The token without value
+    fn find_by_name(&self, name: &str) -> Result<Token, HttpError>;
+
+    /// Get token list
+    ///
+    /// # Returns
+    /// The token list, it the authentication is disabled, it returns an empty list
+    fn get_token_list(&self) -> Result<Vec<Token>, HttpError>;
+
+    /// Validate a token
+    ///
+    /// # Arguments
+    /// `header` - The authorization header with bearer token
+    ///
+    /// # Returns
+    ///
+    /// Token with given value
+    fn validate_token(&self, header: Option<&str>) -> Result<Token, HttpError>;
+
+    /// Remove a token
+    ///
+    /// # Arguments
+    /// `name` - The name of the token
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the token was removed successfully
+    fn remove_token(&mut self, name: &str) -> Result<(), HttpError>;
+}
+
 /// The TokenRepository trait is used to store and retrieve tokens.
-pub struct TokenRepository {
+struct TokenRepository {
     config_path: PathBuf,
-    init_token: Option<Token>,
-    // TODO: Make it non-optional after C++ is removed
     repo: HashMap<String, Token>,
 }
 
@@ -52,29 +112,12 @@ impl TokenRepository {
         let config_path = data_path.join(TOKEN_REPO_FILE_NAME);
         let repo = HashMap::new();
 
-        let init_token = if !api_token.is_empty() {
-            Some(Token {
-                name: INIT_TOKEN_NAME.to_string(),
-                value: api_token.to_string(),
-                created_at: Timestamp::try_from(SystemTime::now()).ok(),
-                permissions: Some(Permissions {
-                    full_access: true,
-                    read: vec![],
-                    write: vec![],
-                }),
-            })
-        } else {
-            // TODO: After C++ is removed, this should use traits and an empty implementation
-            warn!("API token is not set, no authentication is required");
-            None
-        };
+        if api_token.is_empty() {
+            panic!("API must be set");
+        }
 
         // Load the token repository from the file system
-        let mut token_repository = TokenRepository {
-            config_path,
-            init_token,
-            repo,
-        };
+        let mut token_repository = TokenRepository { config_path, repo };
 
         match std::fs::read(&token_repository.config_path) {
             Ok(data) => {
@@ -99,208 +142,21 @@ impl TokenRepository {
             }
         };
 
-        token_repository
-    }
-
-    /// Create a new token
-    ///
-    /// # Arguments
-    ///
-    /// `name` - The name of the token
-    /// `permissions` - The permissions of the token
-    ///
-    /// # Returns
-    ///
-    /// token value and creation time
-    pub fn create_token(
-        &mut self,
-        name: &str,
-        permissions: Permissions,
-    ) -> Result<TokenCreateResponse, HttpError> {
-        if self.init_token.is_none() {
-            return Err(HttpError::bad_request("Authentication is disabled"));
-        }
-
-        // Check if the token isn't empty
-        if name.is_empty() {
-            return Err(HttpError::unprocessable_entity("Token name can't be empty"));
-        }
-
-        // Check if the token already exists
-        if self.repo.contains_key(name) {
-            return Err(HttpError::conflict(
-                format!("Token '{}' already exists", name).as_str(),
-            ));
-        }
-
-        let created_at = Timestamp::try_from(SystemTime::now()).ok();
-
-        // Create a random hex string
-        let mut rng = rand::thread_rng();
-        let value: String = (0..32)
-            .map(|_| format!("{:x}", rng.gen_range(0..16)))
-            .collect();
-        let value = format!("{}-{}", name, value);
-        let token = Token {
-            name: name.to_string(),
-            value: value.clone(),
-            created_at: created_at.clone(),
-            permissions: Some(permissions),
+        let init_token = Token {
+            name: INIT_TOKEN_NAME.to_string(),
+            value: api_token.to_string(),
+            created_at: Timestamp::try_from(SystemTime::now()).ok(),
+            permissions: Some(Permissions {
+                full_access: true,
+                read: vec![],
+                write: vec![],
+            }),
         };
 
-        self.repo.insert(name.to_string(), token);
-        self.save_repo()?;
-
-        Ok(TokenCreateResponse { value, created_at })
-    }
-
-    /// Update a token
-    ///
-    /// # Arguments
-    ///
-    /// `name` - The name of the token
-    /// `permissions` - The permissions of the token
-    pub fn update_token(&mut self, name: &str, permissions: Permissions) -> Result<(), HttpError> {
-        if self.init_token.is_none() {
-            return Err(HttpError::bad_request("Authentication is disabled"));
-        }
-
-        debug!("Updating token '{}'", name);
-
-        match self.repo.get(name) {
-            Some(token) => {
-                let mut updated_token = token.clone();
-                updated_token.permissions = Some(permissions);
-                self.repo.insert(name.to_string(), updated_token);
-                self.save_repo()?;
-                Ok(())
-            }
-
-            None => Err(HttpError::not_found(
-                format!("Token '{}' doesn't exist", name).as_str(),
-            )),
-        }
-    }
-
-    /// Find a token by name
-    ///
-    /// # Arguments
-    ///
-    /// `name` - The name of the token
-    ///
-    /// # Returns
-    /// The token without value
-    pub fn find_by_name(&self, name: &str) -> Result<Token, HttpError> {
-        if self.init_token.is_none() {
-            return Err(HttpError::bad_request("Authentication is disabled"));
-        }
-
-        match self.repo.get(name) {
-            Some(token) => Ok(Token {
-                name: token.name.clone(),
-                value: "".to_string(),
-                created_at: token.created_at.clone(),
-                permissions: token.permissions.clone(),
-            }),
-            None => Err(HttpError::not_found(
-                format!("Token '{}' doesn't exist", name).as_str(),
-            )),
-        }
-    }
-
-    /// Get token list
-    ///
-    /// # Returns
-    /// The token list, it the authentication is disabled, it returns an empty list
-    pub fn get_token_list(&self) -> Result<Vec<Token>, HttpError> {
-        if self.init_token.is_none() {
-            return Ok(vec![]);
-        }
-
-        let mut sorted: Vec<_> = self.repo.iter().collect();
-        sorted.sort_by_key(|item| item.0);
-        Ok(sorted
-            .iter()
-            .map(|item| Token {
-                name: item.1.name.clone(),
-                value: "".to_string(),
-                created_at: item.1.created_at.clone(),
-                permissions: item.1.permissions.clone(),
-            })
-            .collect())
-    }
-
-    /// Validate a token
-    ///
-    /// # Arguments
-    /// `header` - The authorization header with bearer token
-    ///
-    /// # Returns
-    ///
-    /// Token with given value
-    pub fn validate_token(&self, header: Option<&str>) -> Result<Token, HttpError> {
-        if self.init_token.is_none() {
-            // Return placeholder
-            return Ok(Token {
-                name: "AUTHENTICATION-DISABLED".to_string(),
-                value: "".to_string(),
-                created_at: None,
-                permissions: Some(Permissions {
-                    full_access: true,
-                    read: vec![],
-                    write: vec![],
-                }),
-            });
-        }
-
-        let value = parse_bearer_token(header.unwrap_or(""))?;
-
-        // Check init token first
-        if let Some(init_token) = &self.init_token {
-            if init_token.value == value {
-                return Ok(Token {
-                    name: init_token.name.clone(),
-                    value: "".to_string(),
-                    created_at: init_token.created_at.clone(),
-                    permissions: init_token.permissions.clone(),
-                });
-            }
-        }
-
-        match self.repo.values().find(|token| token.value == value) {
-            Some(token) => {
-                // for security reasons, we don't return the value
-                Ok(Token {
-                    name: token.name.clone(),
-                    value: "".to_string(),
-                    created_at: token.created_at.clone(),
-                    permissions: token.permissions.clone(),
-                })
-            }
-            None => Err(HttpError::unauthorized("Invalid token")),
-        }
-    }
-
-    /// Remove a token
-    ///
-    /// # Arguments
-    /// `name` - The name of the token
-    ///
-    /// # Returns
-    ///
-    /// `Ok(())` if the token was removed successfully
-    pub fn remove_token(&mut self, name: &str) -> Result<(), HttpError> {
-        if self.init_token.is_none() {
-            return Ok(());
-        }
-
-        if self.repo.remove(name).is_none() {
-            Err(HttpError::not_found(
-                format!("Token '{}' doesn't exist", name).as_str(),
-            ))
-        } else {
-            self.save_repo()
-        }
+        token_repository
+            .repo
+            .insert(init_token.name.clone(), init_token);
+        token_repository
     }
 
     /// Remove a bucket from all tokens and save the repository
@@ -345,6 +201,181 @@ impl TokenRepository {
     }
 }
 
+impl ManageTokens for TokenRepository {
+    fn create_token(
+        &mut self,
+        name: &str,
+        permissions: Permissions,
+    ) -> Result<TokenCreateResponse, HttpError> {
+        // Check if the token isn't empty
+        if name.is_empty() {
+            return Err(HttpError::unprocessable_entity("Token name can't be empty"));
+        }
+
+        // Check if the token already exists
+        if self.repo.contains_key(name) {
+            return Err(HttpError::conflict(
+                format!("Token '{}' already exists", name).as_str(),
+            ));
+        }
+
+        let created_at = Timestamp::try_from(SystemTime::now()).ok();
+
+        // Create a random hex string
+        let mut rng = rand::thread_rng();
+        let value: String = (0..32)
+            .map(|_| format!("{:x}", rng.gen_range(0..16)))
+            .collect();
+        let value = format!("{}-{}", name, value);
+        let token = Token {
+            name: name.to_string(),
+            value: value.clone(),
+            created_at: created_at.clone(),
+            permissions: Some(permissions),
+        };
+
+        self.repo.insert(name.to_string(), token);
+        self.save_repo()?;
+
+        Ok(TokenCreateResponse { value, created_at })
+    }
+
+    fn update_token(&mut self, name: &str, permissions: Permissions) -> Result<(), HttpError> {
+        debug!("Updating token '{}'", name);
+
+        match self.repo.get(name) {
+            Some(token) => {
+                let mut updated_token = token.clone();
+                updated_token.permissions = Some(permissions);
+                self.repo.insert(name.to_string(), updated_token);
+                self.save_repo()?;
+                Ok(())
+            }
+
+            None => Err(HttpError::not_found(
+                format!("Token '{}' doesn't exist", name).as_str(),
+            )),
+        }
+    }
+
+    fn find_by_name(&self, name: &str) -> Result<Token, HttpError> {
+        match self.repo.get(name) {
+            Some(token) => Ok(Token {
+                name: token.name.clone(),
+                value: "".to_string(),
+                created_at: token.created_at.clone(),
+                permissions: token.permissions.clone(),
+            }),
+            None => Err(HttpError::not_found(
+                format!("Token '{}' doesn't exist", name).as_str(),
+            )),
+        }
+    }
+
+    fn get_token_list(&self) -> Result<Vec<Token>, HttpError> {
+        let mut sorted: Vec<_> = self.repo.iter().collect();
+        sorted.sort_by_key(|item| item.0);
+        Ok(sorted
+            .iter()
+            .map(|item| Token {
+                name: item.1.name.clone(),
+                value: "".to_string(),
+                created_at: item.1.created_at.clone(),
+                permissions: item.1.permissions.clone(),
+            })
+            .collect())
+    }
+
+    fn validate_token(&self, header: Option<&str>) -> Result<Token, HttpError> {
+        let value = parse_bearer_token(header.unwrap_or(""))?;
+
+        match self.repo.values().find(|token| token.value == value) {
+            Some(token) => {
+                // for security reasons, we don't return the value
+                Ok(Token {
+                    name: token.name.clone(),
+                    value: "".to_string(),
+                    created_at: token.created_at.clone(),
+                    permissions: token.permissions.clone(),
+                })
+            }
+            None => Err(HttpError::unauthorized("Invalid token")),
+        }
+    }
+
+    fn remove_token(&mut self, name: &str) -> Result<(), HttpError> {
+        if self.repo.remove(name).is_none() {
+            Err(HttpError::not_found(
+                format!("Token '{}' doesn't exist", name).as_str(),
+            ))
+        } else {
+            self.save_repo()
+        }
+    }
+}
+
+/// A repository that doesn't require authentication
+struct NoAuthRepository {}
+
+impl NoAuthRepository {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ManageTokens for NoAuthRepository {
+    fn create_token(
+        &mut self,
+        _name: &str,
+        _permissions: Permissions,
+    ) -> Result<TokenCreateResponse, HttpError> {
+        Err(HttpError::bad_request("Authentication is disabled"))
+    }
+
+    fn update_token(&mut self, _name: &str, _permissions: Permissions) -> Result<(), HttpError> {
+        Err(HttpError::bad_request("Authentication is disabled"))
+    }
+
+    fn find_by_name(&self, _name: &str) -> Result<Token, HttpError> {
+        Err(HttpError::bad_request("Authentication is disabled"))
+    }
+
+    fn get_token_list(&self) -> Result<Vec<Token>, HttpError> {
+        Ok(vec![])
+    }
+
+    fn validate_token(&self, _header: Option<&str>) -> Result<Token, HttpError> {
+        Ok(Token {
+            name: "AUTHENTICATION-DISABLED".to_string(),
+            value: "".to_string(),
+            created_at: None,
+            permissions: Some(Permissions {
+                full_access: true,
+                read: vec![],
+                write: vec![],
+            }),
+        })
+    }
+
+    fn remove_token(&mut self, _name: &str) -> Result<(), HttpError> {
+        Ok(())
+    }
+}
+
+/// Creates a token repository
+///
+/// If `init_token` is empty, the repository will be stubbed and authentication will be disabled.
+pub fn create_token_repository(
+    path: PathBuf,
+    init_token: &str,
+) -> Box<dyn ManageTokens + Send + Sync> {
+    if init_token.is_empty() {
+        Box::new(NoAuthRepository::new())
+    } else {
+        Box::new(TokenRepository::new(path, init_token))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -352,11 +383,15 @@ mod tests {
 
     #[test]
     pub fn test_init_token() {
-        let repo = setup();
+        let repo = setup("init-token");
 
-        let token = repo.validate_token(Some("Bearer test")).unwrap();
+        let token = repo.validate_token(Some("Bearer init-token")).unwrap();
         assert_eq!(token.name, "init-token");
         assert_eq!(token.value, "");
+
+        let token_list = repo.get_token_list().unwrap();
+        assert_eq!(token_list.len(), 1);
+        assert_eq!(token_list[0].name, "init-token");
     }
 
     //------------
@@ -364,7 +399,7 @@ mod tests {
     //------------
     #[test]
     pub fn test_create_empty_token() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         let token = repo.create_token(
             "",
             Permissions {
@@ -382,7 +417,7 @@ mod tests {
 
     #[test]
     pub fn test_create_existing_token() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         repo.create_token(
             "test",
             Permissions {
@@ -410,7 +445,7 @@ mod tests {
 
     #[test]
     pub fn test_create_token() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         let token = repo
             .create_token(
                 "test",
@@ -447,7 +482,7 @@ mod tests {
 
     #[test]
     pub fn test_create_token_no_init_token() {
-        let mut repo = TokenRepository::new(tempdir().unwrap().into_path(), "");
+        let mut repo = setup("");
         let token = repo.create_token(
             "test",
             Permissions {
@@ -468,7 +503,7 @@ mod tests {
     //------------
     #[test]
     pub fn test_update_token_ok() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         repo.create_token(
             "test",
             Permissions {
@@ -503,7 +538,7 @@ mod tests {
 
     #[test]
     pub fn test_update_token_not_found() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         let token = repo.update_token(
             "test",
             Permissions {
@@ -555,7 +590,7 @@ mod tests {
 
     #[test]
     pub fn test_update_token_no_init_token() {
-        let mut repo = TokenRepository::new(tempdir().unwrap().into_path(), "");
+        let mut repo = setup("");
         let token = repo.update_token(
             "test",
             Permissions {
@@ -576,7 +611,7 @@ mod tests {
     //----------------
     #[test]
     pub fn test_find_by_name() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         repo.create_token(
             "test",
             Permissions {
@@ -595,7 +630,7 @@ mod tests {
 
     #[test]
     pub fn test_find_by_name_not_found() {
-        let repo = setup();
+        let repo = setup("init-token");
         let token = repo.find_by_name("test");
 
         assert_eq!(
@@ -606,7 +641,7 @@ mod tests {
 
     #[test]
     pub fn test_find_by_name_no_init_token() {
-        let repo = TokenRepository::new(tempdir().unwrap().into_path(), "");
+        let repo = setup("");
         let token = repo.find_by_name("test");
 
         assert_eq!(
@@ -620,7 +655,7 @@ mod tests {
     //------------
     #[test]
     pub fn test_get_token_list() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         repo.create_token(
             "test",
             Permissions {
@@ -633,14 +668,14 @@ mod tests {
 
         let token_list = repo.get_token_list().unwrap();
 
-        assert_eq!(token_list.len(), 1);
-        assert_eq!(token_list[0].name, "test");
-        assert_eq!(token_list[0].value, "");
+        assert_eq!(token_list.len(), 2);
+        assert_eq!(token_list[1].name, "test");
+        assert_eq!(token_list[1].value, "");
     }
 
     #[test]
     pub fn test_get_token_list_no_init_token() {
-        let repo = TokenRepository::new(tempdir().unwrap().into_path(), "");
+        let repo = setup("");
         let token_list = repo.get_token_list().unwrap();
 
         assert_eq!(token_list, vec![]);
@@ -651,7 +686,7 @@ mod tests {
     //------------
     #[test]
     pub fn test_validate_token() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         let value = repo
             .create_token(
                 "test",
@@ -685,7 +720,7 @@ mod tests {
 
     #[test]
     pub fn test_validate_token_not_found() {
-        let repo = setup();
+        let repo = setup("init-token");
         let token = repo.validate_token(Some("Bearer invalid-value"));
 
         assert_eq!(token, Err(HttpError::unauthorized("Invalid token")));
@@ -693,7 +728,7 @@ mod tests {
 
     #[test]
     pub fn test_validate_token_no_init_token() {
-        let repo = TokenRepository::new(tempdir().unwrap().into_path(), "");
+        let repo = setup("");
         let placeholder = repo.validate_token(Some("invalid-value")).unwrap();
 
         assert_eq!(placeholder.name, "AUTHENTICATION-DISABLED");
@@ -706,7 +741,7 @@ mod tests {
     //------------
     #[test]
     pub fn test_remove_token() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         repo.create_token(
             "test",
             Permissions {
@@ -724,7 +759,7 @@ mod tests {
 
     #[test]
     pub fn test_remove_token_not_found() {
-        let mut repo = setup();
+        let mut repo = setup("init-token");
         let token = repo.remove_token("test");
 
         assert_eq!(
@@ -760,13 +795,13 @@ mod tests {
 
     #[test]
     pub fn test_remove_token_no_init_token() {
-        let mut repo = TokenRepository::new(tempdir().unwrap().into_path(), "");
+        let mut repo = setup("");
         let token = repo.remove_token("test");
 
         assert_eq!(token, Ok(()));
     }
 
-    fn setup() -> TokenRepository {
-        TokenRepository::new(tempdir().unwrap().into_path(), "test")
+    fn setup(init_token: &str) -> Box<dyn ManageTokens> {
+        create_token_repository(tempdir().unwrap().into_path(), init_token)
     }
 }

--- a/src/http_frontend.rs
+++ b/src/http_frontend.rs
@@ -6,7 +6,7 @@
 
 use crate::asset::asset_manager::ZipAssetManager;
 use crate::auth::token_auth::TokenAuthorization;
-use crate::auth::token_repository::TokenRepository;
+use crate::auth::token_repository::ManageTokens;
 use crate::core::status::HttpError;
 use crate::storage::storage::Storage;
 use axum::http::StatusCode;
@@ -24,7 +24,7 @@ pub mod ui_api;
 pub struct HttpServerComponents {
     pub storage: Storage,
     pub auth: TokenAuthorization,
-    pub token_repo: TokenRepository,
+    pub token_repo: Box<dyn ManageTokens + Send + Sync>,
     pub console: ZipAssetManager,
     pub base_path: String,
 }

--- a/src/http_frontend/bucket_api.rs
+++ b/src/http_frontend/bucket_api.rs
@@ -164,7 +164,7 @@ mod tests {
     use super::*;
     use crate::asset::asset_manager::ZipAssetManager;
     use crate::auth::token_auth::TokenAuthorization;
-    use crate::auth::token_repository::TokenRepository;
+    use crate::auth::token_repository::create_token_repository;
     use crate::http_frontend::HttpServerComponents;
     use crate::storage::proto::BucketSettings;
     use crate::storage::storage::Storage;
@@ -243,7 +243,7 @@ mod tests {
         let mut components = HttpServerComponents {
             storage: Storage::new(PathBuf::from(data_path.clone())),
             auth: TokenAuthorization::new(""),
-            token_repo: TokenRepository::new(PathBuf::from(data_path), ""),
+            token_repo: create_token_repository(data_path.clone(), ""),
             console: ZipAssetManager::new(&[]),
             base_path: "/".to_string(),
         };

--- a/src/http_frontend/middleware.rs
+++ b/src/http_frontend/middleware.rs
@@ -65,7 +65,7 @@ where
         headers
             .get("Authorization")
             .map(|header| header.to_str().unwrap()),
-        &components.token_repo,
+        components.token_repo.as_ref(),
         policy,
     )?;
     Ok(())

--- a/src/http_frontend/server_api.rs
+++ b/src/http_frontend/server_api.rs
@@ -14,6 +14,7 @@ use serde_json::json;
 
 use crate::auth::policy::AuthenticatedPolicy;
 use crate::auth::proto::Token;
+use crate::auth::token_repository::ManageTokens;
 use crate::core::status::HttpError;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerComponents;
@@ -101,7 +102,7 @@ mod tests {
 
     use crate::asset::asset_manager::ZipAssetManager;
     use crate::auth::token_auth::TokenAuthorization;
-    use crate::auth::token_repository::TokenRepository;
+    use crate::auth::token_repository::create_token_repository;
     use crate::storage::proto::BucketSettings;
     use crate::storage::storage::Storage;
 
@@ -140,7 +141,7 @@ mod tests {
         let mut components = HttpServerComponents {
             storage: Storage::new(PathBuf::from(data_path.clone())),
             auth: TokenAuthorization::new(""),
-            token_repo: TokenRepository::new(PathBuf::from(data_path), ""),
+            token_repo: create_token_repository(data_path.clone(), ""),
             console: ZipAssetManager::new(&[]),
             base_path: "/".to_string(),
         };

--- a/src/http_frontend/server_api.rs
+++ b/src/http_frontend/server_api.rs
@@ -14,7 +14,6 @@ use serde_json::json;
 
 use crate::auth::policy::AuthenticatedPolicy;
 use crate::auth::proto::Token;
-use crate::auth::token_repository::ManageTokens;
 use crate::core::status::HttpError;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerComponents;

--- a/src/http_frontend/token_api.rs
+++ b/src/http_frontend/token_api.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::auth::proto::token::Permissions;
 use crate::auth::proto::{Token, TokenCreateResponse, TokenRepo};
+use crate::auth::token_repository::ManageTokens;
 use crate::core::status::HttpError;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerComponents;
@@ -142,7 +143,7 @@ mod tests {
     use super::*;
     use crate::asset::asset_manager::ZipAssetManager;
     use crate::auth::token_auth::TokenAuthorization;
-    use crate::auth::token_repository::TokenRepository;
+    use crate::auth::token_repository::create_token_repository;
     use crate::storage::storage::Storage;
 
     use axum::headers::Authorization;
@@ -154,8 +155,9 @@ mod tests {
         let list = TokenApi::token_list(State(components), auth_headers())
             .await
             .unwrap();
-        assert_eq!(list.tokens.len(), 1);
-        assert_eq!(list.tokens[0].name, "test");
+        assert_eq!(list.tokens.len(), 2);
+        assert_eq!(list.tokens[0].name, "init-token");
+        assert_eq!(list.tokens[1].name, "test");
     }
 
     #[tokio::test]
@@ -197,7 +199,7 @@ mod tests {
         let mut components = HttpServerComponents {
             storage: Storage::new(PathBuf::from(data_path.clone())),
             auth: TokenAuthorization::new("inti-token"),
-            token_repo: TokenRepository::new(PathBuf::from(data_path), "init-token"),
+            token_repo: create_token_repository(data_path.clone(), "init-token"),
             console: ZipAssetManager::new(&[]),
             base_path: "/".to_string(),
         };

--- a/src/http_frontend/token_api.rs
+++ b/src/http_frontend/token_api.rs
@@ -17,7 +17,6 @@ use std::sync::{Arc, RwLock};
 
 use crate::auth::proto::token::Permissions;
 use crate::auth::proto::{Token, TokenCreateResponse, TokenRepo};
-use crate::auth::token_repository::ManageTokens;
 use crate::core::status::HttpError;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerComponents;

--- a/src/http_frontend/ui_api.rs
+++ b/src/http_frontend/ui_api.rs
@@ -79,7 +79,7 @@ mod tests {
     use super::*;
     use crate::asset::asset_manager::ZipAssetManager;
     use crate::auth::token_auth::TokenAuthorization;
-    use crate::auth::token_repository::TokenRepository;
+    use crate::auth::token_repository::create_token_repository;
     use crate::storage::storage::Storage;
     use axum::body::HttpBody;
 
@@ -103,7 +103,7 @@ mod tests {
         let components = HttpServerComponents {
             storage: Storage::new(PathBuf::from(data_path.clone())),
             auth: TokenAuthorization::new(""),
-            token_repo: TokenRepository::new(PathBuf::from(data_path), ""),
+            token_repo: create_token_repository(data_path.clone(), ""),
             console: ZipAssetManager::new(include_bytes!(concat!(env!("OUT_DIR"), "/console.zip"))),
             base_path: "/".to_string(),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::asset::asset_manager::ZipAssetManager;
 use crate::auth::token_auth::TokenAuthorization;
-use crate::auth::token_repository::TokenRepository;
+use crate::auth::token_repository::create_token_repository;
 use crate::storage::storage::Storage;
 
 use crate::core::env::Env;
@@ -73,7 +73,7 @@ async fn main() {
     let components = HttpServerComponents {
         storage: Storage::new(PathBuf::from(data_path.clone())),
         auth: TokenAuthorization::new(&api_token),
-        token_repo: TokenRepository::new(PathBuf::from(data_path), &api_token),
+        token_repo: create_token_repository(PathBuf::from(data_path), &api_token),
         console: ZipAssetManager::new(include_bytes!(concat!(env!("OUT_DIR"), "/console.zip"))),
         base_path: api_base_path.clone(),
     };


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix + refactoring

### What is the current behavior?

After the Rust migration, the database doesn't show the init token in the list (RS_API_TOKEN)

### What is the new behavior?

I fixed this and refactored `token_repository.rs` by using trait `ManageTokens` and a factory method.

### Does this PR introduce a breaking change?

No

### Other information:
