### PR TITLE
First query ID is 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Return `init-token` to token list, [PR-280](https://github.com/reductstore/reductstore/pull/280)
+- First query ID is 1, [PR-281](https://github.com/reductstore/reductstore/pull/281)
 
 ## [1.4.0-alpha.2] - 2023-05-26
 

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -737,7 +737,7 @@ mod tests {
                 0,
                 4000000,
                 QueryOptions {
-                    ttl: Duration::from_millis(250),
+                    ttl: Duration::from_millis(500),
                     continuous: true,
                     ..QueryOptions::default()
                 },
@@ -760,7 +760,7 @@ mod tests {
             assert_eq!(reader.read().unwrap().timestamp(), 2000000);
         }
 
-        sleep(Duration::from_millis(300));
+        sleep(Duration::from_millis(600));
         assert_eq!(
             entry.next(id).err(),
             Some(HttpError::not_found(&format!("Query {} not found", id)))

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -291,7 +291,7 @@ impl Entry {
     pub fn query(&mut self, start: u64, end: u64, options: QueryOptions) -> Result<u64, HttpError> {
         static QUERY_ID: AtomicU64 = AtomicU64::new(1); // start with 1 because 0 may confuse with false
 
-        let id = QUERY_ID.fetch_add(1, Ordering::Relaxed);
+        let id = QUERY_ID.fetch_add(1, Ordering::SeqCst);
         self.remove_expired_query();
         self.queries.insert(id, build_query(start, end, options));
 
@@ -702,7 +702,7 @@ mod tests {
         write_stub_record(&mut entry, 3000000).unwrap();
 
         let id = entry.query(0, 4000000, QueryOptions::default()).unwrap();
-        assert_eq!(id, 1);
+        assert!(id >= 1);
 
         {
             let (reader, _) = entry.next(id).unwrap();

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -289,7 +289,7 @@ impl Entry {
     /// * `u64` - The query ID.
     /// * `HTTPError` - The error if any.
     pub fn query(&mut self, start: u64, end: u64, options: QueryOptions) -> Result<u64, HttpError> {
-        static QUERY_ID: AtomicU64 = AtomicU64::new(0);
+        static QUERY_ID: AtomicU64 = AtomicU64::new(1); // start with 1 because 0 may confuse with false
 
         let id = QUERY_ID.fetch_add(1, Ordering::Relaxed);
         self.remove_expired_query();
@@ -680,9 +680,15 @@ mod tests {
         let reader = entry.begin_read(1000000).unwrap();
         let mut wr = reader.write().unwrap();
         let chunk = wr.read().unwrap();
-        assert!(chunk.unwrap().to_vec() == data[0..DEFAULT_MAX_READ_CHUNK as usize]);
+        assert_eq!(
+            chunk.unwrap().to_vec(),
+            data[0..DEFAULT_MAX_READ_CHUNK as usize]
+        );
         let chunk = wr.read().unwrap();
-        assert!(chunk.unwrap().to_vec() == data[DEFAULT_MAX_READ_CHUNK as usize..]);
+        assert_eq!(
+            chunk.unwrap().to_vec(),
+            data[DEFAULT_MAX_READ_CHUNK as usize..]
+        );
         let chunk = wr.read().unwrap();
         assert_eq!(chunk, None);
     }
@@ -696,6 +702,7 @@ mod tests {
         write_stub_record(&mut entry, 3000000).unwrap();
 
         let id = entry.query(0, 4000000, QueryOptions::default()).unwrap();
+        assert_eq!(id, 1);
 
         {
             let (reader, _) = entry.next(id).unwrap();


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The engine has a global static counter for the query ID. It begins from 0, but it may confuse some programming language and be considered as `false` or an error. 

### What is the new behavior?

The engine returns 1 for the first query ID.

### Does this PR introduce a breaking change?

No

### Other information:
