### PR TITLE
Add health-check to Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - reduct-cli: Add `alias` and `server` commands, [PR-343](https://github.com/reductstore/reductstore/pull/343)
 - reduct-rs: Add `ReductClient.url`, `ReductClient.token`, `ReductCientBuilder.try_build` [PR-350](https://github.com/reductstore/reductstore/pull/350)
-- reductstore: Add `healthchek` to buildx.Dockerfile, [PR-350](https://github.com/reductstore/reductstore/pull/350)
+- reductstore: Add `healthcheck` to buildx.Dockerfile, [PR-350](https://github.com/reductstore/reductstore/pull/350)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - reduct-cli: Add `alias` and `server` commands, [PR-343](https://github.com/reductstore/reductstore/pull/343)
+- reduct-rs:
+  Add `ReductClient.url`, `ReductClient.token`, `ReductCientBuilder.try_build` [PR-344](https://github.com/reductstore/reductstore/pull/344)
 
 ### Changed
 
 - reductstore: Update dependencies, min. rust v1.67.0, [PR-341](https://github.com/reductstore/reductstore/pull/341)
-- reductstore: use Web Console v1.3.0, [PR-342](https://github.com/reductstore/reductstore/pull/342)
+- reductstore: use Web Console v1.3.0, [PR-345](https://github.com/reductstore/reductstore/pull/342)
+- reduct-base: Rename `HttpError` -> `ReductError`, [PR-344](https://github.com/reductstore/reductstore/pull/344)
 
 ### Fixed
 
-- reduct-rs: Normalize instance URL in `ClientBuilder.url`, [PR-343](https://github.com/reductstore/reductstore/pull/343)
+- reduct-rs: Normalize instance URL
+  in `ClientBuilder.url`, [PR-343](https://github.com/reductstore/reductstore/pull/343)
 
 ## [1.6.1] - 2023-08-28
 
@@ -28,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- reductstore: Update `rustls` with patched `rustls-webpki`, [PR-349](https://github.com/reductstore/reductstore/pull/349)
+- reductstore: Update `rustls` with
+  patched `rustls-webpki`, [PR-349](https://github.com/reductstore/reductstore/pull/349)
 
 ## [1.6.0] - 2023-08-14
 
@@ -466,7 +471,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 
 - Searching start block in Entry List request, [PR-61](https://github.com/reductstore/reductstore/pull/61)
-- Qborting GET requests, [PR-64](https://github.com/reductstore/reductstore/pull/64)
+- Aborting GET requests, [PR-64](https://github.com/reductstore/reductstore/pull/64)
 
 ### Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - reduct-cli: Add `alias` and `server` commands, [PR-343](https://github.com/reductstore/reductstore/pull/343)
-- reduct-rs:
-  Add `ReductClient.url`, `ReductClient.token`, `ReductCientBuilder.try_build` [PR-344](https://github.com/reductstore/reductstore/pull/344)
+- reduct-rs: Add `ReductClient.url`, `ReductClient.token`, `ReductCientBuilder.try_build` [PR-350](https://github.com/reductstore/reductstore/pull/350)
+- reductstore: Add `healthchek` to buildx.Dockerfile, [PR-350](https://github.com/reductstore/reductstore/pull/350)
 
 ### Changed
 
 - reductstore: Update dependencies, min. rust v1.67.0, [PR-341](https://github.com/reductstore/reductstore/pull/341)
 - reductstore: use Web Console v1.3.0, [PR-345](https://github.com/reductstore/reductstore/pull/342)
-- reduct-base: Rename `HttpError` -> `ReductError`, [PR-344](https://github.com/reductstore/reductstore/pull/344)
+- reduct-base: Rename `HttpError` -> `ReductError`, [PR-350](https://github.com/reductstore/reductstore/pull/350)
 
 ### Fixed
 
-- reduct-rs: Normalize instance URL
-  in `ClientBuilder.url`, [PR-343](https://github.com/reductstore/reductstore/pull/343)
+- reduct-rs: Normalize instance URL in `ClientBuilder.url`, [PR-343](https://github.com/reductstore/reductstore/pull/343)
 
 ## [1.6.1] - 2023-08-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/buildx.Dockerfile
+++ b/buildx.Dockerfile
@@ -32,6 +32,7 @@ COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 
 RUN GIT_COMMIT=${GIT_COMMIT} cargo build --release --target ${CARGO_TARGET} --package reductstore
+RUN GIT_COMMIT=${GIT_COMMIT} cargo build --release --target ${CARGO_TARGET} --package reduct-cli
 
 RUN mkdir /data
 
@@ -39,7 +40,11 @@ FROM ubuntu:22.04
 
 ARG CARGO_TARGET
 COPY --from=builder /src/target/${CARGO_TARGET}/release/reductstore /usr/local/bin/reductstore
+COPY --from=builder /src/target/${CARGO_TARGET}/release/reduct-cli /usr/local/bin/reduct-cli
 COPY --from=builder /data /data
+
+HEALTHCHECK --interval=5s --timeout=3s \
+  CMD reduct-cli server alive http://localhost:8383 || exit 1
 
 EXPOSE 8383
 

--- a/reduct_base/Cargo.toml
+++ b/reduct_base/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 int-enum = "0.5.0"
 chrono = { version = "0.4.11", features = ["serde"] }
-
+url = "2.4.1"
 
 [dev-dependencies]
 rstest="0.18"

--- a/reduct_cli/src/cmd/server.rs
+++ b/reduct_cli/src/cmd/server.rs
@@ -23,10 +23,10 @@ pub(crate) async fn server_handler(
 ) -> anyhow::Result<()> {
     match matches {
         Some(("alive", args)) => {
-            alive::check_server(ctx, args.get_one::<String>("ALIAS").unwrap()).await?
+            alive::check_server(ctx, args.get_one::<String>("ALIAS_OR_URL").unwrap()).await?
         }
         Some(("status", args)) => {
-            status::get_server_status(ctx, args.get_one::<String>("ALIAS").unwrap()).await?
+            status::get_server_status(ctx, args.get_one::<String>("ALIAS_OR_URL").unwrap()).await?
         }
         _ => (),
     }

--- a/reduct_cli/src/cmd/server/alive.rs
+++ b/reduct_cli/src/cmd/server/alive.rs
@@ -10,11 +10,13 @@ use clap::{arg, Command};
 pub(super) fn check_server_cmd() -> Command {
     Command::new("alive")
         .about("Check if a ReductStore instance is alive")
-        .arg(arg!(<ALIAS> "Alias of the ReductStore instance to check").required(true))
+        .arg(
+            arg!(<ALIAS_OR_URL> "Alias or URL of the ReductStore instance to check").required(true),
+        )
 }
 
-pub(super) async fn check_server(ctx: &CliContext, alias: &str) -> anyhow::Result<()> {
-    let client = build_client(ctx, alias)?;
+pub(super) async fn check_server(ctx: &CliContext, alias_or_url: &str) -> anyhow::Result<()> {
+    let client = build_client(ctx, alias_or_url)?;
     client.alive().await?;
     Ok(())
 }
@@ -29,23 +31,5 @@ mod tests {
     #[tokio::test]
     async fn test_check_server(context: CliContext) {
         check_server(&context, "local").await.unwrap();
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_check_server_invalid_alias(context: CliContext) {
-        let result = check_server(&context, "invalid").await;
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Alias 'invalid' does not exist"
-        );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_check_server_no_connection(context: CliContext) {
-        let result = check_server(&context, "default").await;
-        assert!(result.is_err());
     }
 }

--- a/reduct_cli/src/cmd/server/status.rs
+++ b/reduct_cli/src/cmd/server/status.rs
@@ -10,7 +10,7 @@ use time_humanize::{Accuracy, HumanTime, Tense};
 pub(super) fn server_status_cmd() -> Command {
     Command::new("status")
         .about("Get the status of a ReductStore instance")
-        .arg(arg!(<ALIAS> "Alias of the ReductStore instance").required(true))
+        .arg(arg!(<ALIAS_OR_URL> "Alias or URL of the ReductStore instance").required(true))
 }
 
 pub(super) async fn get_server_status(
@@ -46,23 +46,5 @@ mod tests {
             format!("Version:\t{}", env!("CARGO_PKG_VERSION"))
         );
         assert!(context.output().history()[2].starts_with("Uptime: \t"));
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_get_server_status_invalid_alias(context: crate::context::CliContext) {
-        let result = get_server_status(&context, "invalid").await;
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "Alias 'invalid' does not exist"
-        );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_get_server_status_no_connection(context: crate::context::CliContext) {
-        let result = get_server_status(&context, "default").await;
-        assert!(result.is_err());
     }
 }

--- a/reduct_cli/src/context.rs
+++ b/reduct_cli/src/context.rs
@@ -115,7 +115,12 @@ pub(crate) mod tests {
     }
 
     #[fixture]
-    pub(crate) fn context(output: Box<dyn Output>) -> CliContext {
+    pub(crate) fn current_token() -> String {
+        std::env::var("RS_API_TOKEN").unwrap_or_default()
+    }
+
+    #[fixture]
+    pub(crate) fn context(output: Box<dyn Output>, current_token: String) -> CliContext {
         let tmp_dir = tempdir().unwrap();
         let ctx = ContextBuilder::new()
             .config_path(tmp_dir.into_path().join("config.toml").to_str().unwrap())
@@ -136,7 +141,7 @@ pub(crate) mod tests {
             "local".to_string(),
             Alias {
                 url: url::Url::parse("http://localhost:8383").unwrap(),
-                token: std::env::var("RS_API_TOKEN").unwrap_or_default(),
+                token: current_token,
             },
         );
         config_file.save().unwrap();

--- a/reduct_cli/src/reduct.rs
+++ b/reduct_cli/src/reduct.rs
@@ -5,14 +5,71 @@
 
 use crate::config::find_alias;
 use crate::context::CliContext;
+use anyhow::anyhow;
 use reduct_rs::ReductClient;
+use url::Url;
 
-pub(crate) fn build_client(ctx: &CliContext, alias: &str) -> anyhow::Result<ReductClient> {
-    let alias = find_alias(ctx, alias)?;
+/// Build a ReductStore client from an alias or URL
+pub(crate) fn build_client(ctx: &CliContext, alias_or_url: &str) -> anyhow::Result<ReductClient> {
+    let (url, token) = match find_alias(ctx, alias_or_url) {
+        Ok(alias) => (alias.url, alias.token),
+        Err(_) => {
+            if let Ok(mut url) = Url::parse(alias_or_url) {
+                let token = url.username().to_string();
+                url.set_username("").unwrap();
+                (url, token)
+            } else {
+                return Err(anyhow!("'{}' isn't an alias or a valid URL", alias_or_url));
+            }
+        }
+    };
 
     let client = ReductClient::builder()
-        .url(alias.url.as_str())
-        .api_token(alias.token.as_str())
-        .build();
+        .url(url.as_str())
+        .api_token(token.as_str())
+        .try_build()?;
     Ok(client)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::tests::{context, current_token};
+    use rstest::rstest;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_build_client(context: CliContext, current_token: String) {
+        let client = build_client(&context, "local").unwrap();
+        assert_eq!(client.url(), "http://localhost:8383");
+        assert_eq!(client.api_token(), current_token);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_build_client_with_url(context: CliContext) {
+        let client = build_client(&context, "http://localhost:8000").unwrap();
+        assert_eq!(client.url(), "http://localhost:8000");
+        assert_eq!(client.api_token(), "");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_build_client_with_url_and_token(context: CliContext) {
+        let client = build_client(&context, "http://sometoken@localhost:8000").unwrap();
+        assert_eq!(client.url(), "http://localhost:8000");
+        assert_eq!(client.api_token(), "sometoken");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_build_client_with_invalid_url(context: CliContext) {
+        assert!(build_client(&context, "xxx://localhost:8000/").is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_build_client_with_invalid_alias(context: CliContext) {
+        assert!(build_client(&context, "invalid").is_err());
+    }
 }

--- a/reduct_rs/examples/hallo_world.rs
+++ b/reduct_rs/examples/hallo_world.rs
@@ -4,14 +4,14 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use bytes::Bytes;
-use reduct_rs::{HttpError, ReductClient};
+use reduct_rs::{ReductClient, ReductError};
 use std::str::from_utf8;
 use std::time::SystemTime;
 
 use tokio;
 
 #[tokio::main]
-async fn main() -> Result<(), HttpError> {
+async fn main() -> Result<(), ReductError> {
     let client = ReductClient::builder().url("http://127.0.0.1:8383").build();
 
     let timestamp = SystemTime::now();

--- a/reduct_rs/examples/query.rs
+++ b/reduct_rs/examples/query.rs
@@ -5,13 +5,13 @@
 
 use bytes::Bytes;
 use futures_util::StreamExt;
-use reduct_rs::{HttpError, ReductClient};
+use reduct_rs::{ReductClient, ReductError};
 use std::str::from_utf8;
 
 use tokio;
 
 #[tokio::main]
-async fn main() -> Result<(), HttpError> {
+async fn main() -> Result<(), ReductError> {
     let client = ReductClient::builder().url("http://127.0.0.1:8383").build();
 
     println!("Server v{:?}", client.server_info().await?.version);

--- a/reduct_rs/src/lib.rs
+++ b/reduct_rs/src/lib.rs
@@ -13,4 +13,4 @@ pub use client::ReductClient;
 pub use record::read_record::ReadRecordBuilder;
 pub use record::write_record::WriteRecordBuilder;
 pub use record::{Labels, Record, RecordStream};
-pub use reduct_base::error::{ErrorCode, HttpError};
+pub use reduct_base::error::{ErrorCode, ReductError};

--- a/reduct_rs/src/record.rs
+++ b/reduct_rs/src/record.rs
@@ -12,7 +12,7 @@ use bytes::{Bytes, BytesMut};
 use futures::stream::Stream;
 
 use futures_util::StreamExt;
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
@@ -21,7 +21,7 @@ use std::pin::Pin;
 use std::time::SystemTime;
 
 pub type Labels = HashMap<String, String>;
-pub type RecordStream = Pin<Box<dyn Stream<Item = Result<Bytes, HttpError>>>>;
+pub type RecordStream = Pin<Box<dyn Stream<Item = Result<Bytes, ReductError>>>>;
 
 pub use write_record::WriteRecordBuilder;
 
@@ -74,7 +74,7 @@ impl Record {
     /// Content of the record
     ///
     /// This consumes the record and returns bytes
-    pub async fn bytes(mut self) -> Result<Bytes, HttpError> {
+    pub async fn bytes(mut self) -> Result<Bytes, ReductError> {
         if let Some(data) = &mut self.data {
             let mut bytes = BytesMut::new();
             while let Some(chunk) = data.next().await {
@@ -86,7 +86,7 @@ impl Record {
         }
     }
 
-    pub fn stream_bytes(self) -> Pin<Box<dyn Stream<Item = Result<Bytes, HttpError>>>> {
+    pub fn stream_bytes(self) -> Pin<Box<dyn Stream<Item = Result<Bytes, ReductError>>>> {
         if let Some(data) = self.data {
             return data;
         } else {

--- a/reduct_rs/src/record/query.rs
+++ b/reduct_rs/src/record/query.rs
@@ -13,7 +13,7 @@ use bytes::BytesMut;
 use chrono::Duration;
 use futures::Stream;
 use futures_util::{pin_mut, StreamExt};
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::QueryInfo;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Method;
@@ -145,7 +145,9 @@ impl QueryBuilder {
     }
 
     /// Set the query to be continuous.
-    pub async fn send(self) -> Result<impl Stream<Item = Result<Record, HttpError>>, HttpError> {
+    pub async fn send(
+        self,
+    ) -> Result<impl Stream<Item = Result<Record, ReductError>>, ReductError> {
         let mut url = format!("/b/{}/{}/q", self.bucket, self.entry);
         if let Some(start) = self.start {
             url.push_str(&format!("?start={}", start));
@@ -225,7 +227,7 @@ async fn parse_batched_records(
     headers: HeaderMap,
     rx: Receiver<Bytes>,
     head_only: bool,
-) -> Result<impl Stream<Item = Result<(Record, bool), HttpError>>, HttpError> {
+) -> Result<impl Stream<Item = Result<(Record, bool), ReductError>>, ReductError> {
     //sort headers by names
     let mut sorted_headers: Vec<_> = headers
         .clone()

--- a/reduct_rs/src/record/read_record.rs
+++ b/reduct_rs/src/record/read_record.rs
@@ -6,7 +6,7 @@
 use crate::http_client::{map_error, HttpClient};
 use crate::record::{from_system_time, Labels, Record};
 use futures_util::StreamExt;
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 use reqwest::Method;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -55,7 +55,7 @@ impl ReadRecordBuilder {
     /// # Returns
     ///
     /// A [`Record`] object containing the record data.
-    pub async fn send(self) -> Result<Record, HttpError> {
+    pub async fn send(self) -> Result<Record, ReductError> {
         let mut url = format!("/b/{}/{}", self.bucket, self.entry);
         if let Some(timestamp) = self.timestamp {
             url = format!("{}?ts={}", url, &timestamp.to_string());

--- a/reduct_rs/src/record/write_record.rs
+++ b/reduct_rs/src/record/write_record.rs
@@ -12,7 +12,7 @@ use futures::TryStream;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use reqwest::{Body, Method};
 
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -98,7 +98,7 @@ impl WriteRecordBuilder {
     }
 
     /// Send the write record request.
-    pub async fn send(self) -> Result<(), HttpError> {
+    pub async fn send(self) -> Result<(), ReductError> {
         let timestamp = self
             .timestamp
             .unwrap_or_else(|| from_system_time(SystemTime::now()));

--- a/reductstore/src/asset/asset_manager.rs
+++ b/reductstore/src/asset/asset_manager.rs
@@ -8,7 +8,7 @@ use std::io::{Cursor, Read};
 use tempfile::{tempdir, TempDir};
 use zip::ZipArchive;
 
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 
 /// Asset manager that reads files from a zip archive as hex string and returns them as string
 pub struct ZipAssetManager {
@@ -69,10 +69,10 @@ impl ZipAssetManager {
     /// # Returns
     ///
     /// The file content as string.
-    pub fn read(&self, relative_path: &str) -> Result<Bytes, HttpError> {
+    pub fn read(&self, relative_path: &str) -> Result<Bytes, ReductError> {
         if self.path.is_none() {
             // TODO: When C++ is gone, use trait and emtpy implementation
-            return Err(HttpError::not_found("No static files supported"));
+            return Err(ReductError::not_found("No static files supported"));
         }
 
         // check if file exists
@@ -80,7 +80,7 @@ impl ZipAssetManager {
 
         trace!("Reading file {:?}", path);
         if !path.exists() {
-            return Err(HttpError::not_found(
+            return Err(ReductError::not_found(
                 format!("File {:?} not found", path).as_str(),
             ));
         }
@@ -97,13 +97,13 @@ impl ZipAssetManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reduct_base::error::HttpError;
+    use reduct_base::error::ReductError;
 
     #[test]
     fn test_empty_asset_manager() {
         let asset_manager = ZipAssetManager::new(&[]);
         assert!(
-            asset_manager.read("test") == Err(HttpError::not_found("No static files supported"))
+            asset_manager.read("test") == Err(ReductError::not_found("No static files supported"))
         );
     }
 }

--- a/reductstore/src/auth/token_auth.rs
+++ b/reductstore/src/auth/token_auth.rs
@@ -3,7 +3,7 @@
 
 use crate::auth::policy::Policy;
 use crate::auth::token_repository::ManageTokens;
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 
 /// Authorization by token
 pub struct TokenAuthorization {
@@ -35,7 +35,7 @@ impl TokenAuthorization {
         authorization_header: Option<&str>,
         repo: &dyn ManageTokens,
         policy: Plc,
-    ) -> Result<(), HttpError>
+    ) -> Result<(), ReductError>
     where
         Plc: Policy,
     {
@@ -78,11 +78,13 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(HttpError::unauthorized("No bearer token in request header"))
+            Err(ReductError::unauthorized(
+                "No bearer token in request header"
+            ))
         );
 
         let result = auth.check(Some("Bearer invalid"), repo.as_ref(), FullAccessPolicy {});
-        assert_eq!(result, Err(HttpError::unauthorized("Invalid token")));
+        assert_eq!(result, Err(ReductError::unauthorized("Invalid token")));
 
         let result = auth.check(Some("Bearer test"), repo.as_ref(), FullAccessPolicy {});
         assert!(result.is_ok());

--- a/reductstore/src/http_frontend.rs
+++ b/reductstore/src/http_frontend.rs
@@ -22,7 +22,7 @@ use crate::http_frontend::server_api::create_server_api_routes;
 use crate::http_frontend::token_api::create_token_api_routes;
 use crate::http_frontend::ui_api::{redirect_to_index, show_ui};
 use crate::storage::storage::Storage;
-use reduct_base::error::HttpError as BaseHttpError;
+use reduct_base::error::ReductError as BaseHttpError;
 use reduct_macros::Twin;
 
 pub use reduct_base::error::ErrorCode;

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -3,7 +3,7 @@
 
 use crate::storage::block_manager::BlockManager;
 use crate::storage::reader::RecordReader;
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 
 use std::collections::{BTreeSet, HashMap};
 
@@ -42,7 +42,7 @@ pub trait Query {
         &mut self,
         block_indexes: &BTreeSet<u64>,
         block_manager: &mut BlockManager,
-    ) -> Result<(Arc<RwLock<RecordReader>>, bool), HttpError>;
+    ) -> Result<(Arc<RwLock<RecordReader>>, bool), ReductError>;
 
     /// Get the state of the query.
     fn state(&self) -> &QueryState;

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -10,7 +10,7 @@ use crate::storage::block_manager::{find_first_block, BlockManager, ManageBlock}
 use crate::storage::proto::{record::State as RecordState, ts_to_us, us_to_ts, Block, Record};
 use crate::storage::query::base::{Query, QueryOptions, QueryState};
 use crate::storage::reader::RecordReader;
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 
 pub struct HistoricalQuery {
     start_time: u64,
@@ -39,7 +39,7 @@ impl Query for HistoricalQuery {
         &mut self,
         block_index: &BTreeSet<u64>,
         block_manager: &mut BlockManager,
-    ) -> Result<(Arc<RwLock<RecordReader>>, bool), HttpError> {
+    ) -> Result<(Arc<RwLock<RecordReader>>, bool), ReductError> {
         self.last_update = Instant::now();
 
         let check_next_block = |start, stop| -> bool {
@@ -117,7 +117,7 @@ impl Query for HistoricalQuery {
 
         if records.is_empty() {
             self.state = QueryState::Done;
-            return Err(HttpError::no_content("No content"));
+            return Err(ReductError::no_content("No content"));
         }
 
         records.sort_by_key(|rec| ts_to_us(rec.timestamp.as_ref().unwrap()));
@@ -227,7 +227,7 @@ mod tests {
 
         assert_eq!(
             query.next(&index, &mut block_manager).err(),
-            Some(HttpError {
+            Some(ReductError {
                 status: ErrorCode::NoContent,
                 message: "No content".to_string(),
             })
@@ -269,7 +269,7 @@ mod tests {
         }
         assert_eq!(
             query.next(&index, &mut block_manager).err(),
-            Some(HttpError {
+            Some(ReductError {
                 status: ErrorCode::NoContent,
                 message: "No content".to_string(),
             })
@@ -306,7 +306,7 @@ mod tests {
 
         assert_eq!(
             query.next(&index, &mut block_manager).err(),
-            Some(HttpError {
+            Some(ReductError {
                 status: ErrorCode::NoContent,
                 message: "No content".to_string(),
             })
@@ -354,7 +354,7 @@ mod tests {
 
         assert_eq!(
             query.next(&index, &mut block_manager).err(),
-            Some(HttpError {
+            Some(ReductError {
                 status: ErrorCode::NoContent,
                 message: "No content".to_string(),
             })
@@ -377,7 +377,7 @@ mod tests {
 
         assert_eq!(
             query.next(&index, &mut block_manager).err(),
-            Some(HttpError {
+            Some(ReductError {
                 status: ErrorCode::NoContent,
                 message: "No content".to_string(),
             })

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -6,7 +6,7 @@ use crate::storage::query::base::QueryState::Running;
 use crate::storage::query::base::{Query, QueryOptions, QueryState};
 use crate::storage::query::historical::HistoricalQuery;
 use crate::storage::reader::RecordReader;
-use reduct_base::error::{ErrorCode, HttpError};
+use reduct_base::error::{ErrorCode, ReductError};
 use std::collections::BTreeSet;
 use std::sync::{Arc, RwLock};
 
@@ -30,12 +30,12 @@ impl Query for LimitedQuery {
         &mut self,
         block_indexes: &BTreeSet<u64>,
         block_manager: &mut BlockManager,
-    ) -> Result<(Arc<RwLock<RecordReader>>, bool), HttpError> {
+    ) -> Result<(Arc<RwLock<RecordReader>>, bool), ReductError> {
         // TODO: It could be done better, maybe it make sense to move the limit into HistoricalQuery instead of manipulating the state here.
         if let Running(count) = self.state() {
             if *count == self.options.limit.unwrap() {
                 self.query.state = QueryState::Done;
-                return Err(HttpError {
+                return Err(ReductError {
                     status: ErrorCode::NoContent,
                     message: "No content".to_string(),
                 });
@@ -85,7 +85,7 @@ mod tests {
 
         assert_eq!(
             query.next(&block_indexes, &mut block_manager).err(),
-            Some(HttpError {
+            Some(ReductError {
                 status: ErrorCode::NoContent,
                 message: "No content".to_string(),
             })

--- a/reductstore/src/storage/reader.rs
+++ b/reductstore/src/storage/reader.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::proto::{ts_to_us, Block};
-use reduct_base::error::HttpError;
+use reduct_base::error::ReductError;
 
 use bytes::Bytes;
 use std::collections::HashMap;
@@ -39,7 +39,7 @@ impl RecordReader {
         block: &Block,
         record_index: usize,
         chunk_size: u64,
-    ) -> Result<RecordReader, HttpError> {
+    ) -> Result<RecordReader, ReductError> {
         let mut file = OpenOptions::new().read(true).open(path)?;
         let record = &block.records[record_index];
         let offset = record.begin;
@@ -66,7 +66,7 @@ impl RecordReader {
     ///
     /// * `Option<Bytes>` - The next chunk of data. If it is None, the record is finished.
     /// * `HTTPError` - If the data cannot be read.
-    pub fn read(&mut self) -> Result<Option<Bytes>, HttpError> {
+    pub fn read(&mut self) -> Result<Option<Bytes>, ReductError> {
         if self.is_done() {
             return Ok(None);
         }


### PR DESCRIPTION
Closes #300 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #300 

### What is the new behavior?

I've implemented the health check using the `reduct-cli server alive' command. It only worked with aliases, which was inconvenient in the dockerfile. I've added an option to use URL instead of alias:

```
reduct-cli server alive http://token@127.0.0.1:8383
```

### Does this PR introduce a breaking change?

No

### Other information:
