### PR TITLE
Cache last block to reduce read operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - reductstore: Refactor `http_frontend` module, [PR-306](https://github.com/reductstore/reductstore/pull/306)
+- reductstore: Cache last block to reduce read operations, [PR-318](https://github.com/reductstore/reductstore/pull/318)
 - all: Organize workspaces, [PR-310](https://github.com/reductstore/reductstore/pull/310)
 
 ### Removed

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -30,8 +30,7 @@ pub struct BlockManager {
     path: PathBuf,
     readers: HashMap<u64, Vec<Weak<RwLock<RecordReader>>>>,
     writers: HashMap<u64, Vec<Weak<RwLock<RecordWriter>>>>,
-    file_mutex: RwLock<()>,
-    last_block: RwLock<Option<Block>>,
+    last_block: Option<Block>,
 }
 
 pub const DESCRIPTOR_FILE_EXT: &str = ".meta";
@@ -67,8 +66,7 @@ impl BlockManager {
             path,
             readers: HashMap::new(),
             writers: HashMap::new(),
-            file_mutex: RwLock::new(()),
-            last_block: RwLock::new(None),
+            last_block: None,
         }
     }
 
@@ -212,7 +210,7 @@ pub trait ManageBlock {
     /// # Returns
     ///
     /// * `Ok(())` - Block was saved successfully.
-    fn save(&self, block: &Block) -> Result<(), HttpError>;
+    fn save(&mut self, block: Block) -> Result<(), HttpError>;
 
     /// Start a new block
     ///
@@ -224,7 +222,7 @@ pub trait ManageBlock {
     /// # Returns
     ///
     /// * `Ok(block)` - Block was created successfully.
-    fn start(&self, block_id: u64, max_block_size: u64) -> Result<Block, HttpError>;
+    fn start(&mut self, block_id: u64, max_block_size: u64) -> Result<Block, HttpError>;
 
     /// Finish a block by truncating the file to the actual size.
     ///
@@ -235,7 +233,7 @@ pub trait ManageBlock {
     /// # Returns
     ///
     /// * `Ok(())` - Block was finished successfully.
-    fn finish(&self, block: &Block) -> Result<(), HttpError>;
+    fn finish(&mut self, block: &Block) -> Result<(), HttpError>;
 
     /// Remove a block from disk if there are no readers or writers.
     fn remove(&mut self, block_id: u64) -> Result<(), HttpError>;
@@ -244,15 +242,12 @@ pub trait ManageBlock {
 impl ManageBlock for BlockManager {
     fn load(&self, block_id: u64) -> Result<Block, HttpError> {
         {
-            let block = self.last_block.read().unwrap();
-            if let Some(block) = block.as_ref() {
+            if let Some(block) = self.last_block.as_ref() {
                 if ts_to_us(&block.begin_time.clone().unwrap()) == block_id {
                     return Ok(block.clone());
                 }
             }
         }
-
-        let _guard = self.file_mutex.read().unwrap();
 
         let proto_ts = us_to_ts(&block_id);
         let buf = std::fs::read(self.path_to_desc(&proto_ts))?;
@@ -260,13 +255,10 @@ impl ManageBlock for BlockManager {
             HttpError::internal_server_error(&format!("Failed to decode block descriptor: {}", e))
         })?;
 
-        self.last_block.write().unwrap().replace(block.clone());
         Ok(block)
     }
 
-    fn save(&self, block: &Block) -> Result<(), HttpError> {
-        let _guard = self.file_mutex.write().unwrap();
-
+    fn save(&mut self, block: Block) -> Result<(), HttpError> {
         let path = self.path_to_desc(block.begin_time.as_ref().unwrap());
         let mut buf = BytesMut::new();
         block.encode(&mut buf).map_err(|e| {
@@ -275,11 +267,11 @@ impl ManageBlock for BlockManager {
         let mut file = std::fs::File::create(path.clone())?;
         file.write_all(&buf)?;
 
-        self.last_block.write().unwrap().replace(block.clone());
+        self.last_block = Some(block);
         Ok(())
     }
 
-    fn start(&self, block_id: u64, max_block_size: u64) -> Result<Block, HttpError> {
+    fn start(&mut self, block_id: u64, max_block_size: u64) -> Result<Block, HttpError> {
         let mut block = Block::default();
         block.begin_time = Some(us_to_ts(&block_id));
 
@@ -287,20 +279,20 @@ impl ManageBlock for BlockManager {
         let file = std::fs::File::create(self.path_to_data(block.begin_time.as_ref().unwrap()))?;
 
         file.set_len(max_block_size)?;
-        self.save(&block)?;
+        self.save(block.clone())?;
 
-        self.last_block.write().unwrap().replace(block.clone());
         Ok(block)
     }
 
-    fn finish(&self, block: &Block) -> Result<(), HttpError> {
-        let _guard = self.file_mutex.write().unwrap();
+    fn finish(&mut self, block: &Block) -> Result<(), HttpError> {
         let path = self.path_to_data(block.begin_time.as_ref().unwrap());
         let file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
             .open(path)?;
         file.set_len(block.size as u64)?;
+
+        self.last_block = None;
         Ok(())
     }
 
@@ -311,8 +303,6 @@ impl ManageBlock for BlockManager {
                 block_id
             )));
         }
-
-        let _guard = self.file_mutex.write().unwrap();
 
         let proto_ts = us_to_ts(&block_id);
         let path = self.path_to_data(&proto_ts);
@@ -331,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_starting_block() {
-        let bm = setup();
+        let mut bm = setup();
         let block = bm.start(1_000_005, 1024).unwrap();
 
         let ts = block.begin_time.clone().unwrap();
@@ -361,7 +351,7 @@ mod tests {
 
     #[test]
     fn test_loading_block() {
-        let bm = setup();
+        let mut bm = setup();
 
         bm.start(1, 1024).unwrap();
         let block = bm.start(20000005, 1024).unwrap();
@@ -373,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_start_reading() {
-        let bm = setup();
+        let mut bm = setup();
 
         let block = bm.start(1, 1024).unwrap();
         let ts = block.begin_time.clone().unwrap();
@@ -383,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_finish_block() {
-        let bm = setup();
+        let mut bm = setup();
 
         let block = bm.start(1, 1024).unwrap();
         let ts = block.begin_time.clone().unwrap();
@@ -399,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_start_writing() {
-        let bm = setup();
+        let mut bm = setup();
 
         let block_id = 1;
         let mut block = bm.start(block_id, 1024).unwrap().clone();
@@ -415,7 +405,7 @@ mod tests {
             content_type: "".to_string(),
         });
 
-        bm.save(&block).unwrap();
+        bm.save(block.clone()).unwrap();
 
         let bm_ref = Arc::new(RwLock::new(bm));
         {
@@ -427,12 +417,12 @@ mod tests {
                 .unwrap();
         }
 
-        bm_ref.read().unwrap().finish(&block).unwrap();
+        bm_ref.write().unwrap().finish(&block).unwrap();
     }
 
     #[test]
     fn test_remove_with_writers() {
-        let bm = setup();
+        let mut bm = setup();
         let block_id = 1;
 
         {

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -241,11 +241,9 @@ pub trait ManageBlock {
 
 impl ManageBlock for BlockManager {
     fn load(&self, block_id: u64) -> Result<Block, HttpError> {
-        {
-            if let Some(block) = self.last_block.as_ref() {
-                if ts_to_us(&block.begin_time.clone().unwrap()) == block_id {
-                    return Ok(block.clone());
-                }
+        if let Some(block) = self.last_block.as_ref() {
+            if ts_to_us(&block.begin_time.clone().unwrap()) == block_id {
+                return Ok(block.clone());
             }
         }
 
@@ -309,6 +307,13 @@ impl ManageBlock for BlockManager {
         std::fs::remove_file(path)?;
         let path = self.path_to_desc(&proto_ts);
         std::fs::remove_file(path)?;
+
+        if let Some(block) = self.last_block.as_ref() {
+            if ts_to_us(&block.begin_time.clone().unwrap()) == block_id {
+                self.last_block = None;
+            }
+        }
+
         Ok(())
     }
 }

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -217,7 +217,7 @@ impl Entry {
             block.latest_record_time = Some(us_to_ts(&time));
         }
 
-        self.block_manager.write().unwrap().save(&block)?;
+        self.block_manager.write().unwrap().save(block.clone())?;
         BlockManager::begin_write(
             Arc::clone(&self.block_manager),
             &block,

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -116,7 +116,7 @@ mod tests {
 
     fn setup() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
         let dir = tempdir().unwrap().into_path();
-        let block_manager = BlockManager::new(dir);
+        let mut block_manager = BlockManager::new(dir);
         let mut block = block_manager.start(0, 10).unwrap();
 
         block.records.push(Record {
@@ -136,7 +136,7 @@ mod tests {
             nanos: 0,
         });
         block.size = 10;
-        block_manager.save(&block).unwrap();
+        block_manager.save(block.clone()).unwrap();
 
         let bm_ref = Arc::new(RwLock::new(block_manager));
         {

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -368,7 +368,7 @@ mod tests {
 
         let mut block = block_manager.load(*index.get(&0u64).unwrap()).unwrap();
         block.records[0].state = record::State::Errored as i32;
-        block_manager.save(&block).unwrap();
+        block_manager.save(block).unwrap();
 
         assert_eq!(
             query.next(&index, &mut block_manager).err(),
@@ -381,7 +381,7 @@ mod tests {
 
     fn setup_2_blocks() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
         let dir = tempdir().unwrap().into_path();
-        let block_manager = BlockManager::new(dir);
+        let mut block_manager = BlockManager::new(dir);
         let mut block = block_manager.start(0, 10).unwrap();
 
         block.records.push(Record {
@@ -431,7 +431,7 @@ mod tests {
             nanos: 5000,
         });
         block.size = 20;
-        block_manager.save(&block).unwrap();
+        block_manager.save(block.clone()).unwrap();
 
         let block_manager = Arc::new(RwLock::new(block_manager));
         {
@@ -482,7 +482,7 @@ mod tests {
             nanos: 1000_000,
         });
         block.size = 10;
-        block_manager.write().unwrap().save(&block).unwrap();
+        block_manager.write().unwrap().save(block.clone()).unwrap();
 
         {
             let writer = BlockManager::begin_write(Arc::clone(&block_manager), &block, 0).unwrap();

--- a/reductstore/src/storage/writer.rs
+++ b/reductstore/src/storage/writer.rs
@@ -133,7 +133,7 @@ impl RecordWriter {
         self.block_manager
             .write()
             .unwrap()
-            .save(&block)
+            .save(block)
             .map_err(|e| {
                 log::error!("Failed to save block: {}", e);
             })
@@ -154,9 +154,9 @@ mod tests {
 
         impl ManageBlock for BlockManager {
             fn load(&self, begin_time: u64) -> Result<Block, HttpError>;
-            fn save(&self, block: &Block) -> Result<(), HttpError>;
-            fn start(&self, begin_time: u64, max_block_size: u64) -> Result<Block, HttpError>;
-            fn finish(&self, block: &Block) -> Result<(), HttpError>;
+            fn save(&mut self, block: Block) -> Result<(), HttpError>;
+            fn start(&mut self, begin_time: u64, max_block_size: u64) -> Result<Block, HttpError>;
+            fn finish(&mut self, block: &Block) -> Result<(), HttpError>;
             fn remove(&mut self, block_id: u64) -> Result<(), HttpError>;
 
         }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Optimization

### What is the current behavior?

We always read the last block from disk and decode it. However, we could cache it in memory and reduce the number of the expensive operations.

### What is the new behavior?

I've saved the last block in `BlockManager` and returned it in the load method.

### Does this PR introduce a breaking change?

No

### Other information:
