### PR TITLE
reductstore: Move some Python API tests in Rust part

### DIFF
--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -19,6 +19,7 @@ def test__create_bucket_ok(base_url, session, bucket_name):
 
     assert resp.headers['Content-Type'] == "application/json"
 
+
 def test__create_bucket_quota_type_null(base_url, session, bucket_name):
     """Should create a bucket if quota_type is null"""
     resp = session.post(f'{base_url}/b/{bucket_name}', json={"quota_type": None})
@@ -62,22 +63,6 @@ def test__create_bucket_custom(base_url, session, bucket_name):
     data = json.loads(resp.content)
     assert data['settings'] == {"max_block_records": 256, "max_block_size": 500, "quota_type": "NONE",
                                 "quota_size": 0}
-
-
-def test__create_twice_bucket(base_url, session, bucket_name):
-    """Should not create a bucket twice with the same name"""
-    session.post(f'{base_url}/b/{bucket_name}')
-    resp = session.post(f'{base_url}/b/{bucket_name}')
-
-    assert resp.status_code == 409
-    assert "already exists" in resp.headers["x-reduct-error"]
-
-
-def test__get_bucket_not_exist(base_url, session, bucket_name):
-    """Should return error if the bucket is not found"""
-    resp = session.get(f'{base_url}/b/{bucket_name}')
-    assert resp.status_code == 404
-    assert "is not found" in resp.headers["x-reduct-error"]
 
 
 @requires_env("API_TOKEN")
@@ -170,13 +155,6 @@ def test__update_bucket_with_full_access_token(base_url, session, bucket_name, t
     assert resp.status_code == 403
 
 
-def test__update_bucket_not_found(base_url, session, bucket_name):
-    """Should not update setting if no bucket is found"""
-    resp = session.put(f'{base_url}/b/{bucket_name}',
-                       json={"max_block_size": 1000, "quota_type": "FIFO", "quota_size": 500})
-    assert resp.status_code == 404
-
-
 def test__remove_bucket_ok(base_url, session, bucket_name):
     """Should remove a bucket"""
     resp = session.post(f'{base_url}/b/{bucket_name}')
@@ -187,13 +165,6 @@ def test__remove_bucket_ok(base_url, session, bucket_name):
 
     resp = session.get(f'{base_url}/b/{bucket_name}')
     assert resp.status_code == 404
-
-
-def test__remove_bucket_not_exist(base_url, session, bucket_name):
-    """Should return an error if  bucket doesn't exist"""
-    resp = session.delete(f'{base_url}/b/{bucket_name}')
-    assert resp.status_code == 404
-    assert "is not found" in resp.headers["x-reduct-error"]
 
 
 @requires_env("API_TOKEN")

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -56,35 +56,6 @@ def test_read_write_entries_big_blob_ok(base_url, session, bucket):
     assert resp.headers['x-reduct-last'] == '1'
 
 
-def test_read_no_bucket(base_url, session):
-    """Should return 404 if no bucket found"""
-    resp = session.get(f'{base_url}/b/xxx/entry?ts=100')
-    assert resp.status_code == 404
-    assert 'xxx' in resp.headers["x-reduct-error"]
-
-
-def test_read_no_data(base_url, session, bucket):
-    """Should return 404 if no data for ts"""
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts=100')
-    assert resp.status_code == 404
-
-
-def test_read_bad_ts(base_url, session, bucket):
-    """Should return 400 if ts is bad"""
-    session.post(f"{base_url}/b/{bucket}/entry?ts=100", data=b"somedata")
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts=XXXX')
-
-    assert resp.status_code == 422
-    assert "'ts' must be an unix timestamp in microseconds" in resp.headers["x-reduct-error"]
-
-
-def test_read_bad_no_entry(base_url, session, bucket):
-    """Should return 400 if ts is bad"""
-    resp = session.get(f'{base_url}/b/{bucket}/entry')
-    assert resp.status_code == 404
-    assert 'entry' in resp.headers["x-reduct-error"]
-
-
 @requires_env("API_TOKEN")
 def test__read_with_read_token(base_url, session, bucket, token_without_permissions, token_read_bucket,
                                token_write_bucket):
@@ -100,21 +71,6 @@ def test__read_with_read_token(base_url, session, bucket, token_without_permissi
 
     resp = session.get(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(token_write_bucket))
     assert resp.status_code == 403
-
-
-def test_write_no_bucket(base_url, session):
-    """Should return 404 if no bucket found"""
-    resp = session.post(f'{base_url}/b/xxx/entry?ts=100')
-    assert resp.status_code == 404
-    assert 'xxx' in resp.headers["x-reduct-error"]
-
-
-def test_write_bad_ts(base_url, session, bucket):
-    """Should return 422 if ts is bad"""
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=XXXX')
-    assert resp.status_code == 422
-    assert "'ts' must be an unix timestamp in microseconds" in resp.headers["x-reduct-error"]
-
 
 def test_get_record_ok(base_url, session, bucket):
     """Should return list with timestamps and sizes"""

--- a/api_tests/token_api_test.py
+++ b/api_tests/token_api_test.py
@@ -22,18 +22,6 @@ def test__create_token(base_url, session, token_name, bucket_name):
 
 
 @requires_env("API_TOKEN")
-def test__create_token_exist(base_url, session, token_name):
-    """Should return 409 if a token already exists"""
-    permissions = {}
-
-    resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions)
-    assert resp.status_code == 200
-    resp = session.post(f'{base_url}/tokens/{token_name}', json={})
-    assert resp.status_code == 409
-    assert resp.headers["x-reduct-error"] == f"Token '{token_name}' already exists"
-
-
-@requires_env("API_TOKEN")
 def test__creat_token_with_full_access(base_url, session, token_name, token_without_permissions):
     """Needs full access to create a token"""
     permissions = {}
@@ -100,14 +88,6 @@ def test__get_token(base_url, session, bucket_name, token_name):
 
 
 @requires_env("API_TOKEN")
-def test__get_token_not_found(base_url, session):
-    """Should return 404 if a token does not exist"""
-    resp = session.get(f'{base_url}/tokens/token-not-found')
-    assert resp.status_code == 404
-    assert resp.headers["x-reduct-error"] == "Token 'token-not-found' doesn't exist"
-
-
-@requires_env("API_TOKEN")
 def test__get_token_with_full_access(base_url, session, token_without_permissions):
     """Needs full access to get a token"""
     resp = session.get(f'{base_url}/tokens/token-name', headers=auth_headers(''))
@@ -132,14 +112,6 @@ def test__delete_token(base_url, session, token_name):
     resp = session.get(f'{base_url}/tokens')
     assert resp.status_code == 200
     assert token_name not in [t["name"] for t in json.loads(resp.content)["tokens"]]
-
-
-@requires_env("API_TOKEN")
-def test__delete_token_not_found(base_url, session):
-    """Should return 404 if a token does not exist"""
-    resp = session.delete(f'{base_url}/tokens/token-not-found')
-    assert resp.status_code == 404
-    assert resp.headers["x-reduct-error"] == "Token 'token-not-found' doesn't exist"
 
 
 @requires_env("API_TOKEN")

--- a/reductstore/src/http_frontend.rs
+++ b/reductstore/src/http_frontend.rs
@@ -42,7 +42,7 @@ pub struct HttpServerState {
     pub base_path: String,
 }
 
-#[derive(Twin)]
+#[derive(Twin, PartialEq)]
 pub struct HttpError(BaseHttpError);
 
 impl HttpError {

--- a/reductstore/src/http_frontend/bucket_api/create.rs
+++ b/reductstore/src/http_frontend/bucket_api/create.rs
@@ -35,6 +35,7 @@ mod tests {
 
     use rstest::rstest;
 
+    use reduct_base::error::ErrorCode;
     use std::sync::Arc;
 
     #[rstest]
@@ -48,5 +49,26 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_create_bucket_already_exists(
+        components: Arc<HttpServerState>,
+        headers: HeaderMap,
+    ) {
+        let err = create_bucket(
+            State(components),
+            Path("bucket-1".to_string()),
+            headers,
+            BucketSettingsAxum::default(),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::Conflict, "Bucket 'bucket-1' already exists",)
+        )
     }
 }

--- a/reductstore/src/http_frontend/bucket_api/get.rs
+++ b/reductstore/src/http_frontend/bucket_api/get.rs
@@ -36,6 +36,7 @@ mod tests {
 
     use rstest::rstest;
 
+    use reduct_base::error::ErrorCode;
     use std::sync::Arc;
 
     #[rstest]
@@ -45,5 +46,18 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(info.0.info.name, "bucket-1");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_bucket_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+        let err = get_bucket(State(components), Path("not-found".to_string()), headers)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::NotFound, "Bucket 'not-found' is not found")
+        )
     }
 }

--- a/reductstore/src/http_frontend/bucket_api/remove.rs
+++ b/reductstore/src/http_frontend/bucket_api/remove.rs
@@ -40,6 +40,7 @@ mod tests {
 
     use rstest::rstest;
 
+    use reduct_base::error::ErrorCode;
     use std::sync::Arc;
 
     #[rstest]
@@ -48,6 +49,19 @@ mod tests {
         remove_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_bucket_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+        let err = remove_bucket(State(components), Path("not-found".to_string()), headers)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::NotFound, "Bucket 'not-found' is not found",)
+        )
     }
 
     #[rstest]

--- a/reductstore/src/http_frontend/bucket_api/update.rs
+++ b/reductstore/src/http_frontend/bucket_api/update.rs
@@ -28,6 +28,7 @@ pub async fn update_bucket(
 mod tests {
     use super::*;
     use crate::http_frontend::tests::{components, headers};
+    use reduct_base::error::ErrorCode;
     use rstest::rstest;
 
     #[rstest]
@@ -41,5 +42,23 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_bucket_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+        let err = update_bucket(
+            State(components),
+            Path("not-found".to_string()),
+            headers,
+            BucketSettingsAxum::default(),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::NotFound, "Bucket 'not-found' is not found",)
+        )
     }
 }

--- a/reductstore/src/http_frontend/entry_api/remove.rs
+++ b/reductstore/src/http_frontend/entry_api/remove.rs
@@ -70,4 +70,41 @@ mod tests {
             ErrorCode::NotFound
         );
     }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_bucket_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+        let path = HashMap::from_iter(vec![
+            ("bucket_name".to_string(), "XXX".to_string()),
+            ("entry_name".to_string(), "entry-1".to_string()),
+        ]);
+        let err = remove_entry(State(Arc::clone(&components)), Path(path), headers)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::NotFound, "Bucket 'XXX' is not found",)
+        )
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_entry_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+        let path = HashMap::from_iter(vec![
+            ("bucket_name".to_string(), "bucket-1".to_string()),
+            ("entry_name".to_string(), "XXX".to_string()),
+        ]);
+        let err = remove_entry(State(Arc::clone(&components)), Path(path), headers)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(
+                ErrorCode::NotFound,
+                "Entry 'XXX' not found in bucket 'bucket-1'",
+            )
+        )
+    }
 }

--- a/reductstore/src/http_frontend/token_api/create.rs
+++ b/reductstore/src/http_frontend/token_api/create.rs
@@ -34,6 +34,7 @@ mod tests {
 
     use crate::http_frontend::tests::{components, headers};
 
+    use reduct_base::error::ErrorCode;
     use reduct_base::msg::token_api::Permissions;
     use rstest::rstest;
 
@@ -50,5 +51,26 @@ mod tests {
         .unwrap()
         .0;
         assert!(token.value.starts_with("new-token"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_create_token_already_exists(
+        components: Arc<HttpServerState>,
+        headers: HeaderMap,
+    ) {
+        let err = create_token(
+            State(components),
+            Path("test".to_string()),
+            headers,
+            PermissionsAxum(Permissions::default()),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::Conflict, "Token 'test' already exists")
+        );
     }
 }

--- a/reductstore/src/http_frontend/token_api/get.rs
+++ b/reductstore/src/http_frontend/token_api/get.rs
@@ -32,6 +32,7 @@ mod tests {
 
     use crate::http_frontend::tests::{components, headers};
 
+    use reduct_base::error::ErrorCode;
     use rstest::rstest;
 
     #[rstest]
@@ -42,5 +43,18 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(token.name, "test");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_token_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+        let err = get_token(State(components), Path("not-found".to_string()), headers)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::NotFound, "Token 'not-found' doesn't exist")
+        )
     }
 }

--- a/reductstore/src/http_frontend/token_api/remove.rs
+++ b/reductstore/src/http_frontend/token_api/remove.rs
@@ -28,6 +28,7 @@ mod tests {
     use super::*;
     use crate::http_frontend::tests::{components, headers};
 
+    use reduct_base::error::ErrorCode;
     use rstest::rstest;
 
     #[rstest]
@@ -35,5 +36,18 @@ mod tests {
     async fn test_remove_token(components: Arc<HttpServerState>, headers: HeaderMap) {
         let token = remove_token(State(components), Path("test".to_string()), headers).await;
         assert!(token.is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_token_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+        let err = remove_token(State(components), Path("not-found".to_string()), headers)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::NotFound, "Token 'not-found' doesn't exist")
+        )
     }
 }


### PR DESCRIPTION
Closes #307 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Refactoring 

### What is the current behavior?

See #307 

### What is the new behavior?

Move many tests from Python API  tests to rust modules. 

### Does this PR introduce a breaking change?

No

### Other information:
