### PR TITLE
Show file paths in logs without registry path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Parsing non-string quota type, [PR-286](https://github.com/reductstore/reductstore/pull/286)
+- Show file paths in logs without registry path, [PR-288](https://github.com/reductstore/reductstore/pull/288)
 
 ## [1.4.0-alpha.3] - 2023-05-29
 

--- a/src/core/logger.rs
+++ b/src/core/logger.rs
@@ -27,12 +27,10 @@ impl Log for Logger {
                     file
                 } else {
                     // Absolute path to crate, remove path to registry
-                    file.split_once("src/")
-                        .unwrap()
-                        .1
-                        .split_once("/")
-                        .unwrap()
-                        .1
+                    match file.split_once("src/") {
+                        Some((_, file)) => file.split_once("/").unwrap().1,
+                        None => file,
+                    }
                 }
             } else {
                 "(unknown)"

--- a/src/core/logger.rs
+++ b/src/core/logger.rs
@@ -19,17 +19,26 @@ impl Log for Logger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            //  std::cout << fmt::format(fmt::fg(color), "{}.{:03d} ({:>5}) {:>7} -- {}:{} {}", ss.str(), milliseconds,
-            //                                reinterpret_cast<uint16_t &>(thid), level_str, file, line, msg)
-            //                 << std::endl;
-
             let now: DateTime<Utc> = Utc::now();
+            let file = record.file().unwrap();
+            let file = if file.starts_with("src/") {
+                // Local path
+                file
+            } else {
+                // Absolute path to crate, remove path to registry
+                file.split_once("src/")
+                    .unwrap()
+                    .1
+                    .split_once("/")
+                    .unwrap()
+                    .1
+            };
             println!(
                 "{} ({:>5}) [{}] -- {:}:{:} {:?}",
                 now.format("%Y-%m-%d %H:%M:%S.%3f"),
                 thread_id::get() % 100000,
                 record.level(),
-                record.file().unwrap(),
+                file,
                 record.line().unwrap(),
                 record.args()
             );

--- a/src/core/logger.rs
+++ b/src/core/logger.rs
@@ -20,19 +20,24 @@ impl Log for Logger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             let now: DateTime<Utc> = Utc::now();
-            let file = record.file().unwrap();
-            let file = if file.starts_with("src/") {
-                // Local path
-                file
+
+            let file = if let Some(file) = record.file() {
+                if file.starts_with("src/") {
+                    // Local path
+                    file
+                } else {
+                    // Absolute path to crate, remove path to registry
+                    file.split_once("src/")
+                        .unwrap()
+                        .1
+                        .split_once("/")
+                        .unwrap()
+                        .1
+                }
             } else {
-                // Absolute path to crate, remove path to registry
-                file.split_once("src/")
-                    .unwrap()
-                    .1
-                    .split_once("/")
-                    .unwrap()
-                    .1
+                "(unknown)"
             };
+
             println!(
                 "{} ({:>5}) [{}] -- {:}:{:} {:?}",
                 now.format("%Y-%m-%d %H:%M:%S.%3f"),


### PR DESCRIPTION
Closes #279 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #279 

### What is the new behavior?

Now, we check if the file path from crate and cut off the absolute part to the cargo registry:

```
2023-06-03 10:09:34.654 (97152) [DEBUG] -- src/http_frontend/middleware.rs:49 GET /api/v1/list [200 OK] 
2023-06-03 10:09:34.654 (97152) [DEBUG] -- hyper-0.14.26/src/proto/h1/io.rs:320 flushed 767 bytes
2023-06-03 10:09:36.937 (97152) [INFO] -- src/main.rs:193 Ctrl-C received, shutting down...
```

### Does this PR introduce a breaking change?

No

### Other information:
