### PR TITLE
Fix showing permissions in token list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return `init-token` to token list, [PR-280](https://github.com/reductstore/reductstore/pull/280)
 - First query ID is 1, [PR-281](https://github.com/reductstore/reductstore/pull/281)
+- Showing permissions in `GET /api/v1/tokens`, [PR-282](https://github.com/reductstore/reductstore/pull/282)
 
 ## [1.4.0-alpha.2] - 2023-05-26
 

--- a/src/auth/token_repository.rs
+++ b/src/auth/token_repository.rs
@@ -281,7 +281,7 @@ impl ManageTokens for TokenRepository {
                 name: item.1.name.clone(),
                 value: "".to_string(),
                 created_at: item.1.created_at.clone(),
-                permissions: item.1.permissions.clone(),
+                permissions: None,
             })
             .collect())
     }
@@ -675,6 +675,7 @@ mod tests {
         assert_eq!(token_list.len(), 2);
         assert_eq!(token_list[1].name, "test");
         assert_eq!(token_list[1].value, "");
+        assert_eq!(token_list[1].permissions, None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The `GET /api/v1/tokens` endpoint  returns a list of tokens with their permissions. According documentation, it has to return only names and creation dates.
 
### What is the new behavior?

The endpoint doesn't show the permissions any more.

### Does this PR introduce a breaking change?

No

### Other information:
