### PR TITLE
Fix writing record for clients which don't support for Expect header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Panic when an invalid utf-8 received as a label value, [PR-290](https://github.com/reductstore/reductstore/pull/290)
+- Writing record for clients which don't support for Expect header, [PR-293](https://github.com/reductstore/reductstore/pull/293)
 
 ## [1.4.0-beta.1] - 2023-06-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.4.0-beta.1"
+version = "1.4.0-beta.2"
 dependencies = [
  "axum",
  "axum-server",


### PR DESCRIPTION
Closes #292 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #292 

### What is the new behavior?

The endpoint checks the  "Expect" header and drains the stream if it doesn't exist, but only after the permission check

### Does this PR introduce a breaking change?

No

### Other information:
