### PR TITLE
Fix partial bucket settings

### DIFF
--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -385,7 +385,7 @@ impl Bucket {
     }
 
     pub fn set_settings(&mut self, settings: BucketSettings) -> Result<(), HttpError> {
-        self.settings = Self::fill_settings(settings, Self::defaults());
+        self.settings = Self::fill_settings(settings, self.settings.clone());
         for entry in self.entries.values_mut() {
             entry.set_settings(EntrySettings {
                 max_block_size: self.settings.max_block_size.unwrap(),
@@ -468,6 +468,25 @@ mod tests {
         let default_settings = Bucket::defaults();
         let filled_settings = Bucket::fill_settings(settings, default_settings.clone());
         assert_eq!(filled_settings, default_settings);
+    }
+
+    #[rstest]
+    fn test_set_settings_partially(settings: BucketSettings, mut bucket: Bucket) {
+        let new_settings = BucketSettings {
+            max_block_size: Some(100),
+            quota_type: None,
+            quota_size: None,
+            max_block_records: None,
+        };
+
+        bucket.set_settings(new_settings).unwrap();
+        assert_eq!(bucket.settings().max_block_size.unwrap(), 100);
+        assert_eq!(bucket.settings().quota_type, settings.quota_type);
+        assert_eq!(bucket.settings().quota_size, settings.quota_size);
+        assert_eq!(
+            bucket.settings().max_block_records,
+            settings.max_block_records
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #324 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #324 

### What is the new behavior?

Instead of using the default settings, the `Bucket.set_settings` uses the current ones to fill the unset settings.

### Does this PR introduce a breaking change?

No

### Other information:
