### PR TITLE
HEAD endpoints to read only meta information about records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `x-reduct-api` header to get quick version number in Major.Minor format, [PR-291](https://github.com/reductstore/reductstore/pull/291)
-- `GET /api/v1/:bucket/:entry/batch` endpoint to read a bunch of records, [PR-294](https://github.com/reductstore/reductstore/pull/294)
+- `x-reduct-api` header to get quick version number in Major.Minor
+  format, [PR-291](https://github.com/reductstore/reductstore/pull/291)
+- `GET /api/v1/:bucket/:entry/batch` endpoint to read a bunch of
+  records, [PR-294](https://github.com/reductstore/reductstore/pull/294)
+- `HEAD /api/v1/b/:bucket_name/:entry_name` and `HEAD /api/v1/b/:bucket_name/:entry_name/batch`
+  endpoints, [PR-296]https://github.com/reductstore/reductstore/pull/296)
 
 ## [1.4.0] - 2023-06-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,12 +502,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -515,6 +531,23 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
@@ -540,14 +573,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1407,6 +1450,7 @@ dependencies = [
  "prost-wkt-types",
  "rand",
  "regex",
+ "rstest",
  "rustls",
  "serde",
  "serde_json",
@@ -1448,6 +1492,41 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1560,6 +1639,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ chrono = "0.4.24"
 
 [dev-dependencies]
 mockall = "0.11.4"
+rstest = "0.17.0"

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -70,7 +70,7 @@ A value of a label assigned to the record
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name/:entry_name " summary="Get a record from an entry" %}
+{% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name/:entry_name " summary="Get a record from an entry" fullWidth="false" %}
 {% swagger-description %}
 The method finds a record for the given timestamp and sends its content in the HTTP response body. It also sends additional information in headers:
 
@@ -132,6 +132,16 @@ A UNIX timestamp in microseconds. If it is empty, the latest record is returned.
 {% endswagger-response %}
 {% endswagger %}
 
+{% swagger method="head" path="" baseUrl="/api/v1/b/:bucket_name/:entry_name  " summary="Get only meta information about record" %}
+{% swagger-description %}
+The endpoint works exactly as 
+
+`GET /api/v1/b/:bucket_name/:entry_name`
+
+ but returns only headers with meta information with a body.
+{% endswagger-description %}
+{% endswagger %}
+
 {% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name/:entry_name/batch " summary="Get a bulk of records from an entry" %}
 {% swagger-description %}
 Since version 1.5, ReductStore provides a way to read a multiple records in a request. This can improve latency when you have many small records to read. The endpoint sorts all the records by time and concatenates them into a blob and sends it in the body. The meta information is sent for each record as a separate header `x-reduct-time-<timestamp>` which has a value as a CSV row. An example:
@@ -176,6 +186,16 @@ Name of entry
 {% swagger-response status="422: Unprocessable Entity" description="Bad timestamp" %}
 
 {% endswagger-response %}
+{% endswagger %}
+
+{% swagger method="head" path="" baseUrl="/api/v1/b/:bucket_name/:entry_name/batch  " summary="Get only meta information  in bulk" %}
+{% swagger-description %}
+The endpoint works exactly as 
+
+`GET /api/v1/b/:bucket_name/:entry_name/batch`
+
+ but returns only headers with meta information with a body.
+{% endswagger-description %}
 {% endswagger %}
 
 {% swagger method="get" path="" baseUrl="/api/v1/b/:bucket_name/:entry_name/q " summary="Query records for a time interval" %}

--- a/src/http_frontend/entry_api.rs
+++ b/src/http_frontend/entry_api.rs
@@ -5,7 +5,7 @@
 
 use axum::async_trait;
 use axum::body::StreamBody;
-use axum::extract::{BodyStream, FromRef, FromRequest, Path, Query, State};
+use axum::extract::{BodyStream, FromRequest, Path, Query, State};
 use axum::http::header::HeaderMap;
 use axum::http::{HeaderName, Request, StatusCode};
 use axum::response::{IntoResponse, Response};
@@ -608,9 +608,7 @@ mod tests {
     use axum::body::{Empty, HttpBody};
     use axum::extract::FromRequest;
     use axum::http::Request;
-    use futures_util::StreamExt;
 
-    use futures_util::stream;
     use rstest::{fixture, rstest};
     use std::path::PathBuf;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,12 +156,20 @@ async fn main() {
             get(EntryApi::read_single_record),
         )
         .route(
+            &format!("{}api/v1/b/:bucket_name/:entry_name", api_base_path),
+            head(EntryApi::read_single_record),
+        )
+        .route(
             &format!("{}api/v1/b/:bucket_name/:entry_name/q", api_base_path),
             get(EntryApi::query),
         )
         .route(
             &format!("{}api/v1/b/:bucket_name/:entry_name/batch", api_base_path),
             get(EntryApi::read_batched_records),
+        )
+        .route(
+            &format!("{}api/v1/b/:bucket_name/:entry_name/batch", api_base_path),
+            head(EntryApi::read_batched_records),
         )
         // UI
         .route(&format!("{}", api_base_path), get(UiApi::redirect_to_index))


### PR DESCRIPTION
Closes #296

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #296

### What is the new behavior?

I've implemented two endpoints:

* HEAD `/api/v1/b/:bucket_name/:entry_name`
* HEAD `/api/v1/b/:bucket_name/:entry_name/batch`

### Does this PR introduce a breaking change?

No

### Other information:
