### PR TITLE
reductstore,reduct-rs: Add limit parameter in query request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - reductstore: Build docker image for ARM32 platform, [PR-328](https://github.com/reductstore/reductstore/pull/328)
 - reductstore,reduct-rs: Removing entries from bucket, [PR-334](https://github.com/reductstore/reductstore/pull/334)
+- reductstore,reduct-rs: Limit parameter in query request, [PR-335](https://github.com/reductstore/reductstore/pull/335)
 - reduct-rs: Server API for Client SDK, [PR-321](https://github.com/reductstore/reductstore/pull/321)
 - reduct-rs: Token API for Client SDK, [PR-322](https://github.com/reductstore/reductstore/pull/322)
 - reduct-rs: Bucket API for Client SDK, [PR-323](https://github.com/reductstore/reductstore/pull/323)

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -275,6 +275,26 @@ def test_query_ttl(base_url, session, bucket):
     assert resp.status_code == 404
 
 
+def test_query_limit(base_url, session, bucket):
+    """Should limit number of records returned"""
+    ts = 1000
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    assert resp.status_code == 200
+
+    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 1000}', data="some_data")
+    assert resp.status_code == 200
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry/q?limit=1')
+    assert resp.status_code == 200
+
+    query_id = int(json.loads(resp.content)["id"])
+    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    assert resp.status_code == 200
+
+    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    assert resp.status_code == 204
+
+
 def test_query_with_include_and_exclude(base_url, session, bucket):
     """Should handle include and exclude labels"""
     resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', data="some_data1",
@@ -498,12 +518,13 @@ def test_remove_entry(base_url, session, bucket):
 
 @requires_env("API_TOKEN")
 def test_remove_with_bucket_write_permissions(base_url, session, bucket, token_without_permissions, token_read_bucket,
-                                token_write_bucket):
+                                              token_write_bucket):
     """Needs write permissions to remove entry"""
     resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', data="some_data1")
     assert resp.status_code == 200
 
-    resp = session.delete(f'{base_url}/b/{bucket}/entry', headers={'Authorization': f'Bearer {token_without_permissions}'})
+    resp = session.delete(f'{base_url}/b/{bucket}/entry',
+                          headers={'Authorization': f'Bearer {token_without_permissions}'})
     assert resp.status_code == 403
 
     resp = session.delete(f'{base_url}/b/{bucket}/entry', headers={'Authorization': f'Bearer {token_read_bucket}'})

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -223,6 +223,8 @@ GET /api/v1/:bucket/:entry/q?include-\<label1>=foo\&include-\<label2>=bar
 This would query records that have both `label1` equal to "foo" and `label2` equal to "bar".
 
 Since version 1.4, the method has the `continuous query` flag. If it is true, the current query will not be discarded if there are no records. A client can ask them later. The query will not be removed until its TTL has expired. The `stop` parameter is ignored for continuous queries.
+
+Since version 1.6, the method provides the `limit` query parameter. It limits the number of record in the query. If it is not set, the query is unlimited by default.
 {% endswagger-description %}
 
 {% swagger-parameter in="path" name=":bucket_name" required="true" %}
@@ -255,6 +257,10 @@ Query records that don't have a certain value of a label.
 
 {% swagger-parameter in="query" name="conitnuous" type="Boolean" required="false" %}
 Keep query if no records for the request
+{% endswagger-parameter %}
+
+{% swagger-parameter in="query" name="limit" type="Integer" required="false" %}
+Maximum number of records in the query. Default: unlimited.
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="" %}

--- a/reduct_rs/src/record/query.rs
+++ b/reduct_rs/src/record/query.rs
@@ -31,6 +31,7 @@ pub struct QueryBuilder {
     ttl: Option<Duration>,
     continuous: bool,
     head_only: bool,
+    limit: Option<u64>,
 
     bucket: String,
     entry: String,
@@ -47,6 +48,8 @@ impl QueryBuilder {
             ttl: None,
             continuous: false,
             head_only: false,
+            limit: None,
+
             bucket,
             entry,
             client,
@@ -134,6 +137,13 @@ impl QueryBuilder {
         self
     }
 
+    /// Set a limit for the query.
+    /// default: unlimited
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
     /// Set the query to be continuous.
     pub async fn send(self) -> Result<impl Stream<Item = Result<Record, HttpError>>, HttpError> {
         let mut url = format!("/b/{}/{}/q", self.bucket, self.entry);
@@ -158,6 +168,9 @@ impl QueryBuilder {
         }
         if self.continuous {
             url.push_str("?continuous=true");
+        }
+        if let Some(limit) = self.limit {
+            url.push_str(&format!("?limit={}", limit));
         }
 
         let response = self

--- a/reductstore/src/http_frontend/entry_api/query.rs
+++ b/reductstore/src/http_frontend/entry_api/query.rs
@@ -148,8 +148,7 @@ mod tests {
         )
         .await;
 
-        let result: QueryInfo = result.unwrap().into();
-        assert_eq!(result.id, 1);
+        let query: QueryInfo = result.unwrap().into();
 
         let mut storage = components.storage.write().await;
         let entry = storage
@@ -158,11 +157,11 @@ mod tests {
             .get_mut_entry("entry-1")
             .unwrap();
 
-        let (_, last) = entry.next(result.id).unwrap();
+        let (_, last) = entry.next(query.id).unwrap();
         assert!(last);
 
         assert_eq!(
-            entry.next(result.id).err().unwrap().status,
+            entry.next(query.id).err().unwrap().status,
             ErrorCode::NoContent
         );
     }

--- a/reductstore/src/http_frontend/entry_api/query.rs
+++ b/reductstore/src/http_frontend/entry_api/query.rs
@@ -85,6 +85,16 @@ pub async fn query(
         None => 5,
     };
 
+    let limit = match params.get("limit") {
+        Some(limit) => Some(limit.parse::<usize>().map_err(|_| {
+            HttpError::new(
+                ErrorCode::UnprocessableEntity,
+                "'limit' must unsigned integer",
+            )
+        })?),
+        None => None,
+    };
+
     let mut include = HashMap::new();
     let mut exclude = HashMap::new();
 
@@ -107,9 +117,77 @@ pub async fn query(
             include,
             exclude,
             ttl: Duration::from_secs(ttl),
-            limit: None,
+            limit,
         },
     )?;
 
     Ok(QueryInfoAxum::from(QueryInfo { id }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http_frontend::tests::{components, headers, path_to_entry_1};
+    use rstest::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_limited_query(
+        components: Arc<HttpServerState>,
+        path_to_entry_1: Path<HashMap<String, String>>,
+        headers: HeaderMap,
+    ) {
+        let mut params = HashMap::new();
+        params.insert("limit".to_string(), "1".to_string());
+
+        let result = query(
+            State(Arc::clone(&components)),
+            path_to_entry_1,
+            Query(params),
+            headers,
+        )
+        .await;
+
+        let result: QueryInfo = result.unwrap().into();
+        assert_eq!(result.id, 1);
+
+        let mut storage = components.storage.write().await;
+        let mut entry = storage
+            .get_mut_bucket("bucket-1")
+            .unwrap()
+            .get_mut_entry("entry-1")
+            .unwrap();
+
+        let (_, last) = entry.next(result.id).unwrap();
+        assert!(last);
+
+        assert_eq!(
+            entry.next(result.id).err().unwrap().status,
+            ErrorCode::NoContent
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_bad_limit(
+        components: Arc<HttpServerState>,
+        path_to_entry_1: Path<HashMap<String, String>>,
+        headers: HeaderMap,
+    ) {
+        let mut params = HashMap::new();
+        params.insert("limit".to_string(), "a".to_string());
+
+        let result = query(
+            State(Arc::clone(&components)),
+            path_to_entry_1,
+            Query(params),
+            headers,
+        )
+        .await;
+
+        assert_eq!(
+            result.err().unwrap().0.status,
+            ErrorCode::UnprocessableEntity
+        );
+    }
 }

--- a/reductstore/src/http_frontend/entry_api/query.rs
+++ b/reductstore/src/http_frontend/entry_api/query.rs
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(result.id, 1);
 
         let mut storage = components.storage.write().await;
-        let mut entry = storage
+        let entry = storage
             .get_mut_bucket("bucket-1")
             .unwrap()
             .get_mut_entry("entry-1")

--- a/reductstore/src/http_frontend/entry_api/query.rs
+++ b/reductstore/src/http_frontend/entry_api/query.rs
@@ -107,6 +107,7 @@ pub async fn query(
             include,
             exclude,
             ttl: Duration::from_secs(ttl),
+            limit: None,
         },
     )?;
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -417,7 +417,7 @@ impl Entry {
 
     fn remove_expired_query(&mut self) {
         self.queries
-            .retain(|_, query| query.state() == &QueryState::Running);
+            .retain(|_, query| matches!(query.state(), QueryState::Running(_)));
     }
 }
 

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -6,12 +6,15 @@
 pub mod base;
 mod continuous;
 mod historical;
+mod limited;
 
 use crate::storage::query::base::{Query, QueryOptions};
 
 /// Build a query.
 pub fn build_query(start: u64, stop: u64, options: QueryOptions) -> Box<dyn Query + Send + Sync> {
-    if options.continuous {
+    if let Some(_) = options.limit {
+        Box::new(limited::LimitedQuery::new(start, stop, options))
+    } else if options.continuous {
         Box::new(continuous::ContinuousQuery::new(start, options))
     } else {
         Box::new(historical::HistoricalQuery::new(start, stop, options))

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -46,7 +46,7 @@ pub trait Query {
         block_manager: &mut BlockManager,
     ) -> Result<(Arc<RwLock<RecordReader>>, bool), HttpError>;
 
-    /// Get the state of the query.reductstore-309
+    /// Get the state of the query.
     fn state(&self) -> &QueryState;
 }
 
@@ -59,7 +59,7 @@ pub struct QueryOptions {
     pub include: HashMap<String, String>,
     /// Exclude the records that match the key-value pairs.
     pub exclude: HashMap<String, String>,
-    /// If true, the query will never be donereductstore-309
+    /// If true, the query will never be done
     pub continuous: bool,
     /// The maximum number of records to return only for non-continuous queries.
     pub limit: Option<usize>,

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -70,18 +70,13 @@ impl Query for ContinuousQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
-    use prost_wkt_types::Timestamp;
+
     use rstest::rstest;
     use std::thread::sleep;
-    use tempfile::tempdir;
 
     use reduct_base::error::ErrorCode;
 
-    use crate::storage::block_manager::ManageBlock;
-    use crate::storage::proto::{record::State as RecordState, Record};
     use crate::storage::query::base::tests::block_manager_and_index;
-    use crate::storage::writer::Chunk;
 
     #[rstest]
     fn test_query(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, RwLock};
 pub struct ContinuousQuery {
     query: HistoricalQuery,
     next_start: u64,
+    count: usize,
     options: QueryOptions,
 }
 
@@ -28,6 +29,7 @@ impl ContinuousQuery {
         ContinuousQuery {
             query: HistoricalQuery::new(start, u64::MAX, options.clone()),
             next_start: start,
+            count: 0,
             options,
         }
     }
@@ -42,6 +44,7 @@ impl Query for ContinuousQuery {
         match self.query.next(block_indexes, block_manager) {
             Ok((record, last)) => {
                 self.next_start = record.read().unwrap().timestamp() + 1;
+                self.count += 1;
                 Ok((record, last))
             }
             Err(HttpError {
@@ -49,6 +52,7 @@ impl Query for ContinuousQuery {
                 ..
             }) => {
                 self.query = HistoricalQuery::new(self.next_start, u64::MAX, self.options.clone());
+                self.query.state = QueryState::Running(self.count);
                 Err(HttpError {
                     status: ErrorCode::NoContent,
                     message: "No content".to_string(),
@@ -68,22 +72,24 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use prost_wkt_types::Timestamp;
-
+    use rstest::rstest;
     use std::thread::sleep;
     use tempfile::tempdir;
 
-    use crate::storage::block_manager::ManageBlock;
-    use crate::storage::proto::{record::State as RecordState, Record};
-    use crate::storage::writer::Chunk;
     use reduct_base::error::ErrorCode;
 
-    #[test]
-    fn test_query() {
-        let (block_manager, block_indexes) = setup();
+    use crate::storage::block_manager::ManageBlock;
+    use crate::storage::proto::{record::State as RecordState, Record};
+    use crate::storage::query::base::tests::block_manager_and_index;
+    use crate::storage::writer::Chunk;
+
+    #[rstest]
+    fn test_query(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {
+        let (block_manager, block_indexes) = block_manager_and_index;
         let mut block_manager = block_manager.write().unwrap();
 
         let mut query = ContinuousQuery::new(
-            0,
+            900,
             QueryOptions {
                 ttl: std::time::Duration::from_millis(100),
                 continuous: true,
@@ -108,47 +114,9 @@ mod tests {
                 message: "No content".to_string(),
             })
         );
-        assert_eq!(query.state(), &QueryState::Running);
+        assert_eq!(query.state(), &QueryState::Running(1));
 
         sleep(std::time::Duration::from_millis(200));
         assert_eq!(query.state(), &QueryState::Expired);
-    }
-
-    fn setup() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
-        let dir = tempdir().unwrap().into_path();
-        let mut block_manager = BlockManager::new(dir);
-        let mut block = block_manager.start(0, 10).unwrap();
-
-        block.records.push(Record {
-            timestamp: Some(Timestamp {
-                seconds: 0,
-                nanos: 1000000,
-            }),
-            begin: 0,
-            end: 10,
-            state: RecordState::Finished as i32,
-            labels: vec![],
-            content_type: "".to_string(),
-        });
-
-        block.latest_record_time = Some(Timestamp {
-            seconds: 0,
-            nanos: 0,
-        });
-        block.size = 10;
-        block_manager.save(block.clone()).unwrap();
-
-        let bm_ref = Arc::new(RwLock::new(block_manager));
-        {
-            let writer = BlockManager::begin_write(Arc::clone(&bm_ref), &block, 0).unwrap();
-            writer
-                .write()
-                .unwrap()
-                .write(Chunk::Last(Bytes::from("0123456789")))
-                .unwrap();
-        }
-
-        bm_ref.write().unwrap().finish(&block).unwrap();
-        (Arc::clone(&bm_ref), BTreeSet::from([0]))
     }
 }

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -161,15 +161,13 @@ impl Query for HistoricalQuery {
 mod tests {
     use super::*;
     use crate::storage::proto::record;
-    use crate::storage::proto::record::Label;
-    use crate::storage::writer::Chunk;
+
     use bytes::Bytes;
-    use prost_wkt_types::Timestamp;
+
     use reduct_base::error::ErrorCode;
     use rstest::rstest;
     use std::collections::HashMap;
     use std::time::Duration;
-    use tempfile::tempdir;
 
     use crate::storage::query::base::tests::block_manager_and_index;
 

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -20,7 +20,7 @@ pub struct HistoricalQuery {
     block: Option<Block>,
     last_update: Instant,
     options: QueryOptions,
-    state: QueryState,
+    pub(in crate::storage::query) state: QueryState,
 }
 
 impl HistoricalQuery {
@@ -31,7 +31,7 @@ impl HistoricalQuery {
             block: None,
             last_update: Instant::now(),
             options,
-            state: QueryState::Running,
+            state: QueryState::Running(0),
         }
     }
 }
@@ -140,6 +140,11 @@ impl Query for HistoricalQuery {
             .iter()
             .position(|v| v.timestamp == record.timestamp)
             .unwrap();
+
+        if let QueryState::Running(idx) = &mut self.state {
+            *idx += 1;
+        }
+
         Ok((block_manager.begin_read(&block, record_idx)?, last))
     }
 
@@ -161,24 +166,26 @@ mod tests {
     use bytes::Bytes;
     use prost_wkt_types::Timestamp;
     use reduct_base::error::ErrorCode;
+    use rstest::rstest;
     use std::collections::HashMap;
-
     use std::time::Duration;
     use tempfile::tempdir;
 
-    #[test]
+    use crate::storage::query::base::tests::block_manager_and_index;
+
+    #[rstest]
     fn test_state() {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
-        assert_eq!(query.state(), &QueryState::Running);
+        assert_eq!(query.state(), &QueryState::Running(0));
         query.last_update = Instant::now() - Duration::from_secs(61);
         assert_eq!(query.state(), &QueryState::Expired);
     }
 
-    #[test]
-    fn test_query_ok_1_rec() {
+    #[rstest]
+    fn test_query_ok_1_rec(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
 
-        let (block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = block_manager_and_index;
         let mut block_manager = block_manager.write().unwrap();
         {
             let (reader, _) = query.next(&index, &mut block_manager).unwrap();
@@ -196,11 +203,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_query_ok_2_recs() {
+    #[rstest]
+    fn test_query_ok_2_recs(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {
         let mut query = HistoricalQuery::new(0, 1000, QueryOptions::default());
 
-        let (block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = block_manager_and_index;
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -232,11 +239,11 @@ mod tests {
         assert_eq!(query.state(), &QueryState::Done);
     }
 
-    #[test]
-    fn test_query_ok_3_recs() {
+    #[rstest]
+    fn test_query_ok_3_recs(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {
         let mut query = HistoricalQuery::new(0, 1001, QueryOptions::default());
 
-        let (block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = block_manager_and_index;
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -274,8 +281,8 @@ mod tests {
         assert_eq!(query.state(), &QueryState::Done);
     }
 
-    #[test]
-    fn test_query_include() {
+    #[rstest]
+    fn test_query_include(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {
         let mut query = HistoricalQuery::new(
             0,
             1001,
@@ -287,7 +294,7 @@ mod tests {
                 ..QueryOptions::default()
             },
         );
-        let (block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = block_manager_and_index;
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -311,8 +318,8 @@ mod tests {
         assert_eq!(query.state(), &QueryState::Done);
     }
 
-    #[test]
-    fn test_query_exclude() {
+    #[rstest]
+    fn test_query_exclude(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {
         let mut query = HistoricalQuery::new(
             0,
             1001,
@@ -325,7 +332,7 @@ mod tests {
             },
         );
 
-        let (block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = block_manager_and_index;
         let mut block_manager = block_manager.write().unwrap();
 
         {
@@ -359,11 +366,13 @@ mod tests {
         assert_eq!(query.state(), &QueryState::Done);
     }
 
-    #[test]
-    fn test_ignoring_errored_records() {
+    #[rstest]
+    fn test_ignoring_errored_records(
+        block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>),
+    ) {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
 
-        let (block_manager, index) = setup_2_blocks();
+        let (block_manager, index) = block_manager_and_index;
         let mut block_manager = block_manager.write().unwrap();
 
         let mut block = block_manager.load(*index.get(&0u64).unwrap()).unwrap();
@@ -377,123 +386,5 @@ mod tests {
                 message: "No content".to_string(),
             })
         );
-    }
-
-    fn setup_2_blocks() -> (Arc<RwLock<BlockManager>>, BTreeSet<u64>) {
-        let dir = tempdir().unwrap().into_path();
-        let mut block_manager = BlockManager::new(dir);
-        let mut block = block_manager.start(0, 10).unwrap();
-
-        block.records.push(Record {
-            timestamp: Some(Timestamp {
-                seconds: 0,
-                nanos: 0,
-            }),
-            begin: 0,
-            end: 10,
-            state: RecordState::Finished as i32,
-            labels: vec![
-                Label {
-                    name: "block".to_string(),
-                    value: "1".to_string(),
-                },
-                Label {
-                    name: "record".to_string(),
-                    value: "1".to_string(),
-                },
-            ],
-            content_type: "".to_string(),
-        });
-
-        block.records.push(Record {
-            timestamp: Some(Timestamp {
-                seconds: 0,
-                nanos: 5000,
-            }),
-            begin: 10,
-            end: 20,
-            state: RecordState::Finished as i32,
-            labels: vec![
-                Label {
-                    name: "block".to_string(),
-                    value: "1".to_string(),
-                },
-                Label {
-                    name: "record".to_string(),
-                    value: "2".to_string(),
-                },
-            ],
-            content_type: "".to_string(),
-        });
-
-        block.latest_record_time = Some(Timestamp {
-            seconds: 0,
-            nanos: 5000,
-        });
-        block.size = 20;
-        block_manager.save(block.clone()).unwrap();
-
-        let block_manager = Arc::new(RwLock::new(block_manager));
-        {
-            let writer = BlockManager::begin_write(Arc::clone(&block_manager), &block, 0).unwrap();
-            writer
-                .write()
-                .unwrap()
-                .write(Chunk::Last(Bytes::from("0123456789")))
-                .unwrap();
-        }
-
-        {
-            let writer = BlockManager::begin_write(Arc::clone(&block_manager), &block, 1).unwrap();
-            writer
-                .write()
-                .unwrap()
-                .write(Chunk::Last(Bytes::from("0123456789")))
-                .unwrap();
-        }
-
-        block_manager.write().unwrap().finish(&block).unwrap();
-
-        let mut block = block_manager.write().unwrap().start(1000, 10).unwrap();
-
-        block.records.push(Record {
-            timestamp: Some(Timestamp {
-                seconds: 0,
-                nanos: 1000_000,
-            }),
-            begin: 0,
-            end: 10,
-            state: RecordState::Finished as i32,
-            labels: vec![
-                Label {
-                    name: "block".to_string(),
-                    value: "2".to_string(),
-                },
-                Label {
-                    name: "record".to_string(),
-                    value: "1".to_string(),
-                },
-            ],
-            content_type: "".to_string(),
-        });
-
-        block.latest_record_time = Some(Timestamp {
-            seconds: 0,
-            nanos: 1000_000,
-        });
-        block.size = 10;
-        block_manager.write().unwrap().save(block.clone()).unwrap();
-
-        {
-            let writer = BlockManager::begin_write(Arc::clone(&block_manager), &block, 0).unwrap();
-            writer
-                .write()
-                .unwrap()
-                .write(Chunk::Last(Bytes::from("0123456789")))
-                .unwrap();
-        }
-
-        block_manager.write().unwrap().finish(&block).unwrap();
-        (block_manager, BTreeSet::from([0, 1000]))
     }
 }

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -1,0 +1,94 @@
+// Copyright 2023 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::storage::block_manager::BlockManager;
+use crate::storage::query::base::QueryState::Running;
+use crate::storage::query::base::{Query, QueryOptions, QueryState};
+use crate::storage::query::historical::HistoricalQuery;
+use crate::storage::reader::RecordReader;
+use reduct_base::error::{ErrorCode, HttpError};
+use std::collections::BTreeSet;
+use std::sync::{Arc, RwLock};
+
+/// A query that is limited to a certain number of records.
+pub(crate) struct LimitedQuery {
+    query: HistoricalQuery,
+    options: QueryOptions,
+}
+
+impl LimitedQuery {
+    pub fn new(start: u64, stop: u64, options: QueryOptions) -> LimitedQuery {
+        LimitedQuery {
+            query: HistoricalQuery::new(start, stop, options.clone()),
+            options,
+        }
+    }
+}
+
+impl Query for LimitedQuery {
+    fn next(
+        &mut self,
+        block_indexes: &BTreeSet<u64>,
+        block_manager: &mut BlockManager,
+    ) -> Result<(Arc<RwLock<RecordReader>>, bool), HttpError> {
+        // TODO: It could be done better, maybe it make sense to move the limit into HistoricalQuery instead of manipulating the state here.
+        if let QueryState::Done = self.state() {
+            return Err(HttpError {
+                status: ErrorCode::NoContent,
+                message: "No content".to_string(),
+            });
+        }
+
+        let (reader, last) = self.query.next(block_indexes, block_manager)?;
+
+        if let Running(count) = self.state() {
+            if *count >= self.options.limit.unwrap() {
+                self.query.state = QueryState::Done;
+                return Ok((reader, true));
+            }
+        }
+
+        Ok((reader, last))
+    }
+
+    fn state(&self) -> &QueryState {
+        self.query.state()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::base::tests::block_manager_and_index;
+    use reduct_base::error::ErrorCode;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_limit(block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>)) {
+        let (mut block_manager, block_indexes) = block_manager_and_index;
+        let mut block_manager = block_manager.write().unwrap();
+
+        let mut query = LimitedQuery::new(
+            0,
+            u64::MAX,
+            QueryOptions {
+                limit: Some(1),
+                ..Default::default()
+            },
+        );
+
+        let (reader, last) = query.next(&block_indexes, &mut block_manager).unwrap();
+        assert_eq!(reader.read().unwrap().timestamp(), 0);
+        assert!(last);
+
+        assert_eq!(
+            query.next(&block_indexes, &mut block_manager).err(),
+            Some(HttpError {
+                status: ErrorCode::NoContent,
+                message: "No content".to_string(),
+            })
+        );
+    }
+}


### PR DESCRIPTION
Closes #309 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #309 

### What is the new behavior?

I've added the `limit` parameter to the `GET /api/v1/b/:bucket/:entry/q` endpoint and updated the Rust SDK.

### Does this PR introduce a breaking change?

No

### Other information:
