### PR TITLE
Grained HTTP components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - reductstore: Refactor `http_frontend` module, [PR-306](https://github.com/reductstore/reductstore/pull/306)
 - reductstore: Cache last block to reduce read operations, [PR-318](https://github.com/reductstore/reductstore/pull/318)
+- reductstore: Grained HTTP components, [PR-319](https://github.com/reductstore/reductstore/pull/319)
 - all: Organize workspaces, [PR-310](https://github.com/reductstore/reductstore/pull/310)
 
 ### Removed

--- a/reductstore/src/http_frontend.rs
+++ b/reductstore/src/http_frontend.rs
@@ -106,7 +106,6 @@ pub fn create_axum_app(api_base_path: &String, components: Arc<HttpServerState>)
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::path::PathBuf;
 
     use axum::extract::Path;
     use axum::headers::{Authorization, HeaderMap, HeaderMapExt};

--- a/reductstore/src/http_frontend.rs
+++ b/reductstore/src/http_frontend.rs
@@ -4,14 +4,14 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 
-use std::sync::{Arc, RwLock};
-
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{middleware::from_fn, Router};
 use prost::DecodeError;
 use serde::de::StdError;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use crate::asset::asset_manager::ZipAssetManager;
 use crate::auth::token_auth::TokenAuthorization;
@@ -33,9 +33,9 @@ mod token_api;
 mod ui_api;
 
 pub struct HttpServerState {
-    pub storage: Storage,
+    pub storage: RwLock<Storage>,
     pub auth: TokenAuthorization,
-    pub token_repo: Box<dyn ManageTokens + Send + Sync>,
+    pub token_repo: RwLock<Box<dyn ManageTokens + Send + Sync>>,
     pub console: ZipAssetManager,
     pub base_path: String,
 }
@@ -78,7 +78,7 @@ impl From<axum::Error> for HttpError {
     }
 }
 
-pub fn create_axum_app(api_base_path: &String, components: HttpServerState) -> Router {
+pub fn create_axum_app(api_base_path: &String, components: Arc<HttpServerState>) -> Router {
     let b_route = create_bucket_api_routes().merge(create_entry_api_routes());
 
     let app = Router::new()
@@ -99,7 +99,7 @@ pub fn create_axum_app(api_base_path: &String, components: HttpServerState) -> R
         .fallback(get(show_ui))
         .layer(from_fn(default_headers))
         .layer(from_fn(print_statuses))
-        .with_state(Arc::new(RwLock::new(components)));
+        .with_state(components);
     app
 }
 
@@ -124,13 +124,13 @@ mod tests {
     use super::*;
 
     #[fixture]
-    pub(crate) fn components() -> Arc<RwLock<HttpServerState>> {
+    pub(crate) fn components() -> Arc<HttpServerState> {
         let data_path = tempfile::tempdir().unwrap().into_path();
 
         let mut components = HttpServerState {
-            storage: Storage::new(PathBuf::from(data_path.clone())),
+            storage: RwLock::new(Storage::new(PathBuf::from(data_path.clone()))),
             auth: TokenAuthorization::new("inti-token"),
-            token_repo: create_token_repository(data_path.clone(), "init-token"),
+            token_repo: RwLock::new(create_token_repository(data_path.clone(), "init-token")),
             console: ZipAssetManager::new(include_bytes!(concat!(env!("OUT_DIR"), "/console.zip"))),
             base_path: "/".to_string(),
         };
@@ -168,7 +168,7 @@ mod tests {
             .create_token("test", permissions)
             .unwrap();
 
-        Arc::new(RwLock::new(components))
+        Arc::new(components)
     }
 
     #[fixture]

--- a/reductstore/src/http_frontend/bucket_api.rs
+++ b/reductstore/src/http_frontend/bucket_api.rs
@@ -9,7 +9,7 @@ mod head;
 mod remove;
 mod update;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use axum::extract::FromRequest;
 use axum::headers::HeaderMapExt;

--- a/reductstore/src/http_frontend/bucket_api.rs
+++ b/reductstore/src/http_frontend/bucket_api.rs
@@ -112,7 +112,7 @@ where
     }
 }
 
-pub fn create_bucket_api_routes() -> axum::Router<Arc<RwLock<HttpServerState>>> {
+pub fn create_bucket_api_routes() -> axum::Router<Arc<HttpServerState>> {
     axum::Router::new()
         .route("/:bucket_name", get(get_bucket))
         .route("/:bucket_name", head(head_bucket))

--- a/reductstore/src/http_frontend/bucket_api/create.rs
+++ b/reductstore/src/http_frontend/bucket_api/create.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::HttpServerState;
 use crate::storage::proto::BucketSettings;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // POST /b/:bucket_name
 pub async fn create_bucket(
@@ -39,7 +39,7 @@ mod tests {
 
     use rstest::rstest;
 
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/http_frontend/bucket_api/get.rs
+++ b/reductstore/src/http_frontend/bucket_api/get.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::HttpServerState;
 use crate::storage::proto::FullBucketInfo;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // GET /b/:bucket_name
 pub async fn get_bucket(
@@ -37,7 +37,7 @@ mod tests {
 
     use rstest::rstest;
 
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/http_frontend/bucket_api/head.rs
+++ b/reductstore/src/http_frontend/bucket_api/head.rs
@@ -9,7 +9,7 @@ use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerState;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // HEAD /b/:bucket_name
 pub async fn head_bucket(
@@ -32,7 +32,7 @@ mod tests {
 
     use rstest::rstest;
 
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/http_frontend/bucket_api/head.rs
+++ b/reductstore/src/http_frontend/bucket_api/head.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_head_bucket(components: HttpServerState, headers: HeaderMap) {
+    async fn test_head_bucket(components: Arc<HttpServerState>, headers: HeaderMap) {
         head_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();

--- a/reductstore/src/http_frontend/bucket_api/head.rs
+++ b/reductstore/src/http_frontend/bucket_api/head.rs
@@ -13,13 +13,12 @@ use std::sync::{Arc, RwLock};
 
 // HEAD /b/:bucket_name
 pub async fn head_bucket(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
-    check_permissions(Arc::clone(&components), headers, AuthenticatedPolicy {})?;
-    let mut components = components.write().unwrap();
-    components.storage.get_bucket(&bucket_name)?;
+    check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
+    components.storage.read().await.get_bucket(&bucket_name)?;
     Ok(())
 }
 
@@ -37,7 +36,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_head_bucket(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_head_bucket(components: HttpServerState, headers: HeaderMap) {
         head_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();

--- a/reductstore/src/http_frontend/bucket_api/remove.rs
+++ b/reductstore/src/http_frontend/bucket_api/remove.rs
@@ -47,7 +47,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket(components: HttpServerState, headers: HeaderMap) {
+    async fn test_remove_bucket(components: Arc<HttpServerState>, headers: HeaderMap) {
         remove_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();
@@ -55,7 +55,10 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket_from_permission(components: HttpServerState, headers: HeaderMap) {
+    async fn test_remove_bucket_from_permission(
+        components: Arc<HttpServerState>,
+        headers: HeaderMap,
+    ) {
         let token = components
             .token_repo
             .read()

--- a/reductstore/src/http_frontend/bucket_api/remove.rs
+++ b/reductstore/src/http_frontend/bucket_api/remove.rs
@@ -10,19 +10,25 @@ use crate::http_frontend::HttpServerState;
 
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
+use bytes::Buf;
 use std::sync::{Arc, RwLock};
 
 // DELETE /b/:bucket_name
 pub async fn remove_bucket(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
-    check_permissions(Arc::clone(&components), headers, FullAccessPolicy {})?;
-    let mut components = components.write().unwrap();
-    components.storage.remove_bucket(&bucket_name)?;
+    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    components
+        .storage
+        .write()
+        .await
+        .remove_bucket(&bucket_name)?;
     components
         .token_repo
+        .write()
+        .await
         .remove_bucket_from_tokens(&bucket_name)?;
     Ok(())
 }
@@ -41,7 +47,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_remove_bucket(components: HttpServerState, headers: HeaderMap) {
         remove_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();
@@ -49,14 +55,11 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket_from_permission(
-        components: Arc<RwLock<HttpServerState>>,
-        headers: HeaderMap,
-    ) {
+    async fn test_remove_bucket_from_permission(components: HttpServerState, headers: HeaderMap) {
         let token = components
-            .read()
-            .unwrap()
             .token_repo
+            .read()
+            .await
             .find_by_name("test")
             .unwrap();
         assert_eq!(
@@ -65,7 +68,7 @@ mod tests {
         );
 
         remove_bucket(
-            State(Arc::clone(&components)),
+            State(components.clone()),
             Path("bucket-1".to_string()),
             headers.clone(),
         )
@@ -73,9 +76,9 @@ mod tests {
         .unwrap();
 
         let token = components
-            .read()
-            .unwrap()
             .token_repo
+            .read()
+            .await
             .find_by_name("test")
             .unwrap();
         assert_eq!(

--- a/reductstore/src/http_frontend/bucket_api/remove.rs
+++ b/reductstore/src/http_frontend/bucket_api/remove.rs
@@ -10,8 +10,8 @@ use crate::http_frontend::HttpServerState;
 
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use bytes::Buf;
-use std::sync::{Arc, RwLock};
+
+use std::sync::Arc;
 
 // DELETE /b/:bucket_name
 pub async fn remove_bucket(
@@ -43,7 +43,7 @@ mod tests {
 
     use rstest::rstest;
 
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/http_frontend/bucket_api/update.rs
+++ b/reductstore/src/http_frontend/bucket_api/update.rs
@@ -14,15 +14,17 @@ use std::sync::{Arc, RwLock};
 
 // PUT /b/:bucket_name
 pub async fn update_bucket(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
     settings: BucketSettings,
 ) -> Result<(), HttpError> {
-    check_permissions(Arc::clone(&components), headers, FullAccessPolicy {})?;
-    let mut components = components.write().unwrap();
-    let bucket = components.storage.get_bucket(&bucket_name)?;
-    bucket.set_settings(settings.into())
+    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    let mut storage = components.storage.write().await;
+
+    storage
+        .get_mut_bucket(&bucket_name)?
+        .set_settings(settings.into())
 }
 
 #[cfg(test)]
@@ -40,7 +42,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_update_bucket(components: HttpServerState, headers: HeaderMap) {
         update_bucket(
             State(components),
             Path("bucket-1".to_string()),

--- a/reductstore/src/http_frontend/bucket_api/update.rs
+++ b/reductstore/src/http_frontend/bucket_api/update.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::HttpServerState;
 use crate::storage::proto::BucketSettings;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // PUT /b/:bucket_name
 pub async fn update_bucket(
@@ -38,7 +38,7 @@ mod tests {
 
     use rstest::rstest;
 
-    use std::sync::{Arc, RwLock};
+    use std::sync::Arc;
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/http_frontend/bucket_api/update.rs
+++ b/reductstore/src/http_frontend/bucket_api/update.rs
@@ -42,7 +42,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket(components: HttpServerState, headers: HeaderMap) {
+    async fn test_update_bucket(components: Arc<HttpServerState>, headers: HeaderMap) {
         update_bucket(
             State(components),
             Path("bucket-1".to_string()),

--- a/reductstore/src/http_frontend/entry_api.rs
+++ b/reductstore/src/http_frontend/entry_api.rs
@@ -23,7 +23,7 @@ use axum::headers::HeaderMapExt;
 use axum::routing::{get, head, post};
 
 use crate::storage::storage::Storage;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use crate::core::status::HttpError;
 use crate::http_frontend::entry_api::read_batched::read_batched_records;

--- a/reductstore/src/http_frontend/entry_api/query.rs
+++ b/reductstore/src/http_frontend/entry_api/query.rs
@@ -17,7 +17,7 @@ use axum::headers::HeaderMap;
 
 use std::collections::HashMap;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use std::time::Duration;
 
@@ -86,7 +86,7 @@ pub async fn query(
     }
 
     let mut storage = components.storage.write().await;
-    let mut bucket = storage.get_mut_bucket(bucket_name)?;
+    let bucket = storage.get_mut_bucket(bucket_name)?;
     let entry = bucket.get_or_create_entry(entry_name)?;
     let id = entry.query(
         start,

--- a/reductstore/src/http_frontend/entry_api/query.rs
+++ b/reductstore/src/http_frontend/entry_api/query.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 // GET /:bucket/:entry/q?start=<number>&stop=<number>&continue=<number>&exclude-<label>=<value>&include-<label>=<value>&ttl=<number>
 pub async fn query(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -32,16 +32,17 @@ pub async fn query(
     let entry_name = path.get("entry_name").unwrap();
 
     check_permissions(
-        Arc::clone(&components),
+        &components,
         headers,
         ReadAccessPolicy {
             bucket: bucket_name.clone(),
         },
-    )?;
+    )
+    .await?;
 
     let entry_info = {
-        let mut components = components.write().unwrap();
-        let bucket = components.storage.get_bucket(bucket_name)?;
+        let mut storage = components.storage.write().await;
+        let bucket = storage.get_mut_bucket(bucket_name)?;
         bucket.get_entry(entry_name)?.info()?
     };
 
@@ -84,8 +85,8 @@ pub async fn query(
         }
     }
 
-    let mut components = components.write().unwrap();
-    let bucket = components.storage.get_bucket(bucket_name)?;
+    let mut storage = components.storage.write().await;
+    let mut bucket = storage.get_mut_bucket(bucket_name)?;
     let entry = bucket.get_or_create_entry(entry_name)?;
     let id = entry.query(
         start,

--- a/reductstore/src/http_frontend/entry_api/read_batched.rs
+++ b/reductstore/src/http_frontend/entry_api/read_batched.rs
@@ -209,7 +209,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_batched_read(
-        components: Arc<RwLock<HttpServerState>>,
+        components: Arc<HttpServerState>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,
@@ -217,12 +217,12 @@ mod tests {
     ) {
         let query_id = {
             components
-                .write()
-                .unwrap()
                 .storage
-                .get_bucket(path_to_entry_1.get("bucket_name").unwrap())
+                .write()
+                .await
+                .get_mut_bucket(path_to_entry_1.get("bucket_name").unwrap())
                 .unwrap()
-                .get_entry(path_to_entry_1.get("entry_name").unwrap())
+                .get_mut_entry(path_to_entry_1.get("entry_name").unwrap())
                 .unwrap()
                 .query(0, u64::MAX, QueryOptions::default())
                 .unwrap()

--- a/reductstore/src/http_frontend/entry_api/read_batched.rs
+++ b/reductstore/src/http_frontend/entry_api/read_batched.rs
@@ -16,7 +16,7 @@ use axum::body::StreamBody;
 use axum::extract::{Path, Query, State};
 use axum::headers::{HeaderMap, HeaderName, HeaderValue};
 use axum::response::IntoResponse;
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use futures_util::Stream;
 
 use std::collections::HashMap;

--- a/reductstore/src/http_frontend/entry_api/read_single.rs
+++ b/reductstore/src/http_frontend/entry_api/read_single.rs
@@ -48,7 +48,7 @@ pub async fn read_single_record(
     let (query_id, ts) =
         check_and_extract_ts_or_query_id(&storage, params, bucket_name, entry_name)?;
 
-    let mut bucket = storage.get_mut_bucket(bucket_name)?;
+    let bucket = storage.get_mut_bucket(bucket_name)?;
     fetch_and_response_single_record(bucket, entry_name, ts, query_id, method.name() == "HEAD")
 }
 
@@ -148,7 +148,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_single_read_ts(
-        components: Arc<RwLock<HttpServerState>>,
+        components: Arc<HttpServerState>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,
@@ -184,7 +184,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_single_read_query(
-        components: Arc<RwLock<HttpServerState>>,
+        components: Arc<HttpServerState>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,
@@ -192,12 +192,12 @@ mod tests {
     ) {
         let query_id = {
             components
-                .write()
-                .unwrap()
                 .storage
-                .get_bucket(path_to_entry_1.get("bucket_name").unwrap())
+                .write()
+                .await
+                .get_mut_bucket(path_to_entry_1.get("bucket_name").unwrap())
                 .unwrap()
-                .get_entry(path_to_entry_1.get("entry_name").unwrap())
+                .get_mut_entry(path_to_entry_1.get("entry_name").unwrap())
                 .unwrap()
                 .query(0, u64::MAX, QueryOptions::default())
                 .unwrap()

--- a/reductstore/src/http_frontend/entry_api/read_single.rs
+++ b/reductstore/src/http_frontend/entry_api/read_single.rs
@@ -26,7 +26,7 @@ use std::task::{Context, Poll};
 
 // GET /:bucket/:entry?ts=<number>|q=<number>|
 pub async fn read_single_record(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -35,27 +35,21 @@ pub async fn read_single_record(
     let bucket_name = path.get("bucket_name").unwrap();
     let entry_name = path.get("entry_name").unwrap();
     check_permissions(
-        Arc::clone(&components),
+        &components,
         headers,
         ReadAccessPolicy {
             bucket: bucket_name.clone(),
         },
-    )?;
+    )
+    .await?;
+
+    let mut storage = components.storage.write().await;
 
     let (query_id, ts) =
-        check_and_extract_ts_or_query_id(&components, params, bucket_name, entry_name)?;
+        check_and_extract_ts_or_query_id(&storage, params, bucket_name, entry_name)?;
 
-    fetch_and_response_single_record(
-        components
-            .write()
-            .unwrap()
-            .storage
-            .get_bucket(bucket_name)?,
-        entry_name,
-        ts,
-        query_id,
-        method.name() == "HEAD",
-    )
+    let mut bucket = storage.get_mut_bucket(bucket_name)?;
+    fetch_and_response_single_record(bucket, entry_name, ts, query_id, method.name() == "HEAD")
 }
 
 fn fetch_and_response_single_record(

--- a/reductstore/src/http_frontend/entry_api/write.rs
+++ b/reductstore/src/http_frontend/entry_api/write.rs
@@ -8,14 +8,14 @@ use crate::core::status::HttpError;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerState;
 use crate::storage::entry::Labels;
-use crate::storage::writer::{Chunk, RecordWriter};
+use crate::storage::writer::Chunk;
 use axum::extract::{BodyStream, Path, Query, State};
 use axum::headers::{Expect, Header, HeaderMap};
 use bytes::Bytes;
 use futures_util::StreamExt;
 use log::{debug, error};
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // POST /:bucket/:entry?ts=<number>
 pub async fn write_record(

--- a/reductstore/src/http_frontend/entry_api/write.rs
+++ b/reductstore/src/http_frontend/entry_api/write.rs
@@ -144,7 +144,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_write_with_label_ok(
-        components: Arc<RwLock<HttpServerState>>,
+        components: Arc<HttpServerState>,
         headers: HeaderMap,
         path_to_entry_1: Path<HashMap<String, String>>,
     ) {
@@ -166,9 +166,9 @@ mod tests {
         .unwrap();
 
         let record = components
-            .write()
-            .unwrap()
             .storage
+            .read()
+            .await
             .get_bucket("bucket-1")
             .unwrap()
             .begin_read("entry-1", 1)

--- a/reductstore/src/http_frontend/middleware.rs
+++ b/reductstore/src/http_frontend/middleware.rs
@@ -4,7 +4,6 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use axum::http::{HeaderMap, Request};
-use std::sync::{Arc, RwLock};
 
 use crate::auth::policy::Policy;
 use crate::core::status::HttpError;

--- a/reductstore/src/http_frontend/middleware.rs
+++ b/reductstore/src/http_frontend/middleware.rs
@@ -57,20 +57,19 @@ pub async fn print_statuses<B>(
     Ok(response)
 }
 
-pub fn check_permissions<P>(
-    components: Arc<RwLock<HttpServerState>>,
+pub async fn check_permissions<P>(
+    components: &HttpServerState,
     headers: HeaderMap,
     policy: P,
 ) -> Result<(), HttpError>
 where
     P: Policy,
 {
-    let components = components.read().unwrap();
     components.auth.check(
         headers
             .get("Authorization")
             .map(|header| header.to_str().unwrap()),
-        components.token_repo.as_ref(),
+        components.token_repo.read().await.as_ref(),
         policy,
     )?;
     Ok(())

--- a/reductstore/src/http_frontend/server_api.rs
+++ b/reductstore/src/http_frontend/server_api.rs
@@ -7,7 +7,7 @@ mod info;
 mod list;
 mod me;
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use axum::headers;
 use axum::headers::HeaderMapExt;

--- a/reductstore/src/http_frontend/server_api.rs
+++ b/reductstore/src/http_frontend/server_api.rs
@@ -54,7 +54,7 @@ impl IntoResponse for BucketInfoList {
     }
 }
 
-pub fn create_server_api_routes() -> axum::Router<Arc<RwLock<HttpServerState>>> {
+pub fn create_server_api_routes() -> axum::Router<Arc<HttpServerState>> {
     axum::Router::new()
         .route("/list", get(list::list))
         .route("/me", get(me::me))

--- a/reductstore/src/http_frontend/server_api/info.rs
+++ b/reductstore/src/http_frontend/server_api/info.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_info(components: HttpServerState, headers: HeaderMap) {
+    async fn test_info(components: Arc<HttpServerState>, headers: HeaderMap) {
         let info = info(State(components), headers).await.unwrap();
         assert_eq!(info.bucket_count, 2);
     }

--- a/reductstore/src/http_frontend/server_api/info.rs
+++ b/reductstore/src/http_frontend/server_api/info.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::HttpServerState;
 use crate::storage::proto::ServerInfo;
 use axum::extract::State;
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // GET /info
 pub async fn info(

--- a/reductstore/src/http_frontend/server_api/info.rs
+++ b/reductstore/src/http_frontend/server_api/info.rs
@@ -14,11 +14,11 @@ use std::sync::{Arc, RwLock};
 
 // GET /info
 pub async fn info(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     headers: HeaderMap,
 ) -> Result<ServerInfo, HttpError> {
-    check_permissions(Arc::clone(&components), headers, AuthenticatedPolicy {})?;
-    components.read().unwrap().storage.info()
+    check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
+    components.storage.read().await.info()
 }
 
 #[cfg(test)]
@@ -29,7 +29,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_info(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_info(components: HttpServerState, headers: HeaderMap) {
         let info = info(State(components), headers).await.unwrap();
         assert_eq!(info.bucket_count, 2);
     }

--- a/reductstore/src/http_frontend/server_api/list.rs
+++ b/reductstore/src/http_frontend/server_api/list.rs
@@ -14,11 +14,11 @@ use std::sync::{Arc, RwLock};
 
 // GET /list
 pub async fn list(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     headers: HeaderMap,
 ) -> Result<BucketInfoList, HttpError> {
-    check_permissions(Arc::clone(&components), headers, AuthenticatedPolicy {})?;
-    components.read().unwrap().storage.get_bucket_list()
+    check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
+    components.storage.read().await.get_bucket_list()
 }
 
 #[cfg(test)]
@@ -29,7 +29,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_list(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_list(components: HttpServerState, headers: HeaderMap) {
         let list = list(State(components), headers).await.unwrap();
         assert_eq!(list.buckets.len(), 2);
     }

--- a/reductstore/src/http_frontend/server_api/list.rs
+++ b/reductstore/src/http_frontend/server_api/list.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::HttpServerState;
 use crate::storage::proto::BucketInfoList;
 use axum::extract::State;
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // GET /list
 pub async fn list(

--- a/reductstore/src/http_frontend/server_api/list.rs
+++ b/reductstore/src/http_frontend/server_api/list.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_list(components: HttpServerState, headers: HeaderMap) {
+    async fn test_list(components: Arc<HttpServerState>, headers: HeaderMap) {
         let list = list(State(components), headers).await.unwrap();
         assert_eq!(list.buckets.len(), 2);
     }

--- a/reductstore/src/http_frontend/server_api/me.rs
+++ b/reductstore/src/http_frontend/server_api/me.rs
@@ -34,7 +34,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_me(components: HttpServerState, headers: HeaderMap) {
+    async fn test_me(components: Arc<HttpServerState>, headers: HeaderMap) {
         let token = me(State(components), headers).await.unwrap();
         assert_eq!(token.name, "init-token");
     }

--- a/reductstore/src/http_frontend/server_api/me.rs
+++ b/reductstore/src/http_frontend/server_api/me.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerState;
 use axum::extract::State;
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // // GET /me
 pub async fn me(

--- a/reductstore/src/http_frontend/token_api.rs
+++ b/reductstore/src/http_frontend/token_api.rs
@@ -18,7 +18,7 @@ use axum::headers::HeaderMapExt;
 use hyper::HeaderMap;
 
 use axum::routing::{delete, get, post};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use crate::auth::proto::token::Permissions;
 use crate::auth::proto::{Token, TokenCreateResponse, TokenRepo};

--- a/reductstore/src/http_frontend/token_api.rs
+++ b/reductstore/src/http_frontend/token_api.rs
@@ -89,7 +89,7 @@ where
     }
 }
 
-pub fn create_token_api_routes() -> axum::Router<Arc<RwLock<HttpServerState>>> {
+pub fn create_token_api_routes() -> axum::Router<Arc<HttpServerState>> {
     axum::Router::new()
         .route("/", get(list_tokens))
         .route("/:token_name", post(create_token))

--- a/reductstore/src/http_frontend/token_api/create.rs
+++ b/reductstore/src/http_frontend/token_api/create.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_token(components: HttpServerState, headers: HeaderMap) {
+    async fn test_create_token(components: Arc<HttpServerState>, headers: HeaderMap) {
         let token = create_token(
             State(components),
             Path("new-token".to_string()),

--- a/reductstore/src/http_frontend/token_api/create.rs
+++ b/reductstore/src/http_frontend/token_api/create.rs
@@ -11,7 +11,7 @@ use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerState;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // POST /tokens/:token_name
 pub async fn create_token(

--- a/reductstore/src/http_frontend/token_api/create.rs
+++ b/reductstore/src/http_frontend/token_api/create.rs
@@ -15,15 +15,18 @@ use std::sync::{Arc, RwLock};
 
 // POST /tokens/:token_name
 pub async fn create_token(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
     permissions: Permissions,
 ) -> Result<TokenCreateResponse, HttpError> {
-    check_permissions(Arc::clone(&components), headers, FullAccessPolicy {})?;
+    check_permissions(&components, headers, FullAccessPolicy {}).await?;
 
-    let mut components = components.write().unwrap();
-    components.token_repo.create_token(&token_name, permissions)
+    components
+        .token_repo
+        .write()
+        .await
+        .create_token(&token_name, permissions)
 }
 
 #[cfg(test)]
@@ -36,7 +39,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_token(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_create_token(components: HttpServerState, headers: HeaderMap) {
         let token = create_token(
             State(components),
             Path("new-token".to_string()),

--- a/reductstore/src/http_frontend/token_api/get.rs
+++ b/reductstore/src/http_frontend/token_api/get.rs
@@ -33,7 +33,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_token(components: HttpServerState, headers: HeaderMap) {
+    async fn test_get_token(components: Arc<HttpServerState>, headers: HeaderMap) {
         let token = get_token(State(components), Path("test".to_string()), headers)
             .await
             .unwrap();

--- a/reductstore/src/http_frontend/token_api/get.rs
+++ b/reductstore/src/http_frontend/token_api/get.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerState;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // GET /tokens/:token_name
 pub async fn get_token(

--- a/reductstore/src/http_frontend/token_api/get.rs
+++ b/reductstore/src/http_frontend/token_api/get.rs
@@ -14,14 +14,13 @@ use std::sync::{Arc, RwLock};
 
 // GET /tokens/:token_name
 pub async fn get_token(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<Token, HttpError> {
-    check_permissions(Arc::clone(&components), headers, FullAccessPolicy {})?;
+    check_permissions(&components, headers, FullAccessPolicy {}).await?;
 
-    let components = components.read().unwrap();
-    components.token_repo.find_by_name(&token_name)
+    components.token_repo.read().await.find_by_name(&token_name)
 }
 
 #[cfg(test)]
@@ -34,7 +33,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_token(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_get_token(components: HttpServerState, headers: HeaderMap) {
         let token = get_token(State(components), Path("test".to_string()), headers)
             .await
             .unwrap();

--- a/reductstore/src/http_frontend/token_api/list.rs
+++ b/reductstore/src/http_frontend/token_api/list.rs
@@ -10,7 +10,7 @@ use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerState;
 use axum::extract::State;
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // GET /tokens
 pub async fn list_tokens(

--- a/reductstore/src/http_frontend/token_api/list.rs
+++ b/reductstore/src/http_frontend/token_api/list.rs
@@ -38,7 +38,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_token_list(components: HttpServerState, headers: HeaderMap) {
+    async fn test_token_list(components: Arc<HttpServerState>, headers: HeaderMap) {
         let list = list_tokens(State(components), headers).await.unwrap();
         assert_eq!(list.tokens.len(), 2);
         assert_eq!(list.tokens[0].name, "init-token");

--- a/reductstore/src/http_frontend/token_api/remove.rs
+++ b/reductstore/src/http_frontend/token_api/remove.rs
@@ -9,7 +9,7 @@ use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::HttpServerState;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 // DELETE /tokens/:name
 pub async fn remove_token(

--- a/reductstore/src/http_frontend/token_api/remove.rs
+++ b/reductstore/src/http_frontend/token_api/remove.rs
@@ -35,7 +35,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_token(components: HttpServerState, headers: HeaderMap) {
+    async fn test_remove_token(components: Arc<HttpServerState>, headers: HeaderMap) {
         let token = remove_token(State(components), Path("test".to_string()), headers).await;
         assert!(token.is_ok());
     }

--- a/reductstore/src/http_frontend/token_api/remove.rs
+++ b/reductstore/src/http_frontend/token_api/remove.rs
@@ -13,14 +13,17 @@ use std::sync::{Arc, RwLock};
 
 // DELETE /tokens/:name
 pub async fn remove_token(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
-    check_permissions(Arc::clone(&components), headers, FullAccessPolicy {})?;
+    check_permissions(&components, headers, FullAccessPolicy {}).await?;
 
-    let mut components = components.write().unwrap();
-    components.token_repo.remove_token(&token_name)
+    components
+        .token_repo
+        .write()
+        .await
+        .remove_token(&token_name)
 }
 
 #[cfg(test)]
@@ -32,7 +35,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_token(components: Arc<RwLock<HttpServerState>>, headers: HeaderMap) {
+    async fn test_remove_token(components: HttpServerState, headers: HeaderMap) {
         let token = remove_token(State(components), Path("test".to_string()), headers).await;
         assert!(token.is_ok());
     }

--- a/reductstore/src/http_frontend/ui_api.rs
+++ b/reductstore/src/http_frontend/ui_api.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use hyper::Body;
 use log::debug;
 use mime_guess::mime;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 pub async fn redirect_to_index(
     State(components): State<Arc<HttpServerState>>,

--- a/reductstore/src/http_frontend/ui_api.rs
+++ b/reductstore/src/http_frontend/ui_api.rs
@@ -80,7 +80,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_img_decoding(components: Arc<RwLock<HttpServerState>>) {
+    async fn test_img_decoding(components: Arc<HttpServerState>) {
         let request = Request::get("/ui/favicon.png").body(Body::empty()).unwrap();
         let response = show_ui(State(components), request)
             .await

--- a/reductstore/src/http_frontend/ui_api.rs
+++ b/reductstore/src/http_frontend/ui_api.rs
@@ -19,19 +19,19 @@ use mime_guess::mime;
 use std::sync::{Arc, RwLock};
 
 pub async fn redirect_to_index(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
 ) -> impl IntoResponse {
-    let base_path = components.read().unwrap().base_path.clone();
+    let base_path = components.base_path.clone();
     let mut headers = HeaderMap::new();
     headers.insert(LOCATION, format!("{}ui/", base_path).parse().unwrap());
     (StatusCode::FOUND, headers, Bytes::new()).into_response()
 }
 
 pub async fn show_ui(
-    State(components): State<Arc<RwLock<HttpServerState>>>,
+    State(components): State<Arc<HttpServerState>>,
     request: Request<Body>,
 ) -> Result<impl IntoResponse, HttpError> {
-    let base_path = components.read().unwrap().base_path.clone();
+    let base_path = components.base_path.clone();
 
     let path = request.uri().path();
     if !path.starts_with(&format!("{}ui/", base_path)) {
@@ -45,11 +45,11 @@ pub async fn show_ui(
         path
     };
 
-    let content = match components.read().unwrap().console.read(&path) {
+    let content = match components.console.read(&path) {
         Ok(content) => Ok(content),
         Err(err) => {
             debug!("Failed to read {}: {}", path, err);
-            components.read().unwrap().console.read("index.html")
+            components.console.read("index.html")
         }
     };
 

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -243,7 +243,7 @@ impl Bucket {
     /// * `RecordReader` - The record reader to read the record content in chunks.
     /// * `HTTPError` - The error if any.
     pub fn begin_read(
-        &mut self,
+        &self,
         name: &str,
         time: u64,
     ) -> Result<Arc<RwLock<RecordReader>>, HttpError> {

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -148,8 +148,27 @@ impl Bucket {
     ///
     /// # Returns
     ///
+    /// * `&Entry` - The entry or an HTTPError
+    pub fn get_entry(&self, name: &str) -> Result<&Entry, HttpError> {
+        let entry = self.entries.get(name).ok_or_else(|| {
+            HttpError::not_found(&format!(
+                "Entry '{}' not found in bucket '{}'",
+                name, self.name
+            ))
+        })?;
+        Ok(entry)
+    }
+
+    /// Get an entry in the bucket
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the entry
+    ///
+    /// # Returns
+    ///
     /// * `&mut Entry` - The entry or an HTTPError
-    pub fn get_entry(&mut self, name: &str) -> Result<&mut Entry, HttpError> {
+    pub fn get_mut_entry(&mut self, name: &str) -> Result<&mut Entry, HttpError> {
         let entry = self.entries.get_mut(name).ok_or_else(|| {
             HttpError::not_found(&format!(
                 "Entry '{}' not found in bucket '{}'",
@@ -249,7 +268,7 @@ impl Bucket {
         name: &str,
         time: u64,
     ) -> Result<(Arc<RwLock<RecordReader>>, bool), HttpError> {
-        let entry = self.get_entry(name)?;
+        let entry = self.get_mut_entry(name)?;
         entry.next(time)
     }
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -618,7 +618,7 @@ mod tests {
     // Test begin_read
     #[rstest]
     #[test]
-    fn test_begin_read_empty(mut entry: Entry) {
+    fn test_begin_read_empty(entry: Entry) {
         let writer = entry.begin_read(1000);
         assert_eq!(
             writer.err(),

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -235,7 +235,7 @@ impl Entry {
     ///
     /// * `RecordReader` - The record reader to read the record content in chunks.
     /// * `HTTPError` - The error if any.
-    pub(crate) fn begin_read(&mut self, time: u64) -> Result<Arc<RwLock<RecordReader>>, HttpError> {
+    pub(crate) fn begin_read(&self, time: u64) -> Result<Arc<RwLock<RecordReader>>, HttpError> {
         debug!("Reading record for ts={}", time);
         let not_found_err = Err(HttpError::not_found(&format!(
             "No record with timestamp {}",

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -106,6 +106,24 @@ impl Storage {
         Ok(self.buckets.get_mut(name).unwrap())
     }
 
+    /// Get a bucket by name
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the bucket
+    ///
+    /// # Returns
+    ///
+    /// * `Bucket` - The bucket or an HTTPError
+    pub fn get_bucket(&self, name: &str) -> Result<&Bucket, HttpError> {
+        match self.buckets.get(name) {
+            Some(bucket) => Ok(bucket),
+            None => Err(HttpError::not_found(
+                format!("Bucket '{}' is not found", name).as_str(),
+            )),
+        }
+    }
+
     /// Get a bucket by name.
     ///
     /// # Arguments
@@ -115,7 +133,7 @@ impl Storage {
     /// # Returns
     ///
     /// * `Bucket` - The bucket or an HTTPError
-    pub fn get_bucket(&mut self, name: &str) -> Result<&mut Bucket, HttpError> {
+    pub fn get_mut_bucket(&mut self, name: &str) -> Result<&mut Bucket, HttpError> {
         match self.buckets.get_mut(name) {
             Some(bucket) => Ok(bucket),
             None => Err(HttpError::not_found(

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -256,7 +256,7 @@ mod tests {
                 .unwrap();
         }
 
-        let mut storage = Storage::new(path);
+        let storage = Storage::new(path);
         assert_eq!(
             storage.info().unwrap(),
             ServerInfo {
@@ -375,7 +375,7 @@ mod tests {
         let result = storage.remove_bucket("test");
         assert_eq!(result, Ok(()));
 
-        let mut storage = Storage::new(path);
+        let storage = Storage::new(path);
         let result = storage.get_bucket("test");
         assert_eq!(
             result.err(),

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_get_bucket_with_non_existing_name() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
+        let storage = Storage::new(tempdir().unwrap().into_path());
         let result = storage.get_bucket("test");
         assert_eq!(
             result.err(),


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Refactoring 

### What is the current behavior?

We're always locking all the components in the HTTP frontend.  

### What is the new behavior?

We lock only the storage and token repository separately by using `token::sync::RwLock`

### Does this PR introduce a breaking change?

No

### Other information:
