### PR TITLE
Implement batching records into a GET response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `GET /api/v1/:bucket/:entry/batch` endpoint to read a bunch of records, [PR-294](https://github.com/reductstore/reductstore/pull/294)
+
 ## [1.4.0] - 2023-06-09
 
 ### Fixed

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -383,6 +383,7 @@ def test__head_entry_with_full_access_token(base_url, session, bucket, token_wit
 
 
 def test_write_with_content_type_header(base_url, session, bucket):
+    """Should write data with content type header"""
     ts = 1000
     resp = session.post(f'{base_url}/b/{bucket}/entry?ts={1000}', data='{"data": "some data"}',
                         headers={'content-type': 'application/json'})
@@ -396,3 +397,63 @@ def test_write_with_content_type_header(base_url, session, bucket):
     assert resp.status_code == 200
     assert resp.content == b"{\"data\": \"some data\"}"
     assert resp.headers['content-type'] == 'application/json'
+
+
+def test_read_batched_records(base_url, session, bucket):
+    """Should read batched records and send metadata in headers"""
+    ts = 1000
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data1")
+    assert resp.status_code == 200
+
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 100}', data="some_data2",
+                        headers={'content-type': 'text/plain', 'x-reduct-label-x': '[a,b]'})
+    assert resp.status_code == 200
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}')
+    assert resp.status_code == 200
+    query_id = int(json.loads(resp.content)["id"])
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    assert resp.status_code == 200
+    assert resp.content == b"some_data1some_data2"
+    assert resp.headers['content-type'] == 'application/octet-stream'
+    assert resp.headers['content-length'] == '20'
+    assert resp.headers['x-reduct-time-1000'] == 'content-length=10,content-type=application/octet-stream'
+    assert resp.headers['x-reduct-time-1100'] == 'content-length=10,content-type=text/plain,label-x="[a,b]"'
+    assert resp.headers['x-reduct-last'] == 'true'
+
+
+def test_read_batched_max_header_size(base_url, session, bucket):
+    """Should limit the header size in response"""
+    for ts in range(0, 100):
+        resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="")
+        assert resp.status_code == 200
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/q')
+    assert resp.status_code == 200
+    query_id = int(json.loads(resp.content)["id"])
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    assert resp.status_code == 200
+    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 84
+    assert resp.headers['x-reduct-last'] == 'false'
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    assert resp.status_code == 200
+    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 16
+    assert resp.headers['x-reduct-last'] == 'true'
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    assert resp.status_code == 404
+
+
+def test_read_batched_max_header_size(base_url, session, bucket):
+    """Should have query id in params"""
+
+    ts = 1000
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data1")
+    assert resp.status_code == 200
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/batch')
+    assert resp.status_code == 422
+    assert resp.headers['x-reduct-error'] == "'q' parameter is required for batched reads"

--- a/docs/how-does-it-work.md
+++ b/docs/how-does-it-work.md
@@ -2,17 +2,16 @@
 
 ## What Is Time Series Storage?
 
-ReductStore is a storage engine which aims to solve the problem of storing data when you need to write data intensively and read it occasionally. The storage engine uses an [HTTP API ](http-api/)and stores the data as blobs. This means:
+ReductStore is a time series database designed specifically for storing and managing large amounts of unstructured data. It uses an [HTTP API ](http-api/)and stores the data as blobs. This means:
 
 * ReductStore has no information about the format of the stored data. So, you can write whatever you want, but the storage can't aggregate your data. You have to read the same data, what you have written.
-* The [HTTP API](http-api/) provides a simple and portable way to communicate with the storage engine, but the engine doesn't provide any query language to access the data.
+* The [HTTP API](http-api/) provides a simple and portable way to communicate with the storage engine, but the engine doesn't provide any query language to access the data. However, you can use labels for filtering data in requests.
 
 In comparison to other S3-like object storage, ReductStore works differently:
 
-
 * **Access By Time.** Each record in an entry is written with a timestamp and to read it you need to know the entry name and time.
 * **Flat Storage Structure.** It doesn't have a tree-like structure for data. There are only buckets and entries with unique names in them.
-* **Batching Data.** It doesn't store each record as a single file. It batches them into blocks of a fixed size so that it can store small objects more efficiently. You don't waste disk space because of the minimum size of file system blocks. Moreover, ReductStore pre-allocate blocks space to increase performance for write operations.&#x20;
+* **Batching Data.** It doesn't store each record as a single file. It batches them into blocks of a fixed size so that it can store small objects more efficiently. You don't waste disk space because of the minimum size of file system blocks. Moreover, ReductStore pre-allocate blocks space to increase performance for write operations.
 * **Forward Writing.** The engine records data fastest if it only needs to append records to the current block. It means that, for better performance, you should always write data with the newest timestamps.
 * **Strong FIFO Quota.** When you have intensive write operations, you may run out of disk space quickly. The engine removes the oldest block in a bucket as soon as the amount of the data reaches a specified quota limit.
 
@@ -26,12 +25,12 @@ As was mentioned above, ReductStore has flat structure:
 
 A container for entries which provides the following storage settings:
 
-* **Maximum block size.**  The storage engine creates a new block after the size of the current block reaches this limit. A block might be bigger than this size because the storage engine can write a belated record.
-* **Maximum number of records.** When the current block has more records than this limit, the storage engine creates a new block.&#x20;
+* **Maximum block size.** The storage engine creates a new block after the size of the current block reaches this limit. A block might be bigger than this size because the storage engine can write a belated record.
+* **Maximum number of records.** When the current block has more records than this limit, the storage engine creates a new block.
 * **Quota type.** The storage supports two quota types:
   * No quota. The bucket will grow to consume as much free disk space as is available - relative to how much data is written.
   * FIFO. The bucket removes the oldest block of some entry when it reaches the quota limit.
-* **Quota size.**&#x20;
+* **Quota size.**
 
 A user can manage bucket with[ Bucket API](http-api/bucket-api.md).
 
@@ -48,4 +47,4 @@ A block of records with a unique ID. The storage engine batches the records by b
 
 #### Record
 
-A blob with a timestamp
+A blob with a timestamp and meta information such as content type and labels.

--- a/docs/http-api/README.md
+++ b/docs/http-api/README.md
@@ -1,6 +1,6 @@
 # ⚙ HTTP API Reference
 
-ReductStore provides a simple HTTP API for interacting with the database. In order to use the API, you must first authenticate using a token, which you can be provisioned  one with the `RS_API_TOKEN`[environment variable ](../#environment-variables)or created with [the Token API](token-authentication.md).
+ReductStore provides an HTTP API for interacting with the database. In order to use the API, you must first authenticate using a token, which you can be provisioned one with the `RS_API_TOKEN`[environment variable ](../#environment-variables)or created with [the Token API](token-authentication.md).
 
 Once you have obtained a token, you can use it to authenticate your requests by including it in the `Authorization` header of your HTTP request, like this:
 
@@ -15,11 +15,11 @@ An example of a request with CURL:
 ```
 
 {% hint style="info" %}
-The storage engine uses the token authentication when the`RS_API_TOKEN` envirnoment is set. You should use it as a full access token to create other tokens with different permission by using the Token API
+The database uses the token authentication when the`RS_API_TOKEN` envirnoment is set. You should use it as a full access token to create other tokens with different permission by using the Token API
 {% endhint %}
 
 ## **Handling Errors**
 
-If a request to ReductStore fails, the API  returns an HTTP status code indicating the type of error that occurred. For example, a `404 Not Found` status code indicates that the requested resource could not be found.
+If a request to ReductStore fails, the API returns an HTTP status code indicating the type of error that occurred. For example, a `404 Not Found` status code indicates that the requested resource could not be found.
 
 Since version 1.2.0, the HTTP API also includes an error message in the `x-reduct-error` header of the response. This error message provides more detailed information about the error, which can be useful for debugging and troubleshooting.

--- a/docs/http-api/bucket-api.md
+++ b/docs/http-api/bucket-api.md
@@ -13,7 +13,7 @@ Before starting to record data, a user must first create a bucket and specify se
 * Quota type
 * Quota size
 
-For more information about buckets, read  [here](../how-does-it-work.md#internal-structure).
+For more information about buckets, read [here](../how-does-it-work.md#internal-structure).
 
 {% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name " summary="Get information about a bucket" %}
 {% swagger-description %}
@@ -56,19 +56,11 @@ Name of bucket
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is invalid or empty" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="404: Not Found" description="The bucket does not exist" %}
-```javascript
-{
-    "detail": "string"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -82,27 +74,15 @@ Name of bucket
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="The bucket exists" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is invalid or empty" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="404: Not Found" description="The bucket does not exist" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -110,7 +90,7 @@ Name of bucket
 {% swagger-description %}
 To create a bucket, the request should contain a JSON document with some parameters or empty body. The new bucket uses default values if some parameters are empty.
 
-If authenticaion is enabled, the method needs a valid API token with full access.
+If authentication is enabled, the method needs a valid API token with full access.
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name=":bucket_name" required="true" %}
@@ -134,43 +114,23 @@ Size of quota in bytes (default: 0)
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="The new bucket is created" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is invalid or empty" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="403: Forbidden" description="Access token doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="409: Conflict" description="A bucket with the same name already exists" %}
-```javascript
-{
-    "detail": "string"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="422: Unprocessable Entity" description="JSON request is invalid" %}
-```javascript
-{
-    "detail": "string"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -202,43 +162,23 @@ Size of quota in bytes
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="The settings are updated" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is invalid or empty" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="403: Forbidden" description="Access token doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="404: Not Found" description="Bucket doesn" %}
-```javascript
-{
-    "detail": "string"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="422: Unprocessable Entity" description="JSON request is invalid" %}
-```javascript
-{
-    "detail": "string"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -246,7 +186,7 @@ Size of quota in bytes
 {% swagger-description %}
 Remove a bucket with **all its entries and stored data.**
 
-If authenticaion is enabled, the method needs a valid API token with full access.
+If authentication is enabled, the method needs a valid API token with full access.
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name=":bucket_name" required="true" %}
@@ -254,34 +194,18 @@ Name of bucket to remove
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="The bucket is removed" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is invalid or empty" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="403: Forbidden" description="Access token doesn" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="404: Not Found" description="Bucket does not exists" %}
-```javascript
-{
-    "detail": "string"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}

--- a/docs/http-api/server-api.md
+++ b/docs/http-api/server-api.md
@@ -34,11 +34,7 @@ You can use this method to get stats of the storage and check its version. If au
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="If authentication is enabled and access token is invalid or empty" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -67,11 +63,7 @@ You can use this method to browse the buckets of the storage. If authenticaion i
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="If authentication is enabled and access token is invalid or empty" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -83,11 +75,7 @@ You can use this method for health checks in Docker or Kubernetes environment. T
 {% endswagger-description %}
 
 {% swagger-response status="200: OK" description="" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -111,10 +99,6 @@ This method takes a token from the Authentication header and returns its name, p
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="API token is invalid" %}
-```javascript
-{
-    "detail": "error message"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}

--- a/docs/http-api/token-authentication.md
+++ b/docs/http-api/token-authentication.md
@@ -5,7 +5,7 @@ description: HTTP methods to manage access tokens.
 # Token API
 
 {% hint style="info" %}
-The storage engine uses the token authentication when the`RS_API_TOKEN` envirnoment is set. You should use it as a full access token to create other tokens with different permission by using the Token API
+The database uses the token authentication when the`RS_API_TOKEN` environment is set. You should use it as a full access token to create other tokens with different permission by using the Token API
 {% endhint %}
 
 {% swagger method="get" path="" baseUrl="/api/v1/tokens" summary="Get a list of tokens" %}
@@ -27,19 +27,11 @@ The method returns a list of tokens with names and creation dates. To use this m
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is empty or invalid" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="403: Forbidden" description="Access token doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -67,27 +59,15 @@ Name of token to show
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is empty or invalid" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="403: Forbidden" description="Access token doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="404: Not Found" description="Token with the given name doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -122,35 +102,19 @@ A list of bucket names for write access. Default: []
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is empty or invalid" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="403: Forbidden" description="Access token doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="409: Conflict" description="Token with the same name already exists" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="422: Unprocessable Entity" description="Speciefied bucket doesn" %}
-```javascript
-{
-    // Response
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}
 
@@ -172,26 +136,14 @@ Name of new token
 {% endswagger-response %}
 
 {% swagger-response status="401: Unauthorized" description="Access token is empty or invalid" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="403: Forbidden" description="Access token doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 
 {% swagger-response status="404: Not Found" description="Token with the given name doesn" %}
-```javascript
-{
-    "detail": "error_message"
-}
-```
+
 {% endswagger-response %}
 {% endswagger %}

--- a/src/http_frontend/entry_api.rs
+++ b/src/http_frontend/entry_api.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use crate::auth::policy::{ReadAccessPolicy, WriteAccessPolicy};
 use axum::headers;
 use axum::headers::{Expect, Header, HeaderMapExt, HeaderValue};
-use hyper::Body;
+
 use log::{debug, error};
 use std::pin::Pin;
 use std::str::FromStr;
@@ -375,7 +375,7 @@ impl EntryApi {
         let mut headers = HeaderMap::new();
         let mut readers = Vec::new();
         loop {
-            let reader = match bucket.next(entry_name, query_id) {
+            let _reader = match bucket.next(entry_name, query_id) {
                 Ok((reader, _)) => {
                     {
                         let reader_lock = reader.read().unwrap();
@@ -563,7 +563,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_read_ts() {
-        let (components, headers, body, path) = setup().await;
+        let (components, headers, _body, path) = setup().await;
 
         let response = EntryApi::read_single_record(
             State(Arc::clone(&components)),
@@ -586,7 +586,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_read_query() {
-        let (components, headers, body, path) = setup().await;
+        let (components, headers, _body, path) = setup().await;
 
         let query_id = query_records(&components);
 
@@ -634,7 +634,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_batched_read() {
-        let (components, headers, body, path) = setup().await;
+        let (components, headers, _body, path) = setup().await;
 
         let query_id = query_records(&components);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,10 @@ async fn main() {
             &format!("{}api/v1/b/:bucket_name/:entry_name/q", api_base_path),
             get(EntryApi::query),
         )
+        .route(
+            &format!("{}api/v1/b/:bucket_name/:entry_name/batch", api_base_path),
+            get(EntryApi::read_batched_records),
+        )
         // UI
         .route(&format!("{}", api_base_path), get(UiApi::redirect_to_index))
         .fallback(get(UiApi::show_ui))

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ async fn main() {
         )
         .route(
             &format!("{}api/v1/b/:bucket_name/:entry_name", api_base_path),
-            get(EntryApi::read_record),
+            get(EntryApi::read_single_record),
         )
         .route(
             &format!("{}api/v1/b/:bucket_name/:entry_name/q", api_base_path),

--- a/src/storage/bucket.rs
+++ b/src/storage/bucket.rs
@@ -242,6 +242,27 @@ impl Bucket {
         entry.begin_read(time)
     }
 
+    /// Get the next record from the entry
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Entry name.
+    /// * `time` - The timestamp of the record.
+    ///
+    /// # Returns
+    ///
+    /// * `RecordReader` - The record reader to read the record content in chunks.
+    /// * `bool` - True if the record is the last one.
+    /// * `HTTPError` - The error if any.
+    pub fn next(
+        &mut self,
+        name: &str,
+        time: u64,
+    ) -> Result<(Arc<RwLock<RecordReader>>, bool), HttpError> {
+        let entry = self.get_entry(name)?;
+        entry.next(time)
+    }
+
     fn keep_quota_for(&mut self, content_size: u64) -> Result<(), HttpError> {
         match QuotaType::from_i32(self.settings.quota_type.unwrap()).unwrap() {
             QuotaType::None => Ok(()),


### PR DESCRIPTION
Closes #236

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #236 

### What is the new behavior?

I've created a separated endpoint: `GET /b/:bucket/:entry/batch?q=<Query ID>` that sends batched records with meta information in a header.

### Does this PR introduce a breaking change?

No

### Other information:
