### PR TITLE
Fix panic for invalid utf-8 labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Panic when an invalid utf-8 received as a label value, [PR-290](https://github.com/reductstore/reductstore/pull/290)
+
 ## [1.4.0-beta.1] - 2023-06-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reductstore"
-version = "1.4.0-beta.1"
+version = "1.4.0-beta.2"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.66.0"

--- a/src/http_frontend/entry_api.rs
+++ b/src/http_frontend/entry_api.rs
@@ -349,14 +349,9 @@ mod tests {
     use crate::storage::storage::Storage;
     use axum::body::Empty;
     use axum::extract::FromRequest;
-    use axum::http::{HeaderValue, Request};
-    use bytes::Buf;
-    use futures_util::stream::{self, Stream};
-    use futures_util::StreamExt;
-    use serde::de::Unexpected::Str;
+    use axum::http::Request;
+
     use std::path::PathBuf;
-    use std::ptr::hash;
-    use std::str::FromStr;
 
     #[tokio::test]
     async fn test_write_with_label_ok() {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

If the server receives a label with an invalid  utf-8 label, it crashes.

### What is the new behavior?

I added an error handling for this case.

### Does this PR introduce a breaking change?

No

### Other information:
