### PR TITLE
Remove removed bucket from token permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return `init-token` to token list, [PR-280](https://github.com/reductstore/reductstore/pull/280)
 - First query ID is 1, [PR-281](https://github.com/reductstore/reductstore/pull/281)
 - Showing permissions in `GET /api/v1/tokens`, [PR-282](https://github.com/reductstore/reductstore/pull/282)
+- Remove removed bucket from token permissions, [PR-283](https://github.com/reductstore/reductstore/pull/283)
 
 ## [1.4.0-alpha.2] - 2023-05-26
 

--- a/src/http_frontend/bucket_api.rs
+++ b/src/http_frontend/bucket_api.rs
@@ -155,6 +155,9 @@ impl BucketApi {
         check_permissions(Arc::clone(&components), headers, FullAccessPolicy {})?;
         let mut components = components.write().unwrap();
         components.storage.remove_bucket(&bucket_name)?;
+        components
+            .token_repo
+            .remove_bucket_from_tokens(&bucket_name)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The database should remove a removed bucket from token permissions, but it doesn't do it.

### What is the new behavior?

Now, it does.

### Does this PR introduce a breaking change?

No

### Other information:
