### PR TITLE
Default max records in block 256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Refactor `http_frontend` module, [PR-306](https://github.com/reductstore/reductstore/pull/306)
 - reductstore: Cache last block to reduce read operations, [PR-318](https://github.com/reductstore/reductstore/pull/318)
 - reductstore: Grained HTTP components, [PR-319](https://github.com/reductstore/reductstore/pull/319)
+- reductstore: Default maximum records in block 256, [PR-320](https://github.com/reductstore/reductstore/pull/320)
 - all: Organize workspaces, [PR-310](https://github.com/reductstore/reductstore/pull/310)
 
 ### Removed

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -12,7 +12,7 @@ def test__create_bucket_ok(base_url, session, bucket_name):
     assert resp.status_code == 200
 
     data = json.loads(resp.content)
-    assert data['settings'] == {"max_block_records": 1024, "max_block_size": 64000000,
+    assert data['settings'] == {"max_block_records": 256, "max_block_size": 64000000,
                                 "quota_type": "NONE", "quota_size": 0}
     assert data['info']['name'] == bucket_name
     assert len(data['entries']) == 0
@@ -60,7 +60,7 @@ def test__create_bucket_custom(base_url, session, bucket_name):
     assert resp.status_code == 200
 
     data = json.loads(resp.content)
-    assert data['settings'] == {"max_block_records": 1024, "max_block_size": 500, "quota_type": "NONE",
+    assert data['settings'] == {"max_block_records": 256, "max_block_size": 500, "quota_type": "NONE",
                                 "quota_size": 0}
 
 
@@ -136,7 +136,7 @@ def test__update_bucket_ok(base_url, session, bucket_name):
     assert resp.status_code == 200
     data = json.loads(resp.content)
 
-    new_settings.update({"quota_size": 0, 'max_block_records': 1024})
+    new_settings.update({"quota_size": 0, 'max_block_records': 256})
     assert data['settings'] == new_settings
 
 

--- a/api_tests/server_api_test.py
+++ b/api_tests/server_api_test.py
@@ -16,7 +16,7 @@ def test__get_info(base_url, session):
     assert int(data['latest_record']) >= 0
     assert int(data['oldest_record']) >= 0
 
-    assert data['defaults']['bucket'] == {'max_block_records': 1024, 'max_block_size': 64000000, 'quota_size': 0,
+    assert data['defaults']['bucket'] == {'max_block_records': 256, 'max_block_size': 64000000, 'quota_size': 0,
                                           'quota_type': 'NONE'}
     assert re.match(r"ReductStore 1\.\d+\.\d+", resp.headers['server'])
     assert resp.headers['Content-Type'] == "application/json"

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -21,7 +21,7 @@ use crate::storage::proto::{BucketInfo, BucketSettings, EntryInfo, FullBucketInf
 use crate::storage::reader::RecordReader;
 use crate::storage::writer::RecordWriter;
 
-const DEFAULT_MAX_RECORDS: u64 = 1024;
+const DEFAULT_MAX_RECORDS: u64 = 256;
 const DEFAULT_MAX_BLOCK_SIZE: u64 = 64000000;
 const SETTINGS_NAME: &str = "bucket.settings";
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Optimization

### What is the current behavior?

The current maximal number of records in a block is 1024. This is not optimal because encoding and decoding of Protobuf is an expensive operation. 

### What is the new behavior?

256 works 20% faster for writing, 200% for reading.  

### Does this PR introduce a breaking change?

No

### Other information:
