### PR TITLE
Fix parsing non-string quota type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Parsing non-string quota type, [PR-286](https://github.com/reductstore/reductstore/pull/286)
+
 ## [1.4.0-alpha.3] - 2023-05-29
 
 ### Fixed
@@ -44,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Disable Windows and Macos builds because of migration on Rust, [PR-251](https://github.com/reductstore/reductstore/pull/251)
+- Disable Windows and Macos builds because of migration on
+  Rust, [PR-251](https://github.com/reductstore/reductstore/pull/251)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.4.0-alpha.3"
+version = "1.4.0-beta.1"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.4.0-alpha.2"
+version = "1.4.0-alpha.3"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reductstore"
-version = "1.4.0-alpha.3"
+version = "1.4.0-beta.1"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.66.0"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The server panics if it receives quota_type as a non-string value.

### What is the new behavior?

I added a handle and test for this case

### Does this PR introduce a breaking change?

No

### Other information:
