### PR TITLE
Make headers for batched records shorter

### DIFF
--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -420,8 +420,8 @@ def test_read_batched_records(base_url, session, bucket, method, expected_conten
     assert resp.content == expected_content
     assert resp.headers['content-type'] == 'application/octet-stream'
     assert resp.headers['content-length'] == '20'
-    assert resp.headers['x-reduct-time-1000'] == 'content-length=10,content-type=application/octet-stream'
-    assert resp.headers['x-reduct-time-1100'] == 'content-length=10,content-type=text/plain,label-x="[a,b]"'
+    assert resp.headers['x-reduct-time-1000'] == '10,application/octet-stream'
+    assert resp.headers['x-reduct-time-1100'] == '10,text/plain,x="[a,b]"'
     assert resp.headers['x-reduct-last'] == 'true'
 
 
@@ -437,12 +437,12 @@ def test_read_batched_max_header_size(base_url, session, bucket):
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
     assert resp.status_code == 200
-    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 84
+    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 86
     assert resp.headers['x-reduct-last'] == 'false'
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
     assert resp.status_code == 200
-    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 16
+    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 14
     assert resp.headers['x-reduct-last'] == 'true'
 
     resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')

--- a/src/http_frontend/entry_api.rs
+++ b/src/http_frontend/entry_api.rs
@@ -120,8 +120,8 @@ fn fetch_and_response_batched_records(
         let name = HeaderName::from_str(&format!("x-reduct-time-{}", reader.timestamp())).unwrap();
 
         let mut meta_data = vec![
-            format!("content-length={}", reader.content_length()),
-            format!("content-type={}", reader.content_type()),
+            reader.content_length().to_string(),
+            reader.content_type().clone(),
         ];
         meta_data.append(
             &mut reader
@@ -129,15 +129,13 @@ fn fetch_and_response_batched_records(
                 .iter()
                 .map(|(k, v)| {
                     if v.contains(",") {
-                        format!("label-{}=\"{}\"", k, v)
+                        format!("{}=\"{}\"", k, v)
                     } else {
-                        format!("label-{}={}", k, v)
+                        format!("{}={}", k, v)
                     }
                 })
                 .collect(),
         );
-        meta_data.sort();
-
         let value: HeaderValue = meta_data.join(",").parse().unwrap();
 
         (name, value)
@@ -819,10 +817,7 @@ mod tests {
         .into_response();
 
         let headers = response.headers();
-        assert_eq!(
-            headers["x-reduct-time-0"],
-            "content-length=6,content-type=text/plain,label-b=\"[a,b]\",label-x=y"
-        );
+        assert_eq!(headers["x-reduct-time-0"], "6,text/plain,b=\"[a,b]\",x=y");
         assert_eq!(headers["content-type"], "application/octet-stream");
         assert_eq!(headers["content-length"], "6");
         assert_eq!(headers["x-reduct-last"], "true");


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Change

### What is the current behavior?

For each batched record, we send a header with meta information:

```
x-reduct-time-XXXXX: content-length=100,content-type=text/plain,label-x=y
```

Most of the servers and clients have a limitation for a header size, so it is not efficient.

### What is the new behavior?

We send a more concise header:

```
x-reduct-time-XXXXX: 100,text/plain,x=y
```

### Does this PR introduce a breaking change?

Yes, but the batching protocol wasn't released.

### Other information:
