### PR TITLE
Security: update `rustls` with patched `rustls-webpki` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- reductstore: README and LICENSE in reductstore crate, [PR-357](https://github.com/reductstore/reductstore/pull/347)
+- reductstore: README and LICENSE in reductstore crate, [PR-347](https://github.com/reductstore/reductstore/pull/347)
+
+### Security
+
+- reductstore: Update `rustls` with patched `rustls-webpki`, [PR-349](https://github.com/reductstore/reductstore/pull/349)
 
 ## [1.6.0] - 2023-08-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "rustls 0.21.2",
+ "rustls 0.21.6",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
@@ -806,7 +806,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.2",
+ "rustls 0.21.6",
  "tokio",
  "tokio-rustls",
 ]
@@ -1471,6 +1471,7 @@ dependencies = [
  "reduct-base",
  "reqwest",
  "rstest 0.18.1",
+ "rustls 0.21.6",
  "serde",
  "serde_json",
  "tokio",
@@ -1501,7 +1502,7 @@ dependencies = [
  "reduct-macros",
  "regex",
  "rstest 0.17.0",
- "rustls 0.21.2",
+ "rustls 0.21.6",
  "serde",
  "serde_json",
  "tempfile",
@@ -1558,7 +1559,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.2",
+ "rustls 0.21.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1690,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -1711,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -2021,7 +2022,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.2",
+ "rustls 0.21.6",
  "tokio",
 ]
 

--- a/reduct_rs/Cargo.toml
+++ b/reduct_rs/Cargo.toml
@@ -23,6 +23,7 @@ reduct-base = { path = "../reduct_base", version = "1.6.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
+rustls = "0.21.6"
 chrono = { version = "0.4.11", features = ["serde"] }
 bytes = "1.4.0"
 futures = "0.3.17"

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -45,7 +45,7 @@ tower = "0.4.12"
 futures-util = "0.3.28"
 tokio-util = "0.7.8"
 axum-server = { version = "0.5.0", features = ["tls-rustls"] }
-rustls = "0.21.1"
+rustls = "0.21.6"
 mime_guess = "2.0.3"
 
 [build-dependencies]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Security update

### What is the current behavior?

See https://github.com/briansmith/webpki/issues/69

### What is the new behavior?

I've bumped version of `rustls` with the patched version.

### Does this PR introduce a breaking change?

No

### Other information:
