### PR TITLE
Remove `x-reduct-last` header from batch endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HEAD /api/v1/b/:bucket_name/:entry_name` and `HEAD /api/v1/b/:bucket_name/:entry_name/batch`
   endpoints, [PR-296]https://github.com/reductstore/reductstore/pull/296)
 
+### Removed
+
+- `x-reduct-last` from `GET /api/v1/:bucket/:entry/batch`, [PR-297](https://github.com/reductstore/reductstore/pull/297)
+
 ## [1.4.0] - 2023-06-09
 
 ### Fixed

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -422,7 +422,6 @@ def test_read_batched_records(base_url, session, bucket, method, expected_conten
     assert resp.headers['content-length'] == '20'
     assert resp.headers['x-reduct-time-1000'] == 'content-length=10,content-type=application/octet-stream'
     assert resp.headers['x-reduct-time-1100'] == 'content-length=10,content-type=text/plain,label-x="[a,b]"'
-    assert resp.headers['x-reduct-last'] == 'true'
 
 
 def test_read_batched_max_header_size(base_url, session, bucket):
@@ -438,12 +437,10 @@ def test_read_batched_max_header_size(base_url, session, bucket):
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
     assert resp.status_code == 200
     assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 84
-    assert resp.headers['x-reduct-last'] == 'false'
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
     assert resp.status_code == 200
     assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 16
-    assert resp.headers['x-reduct-last'] == 'true'
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
     assert resp.status_code == 404
@@ -472,7 +469,6 @@ def test_read_batched_continuous_query(base_url, session, bucket):
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
     assert resp.status_code == 200
-    assert resp.headers['x-reduct-last'] == 'true'
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
     assert resp.status_code == 204

--- a/src/http_frontend/entry_api.rs
+++ b/src/http_frontend/entry_api.rs
@@ -822,7 +822,6 @@ mod tests {
         );
         assert_eq!(headers["content-type"], "application/octet-stream");
         assert_eq!(headers["content-length"], "6");
-        assert_eq!(headers["x-reduct-last"], "true");
 
         assert_eq!(
             response.data().await.unwrap_or(Ok(Bytes::new())).unwrap(),

--- a/src/http_frontend/entry_api.rs
+++ b/src/http_frontend/entry_api.rs
@@ -147,7 +147,6 @@ fn fetch_and_response_batched_records(
     let mut body_size = 0u64;
     let mut headers = HeaderMap::new();
     let mut readers = Vec::new();
-    let mut last = false;
     loop {
         let _reader = match bucket.next(entry_name, query_id) {
             Ok((reader, _)) => {
@@ -175,7 +174,6 @@ fn fetch_and_response_batched_records(
                     return Err(err);
                 } else {
                     if err.status() == HttpStatus::NoContent as i32 {
-                        last = true;
                         break;
                     } else {
                         return Err(err);
@@ -187,7 +185,6 @@ fn fetch_and_response_batched_records(
 
     headers.insert("content-length", body_size.to_string().parse().unwrap());
     headers.insert("content-type", "application/octet-stream".parse().unwrap());
-    headers.insert("x-reduct-last", last.to_string().parse().unwrap());
 
     struct ReadersWrapper {
         readers: Vec<Arc<RwLock<RecordReader>>>,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

I added the `x-reduct-last` header to the batching endpoint by mistake. It is not reliable and causes some additional computation.

### What is the new behavior?

I have removed it

### Does this PR introduce a breaking change?

Yes, but we haven't released the batching endpoint yet. 

### Other information:
