### PR TITLE
Provisioning buckets and tokens with environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- reduct-cli: Add `alias` and `server` commands, [PR-343](https://github.com/reductstore/reductstore/pull/343)
-- reduct-rs: Add `ReductClient.url`, `ReductClient.token`, `ReductCientBuilder.try_build` [PR-350](https://github.com/reductstore/reductstore/pull/350)
-- reductstore: Add `healthcheck` to buildx.Dockerfile, [PR-350](https://github.com/reductstore/reductstore/pull/350)
+- reduct-cli: `alias` and `server` commands, [PR-343](https://github.com/reductstore/reductstore/pull/343)
+- reduct-rs: `ReductClient.url`, `ReductClient.token`, `ReductCientBuilder.try_build` [PR-350](https://github.com/reductstore/reductstore/pull/350)
+- reductstore: `healthcheck` to buildx.Dockerfile, [PR-350](https://github.com/reductstore/reductstore/pull/350)
+- reductstore: provisioning with environment variables, [PR-352](https://github.com/reductstore/reductstore/pull/352)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+
+[[package]]
 name = "bzip2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1605,7 @@ dependencies = [
  "axum",
  "axum-server",
  "bytes",
+ "bytesize",
  "chrono",
  "futures-util",
  "hermit-abi",

--- a/api_tests/auth_test.py
+++ b/api_tests/auth_test.py
@@ -5,14 +5,14 @@ from conftest import requires_env, auth_headers
 @requires_env("API_TOKEN")
 def test__compare_api_token(base_url, session):
     """should provide /alive without token"""
-    resp = session.head(f'{base_url}/alive', headers={})
+    resp = session.head(f"{base_url}/alive", headers={})
     assert resp.status_code == 200
 
 
 @requires_env("API_TOKEN")
 def test__compare_api_token(base_url, session):
     """should compare token"""
-    resp = session.get(f'{base_url}/info', headers=auth_headers('ABCB0001'))
+    resp = session.get(f"{base_url}/info", headers=auth_headers("ABCB0001"))
     assert resp.status_code == 401
     assert resp.headers["x-reduct-error"] == "Invalid token"
 
@@ -20,6 +20,6 @@ def test__compare_api_token(base_url, session):
 @requires_env("API_TOKEN")
 def test__empty_token(base_url, session):
     """should use Bearer token"""
-    resp = session.get(f'{base_url}/info', headers={'Authorization': ''})
+    resp = session.get(f"{base_url}/info", headers={"Authorization": ""})
     assert resp.status_code == 401
     assert resp.headers["x-reduct-error"] == "No bearer token in request header"

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -5,209 +5,268 @@ from conftest import requires_env, auth_headers
 
 def test__create_bucket_ok(base_url, session, bucket_name):
     """Should create a bucket with default settings"""
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
 
     assert resp.status_code == 200
-    resp = session.get(f'{base_url}/b/{bucket_name}')
+    resp = session.get(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
     data = json.loads(resp.content)
-    assert data['settings'] == {"max_block_records": 256, "max_block_size": 64000000,
-                                "quota_type": "NONE", "quota_size": 0}
-    assert data['info']['name'] == bucket_name
-    assert len(data['entries']) == 0
+    assert data["settings"] == {
+        "max_block_records": 256,
+        "max_block_size": 64000000,
+        "quota_type": "NONE",
+        "quota_size": 0,
+    }
+    assert data["info"]["name"] == bucket_name
+    assert len(data["entries"]) == 0
 
-    assert resp.headers['Content-Type'] == "application/json"
+    assert resp.headers["Content-Type"] == "application/json"
 
 
 def test__create_bucket_quota_type_null(base_url, session, bucket_name):
     """Should create a bucket if quota_type is null"""
-    resp = session.post(f'{base_url}/b/{bucket_name}', json={"quota_type": None})
+    resp = session.post(f"{base_url}/b/{bucket_name}", json={"quota_type": None})
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket_name}')
+    resp = session.get(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
     data = json.loads(resp.content)
-    assert data['settings']['quota_type'] == "NONE"
+    assert data["settings"]["quota_type"] == "NONE"
 
 
 @requires_env("API_TOKEN")
-def test__create_bucket_with_full_access_token(base_url, session, bucket_name, token_without_permissions):
+def test__create_bucket_with_full_access_token(
+    base_url, session, bucket_name, token_without_permissions
+):
     """Needs full access token"""
-    resp = session.post(f'{base_url}/b/{bucket_name}', headers=auth_headers(''))
+    resp = session.post(f"{base_url}/b/{bucket_name}", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.post(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_without_permissions))
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 403
 
 
 def test__create_bucket_bad_format(base_url, session, bucket_name):
-    """Should not create a bucket if JSON data is invalid """
-    resp = session.post(f'{base_url}/b/{bucket_name}', data="xxx")
+    """Should not create a bucket if JSON data is invalid"""
+    resp = session.post(f"{base_url}/b/{bucket_name}", data="xxx")
     assert resp.status_code == 422
 
-    resp = session.post(f'{base_url}/b/{bucket_name}', json={"quota_type": "UNKNOWN"})
+    resp = session.post(f"{base_url}/b/{bucket_name}", json={"quota_type": "UNKNOWN"})
     assert resp.status_code == 422
-    assert resp.headers['Content-Type'] == "application/json"
+    assert resp.headers["Content-Type"] == "application/json"
 
 
 def test__create_bucket_custom(base_url, session, bucket_name):
     """Should create a bucket with some settings"""
-    resp = session.post(f'{base_url}/b/{bucket_name}', json={"max_block_size": 500})
+    resp = session.post(f"{base_url}/b/{bucket_name}", json={"max_block_size": 500})
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket_name}')
+    resp = session.get(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
     data = json.loads(resp.content)
-    assert data['settings'] == {"max_block_records": 256, "max_block_size": 500, "quota_type": "NONE",
-                                "quota_size": 0}
+    assert data["settings"] == {
+        "max_block_records": 256,
+        "max_block_size": 500,
+        "quota_type": "NONE",
+        "quota_size": 0,
+    }
 
 
 @requires_env("API_TOKEN")
-def test__get_bucket_with_authenticated_token(base_url, session, bucket_name, token_without_permissions):
+def test__get_bucket_with_authenticated_token(
+    base_url, session, bucket_name, token_without_permissions
+):
     """Needs an authenticated token"""
-    session.post(f'{base_url}/b/{bucket_name}')
+    session.post(f"{base_url}/b/{bucket_name}")
 
-    resp = session.get(f'{base_url}/b/{bucket_name}', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/b/{bucket_name}", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_without_permissions))
+    resp = session.get(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 200
 
 
 def test__get_bucket_stats(base_url, session, bucket_name):
     """Should get stats from bucket"""
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket_name}/entry_1?ts=1000000', data="somedata")
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/entry_1?ts=1000000", data="somedata"
+    )
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket_name}/entry_2?ts=2000000', data="anotherdata")
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/entry_2?ts=2000000", data="anotherdata"
+    )
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket_name}')
+    resp = session.get(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
     data = json.loads(resp.content)
-    assert data['entries'] == [{'block_count': 1,
-                                'latest_record': 1000000,
-                                'name': 'entry_1',
-                                'oldest_record': 1000000,
-                                'record_count': 1,
-                                'size': 8
-                                },
-                               {'block_count': 1,
-                                'latest_record': 2000000,
-                                'name': 'entry_2',
-                                'oldest_record': 2000000,
-                                'record_count': 1,
-                                'size': 11
-                                }]
-    assert data['info'] == dict(name=bucket_name, entry_count=2, size=19, latest_record=2000000,
-                                oldest_record=1000000, is_provisioned=False)
+    assert data["entries"] == [
+        {
+            "block_count": 1,
+            "latest_record": 1000000,
+            "name": "entry_1",
+            "oldest_record": 1000000,
+            "record_count": 1,
+            "size": 8,
+        },
+        {
+            "block_count": 1,
+            "latest_record": 2000000,
+            "name": "entry_2",
+            "oldest_record": 2000000,
+            "record_count": 1,
+            "size": 11,
+        },
+    ]
+    assert data["info"] == dict(
+        name=bucket_name,
+        entry_count=2,
+        size=19,
+        latest_record=2000000,
+        oldest_record=1000000,
+        is_provisioned=False,
+    )
 
 
 def test__update_bucket_ok(base_url, session, bucket_name):
     """Should update setting of the bucket"""
-    session.post(f'{base_url}/b/{bucket_name}')
+    session.post(f"{base_url}/b/{bucket_name}")
 
     new_settings: dict = {"max_block_size": 1000, "quota_type": "FIFO"}
-    resp = session.put(f'{base_url}/b/{bucket_name}',
-                       json=new_settings)
+    resp = session.put(f"{base_url}/b/{bucket_name}", json=new_settings)
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket_name}')
+    resp = session.get(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
     data = json.loads(resp.content)
 
-    new_settings.update({"quota_size": 0, 'max_block_records': 256})
-    assert data['settings'] == new_settings
+    new_settings.update({"quota_size": 0, "max_block_records": 256})
+    assert data["settings"] == new_settings
 
 
 def test__update_bucket_bad_format(base_url, session, bucket_name):
     """Should not update setting if JSON format is bad"""
-    session.post(f'{base_url}/b/{bucket_name}')
+    session.post(f"{base_url}/b/{bucket_name}")
 
-    resp = session.put(f'{base_url}/b/{bucket_name}',
-                       json={"max_block_size": 1000, "quota_type": "UNKNOWN", "quota_size": 500})
+    resp = session.put(
+        f"{base_url}/b/{bucket_name}",
+        json={"max_block_size": 1000, "quota_type": "UNKNOWN", "quota_size": 500},
+    )
     assert resp.status_code == 422
 
-    resp = session.put(f'{base_url}/b/{bucket_name}', data="NOT_JSON")
+    resp = session.put(f"{base_url}/b/{bucket_name}", data="NOT_JSON")
     assert resp.status_code == 422
 
 
 @requires_env("API_TOKEN")
-def test__update_bucket_with_full_access_token(base_url, session, bucket_name, token_without_permissions,
-                                               token_read_bucket, token_write_bucket):
+def test__update_bucket_with_full_access_token(
+    base_url,
+    session,
+    bucket_name,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
+):
     """Needs full access to change bucket"""
 
-    resp = session.put(f'{base_url}/b/{bucket_name}', headers=auth_headers(''))
+    resp = session.put(f"{base_url}/b/{bucket_name}", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.put(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_without_permissions))
+    resp = session.put(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 403
 
-    resp = session.put(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_read_bucket))
+    resp = session.put(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket)
+    )
     assert resp.status_code == 403
 
-    resp = session.put(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_write_bucket))
+    resp = session.put(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket)
+    )
     assert resp.status_code == 403
 
 
 def test__remove_bucket_ok(base_url, session, bucket_name):
     """Should remove a bucket"""
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
-    resp = session.delete(f'{base_url}/b/{bucket_name}')
+    resp = session.delete(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket_name}')
+    resp = session.get(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 404
 
 
 @requires_env("API_TOKEN")
-def test__remove_bucket_with_full_access_token(base_url, session, bucket_name, token_without_permissions,
-                                               token_read_bucket, token_write_bucket):
+def test__remove_bucket_with_full_access_token(
+    base_url,
+    session,
+    bucket_name,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
+):
     """Needs full access to remove bucket"""
-    resp = session.delete(f'{base_url}/b/{bucket_name}', headers=auth_headers(''))
+    resp = session.delete(f"{base_url}/b/{bucket_name}", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.delete(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_without_permissions))
+    resp = session.delete(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 403
 
-    resp = session.delete(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_read_bucket))
+    resp = session.delete(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket)
+    )
     assert resp.status_code == 403
 
-    resp = session.delete(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_write_bucket))
+    resp = session.delete(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket)
+    )
     assert resp.status_code == 403
 
 
 def test__head_bucket_ok(base_url, session, bucket_name):
     """Should check if bucket exist"""
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
-    resp = session.head(f'{base_url}/b/{bucket_name}')
+    resp = session.head(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
     assert len(resp.content) == 0
 
-    resp = session.head(f'{base_url}/b/{bucket_name}_________')
+    resp = session.head(f"{base_url}/b/{bucket_name}_________")
     assert resp.status_code == 404
     assert len(resp.content) == 0
 
 
 @requires_env("API_TOKEN")
-def test__head_bucket_with_full_access_token(base_url, session, bucket_name, token_without_permissions):
+def test__head_bucket_with_full_access_token(
+    base_url, session, bucket_name, token_without_permissions
+):
     """Needs authenticated token"""
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
-    resp = session.head(f'{base_url}/b/{bucket_name}', headers=auth_headers(''))
+    resp = session.head(f"{base_url}/b/{bucket_name}", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.head(f'{base_url}/b/{bucket_name}', headers=auth_headers(token_without_permissions))
+    resp = session.head(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 200

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -97,15 +97,17 @@ def test__get_bucket_stats(base_url, session, bucket_name):
                                 'name': 'entry_1',
                                 'oldest_record': 1000000,
                                 'record_count': 1,
-                                'size': 8},
+                                'size': 8
+                                },
                                {'block_count': 1,
                                 'latest_record': 2000000,
                                 'name': 'entry_2',
                                 'oldest_record': 2000000,
                                 'record_count': 1,
-                                'size': 11}]
+                                'size': 11
+                                }]
     assert data['info'] == dict(name=bucket_name, entry_count=2, size=19, latest_record=2000000,
-                                oldest_record=1000000)
+                                oldest_record=1000000, is_provisioned=False)
 
 
 def test__update_bucket_ok(base_url, session, bucket_name):

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -10,7 +10,7 @@ import requests
 
 @pytest.fixture(name="storage_url")
 def _storage_url():
-    return os.environ.get("STORAGE_URL", 'http://127.0.0.1:8383')
+    return os.environ.get("STORAGE_URL", "http://127.0.0.1:8383")
 
 
 @pytest.fixture(name="base_url")
@@ -18,9 +18,9 @@ def _base_url(storage_url) -> str:
     return f"{storage_url}/api/v1"
 
 
-@pytest.fixture(name='bucket_name')
+@pytest.fixture(name="bucket_name")
 def _gen_bucket_name() -> str:
-    return f'bucket_{random.randint(0, 1000000)}'
+    return f"bucket_{random.randint(0, 1000000)}"
 
 
 def requires_env(key):
@@ -28,12 +28,12 @@ def requires_env(key):
 
     return pytest.mark.skipif(
         env is None or env == "",
-        reason=f"Not suitable environment {key} for current test"
+        reason=f"Not suitable environment {key} for current test",
     )
 
 
 def auth_headers(token):
-    return {'Authorization': f'Bearer {token}'}
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture(name="session")
@@ -41,7 +41,7 @@ def _session(base_url):
     session = requests.session()
     session.verify = False
     session.trust_env = False
-    session.headers['Authorization'] = f'Bearer {os.getenv("API_TOKEN")}'
+    session.headers["Authorization"] = f'Bearer {os.getenv("API_TOKEN")}'
     return session
 
 
@@ -63,31 +63,31 @@ def _make_token_permissions(session, base_url, token_generator):
     permissions = {
         "full_access": False,
     }
-    resp = session.post(f'{base_url}/tokens/{token_generator()}', json=permissions)
+    resp = session.post(f"{base_url}/tokens/{token_generator()}", json=permissions)
     assert resp.status_code == 200
     return json.loads(resp.content)["value"]
 
 
 @pytest.fixture(name="token_read_bucket")
 def _make_token_read_bucket(session, base_url, bucket_name, token_generator):
-    session.post(f'{base_url}/b/{bucket_name}')
+    session.post(f"{base_url}/b/{bucket_name}")
     permissions = {
         "full_access": False,
         "read": [bucket_name],
     }
-    resp = session.post(f'{base_url}/tokens/{token_generator()}', json=permissions)
+    resp = session.post(f"{base_url}/tokens/{token_generator()}", json=permissions)
     assert resp.status_code == 200
     return json.loads(resp.content)["value"]
 
 
 @pytest.fixture(name="token_write_bucket")
 def _make_token_write_bucket(session, base_url, bucket_name, token_generator):
-    session.post(f'{base_url}/b/{bucket_name}')
+    session.post(f"{base_url}/b/{bucket_name}")
 
     permissions = {
         "full_access": False,
         "write": [bucket_name],
     }
-    resp = session.post(f'{base_url}/tokens/{token_generator()}', json=permissions)
+    resp = session.post(f"{base_url}/tokens/{token_generator()}", json=permissions)
     assert resp.status_code == 200
     return json.loads(resp.content)["value"]

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -7,111 +7,130 @@ import pytest
 from conftest import requires_env, auth_headers
 
 
-@pytest.fixture(name='bucket')
+@pytest.fixture(name="bucket")
 def _make_bucket_and_return_name(base_url, session, bucket_name) -> str:
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
     return bucket_name
 
 
-@pytest.mark.parametrize("data,ts", [(b"some_data_1", 100), (b"some_data_2", 60), (b"some_data_3", 1000)])
+@pytest.mark.parametrize(
+    "data,ts", [(b"some_data_1", 100), (b"some_data_2", 60), (b"some_data_3", 1000)]
+)
 def test_read_write_entries_ok(base_url, session, bucket, data, ts):
     """Should write few entries and read them back"""
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data=data)
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data=data)
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts={ts}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?ts={ts}")
     assert resp.status_code == 200
     assert resp.content == data
 
 
 def test_read_write_entries_ok_with_labels(base_url, session, bucket):
     """Should write few entries and read them back with labels"""
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', data="nomater",
-                        headers={"x-reduct-label-x": "0", "x-reduct-label-y": "1"})
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        data="nomater",
+        headers={"x-reduct-label-x": "0", "x-reduct-label-y": "1"},
+    )
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts=1000')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?ts=1000")
     assert resp.status_code == 200
-    assert resp.headers['x-reduct-label-x'] == '0'
-    assert resp.headers['x-reduct-label-y'] == '1'
+    assert resp.headers["x-reduct-label-x"] == "0"
+    assert resp.headers["x-reduct-label-y"] == "1"
 
 
 def test_read_write_entries_big_blob_ok(base_url, session, bucket):
     """Should write and read files more than max block size"""
     huge_data = b"xaz" * 1024 * 1024
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data=huge_data)
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data=huge_data)
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 100}', data=huge_data)
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 100}", data=huge_data)
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts={ts}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?ts={ts}")
     assert resp.status_code == 200
     assert resp.content == huge_data
 
-    assert resp.headers['content-type'] == "application/octet-stream"
-    assert resp.headers['x-reduct-time'] == str(ts)
-    assert resp.headers['x-reduct-last'] == '1'
+    assert resp.headers["content-type"] == "application/octet-stream"
+    assert resp.headers["x-reduct-time"] == str(ts)
+    assert resp.headers["x-reduct-last"] == "1"
 
 
 @requires_env("API_TOKEN")
-def test__read_with_read_token(base_url, session, bucket, token_without_permissions, token_read_bucket,
-                               token_write_bucket):
+def test__read_with_read_token(
+    base_url,
+    session,
+    bucket,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
+):
     """Needs read permissions to read"""
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(token_without_permissions))
+    resp = session.get(
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        headers=auth_headers(token_without_permissions),
+    )
     assert resp.status_code == 403
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(token_read_bucket))
+    resp = session.get(
+        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_read_bucket)
+    )
     assert resp.status_code == 404  # no data
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(token_write_bucket))
+    resp = session.get(
+        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_write_bucket)
+    )
     assert resp.status_code == 403
+
 
 def test_get_record_ok(base_url, session, bucket):
     """Should return list with timestamps and sizes"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 100}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 100}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 200}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 200}", data="some_data")
     assert resp.status_code == 200
 
 
 def test_latest_record(base_url, session, bucket):
     """Should return the latest record"""
     ts = 1000
-    resp = session.get(f'{base_url}/b/{bucket}/entry')
+    resp = session.get(f"{base_url}/b/{bucket}/entry")
     assert resp.status_code == 404
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data1")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data1")
     assert resp.status_code == 200
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 10}', data="some_data2")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 10}", data="some_data2")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry')
+    resp = session.get(f"{base_url}/b/{bucket}/entry")
     assert resp.status_code == 200
     assert resp.content == b"some_data2"
-    assert resp.headers['x-reduct-time'] == '1010'
-    assert resp.headers['x-reduct-last'] == '1'
+    assert resp.headers["x-reduct-time"] == "1010"
+    assert resp.headers["x-reduct-last"] == "1"
 
 
 def test_read_write_big_blob(base_url, session, bucket):
     """Should read and write a big blob"""
-    blob = np.random.bytes(2 ** 20).hex()
+    blob = np.random.bytes(2**20).hex()
     ts = 1000
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data=blob)
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data=blob)
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry')
+    resp = session.get(f"{base_url}/b/{bucket}/entry")
     assert resp.status_code == 200
     assert len(resp.text) == len(blob)
     assert resp.text == blob
@@ -119,63 +138,78 @@ def test_read_write_big_blob(base_url, session, bucket):
 
 def test_write_big_blob_with_error(base_url, session, bucket):
     """Should write a big blob with error and don't crush"""
-    blob = np.random.bytes(2 ** 20).hex()
+    blob = np.random.bytes(2**20).hex()
     ts = 1000
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data=blob)
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data=blob)
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data=blob)
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data=blob)
     assert resp.status_code == 409
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry')
+    resp = session.get(f"{base_url}/b/{bucket}/entry")
     assert resp.status_code == 200
 
 
 @requires_env("API_TOKEN")
-def test__write_with_write_token(base_url, session, bucket, token_without_permissions, token_read_bucket,
-                                 token_write_bucket):
+def test__write_with_write_token(
+    base_url,
+    session,
+    bucket,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
+):
     """Needs write permissions to write"""
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(''))
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers("")
+    )
     assert resp.status_code == 401
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(token_without_permissions))
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        headers=auth_headers(token_without_permissions),
+    )
     assert resp.status_code == 403
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(token_read_bucket))
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_read_bucket)
+    )
     assert resp.status_code == 403
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', headers=auth_headers(token_write_bucket))
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_write_bucket)
+    )
     assert resp.status_code == 200
 
 
 def test_query_entry_ok(base_url, session, bucket):
-    """Should return incrementing id with """
+    """Should return incrementing id with"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}")
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])
     assert query_id >= 0
 
     last_id = query_id
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?start={ts}")
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])
     assert query_id > last_id
 
     last_id = query_id
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?stop={ts + 200}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?stop={ts + 200}")
 
     query_id = int(json.loads(resp.content)["id"])
     assert query_id > last_id
 
     last_id = query_id
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q")
 
     query_id = int(json.loads(resp.content)["id"])
     assert query_id > last_id
@@ -185,34 +219,34 @@ def test_query_entry_next(base_url, session, bucket):
     """Should read next few records"""
 
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 100}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 100}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 200}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 200}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}")
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
 
     assert resp.status_code == 200
     assert resp.content == b"some_data"
-    assert resp.headers['x-reduct-time'] == '1000'
-    assert resp.headers['x-reduct-last'] == '0'
+    assert resp.headers["x-reduct-time"] == "1000"
+    assert resp.headers["x-reduct-last"] == "0"
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
 
     assert resp.status_code == 200
     assert resp.content == b"some_data"
-    assert resp.headers['x-reduct-time'] == '1100'
-    assert resp.headers['x-reduct-last'] == '0'
+    assert resp.headers["x-reduct-time"] == "1100"
+    assert resp.headers["x-reduct-last"] == "0"
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 204
 
 
@@ -220,59 +254,67 @@ def test_query_ttl(base_url, session, bucket):
     """Should keep TTL of query"""
 
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}&ttl=0')
+    resp = session.get(
+        f"{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}&ttl=0"
+    )
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 404
 
 
 def test_query_limit(base_url, session, bucket):
     """Should limit number of records returned"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 1000}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 1000}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?limit=1')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?limit=1")
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 204
 
 
 def test_query_with_include_and_exclude(base_url, session, bucket):
     """Should handle include and exclude labels"""
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', data="some_data1",
-                        headers={'x-reduct-label-foo': 'bar'})
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        data="some_data1",
+        headers={"x-reduct-label-foo": "bar"},
+    )
     assert resp.status_code == 200
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=2000', data="some_data2",
-                        headers={'x-reduct-label-foo': 'baz'})
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts=2000",
+        data="some_data2",
+        headers={"x-reduct-label-foo": "baz"},
+    )
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?exclude-foo=bar')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?exclude-foo=bar")
     assert resp.status_code == 200
     query_id = int(json.loads(resp.content)["id"])
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 200
     assert resp.content == b"some_data2"
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?include-foo=bar')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?include-foo=bar")
     assert resp.status_code == 200
     query_id = int(json.loads(resp.content)["id"])
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 200
     assert resp.content == b"some_data1"
 
@@ -280,51 +322,64 @@ def test_query_with_include_and_exclude(base_url, session, bucket):
 def test_query_entry_no_next(base_url, session, bucket):
     """Should return no content if there is no record for the query"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts + 1}&stop={ts + 200}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?start={ts + 1}&stop={ts + 200}")
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 204
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 404
 
 
 def test_query_continuous(base_url, session, bucket):
     """Should  request next records continuously even if there is no data"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts + 1}&continuous=true')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?start={ts + 1}&continuous=true")
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 204
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 204
 
 
 @requires_env("API_TOKEN")
-def test__query_with_read_token(base_url, session, bucket, token_without_permissions, token_read_bucket,
-                                token_write_bucket):
+def test__query_with_read_token(
+    base_url,
+    session,
+    bucket,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
+):
     """Needs read permissions to query"""
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q', headers=auth_headers(token_without_permissions))
+    resp = session.get(
+        f"{base_url}/b/{bucket}/entry/q",
+        headers=auth_headers(token_without_permissions),
+    )
     assert resp.status_code == 403
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q', headers=auth_headers(token_read_bucket))
+    resp = session.get(
+        f"{base_url}/b/{bucket}/entry/q", headers=auth_headers(token_read_bucket)
+    )
     assert resp.status_code == 404  # no data
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q', headers=auth_headers(token_write_bucket))
+    resp = session.get(
+        f"{base_url}/b/{bucket}/entry/q", headers=auth_headers(token_write_bucket)
+    )
     assert resp.status_code == 403
 
 
@@ -333,158 +388,193 @@ def test__head_entry_ok(base_url, session, bucket):
     ts = 1000
     entry_name = "testentry"
     dummy_data = "dummy data"
-    resp = session.post(f'{base_url}/b/{bucket}/{entry_name}?ts={ts}', data=dummy_data)
+    resp = session.post(f"{base_url}/b/{bucket}/{entry_name}?ts={ts}", data=dummy_data)
     assert resp.status_code == 200
 
-    resp = session.head(f'{base_url}/b/{bucket}/{entry_name}')
+    resp = session.head(f"{base_url}/b/{bucket}/{entry_name}")
     assert resp.status_code == 200
     assert len(resp.content) == 0
-    assert resp.headers['Content-Length'] == str(len(dummy_data))
+    assert resp.headers["Content-Length"] == str(len(dummy_data))
 
 
 @requires_env("API_TOKEN")
-def test__head_entry_with_full_access_token(base_url, session, bucket, token_without_permissions, token_write_bucket,
-                                            token_read_bucket):
+def test__head_entry_with_full_access_token(
+    base_url,
+    session,
+    bucket,
+    token_without_permissions,
+    token_write_bucket,
+    token_read_bucket,
+):
     """Needs authenticated token. Should not return the body, only headers."""
     ts = 1000
     entry_name = "testentry"
     dummy_data = "dummy data"
-    resp = session.post(f'{base_url}/b/{bucket}/{entry_name}?ts={ts}', data=dummy_data,
-                        headers=auth_headers(token_write_bucket))
+    resp = session.post(
+        f"{base_url}/b/{bucket}/{entry_name}?ts={ts}",
+        data=dummy_data,
+        headers=auth_headers(token_write_bucket),
+    )
     assert resp.status_code == 200
 
-    resp = session.head(f'{base_url}/b/{bucket}/{entry_name}', headers=auth_headers(token_read_bucket))
+    resp = session.head(
+        f"{base_url}/b/{bucket}/{entry_name}", headers=auth_headers(token_read_bucket)
+    )
     assert resp.status_code == 200
     assert len(resp.content) == 0
-    assert resp.headers['Content-Length'] == str(len(dummy_data))
+    assert resp.headers["Content-Length"] == str(len(dummy_data))
 
 
 def test_write_with_content_type_header(base_url, session, bucket):
     """Should write data with content type header"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={1000}', data='{"data": "some data"}',
-                        headers={'content-type': 'application/json'})
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts={1000}",
+        data='{"data": "some data"}',
+        headers={"content-type": "application/json"},
+    )
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}")
     assert resp.status_code == 200
     query_id = int(json.loads(resp.content)["id"])
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 200
-    assert resp.content == b"{\"data\": \"some data\"}"
-    assert resp.headers['content-type'] == 'application/json'
+    assert resp.content == b'{"data": "some data"}'
+    assert resp.headers["content-type"] == "application/json"
 
 
-@pytest.mark.parametrize("method, expected_content", [("GET", b"some_data1some_data2"), ("HEAD", b"")])
+@pytest.mark.parametrize(
+    "method, expected_content", [("GET", b"some_data1some_data2"), ("HEAD", b"")]
+)
 def test_read_batched_records(base_url, session, bucket, method, expected_content):
     """Should read batched records and send metadata in headers"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data1")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data1")
     assert resp.status_code == 200
 
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts + 100}', data="some_data2",
-                        headers={'content-type': 'text/plain', 'x-reduct-label-x': '[a,b]'})
+    resp = session.post(
+        f"{base_url}/b/{bucket}/entry?ts={ts + 100}",
+        data="some_data2",
+        headers={"content-type": "text/plain", "x-reduct-label-x": "[a,b]"},
+    )
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?start={ts}&stop={ts + 200}")
     assert resp.status_code == 200
     query_id = int(json.loads(resp.content)["id"])
 
-    resp = session.request(method, f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    resp = session.request(method, f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 200
     assert resp.content == expected_content
-    assert resp.headers['content-type'] == 'application/octet-stream'
-    assert resp.headers['content-length'] == '20'
-    assert resp.headers['x-reduct-time-1000'] == '10,application/octet-stream'
-    assert resp.headers['x-reduct-time-1100'] == '10,text/plain,x="[a,b]"'
-    assert resp.headers['x-reduct-last'] == 'true'
+    assert resp.headers["content-type"] == "application/octet-stream"
+    assert resp.headers["content-length"] == "20"
+    assert resp.headers["x-reduct-time-1000"] == "10,application/octet-stream"
+    assert resp.headers["x-reduct-time-1100"] == '10,text/plain,x="[a,b]"'
+    assert resp.headers["x-reduct-last"] == "true"
 
 
 def test_read_batched_max_header_size(base_url, session, bucket):
     """Should limit the header size in response"""
     for ts in range(0, 100):
-        resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="")
+        resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="")
         assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q")
     assert resp.status_code == 200
     query_id = int(json.loads(resp.content)["id"])
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 200
-    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 86
-    assert resp.headers['x-reduct-last'] == 'false'
+    assert sum(header.startswith("x-reduct-time-") for header in resp.headers) == 86
+    assert resp.headers["x-reduct-last"] == "false"
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 200
-    assert sum(header.startswith('x-reduct-time-') for header in resp.headers) == 14
-    assert resp.headers['x-reduct-last'] == 'true'
+    assert sum(header.startswith("x-reduct-time-") for header in resp.headers) == 14
+    assert resp.headers["x-reduct-last"] == "true"
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 404
 
 
 def test_read_batched_query_required(base_url, session, bucket):
     """Should have query id in params"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data1")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data1")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/batch')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/batch")
     assert resp.status_code == 422
-    assert resp.headers['x-reduct-error'] == "'q' parameter is required for batched reads"
+    assert (
+        resp.headers["x-reduct-error"] == "'q' parameter is required for batched reads"
+    )
 
 
 def test_read_batched_continuous_query(base_url, session, bucket):
     """Should read batched records in continuous mode"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data1")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data1")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/q?ttl=1&continuous=true')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?ttl=1&continuous=true")
     assert resp.status_code == 200
     query_id = int(json.loads(resp.content)["id"])
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 200
-    assert resp.headers['x-reduct-last'] == 'true'
+    assert resp.headers["x-reduct-last"] == "true"
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 204
 
     sleep(1.1)
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry/batch?q={query_id}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 404
 
 
 def test_remove_entry(base_url, session, bucket):
     """Should remove entry"""
     ts = 1000
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts={ts}', data="some_data1")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data1")
     assert resp.status_code == 200
 
-    resp = session.delete(f'{base_url}/b/{bucket}/entry?ts={ts}')
+    resp = session.delete(f"{base_url}/b/{bucket}/entry?ts={ts}")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/b/{bucket}/entry?ts={ts}')
+    resp = session.get(f"{base_url}/b/{bucket}/entry?ts={ts}")
     assert resp.status_code == 404
 
 
 @requires_env("API_TOKEN")
-def test_remove_with_bucket_write_permissions(base_url, session, bucket, token_without_permissions, token_read_bucket,
-                                              token_write_bucket):
+def test_remove_with_bucket_write_permissions(
+    base_url,
+    session,
+    bucket,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
+):
     """Needs write permissions to remove entry"""
-    resp = session.post(f'{base_url}/b/{bucket}/entry?ts=1000', data="some_data1")
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts=1000", data="some_data1")
     assert resp.status_code == 200
 
-    resp = session.delete(f'{base_url}/b/{bucket}/entry',
-                          headers={'Authorization': f'Bearer {token_without_permissions}'})
+    resp = session.delete(
+        f"{base_url}/b/{bucket}/entry",
+        headers={"Authorization": f"Bearer {token_without_permissions}"},
+    )
     assert resp.status_code == 403
 
-    resp = session.delete(f'{base_url}/b/{bucket}/entry', headers={'Authorization': f'Bearer {token_read_bucket}'})
+    resp = session.delete(
+        f"{base_url}/b/{bucket}/entry",
+        headers={"Authorization": f"Bearer {token_read_bucket}"},
+    )
     assert resp.status_code == 403
 
-    resp = session.delete(f'{base_url}/b/{bucket}/entry', headers={'Authorization': f'Bearer {token_write_bucket}'})
+    resp = session.delete(
+        f"{base_url}/b/{bucket}/entry",
+        headers={"Authorization": f"Bearer {token_write_bucket}"},
+    )
     assert resp.status_code == 200

--- a/api_tests/http_test.py
+++ b/api_tests/http_test.py
@@ -1,8 +1,9 @@
 """Test basic HTTP things"""
 
+
 def test_api_version(base_url, session):
     """Should get api version in header"""
-    resp = session.get(f'{base_url}/info')
+    resp = session.get(f"{base_url}/info")
 
     assert resp.status_code == 200
-    assert resp.headers['x-reduct-api'] == "1.7"
+    assert resp.headers["x-reduct-api"] == "1.7"

--- a/api_tests/server_api_test.py
+++ b/api_tests/server_api_test.py
@@ -6,35 +6,41 @@ from conftest import requires_env, auth_headers
 
 def test__get_info(base_url, session):
     """Should provide information about the storage"""
-    resp = session.get(f'{base_url}/info')
+    resp = session.get(f"{base_url}/info")
 
     assert resp.status_code == 200
     data = json.loads(resp.content)
-    assert data['version'] >= '1.5.0'
-    assert int(data['bucket_count']) > 0
-    assert int(data['uptime']) >= 0
-    assert int(data['latest_record']) >= 0
-    assert int(data['oldest_record']) >= 0
+    assert data["version"] >= "1.5.0"
+    assert int(data["bucket_count"]) > 0
+    assert int(data["uptime"]) >= 0
+    assert int(data["latest_record"]) >= 0
+    assert int(data["oldest_record"]) >= 0
 
-    assert data['defaults']['bucket'] == {'max_block_records': 256, 'max_block_size': 64000000, 'quota_size': 0,
-                                          'quota_type': 'NONE'}
-    assert re.match(r"ReductStore 1\.\d+\.\d+", resp.headers['server'])
-    assert resp.headers['Content-Type'] == "application/json"
+    assert data["defaults"]["bucket"] == {
+        "max_block_records": 256,
+        "max_block_size": 64000000,
+        "quota_size": 0,
+        "quota_type": "NONE",
+    }
+    assert re.match(r"ReductStore 1\.\d+\.\d+", resp.headers["server"])
+    assert resp.headers["Content-Type"] == "application/json"
 
 
 @requires_env("API_TOKEN")
 def test__authorized_info(base_url, session, token_without_permissions):
     """Needs authenticated token /info with token"""
-    resp = session.get(f'{base_url}/info', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/info", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/info', headers=auth_headers(token_without_permissions))
+    resp = session.get(
+        f"{base_url}/info", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 200
 
 
 def test__get_list_of_buckets(base_url, session):
     """Should provide information about the storage"""
-    resp = session.get(f'{base_url}/list')
+    resp = session.get(f"{base_url}/list")
 
     assert resp.status_code == 200
     data = json.loads(resp.content)
@@ -46,50 +52,55 @@ def test__get_list_of_buckets(base_url, session):
     assert int(data["buckets"][0]["oldest_record"]) >= 0
     assert int(data["buckets"][0]["latest_record"]) >= 0
 
-    assert resp.headers['Content-Type'] == "application/json"
+    assert resp.headers["Content-Type"] == "application/json"
 
 
 @requires_env("API_TOKEN")
 def test__authorized_list(base_url, session, token_without_permissions):
     """Needs authenticated token /list with token"""
-    resp = session.get(f'{base_url}/list', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/list", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/list', headers=auth_headers(token_without_permissions))
+    resp = session.get(
+        f"{base_url}/list", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 200
 
 
 def test__get_wrong_path(base_url, session):
     """Should return 404"""
-    resp = session.get(f'{base_url}/NOTEXIST')
+    resp = session.get(f"{base_url}/NOTEXIST")
     assert resp.status_code == 404
 
-    resp = session.get(f'{base_url}/NOTEXIST/XXXX')
+    resp = session.get(f"{base_url}/NOTEXIST/XXXX")
     assert resp.status_code == 404
 
 
 def test__head_alive(base_url, session):
     """Should provide HEAD /alive method"""
-    resp = session.head(f'{base_url}/alive')
+    resp = session.head(f"{base_url}/alive")
     assert resp.status_code == 200
 
 
 @requires_env("API_TOKEN")
 def test__anonymous_alive(base_url, session):
     """should access /alive without token"""
-    resp = session.head(f'{base_url}/alive', headers={})
+    resp = session.head(f"{base_url}/alive", headers={})
     assert resp.status_code == 200
 
 
 @requires_env("API_TOKEN")
-def test__me(base_url, session, ):
+def test__me(
+    base_url,
+    session,
+):
     """Should provide information about current token"""
-    resp = session.get(f'{base_url}/me')
+    resp = session.get(f"{base_url}/me")
 
     assert resp.status_code == 200
     data = json.loads(resp.content)
-    assert data['name'] == 'init-token'
-    assert data['permissions'] == {'full_access': True, 'read': [], 'write': []}
+    assert data["name"] == "init-token"
+    assert data["permissions"] == {"full_access": True, "read": [], "write": []}
 
-    resp = session.get(f'{base_url}/me', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/me", headers=auth_headers(""))
     assert resp.status_code == 401

--- a/api_tests/token_api_test.py
+++ b/api_tests/token_api_test.py
@@ -6,7 +6,7 @@ from conftest import auth_headers, requires_env
 @requires_env("API_TOKEN")
 def test__create_token(base_url, session, token_name, bucket_name):
     """Should create a token"""
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
     permissions = {
@@ -15,22 +15,29 @@ def test__create_token(base_url, session, token_name, bucket_name):
         "write": [bucket_name],
     }
 
-    resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions)
+    resp = session.post(f"{base_url}/tokens/{token_name}", json=permissions)
     assert resp.status_code == 200
-    assert resp.headers['content-type'] == "application/json"
+    assert resp.headers["content-type"] == "application/json"
     assert "token-" in json.loads(resp.content)["value"]
 
 
 @requires_env("API_TOKEN")
-def test__creat_token_with_full_access(base_url, session, token_name, token_without_permissions):
+def test__creat_token_with_full_access(
+    base_url, session, token_name, token_without_permissions
+):
     """Needs full access to create a token"""
     permissions = {}
 
-    resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions, headers=auth_headers(''))
+    resp = session.post(
+        f"{base_url}/tokens/{token_name}", json=permissions, headers=auth_headers("")
+    )
     assert resp.status_code == 401
 
-    resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions,
-                        headers=auth_headers(token_without_permissions))
+    resp = session.post(
+        f"{base_url}/tokens/{token_name}",
+        json=permissions,
+        headers=auth_headers(token_without_permissions),
+    )
     assert resp.status_code == 403
     assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
 
@@ -40,22 +47,24 @@ def test__list_tokens(base_url, session, token_name):
     """Should list all tokens"""
     permissions = {}
 
-    resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions)
+    resp = session.post(f"{base_url}/tokens/{token_name}", json=permissions)
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/tokens')
+    resp = session.get(f"{base_url}/tokens")
     assert resp.status_code == 200
-    assert resp.headers['content-type'] == "application/json"
+    assert resp.headers["content-type"] == "application/json"
     assert token_name in [t["name"] for t in json.loads(resp.content)["tokens"]]
 
 
 @requires_env("API_TOKEN")
 def test__list_token_with_full_access(base_url, session, token_without_permissions):
     """Needs full access to list tokens"""
-    resp = session.get(f'{base_url}/tokens', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/tokens", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/tokens', headers=auth_headers(token_without_permissions))
+    resp = session.get(
+        f"{base_url}/tokens", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 403
     assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
 
@@ -63,7 +72,7 @@ def test__list_token_with_full_access(base_url, session, token_without_permissio
 @requires_env("API_TOKEN")
 def test__get_token(base_url, session, bucket_name, token_name):
     """Should show a token name and permissions"""
-    resp = session.post(f'{base_url}/b/{bucket_name}')
+    resp = session.post(f"{base_url}/b/{bucket_name}")
     assert resp.status_code == 200
 
     permissions = {
@@ -72,13 +81,13 @@ def test__get_token(base_url, session, bucket_name, token_name):
         "write": [bucket_name],
     }
 
-    resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions)
+    resp = session.post(f"{base_url}/tokens/{token_name}", json=permissions)
     assert resp.status_code == 200
     created_at = json.loads(resp.content)["created_at"]
 
-    resp = session.get(f'{base_url}/tokens/{token_name}')
+    resp = session.get(f"{base_url}/tokens/{token_name}")
     assert resp.status_code == 200
-    assert resp.headers['content-type'] == "application/json"
+    assert resp.headers["content-type"] == "application/json"
     assert json.loads(resp.content) == {
         "name": token_name,
         "created_at": created_at,
@@ -91,10 +100,12 @@ def test__get_token(base_url, session, bucket_name, token_name):
 @requires_env("API_TOKEN")
 def test__get_token_with_full_access(base_url, session, token_without_permissions):
     """Needs full access to get a token"""
-    resp = session.get(f'{base_url}/tokens/token-name', headers=auth_headers(''))
+    resp = session.get(f"{base_url}/tokens/token-name", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.get(f'{base_url}/tokens/token-name', headers=auth_headers(token_without_permissions))
+    resp = session.get(
+        f"{base_url}/tokens/token-name", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 403
     assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
 
@@ -104,13 +115,13 @@ def test__delete_token(base_url, session, token_name):
     """Should delete a token"""
     permissions = {}
 
-    resp = session.post(f'{base_url}/tokens/{token_name}', json=permissions)
+    resp = session.post(f"{base_url}/tokens/{token_name}", json=permissions)
     assert resp.status_code == 200
 
-    resp = session.delete(f'{base_url}/tokens/{token_name}')
+    resp = session.delete(f"{base_url}/tokens/{token_name}")
     assert resp.status_code == 200
 
-    resp = session.get(f'{base_url}/tokens')
+    resp = session.get(f"{base_url}/tokens")
     assert resp.status_code == 200
     assert token_name not in [t["name"] for t in json.loads(resp.content)["tokens"]]
 
@@ -118,9 +129,11 @@ def test__delete_token(base_url, session, token_name):
 @requires_env("API_TOKEN")
 def test__delete_token_with_full_access(base_url, session, token_without_permissions):
     """Needs full access to delete a token"""
-    resp = session.delete(f'{base_url}/tokens/token-name', headers=auth_headers(''))
+    resp = session.delete(f"{base_url}/tokens/token-name", headers=auth_headers(""))
     assert resp.status_code == 401
 
-    resp = session.delete(f'{base_url}/tokens/token-name', headers=auth_headers(token_without_permissions))
+    resp = session.delete(
+        f"{base_url}/tokens/token-name", headers=auth_headers(token_without_permissions)
+    )
     assert resp.status_code == 403
     assert resp.headers["x-reduct-error"] == "Token doesn't have full access"

--- a/api_tests/token_api_test.py
+++ b/api_tests/token_api_test.py
@@ -84,6 +84,7 @@ def test__get_token(base_url, session, bucket_name, token_name):
         "created_at": created_at,
         "value": "",
         "permissions": permissions,
+        "is_provisioned": False,
     }
 
 

--- a/api_tests/web_console.py
+++ b/api_tests/web_console.py
@@ -11,5 +11,5 @@ def _console_url() -> str:
 
 def test__web_console(console_url, session):
     """should access web console without token"""
-    resp = session.get(f'{console_url}', headers={'Authorization': ''})
+    resp = session.get(f"{console_url}", headers={"Authorization": ""})
     assert resp.status_code == 200

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,38 +44,4 @@ cargo install reductstore
 RS_DATA_PATH=./data reductstore
 ```
 
-## Configuration
-
-ReductStore can be configured with the following environmental variables:
-
-| Name                | Default | Description                                                                               |
-|---------------------|---------|-------------------------------------------------------------------------------------------|
-| RS\_LOG\_LEVEL      | INFO    | Logging level, can be: TRACE, DEBUG, INFO, WARNING, ERROR                                 |
-| RS\_HOST            | 0.0.0.0 | Listening IP address                                                                      |
-| RS\_PORT            | 8383    | Listening port                                                                            |
-| RS\_API\_BASE\_PATH | /       | Prefix for all URLs of requests                                                           |
-| RS\_DATA\_PATH      | /data   | Path to a folder where the storage stores the data                                        |
-| RS\_API\_TOKEN      |         | If set, the storage uses [token authorization](broken-reference)                          |
-| RS\_CERT\_PATH      |         | Path to an SSL certificate. If unset, the storage uses HTTP instead of HTTPS              |
-| RS\_CERT\_KEY\_PATH |         | Path to the private key of the desired SSL certificate. Should be set with RS\_CERT\_PATH |
-
-If you use snap, you can configure the database by using the `snap set` command:
-
-```
-snap set reductstore log-level=DEBUG
-```
-
-This command change the log level to DEBUG and restarts the database. You can check the current configuration with the `snap get reductstoret` command:
-
-```
-snap get reductstore
-Key            Value
-api-base       /
-api-token
-cert-key-path
-cert-path
-data-path      /var/snap/reductstore/common
-host           0.0.0.0
-log-level      DEBUG
-port           8383
-```
+##

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,8 @@
 
 * [💡 Getting Started](README.md)
 * [😯 How Does It Work?](how-does-it-work.md)
-* [⚙ HTTP API Reference](http-api/README.md)
+* [⚙ Configuration](configuration.md)
+* [💫 HTTP API Reference](http-api/README.md)
   * [Server API](http-api/server-api.md)
   * [Bucket API](http-api/bucket-api.md)
   * [Entry API](http-api/entry-api.md)
@@ -10,6 +11,7 @@
 
 ## SDKs
 
+* [Rust Client SDK](https://docs.rs/crate/reduct-rs/latest)
 * [Python Client SDK](https://py.reduct.store)
 * [JavaScript Client SDK](https://js.reduct.store)
 * [C++ Client SDK](https://cpp.reduct.store)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,63 @@
+# ⚙ Configuration
+
+## Settings
+
+ReductStore uses environment variables for configuration. Here is a list of available settings:
+
+| Name                | Default | Description                                                                               |
+| ------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| RS\_LOG\_LEVEL      | INFO    | Logging level, can be: TRACE, DEBUG, INFO, WARNING, ERROR                                 |
+| RS\_HOST            | 0.0.0.0 | Listening IP address                                                                      |
+| RS\_PORT            | 8383    | Listening port                                                                            |
+| RS\_API\_BASE\_PATH | /       | Prefix for all URLs of requests                                                           |
+| RS\_DATA\_PATH      | /data   | Path to a folder where the storage stores the data                                        |
+| RS\_API\_TOKEN      |         | If set, the storage uses [token authorization](broken-reference/)                         |
+| RS\_CERT\_PATH      |         | Path to an SSL certificate. If unset, the storage uses HTTP instead of HTTPS              |
+| RS\_CERT\_KEY\_PATH |         | Path to the private key of the desired SSL certificate. Should be set with RS\_CERT\_PATH |
+
+### For Snap Users
+
+If you use snap, you can configure the database by using the `snap set` command:
+
+```
+snap set reductstore log-level=DEBUG
+```
+
+This command changes the log level to DEBUG and restarts the database. You can check the current configuration with the `snap get reductstoret` command:
+
+```
+snap get reductstore
+Key            Value
+api-base       /
+api-token
+cert-key-path
+cert-path
+data-path      /var/snap/reductstore/common
+host           0.0.0.0
+log-level      DEBUG
+port           8383
+```
+
+## Provisioning
+
+ReductStore provides an HTTP API to create and configure resources such as buckets or access tokens. However, if you are following an Infrastructure as Code (IaC) approach, you may want to provision resources at the deployment stage and ensure that they can't be modified or deleted using the HTTP API. You can use the following environment variables to do this:
+
+<table><thead><tr><th width="378">Name</th><th width="86.33333333333331">Default</th><th>Description</th></tr></thead><tbody><tr><td><strong>Bucket Provisioning</strong></td><td></td><td></td></tr><tr><td>RS_BUCKET_&#x3C;ID>_NAME</td><td></td><td>Provisioned bucket name (required)</td></tr><tr><td>RS_BUCKET_&#x3C;ID>_QUOTA_TYPE</td><td>NONE</td><td>It can be NONE or FIFO.  If it is FIFO, the bucket removes old data.</td></tr><tr><td>RS_BUCKET_&#x3C;ID>_QUOTA_SIZE</td><td>""</td><td>Size of quota to start removing old data e.g. 1 KB, 10.4 MB etc.</td></tr><tr><td>RS_BUCKET_&#x3C;ID>_MAX_BLOCK_SIZE</td><td>64Mb</td><td>Maximal block size for batched records</td></tr><tr><td>RS__BUCKET_&#x3C;ID>_MAX_BLOCK_RECORDS</td><td>256</td><td>Maximal number of batched records in a block</td></tr><tr><td><strong>Token Provisioning</strong></td><td></td><td></td></tr><tr><td>RS_TOKEN_&#x3C;ID>_NAME</td><td></td><td>Provisioned token name (required)</td></tr><tr><td>RS_TOKEN_&#x3C;ID>_VALUE</td><td></td><td>Provisioned value of token (required)</td></tr><tr><td>RS_TOKEN_&#x3C;ID>_FULL_ACCESS</td><td>false</td><td>Full access permission</td></tr><tr><td>RS_TOKEN_&#x3C;ID>_READ</td><td></td><td>List of buckets for reading</td></tr><tr><td>RS_TOKEN_&#x3C;ID>_WRITE</td><td></td><td>List of buckets for writing</td></tr></tbody></table>
+
+{% hint style="info" %}
+You can use any string value for \<ID>. It is only used to group resources of the same type.
+{% endhint %}
+
+&#x20;There is an example where we provide two buckets and a token to access them:
+
+```
+RS_BUCKET_A_NAME=bucket-1
+RS_BUCKET_A_QUOTA_TYPE=FIFO
+RS_BUCKET_A_QUOTA_SIZE=1Tb
+
+RS_BUCKET_B_NAME=bucket-2
+
+RS_TOKEN_A_NAME=token
+RS_TOKEN_A_VALUE=somesecret
+RS_TOKEN_A_READ=bucket-1,bucket-2
+```

--- a/docs/http-api/bucket-api.md
+++ b/docs/http-api/bucket-api.md
@@ -122,7 +122,7 @@ Size of quota in bytes (default: 0)
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 
@@ -170,7 +170,7 @@ Size of quota in bytes
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 
@@ -206,7 +206,7 @@ Name of bucket to remove
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 

--- a/docs/http-api/bucket-api.md
+++ b/docs/http-api/bucket-api.md
@@ -38,7 +38,8 @@ Name of bucket
         "entry_count": "integer", // number of entries in the bucket
         "size": "integer",        // size of stored data in the bucket in bytes
         "oldest_record": "integer", // unix timestamp of oldest record in microseconds
-        "latest_record": "integer"  // unix timestamp of latest record in microseconds
+        "latest_record": "integer",  // unix timestamp of latest record in microseconds
+        "is_provisioned": "bool"  // true if the bucket provisioned and can't be changed via API
     },
     "entries": [        // list of entry stats
         {
@@ -173,7 +174,11 @@ Size of quota in bytes
 
 {% endswagger-response %}
 
-{% swagger-response status="404: Not Found" description="Bucket doesn" %}
+{% swagger-response status="404: Not Found" description="Bucket doesn't exist" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="409: Conflict" description="Bucket is provisioned" %}
 
 {% endswagger-response %}
 
@@ -206,6 +211,10 @@ Name of bucket to remove
 {% endswagger-response %}
 
 {% swagger-response status="404: Not Found" description="Bucket does not exists" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="409: Conflict" description="Bucket is provisioned" %}
 
 {% endswagger-response %}
 {% endswagger %}

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -119,7 +119,7 @@ A UNIX timestamp in microseconds. If it is empty, the latest record is returned.
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 
@@ -177,7 +177,7 @@ Name of entry
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 

--- a/docs/http-api/token-authentication.md
+++ b/docs/http-api/token-authentication.md
@@ -105,7 +105,7 @@ A list of bucket names for write access. Default: []
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 

--- a/docs/http-api/token-authentication.md
+++ b/docs/http-api/token-authentication.md
@@ -30,7 +30,7 @@ The method returns a list of tokens with names and creation dates. To use this m
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 {% endswagger %}
@@ -58,11 +58,11 @@ Name of token to show
 ```
 {% endswagger-response %}
 
-{% swagger-response status="401: Unauthorized" description="Access token is empty or invalid" %}
+{% swagger-response status="401: Unauthorized" description="Current access token is empty or invalid" %}
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Current access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 
@@ -118,6 +118,53 @@ A list of bucket names for write access. Default: []
 {% endswagger-response %}
 {% endswagger %}
 
+{% swagger method="put" path="/:token_name" baseUrl="/api/v1/tokens" summary="Update an access token" %}
+{% swagger-description %}
+The method updates an access token with given permissions as a JSON document in the request body. To use this method, you need an access token with full access.
+{% endswagger-description %}
+
+{% swagger-parameter in="path" name=":token_name" required="true" %}
+Name of new token
+{% endswagger-parameter %}
+
+{% swagger-parameter in="body" name="full_access" type="Boolean" required="false" %}
+Create a token with full acces. Default: false
+{% endswagger-parameter %}
+
+{% swagger-parameter in="body" name="read" type="String[]" required="false" %}
+A list of bucket names for read access. Default: []
+{% endswagger-parameter %}
+
+{% swagger-parameter in="body" name="write" type="String[]" required="false" %}
+A list of bucket names for write access. Default: []
+{% endswagger-parameter %}
+
+{% swagger-response status="200: OK" description="Returns value and timestamp of token" %}
+```javascript
+{
+    "value": "string",        // hash value of the token
+    "created_at": "string"    // date as ISO string
+}
+```
+{% endswagger-response %}
+
+{% swagger-response status="401: Unauthorized" description="Access token is empty or invalid" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="409: Conflict" description="Access token is provisioned" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="422: Unprocessable Entity" description="Speciefied bucket doesn" %}
+
+{% endswagger-response %}
+{% endswagger %}
+
 {% swagger method="delete" path="" baseUrl="/api/v1/tokens/:token_name" summary="Remove a  token" %}
 {% swagger-description %}
 This method removes or invokes a token. To use it, a client should has an access token with full access
@@ -139,15 +186,18 @@ Name of new token
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
 
 {% endswagger-response %}
 
-{% swagger-response status="404: Not Found" description="Token with the given name doesn" %}
+{% swagger-response status="404: Not Found" description="Token with the given name doesn't exist" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="409: Conflict" description="Token is provisioned" %}
 
 {% endswagger-response %}
 {% endswagger %}
-
 
 {% swagger method="get" path="" baseUrl="/api/v1/me" summary="Get full information about current API token" %}
 {% swagger-description %}

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -130,10 +130,6 @@ impl ReductError {
         &self.message
     }
 
-    pub fn to_string(&self) -> String {
-        format!("[{:?}] {}", self.status, self.message)
-    }
-
     pub fn ok() -> ReductError {
         ReductError {
             status: ErrorCode::OK,

--- a/reduct_base/src/msg/bucket_api.rs
+++ b/reduct_base/src/msg/bucket_api.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+use std::str::FromStr;
 // Copyright 2023 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -22,6 +24,27 @@ impl From<i32> for QuotaType {
             0 => QuotaType::NONE,
             1 => QuotaType::FIFO,
             _ => QuotaType::NONE,
+        }
+    }
+}
+
+impl FromStr for QuotaType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NONE" => Ok(QuotaType::NONE),
+            "FIFO" => Ok(QuotaType::FIFO),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Display for QuotaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QuotaType::NONE => write!(f, "NONE"),
+            QuotaType::FIFO => write!(f, "FIFO"),
         }
     }
 }

--- a/reduct_base/src/msg/bucket_api.rs
+++ b/reduct_base/src/msg/bucket_api.rs
@@ -75,6 +75,8 @@ pub struct BucketInfo {
     pub oldest_record: u64,
     /// Latest record in bucket
     pub latest_record: u64,
+    /// Provisioned
+    pub is_provisioned: bool,
 }
 
 /// Full bucket information

--- a/reduct_base/src/msg/bucket_api.rs
+++ b/reduct_base/src/msg/bucket_api.rs
@@ -1,11 +1,11 @@
-use std::fmt::Display;
-use std::str::FromStr;
 // Copyright 2023 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use crate::msg::entry_api::EntryInfo;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::str::FromStr;
 
 /// Quota type
 ///

--- a/reduct_base/src/msg/token_api.rs
+++ b/reduct_base/src/msg/token_api.rs
@@ -31,6 +31,8 @@ pub struct Token {
     pub created_at: DateTime<Utc>,
     /// Permissions
     pub permissions: Option<Permissions>,
+    /// Provisioned
+    pub is_provisioned: bool,
 }
 
 /// Response for created token

--- a/reduct_rs/examples/hallo_world.rs
+++ b/reduct_rs/examples/hallo_world.rs
@@ -8,8 +8,6 @@ use reduct_rs::{ReductClient, ReductError};
 use std::str::from_utf8;
 use std::time::SystemTime;
 
-use tokio;
-
 #[tokio::main]
 async fn main() -> Result<(), ReductError> {
     let client = ReductClient::builder().url("http://127.0.0.1:8383").build();
@@ -31,10 +29,7 @@ async fn main() -> Result<(), ReductError> {
         .await?;
 
     println!("Record: {:?}", record);
-    println!(
-        "Data: {}",
-        from_utf8(&record.bytes().await?.to_vec()).unwrap()
-    );
+    println!("Data: {}", from_utf8(&record.bytes().await?).unwrap());
 
     Ok(())
 }

--- a/reduct_rs/examples/query.rs
+++ b/reduct_rs/examples/query.rs
@@ -8,8 +8,6 @@ use futures_util::StreamExt;
 use reduct_rs::{ReductClient, ReductError};
 use std::str::from_utf8;
 
-use tokio;
-
 #[tokio::main]
 async fn main() -> Result<(), ReductError> {
     let client = ReductClient::builder().url("http://127.0.0.1:8383").build();
@@ -43,10 +41,7 @@ async fn main() -> Result<(), ReductError> {
     while let Some(record) = query.next().await {
         let record = record?;
         println!("Record: {:?}", record);
-        println!(
-            "Data: {}",
-            from_utf8(&record.bytes().await?.to_vec()).unwrap()
-        );
+        println!("Data: {}", from_utf8(&record.bytes().await?).unwrap());
     }
 
     Ok(())

--- a/reduct_rs/src/bucket.rs
+++ b/reduct_rs/src/bucket.rs
@@ -398,7 +398,7 @@ mod tests {
 
                 bucket
                     .write_record("entry-3")
-                    .timestamp_us((i as u64) * 1000_000)
+                    .timestamp_us((i as u64) * 1_000_000)
                     .data(Bytes::from(bodies[i].clone()))
                     .send()
                     .await
@@ -426,7 +426,7 @@ mod tests {
             }
 
             let record = query.next().await.unwrap().unwrap();
-            assert_eq!(record.timestamp_us(), 1000_000);
+            assert_eq!(record.timestamp_us(), 1_000_000);
             assert_eq!(record.content_length(), size);
             assert_eq!(record.content_type(), "application/octet-stream");
 
@@ -438,7 +438,7 @@ mod tests {
             }
 
             let record = query.next().await.unwrap().unwrap();
-            assert_eq!(record.timestamp_us(), 2000_000);
+            assert_eq!(record.timestamp_us(), 2_000_000);
             assert_eq!(record.content_length(), size);
             assert_eq!(record.content_type(), "application/octet-stream");
 

--- a/reduct_rs/src/client.rs
+++ b/reduct_rs/src/client.rs
@@ -237,7 +237,6 @@ pub(crate) mod tests {
     use bytes::Bytes;
     use reduct_base::msg::bucket_api::{BucketSettings, QuotaType};
     use rstest::{fixture, rstest};
-    use tokio;
 
     mod serve_api {
         use super::*;
@@ -331,7 +330,7 @@ pub(crate) mod tests {
         #[tokio::test]
         async fn test_list_tokens(#[future] client: ReductClient) {
             let tokens = client.await.list_tokens().await.unwrap();
-            assert!(tokens.len() >= 1);
+            assert!(!tokens.is_empty());
         }
 
         #[rstest]

--- a/reduct_rs/src/http_client.rs
+++ b/reduct_rs/src/http_client.rs
@@ -66,7 +66,7 @@ impl HttpClient {
         response.json::<Out>().await.map_err(|e| {
             ReductError::new(
                 ErrorCode::Unknown,
-                &format!("Failed to parse response: {}", e.to_string()),
+                &format!("Failed to parse response: {}", e),
             )
         })
     }
@@ -93,11 +93,9 @@ impl HttpClient {
 
     /// Prepare a request with the correct headers.
     pub fn request(&self, method: Method, path: &str) -> RequestBuilder {
-        let request = self
-            .client
-            .request(method, &format!("{}{}", self.base_url, path))
-            .header("Authorization", &self.api_token);
-        request
+        self.client
+            .request(method, format!("{}{}", self.base_url, path))
+            .header("Authorization", &self.api_token)
     }
 
     /// Send a request and handle errors.

--- a/reduct_rs/src/record.rs
+++ b/reduct_rs/src/record.rs
@@ -80,7 +80,7 @@ impl Record {
             while let Some(chunk) = data.next().await {
                 bytes.extend_from_slice(&chunk?);
             }
-            return Ok(bytes.into());
+            Ok(bytes.into())
         } else {
             panic!("Record has no data");
         }
@@ -88,7 +88,7 @@ impl Record {
 
     pub fn stream_bytes(self) -> Pin<Box<dyn Stream<Item = Result<Bytes, ReductError>>>> {
         if let Some(data) = self.data {
-            return data;
+            data
         } else {
             panic!("Record has no data");
         }

--- a/reduct_rs/src/record/read_record.rs
+++ b/reduct_rs/src/record/read_record.rs
@@ -94,7 +94,7 @@ impl ReadRecordBuilder {
                 .unwrap()
                 .parse::<u64>()
                 .unwrap(),
-            labels: labels,
+            labels,
             content_type: response
                 .headers()
                 .get("content-type")

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -49,6 +49,7 @@ tokio-util = "0.7.8"
 axum-server = { version = "0.5.1", features = ["tls-rustls"] }
 rustls = "0.21.6"
 mime_guess = "2.0.4"
+bytesize = "1.3.0"
 
 [build-dependencies]
 prost-build = "0.11.9"

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["database-implementations", "command-line-utilities", "database"]
 include = ["src/**/*", "Cargo.toml", "Cargo.lock", "build.rs", "README.md", "LICENSE"]
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["lib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/reductstore/build.rs
+++ b/reductstore/build.rs
@@ -4,6 +4,7 @@ extern crate core;
 
 use reqwest::blocking::get;
 use reqwest::StatusCode;
+use std::path::Path;
 use std::time::SystemTime;
 use std::{env, fs};
 
@@ -22,7 +23,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .expect("Failed to compile protos");
 
-    // download web console
+    download_web_console();
+
+    // get build time and commit
+    let build_time = chrono::DateTime::<chrono::Utc>::from(SystemTime::now())
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let commit = match std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+    {
+        Ok(output) => String::from_utf8(output.stdout).expect("Failed to get commit"),
+        Err(_) => env::var("GIT_COMMIT").unwrap_or("unknown".to_string()),
+    };
+
+    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
+    println!("cargo:rustc-env=COMMIT={}", commit);
+    Ok(())
+}
+
+fn download_web_console() {
+    if Path::exists(Path::new(&format!(
+        "{}/console.zip",
+        env::var("OUT_DIR").unwrap()
+    ))) {
+        return;
+    }
+
     let mut resp = get(format!(
         "https://github.com/reductstore/web-console/releases/download/{}/web-console.build.zip",
         WEB_CONSOLE_VERSION
@@ -41,19 +67,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         resp.bytes().unwrap(),
     )
     .expect("Failed to write console.zip");
-
-    // get build time and commit
-    let build_time = chrono::DateTime::<chrono::Utc>::from(SystemTime::now())
-        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    let commit = match std::process::Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-    {
-        Ok(output) => String::from_utf8(output.stdout).expect("Failed to get commit"),
-        Err(_) => env::var("GIT_COMMIT").unwrap_or("unknown".to_string()),
-    };
-
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=COMMIT={}", commit);
-    Ok(())
 }

--- a/reductstore/build.rs
+++ b/reductstore/build.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to compile protos");
 
     // download web console
-    let mut resp = get(&format!(
+    let mut resp = get(format!(
         "https://github.com/reductstore/web-console/releases/download/{}/web-console.build.zip",
         WEB_CONSOLE_VERSION
     ))
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let build_time = chrono::DateTime::<chrono::Utc>::from(SystemTime::now())
         .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let commit = match std::process::Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short", "HEAD"])
         .output()
     {
         Ok(output) => String::from_utf8(output.stdout).expect("Failed to get commit"),

--- a/reductstore/src/auth/token_repository.rs
+++ b/reductstore/src/auth/token_repository.rs
@@ -11,7 +11,6 @@ use log::{debug, warn};
 use prost::bytes::Bytes;
 use prost::Message;
 use prost_wkt_types::Timestamp;
-use tempfile::tempdir;
 
 use crate::auth::proto::token::Permissions as ProtoPermissions;
 use crate::auth::proto::{Token as ProtoToken, TokenRepo as ProtoTokenRepo, TokenRepo};
@@ -704,14 +703,14 @@ mod tests {
     // find_by_name tests
     //----------------
     #[rstest]
-    fn test_find_by_name(mut repo: Box<dyn ManageTokens>) {
+    fn test_find_by_name(repo: Box<dyn ManageTokens>) {
         let token = repo.get_token("test").unwrap();
         assert_eq!(token.name, "test");
         assert!(token.value.starts_with("test-"));
     }
 
     #[rstest]
-    fn test_find_by_name_not_found(mut repo: Box<dyn ManageTokens>) {
+    fn test_find_by_name_not_found(repo: Box<dyn ManageTokens>) {
         let token = repo.get_token("test-1");
         assert_eq!(
             token,
@@ -732,7 +731,7 @@ mod tests {
     // get_token_list tests
     //------------
     #[rstest]
-    fn test_get_token_list(mut repo: Box<dyn ManageTokens>) {
+    fn test_get_token_list(repo: Box<dyn ManageTokens>) {
         let token_list = repo.get_token_list().unwrap();
 
         assert_eq!(token_list.len(), 2);

--- a/reductstore/src/auth/token_repository.rs
+++ b/reductstore/src/auth/token_repository.rs
@@ -707,20 +707,21 @@ mod tests {
     #[test]
     pub fn test_find_by_name() {
         let mut repo = setup("init-token");
-        repo.generate_token(
-            "test",
-            Permissions {
-                full_access: true,
-                read: vec![],
-                write: vec![],
-            },
-        )
-        .unwrap();
+        let generated_token = repo
+            .generate_token(
+                "test",
+                Permissions {
+                    full_access: true,
+                    read: vec![],
+                    write: vec![],
+                },
+            )
+            .unwrap();
 
         let token = repo.get_token("test").unwrap();
 
         assert_eq!(token.name, "test");
-        assert_eq!(token.value, "");
+        assert_eq!(token.value, generated_token.value);
     }
 
     #[test]

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -37,7 +37,7 @@ pub struct Cfg<EnvGetter: GetEnv> {
 }
 
 impl<EnvGetter: GetEnv> Cfg<EnvGetter> {
-    pub fn from_env(mut env_getter: EnvGetter) -> Self {
+    pub fn from_env(env_getter: EnvGetter) -> Self {
         let mut env = Env::new(env_getter);
         let cfg = Cfg {
             log_level: env.get("RS_LOG_LEVEL", "INFO".to_string()),
@@ -222,13 +222,12 @@ impl<EnvGetter: GetEnv> Display for Cfg<EnvGetter> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::env::EnvValue;
+
     use mockall::mock;
     use mockall::predicate::eq;
     use rstest::{fixture, rstest};
     use std::collections::BTreeMap;
-    use std::env::{VarError, Vars};
-    use std::str::FromStr;
+    use std::env::VarError;
 
     mock! {
         EnvGetter {}

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -115,8 +115,10 @@ impl<EnvGetter: GetEnv> Cfg<EnvGetter> {
                 Err(e) => {
                     if e.status() == ErrorCode::Conflict {
                         let bucket = storage.get_mut_bucket(&name).unwrap();
-                        bucket.set_provisioned(true);
+                        bucket.set_provisioned(false);
                         bucket.set_settings(settings.clone()).unwrap();
+                        bucket.set_provisioned(true);
+
                         Ok(bucket.settings().clone())
                     } else {
                         Err(e)

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -1,0 +1,107 @@
+// Copyright 2023 ReductStore
+// Licensed under the Business Source License 1.1
+
+/*
+ let host = env.get::<String>("RS_HOST", "0.0.0.0".to_string(), false);
+   let port = env.get::<i32>("RS_PORT", 8383, false);
+   let api_base_path = env.get::<String>("RS_API_BASE_PATH", "/".to_string(), false);
+   let data_path = env.get::<String>("RS_DATA_PATH", "/data".to_string(), false);
+   let api_token = env.get::<String>("RS_API_TOKEN", "".to_string(), true);
+   let cert_path = env.get::<String>("RS_CERT_PATH", "".to_string(), true);
+   let cert_key_path = env.get::<String>("RS_CERT_KEY_PATH", "".to_string(), true);
+*/
+use crate::core::env::Env;
+use log::{log, warn};
+use reduct_base::msg::bucket_api::{BucketSettings, QuotaType};
+use reduct_base::msg::token_api::Permissions;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// Database configuration
+pub struct Cfg {
+    pub log_level: String,
+    pub host: String,
+    pub port: i32,
+    pub api_base_path: String,
+    pub data_path: String,
+    pub api_token: String,
+    pub cert_path: String,
+    pub cert_key_path: String,
+    pub buckets: HashMap<String, Bucket>,
+    pub tokens: HashMap<String, Token>,
+}
+
+/// Provisioned bucket
+pub struct Bucket {
+    pub name: String,
+    pub settings: BucketSettings,
+}
+
+/// Provisioned token
+pub struct Token {
+    pub name: String,
+    pub permissions: Permissions,
+}
+
+impl Cfg {
+    pub fn from_env(env: &mut Env) -> Self {
+        let mut cfg = Cfg {
+            log_level: env.get("RS_LOG_LEVEL", "INFO".to_string(), false),
+            host: env.get("RS_HOST", "0.0.0.0".to_string(), false),
+            port: env.get("RS_PORT", 8383, false),
+            api_base_path: env.get("RS_API_BASE_PATH", "/".to_string(), false),
+            data_path: env.get("RS_DATA_PATH", "/data".to_string(), false),
+            api_token: env.get("RS_API_TOKEN", "".to_string(), true),
+            cert_path: env.get("RS_CERT_PATH", "".to_string(), true),
+            cert_key_path: env.get("RS_CERT_KEY_PATH", "".to_string(), true),
+            buckets: HashMap::new(),
+            tokens: HashMap::new(),
+        };
+
+        let mut buckets = HashMap::<String, (String, BucketSettings)>::new();
+        for (id, name) in env.matches("RS_BUCKET_(.*)_NAME", false) {
+            buckets.insert(id, (name, BucketSettings::default()));
+        }
+
+        macro_rules! parse_settings {
+            ($resource:literal, $name:ident, $buckets:ident, $key:literal, $type:ty) => {
+                for (id, value) in
+                    env.matches::<String>(&format!("RS_{}_(.*)_{}", $resource, $key), false)
+                {
+                    if let Some(bucket) = $buckets.get_mut(&id) {
+                        let (name, settings) = bucket;
+                        if let Ok($name) = <$type>::from_str(&value) {
+                            settings.$name = Some($name);
+                        } else {
+                            warn!("Invalid {} {} for {} '{}'", $key, value, $resource, name);
+                        }
+                    } else {
+                        warn!(
+                            "No name found for provision RS_{}_{}_{}: ignored",
+                            $resource, id, $key
+                        );
+                    }
+                }
+            };
+        }
+
+        parse_settings!("BUCKET", quota_type, buckets, "QUOTA_TYPE", QuotaType);
+        parse_settings!("BUCKET", quota_size, buckets, "QUOTA_SIZE", u64);
+        parse_settings!("BUCKET", max_block_size, buckets, "MAX_BLOCK_SIZE", u64);
+        parse_settings!(
+            "BUCKET",
+            max_block_records,
+            buckets,
+            "MAX_BLOCK_RECORDS",
+            u64
+        );
+
+        // let mut tokens = HashMap::<String, (String, Permissions)>::new();
+        // for (id, name) in env.matches("RS_TOKEN_(.*)_NAME", false) {
+        //     tokens.insert(id, (name, Permissions::default()));
+        // }
+        //
+        // parse_settings!("TOKEN", full_access, tokens, "FULL_ACCESS", bool);
+        cfg
+    }
+}

--- a/reductstore/src/core/env.rs
+++ b/reductstore/src/core/env.rs
@@ -3,7 +3,7 @@
 
 use regex::Regex;
 use std::collections::BTreeMap;
-use std::env::{VarError, Vars};
+use std::env::VarError;
 use std::fmt::Display;
 use std::str::FromStr;
 

--- a/reductstore/src/core/env.rs
+++ b/reductstore/src/core/env.rs
@@ -147,7 +147,7 @@ mod tests {
     use rstest::{fixture, rstest};
 
     #[rstest]
-    fn make_env(mut env: Env) {
+    fn make_env(_env: Env) {
         let env = new_env();
         assert_eq!(env.message(), "");
     }

--- a/reductstore/src/http_frontend.rs
+++ b/reductstore/src/http_frontend.rs
@@ -34,7 +34,7 @@ mod server_api;
 mod token_api;
 mod ui_api;
 
-pub struct HttpServerState {
+pub struct Componentes {
     pub storage: RwLock<Storage>,
     pub auth: TokenAuthorization,
     pub token_repo: RwLock<Box<dyn ManageTokens + Send + Sync>>,
@@ -102,7 +102,7 @@ impl From<serde_json::Error> for HttpError {
     }
 }
 
-pub fn create_axum_app(api_base_path: &String, components: Arc<HttpServerState>) -> Router {
+pub fn create_axum_app(api_base_path: &String, components: Arc<Componentes>) -> Router {
     let b_route = create_bucket_api_routes().merge(create_entry_api_routes());
 
     let app = Router::new()
@@ -142,7 +142,7 @@ mod tests {
     use rstest::fixture;
 
     #[fixture]
-    pub(crate) fn components() -> Arc<HttpServerState> {
+    pub(crate) fn components() -> Arc<Componentes> {
         let data_path = tempfile::tempdir().unwrap().into_path();
 
         let mut storage = Storage::new(data_path.clone());
@@ -175,9 +175,9 @@ mod tests {
             ..Default::default()
         };
 
-        token_repo.create_token("test", permissions).unwrap();
+        token_repo.generate_token("test", permissions).unwrap();
 
-        let components = HttpServerState {
+        let components = Componentes {
             storage: RwLock::new(storage),
             auth: TokenAuthorization::new("inti-token"),
             token_repo: RwLock::new(token_repo),

--- a/reductstore/src/http_frontend/bucket_api.rs
+++ b/reductstore/src/http_frontend/bucket_api.rs
@@ -24,7 +24,7 @@ use crate::http_frontend::bucket_api::head::head_bucket;
 use crate::http_frontend::bucket_api::remove::remove_bucket;
 use crate::http_frontend::bucket_api::update::update_bucket;
 
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use reduct_base::msg::bucket_api::{BucketSettings, FullBucketInfo};
 use reduct_macros::{IntoResponse, Twin};
 //
@@ -66,7 +66,7 @@ where
     }
 }
 
-pub fn create_bucket_api_routes() -> axum::Router<Arc<HttpServerState>> {
+pub fn create_bucket_api_routes() -> axum::Router<Arc<Componentes>> {
     axum::Router::new()
         .route("/:bucket_name", get(get_bucket))
         .route("/:bucket_name", head(head_bucket))

--- a/reductstore/src/http_frontend/bucket_api/create.rs
+++ b/reductstore/src/http_frontend/bucket_api/create.rs
@@ -4,7 +4,7 @@
 use crate::auth::policy::FullAccessPolicy;
 use crate::http_frontend::bucket_api::BucketSettingsAxum;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // POST /b/:bucket_name
 pub async fn create_bucket(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
     settings: BucketSettingsAxum,
@@ -31,7 +31,7 @@ mod tests {
     use super::*;
 
     use crate::http_frontend::tests::{components, headers};
-    use crate::http_frontend::HttpServerState;
+    use crate::http_frontend::Componentes;
 
     use rstest::rstest;
 
@@ -40,7 +40,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_bucket(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_create_bucket(components: Arc<Componentes>, headers: HeaderMap) {
         create_bucket(
             State(components),
             Path("bucket-3".to_string()),
@@ -53,10 +53,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_bucket_already_exists(
-        components: Arc<HttpServerState>,
-        headers: HeaderMap,
-    ) {
+    async fn test_create_bucket_already_exists(components: Arc<Componentes>, headers: HeaderMap) {
         let err = create_bucket(
             State(components),
             Path("bucket-1".to_string()),

--- a/reductstore/src/http_frontend/bucket_api/get.rs
+++ b/reductstore/src/http_frontend/bucket_api/get.rs
@@ -4,15 +4,15 @@
 use crate::auth::policy::AuthenticatedPolicy;
 use crate::http_frontend::bucket_api::FullBucketInfoAxum;
 use crate::http_frontend::middleware::check_permissions;
+use crate::http_frontend::Componentes;
 use crate::http_frontend::HttpError;
-use crate::http_frontend::HttpServerState;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
 
 // GET /b/:bucket_name
 pub async fn get_bucket(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<FullBucketInfoAxum, HttpError> {
@@ -30,7 +30,7 @@ pub async fn get_bucket(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::HttpServerState;
+    use crate::http_frontend::Componentes;
 
     use crate::http_frontend::tests::{components, headers};
 
@@ -41,7 +41,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_bucket(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_get_bucket(components: Arc<Componentes>, headers: HeaderMap) {
         let info = get_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();
@@ -50,7 +50,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_bucket_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_get_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
         let err = get_bucket(State(components), Path("not-found".to_string()), headers)
             .await
             .err()

--- a/reductstore/src/http_frontend/bucket_api/head.rs
+++ b/reductstore/src/http_frontend/bucket_api/head.rs
@@ -3,7 +3,7 @@
 
 use crate::auth::policy::AuthenticatedPolicy;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 // HEAD /b/:bucket_name
 pub async fn head_bucket(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
@@ -24,7 +24,7 @@ pub async fn head_bucket(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::HttpServerState;
+    use crate::http_frontend::Componentes;
 
     use crate::http_frontend::tests::{components, headers};
 
@@ -34,7 +34,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_head_bucket(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_head_bucket(components: Arc<Componentes>, headers: HeaderMap) {
         head_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();

--- a/reductstore/src/http_frontend/bucket_api/update.rs
+++ b/reductstore/src/http_frontend/bucket_api/update.rs
@@ -4,14 +4,14 @@
 use crate::auth::policy::FullAccessPolicy;
 use crate::http_frontend::bucket_api::BucketSettingsAxum;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
 
 // PUT /b/:bucket_name
 pub async fn update_bucket(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
     settings: BucketSettingsAxum,
@@ -33,7 +33,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_update_bucket(components: Arc<Componentes>, headers: HeaderMap) {
         update_bucket(
             State(components),
             Path("bucket-1".to_string()),
@@ -46,7 +46,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_update_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
         let err = update_bucket(
             State(components),
             Path("not-found".to_string()),

--- a/reductstore/src/http_frontend/entry_api.rs
+++ b/reductstore/src/http_frontend/entry_api.rs
@@ -33,7 +33,7 @@ use crate::http_frontend::entry_api::remove::remove_entry;
 use crate::http_frontend::entry_api::write::write_record;
 use crate::http_frontend::HttpError;
 
-use crate::http_frontend::HttpServerState;
+use crate::http_frontend::Componentes;
 
 pub struct MethodExtractor {
     name: String,
@@ -106,7 +106,7 @@ fn check_and_extract_ts_or_query_id(
 #[derive(IntoResponse, Twin)]
 pub struct QueryInfoAxum(QueryInfo);
 
-pub fn create_entry_api_routes() -> axum::Router<Arc<HttpServerState>> {
+pub fn create_entry_api_routes() -> axum::Router<Arc<Componentes>> {
     axum::Router::new()
         .route("/:bucket_name/:entry_name", post(write_record))
         .route("/:bucket_name/:entry_name", get(read_single_record))

--- a/reductstore/src/http_frontend/entry_api/query.rs
+++ b/reductstore/src/http_frontend/entry_api/query.rs
@@ -3,7 +3,7 @@
 
 use crate::auth::policy::ReadAccessPolicy;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use crate::storage::query::base::QueryOptions;
 
 use axum::extract::{Path, Query, State};
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 // GET /:bucket/:entry/q?start=<number>&stop=<number>&continue=<number>&exclude-<label>=<value>&include-<label>=<value>&ttl=<number>
 pub async fn query(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -131,7 +131,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_limited_query(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {
@@ -167,7 +167,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_bad_limit(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {

--- a/reductstore/src/http_frontend/entry_api/read_batched.rs
+++ b/reductstore/src/http_frontend/entry_api/read_batched.rs
@@ -4,7 +4,7 @@
 use crate::auth::policy::ReadAccessPolicy;
 use crate::http_frontend::entry_api::MethodExtractor;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{ErrorCode, HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, ErrorCode, HttpError};
 use crate::storage::bucket::Bucket;
 
 use crate::storage::reader::RecordReader;
@@ -24,7 +24,7 @@ use std::task::{Context, Poll};
 
 // GET /:bucket/:entry/batch?q=<number>
 pub async fn read_batched_records(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -207,7 +207,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_batched_read(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,

--- a/reductstore/src/http_frontend/entry_api/read_single.rs
+++ b/reductstore/src/http_frontend/entry_api/read_single.rs
@@ -4,8 +4,8 @@
 use crate::auth::policy::ReadAccessPolicy;
 use crate::http_frontend::entry_api::{check_and_extract_ts_or_query_id, MethodExtractor};
 use crate::http_frontend::middleware::check_permissions;
+use crate::http_frontend::Componentes;
 use crate::http_frontend::HttpError;
-use crate::http_frontend::HttpServerState;
 use crate::storage::bucket::Bucket;
 
 use crate::storage::reader::RecordReader;
@@ -24,7 +24,7 @@ use std::task::{Context, Poll};
 
 // GET /:bucket/:entry?ts=<number>|q=<number>|
 pub async fn read_single_record(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -148,7 +148,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_single_read_ts(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,
@@ -184,7 +184,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_single_read_query(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,
@@ -230,10 +230,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_single_read_bucket_not_found(
-        components: Arc<HttpServerState>,
-        headers: HeaderMap,
-    ) {
+    async fn test_single_read_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
         let path = Path(HashMap::from_iter(vec![
             ("bucket_name".to_string(), "XXX".to_string()),
             ("entry_name".to_string(), "entru-1".to_string()),
@@ -258,7 +255,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_single_read_ts_not_found(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {
@@ -282,7 +279,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_single_read_bad_ts(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {
@@ -312,7 +309,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_single_read_query_not_found(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {

--- a/reductstore/src/http_frontend/entry_api/remove.rs
+++ b/reductstore/src/http_frontend/entry_api/remove.rs
@@ -3,7 +3,7 @@
 
 use crate::auth::policy::WriteAccessPolicy;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use std::collections::HashMap;
 
 use axum::extract::{Path, State};
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 // DELETE /b/:bucket_name/:entry_name
 pub async fn remove_entry(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(path): Path<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
@@ -47,7 +47,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_entry(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_remove_entry(components: Arc<Componentes>, headers: HeaderMap) {
         let path = HashMap::from_iter(vec![
             ("bucket_name".to_string(), "bucket-1".to_string()),
             ("entry_name".to_string(), "entry-1".to_string()),
@@ -73,7 +73,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_remove_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
         let path = HashMap::from_iter(vec![
             ("bucket_name".to_string(), "XXX".to_string()),
             ("entry_name".to_string(), "entry-1".to_string()),
@@ -90,7 +90,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_entry_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_remove_entry_not_found(components: Arc<Componentes>, headers: HeaderMap) {
         let path = HashMap::from_iter(vec![
             ("bucket_name".to_string(), "bucket-1".to_string()),
             ("entry_name".to_string(), "XXX".to_string()),

--- a/reductstore/src/http_frontend/entry_api/write.rs
+++ b/reductstore/src/http_frontend/entry_api/write.rs
@@ -3,7 +3,7 @@
 
 use crate::auth::policy::WriteAccessPolicy;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{ErrorCode, HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, ErrorCode, HttpError};
 use crate::storage::entry::Labels;
 use crate::storage::writer::Chunk;
 use axum::extract::{BodyStream, Path, Query, State};
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 // POST /:bucket/:entry?ts=<number>
 pub async fn write_record(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     headers: HeaderMap,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
@@ -147,7 +147,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_write_with_label_ok(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         headers: HeaderMap,
         path_to_entry_1: Path<HashMap<String, String>>,
         #[future] empty_body: BodyStream,
@@ -183,7 +183,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_write_bucket_not_found(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         headers: HeaderMap,
         #[future] empty_body: BodyStream,
     ) {
@@ -214,7 +214,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_write_bad_ts(
-        components: Arc<HttpServerState>,
+        components: Arc<Componentes>,
         headers: HeaderMap,
         path_to_entry_1: Path<HashMap<String, String>>,
         #[future] empty_body: BodyStream,

--- a/reductstore/src/http_frontend/middleware.rs
+++ b/reductstore/src/http_frontend/middleware.rs
@@ -8,7 +8,7 @@ use axum::response::IntoResponse;
 use log::{debug, error};
 
 use crate::auth::policy::Policy;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 
 pub async fn default_headers<B>(
     request: Request<B>,
@@ -55,7 +55,7 @@ pub async fn print_statuses<B>(
 }
 
 pub async fn check_permissions<P>(
-    components: &HttpServerState,
+    components: &Componentes,
     headers: HeaderMap,
     policy: P,
 ) -> Result<(), HttpError>

--- a/reductstore/src/http_frontend/server_api.rs
+++ b/reductstore/src/http_frontend/server_api.rs
@@ -16,7 +16,7 @@ use reduct_base::msg::server_api::{BucketInfoList, ServerInfo};
 use reduct_macros::{IntoResponse, Twin};
 
 use crate::http_frontend::token_api::me::me;
-use crate::http_frontend::HttpServerState;
+use crate::http_frontend::Componentes;
 
 #[derive(IntoResponse, Twin)]
 pub struct ServerInfoAxum(ServerInfo);
@@ -24,7 +24,7 @@ pub struct ServerInfoAxum(ServerInfo);
 #[derive(IntoResponse, Twin)]
 pub struct BucketInfoListAxum(BucketInfoList);
 
-pub fn create_server_api_routes() -> axum::Router<Arc<HttpServerState>> {
+pub fn create_server_api_routes() -> axum::Router<Arc<Componentes>> {
     axum::Router::new()
         .route("/list", get(list::list))
         .route("/info", get(info::info))

--- a/reductstore/src/http_frontend/server_api/info.rs
+++ b/reductstore/src/http_frontend/server_api/info.rs
@@ -4,7 +4,7 @@
 use crate::auth::policy::AuthenticatedPolicy;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::server_api::ServerInfoAxum;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::State;
 use axum::headers::HeaderMap;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // GET /info
 pub async fn info(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     headers: HeaderMap,
 ) -> Result<ServerInfoAxum, HttpError> {
     check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
@@ -29,7 +29,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_info(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_info(components: Arc<Componentes>, headers: HeaderMap) {
         let info = info(State(components), headers).await.unwrap();
         assert_eq!(info.0.bucket_count, 2);
     }

--- a/reductstore/src/http_frontend/server_api/list.rs
+++ b/reductstore/src/http_frontend/server_api/list.rs
@@ -4,14 +4,14 @@
 use crate::auth::policy::AuthenticatedPolicy;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::server_api::BucketInfoListAxum;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::State;
 use axum::headers::HeaderMap;
 use std::sync::Arc;
 
 // GET /list
 pub async fn list(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     headers: HeaderMap,
 ) -> Result<BucketInfoListAxum, HttpError> {
     check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
@@ -28,7 +28,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_list(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_list(components: Arc<Componentes>, headers: HeaderMap) {
         let list = list(State(components), headers).await.unwrap();
         assert_eq!(list.0.buckets.len(), 2);
     }

--- a/reductstore/src/http_frontend/token_api.rs
+++ b/reductstore/src/http_frontend/token_api.rs
@@ -24,7 +24,7 @@ use crate::http_frontend::token_api::create::create_token;
 use crate::http_frontend::token_api::get::get_token;
 use crate::http_frontend::token_api::list::list_tokens;
 use crate::http_frontend::token_api::remove::remove_token;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 
 use reduct_base::msg::token_api::{Permissions, Token, TokenCreateResponse, TokenList};
 use reduct_macros::{IntoResponse, Twin};
@@ -63,7 +63,7 @@ where
     }
 }
 
-pub fn create_token_api_routes() -> axum::Router<Arc<HttpServerState>> {
+pub fn create_token_api_routes() -> axum::Router<Arc<Componentes>> {
     axum::Router::new()
         .route("/", get(list_tokens))
         .route("/:token_name", post(create_token))

--- a/reductstore/src/http_frontend/token_api/create.rs
+++ b/reductstore/src/http_frontend/token_api/create.rs
@@ -4,7 +4,7 @@
 use crate::auth::policy::FullAccessPolicy;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::token_api::{PermissionsAxum, TokenCreateResponseAxum};
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // POST /tokens/:token_name
 pub async fn create_token(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
     permissions: PermissionsAxum,
@@ -24,7 +24,7 @@ pub async fn create_token(
             .token_repo
             .write()
             .await
-            .create_token(&token_name, permissions.into())?,
+            .generate_token(&token_name, permissions.into())?,
     ))
 }
 
@@ -40,7 +40,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_token(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_create_token(components: Arc<Componentes>, headers: HeaderMap) {
         let token = create_token(
             State(components),
             Path("new-token".to_string()),
@@ -55,10 +55,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_token_already_exists(
-        components: Arc<HttpServerState>,
-        headers: HeaderMap,
-    ) {
+    async fn test_create_token_already_exists(components: Arc<Componentes>, headers: HeaderMap) {
         let err = create_token(
             State(components),
             Path("test".to_string()),

--- a/reductstore/src/http_frontend/token_api/get.rs
+++ b/reductstore/src/http_frontend/token_api/get.rs
@@ -17,14 +17,14 @@ pub async fn get_token(
 ) -> Result<TokenAxum, HttpError> {
     check_permissions(&components, headers, FullAccessPolicy {}).await?;
 
-    Ok(TokenAxum::from(
-        components
-            .token_repo
-            .read()
-            .await
-            .get_token(&token_name)?
-            .clone(),
-    ))
+    let mut token = components
+        .token_repo
+        .read()
+        .await
+        .get_token(&token_name)?
+        .clone();
+    token.value.clear();
+    Ok(TokenAxum::from(token))
 }
 
 #[cfg(test)]
@@ -44,6 +44,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(token.name, "test");
+        assert!(token.value.is_empty(), "Token value MUST be empty")
     }
 
     #[rstest]

--- a/reductstore/src/http_frontend/token_api/list.rs
+++ b/reductstore/src/http_frontend/token_api/list.rs
@@ -40,6 +40,8 @@ mod tests {
         let list = list_tokens(State(components), headers).await.unwrap().0;
         assert_eq!(list.tokens.len(), 2);
         assert_eq!(list.tokens[0].name, "init-token");
+        assert!(list.tokens[0].value.is_empty(), "Token value MUST be empty");
         assert_eq!(list.tokens[1].name, "test");
+        assert!(list.tokens[1].value.is_empty(), "Token value MUST be empty");
     }
 }

--- a/reductstore/src/http_frontend/token_api/list.rs
+++ b/reductstore/src/http_frontend/token_api/list.rs
@@ -4,7 +4,7 @@
 use crate::auth::policy::FullAccessPolicy;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::token_api::TokenListAxum;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::State;
 use axum::headers::HeaderMap;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // GET /tokens
 pub async fn list_tokens(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     headers: HeaderMap,
 ) -> Result<TokenListAxum, HttpError> {
     check_permissions(&components, headers, FullAccessPolicy {}).await?;
@@ -36,7 +36,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_token_list(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_token_list(components: Arc<Componentes>, headers: HeaderMap) {
         let list = list_tokens(State(components), headers).await.unwrap().0;
         assert_eq!(list.tokens.len(), 2);
         assert_eq!(list.tokens[0].name, "init-token");

--- a/reductstore/src/http_frontend/token_api/me.rs
+++ b/reductstore/src/http_frontend/token_api/me.rs
@@ -4,7 +4,7 @@
 use crate::auth::policy::AuthenticatedPolicy;
 use crate::http_frontend::middleware::check_permissions;
 use crate::http_frontend::token_api::TokenAxum;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 
 use axum::extract::State;
 use axum::headers::HeaderMap;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // // GET /me
 pub async fn me(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     headers: HeaderMap,
 ) -> Result<TokenAxum, HttpError> {
     check_permissions(&components, headers.clone(), AuthenticatedPolicy {}).await?;
@@ -34,7 +34,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_me(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_me(components: Arc<Componentes>, headers: HeaderMap) {
         let token = me(State(components), headers).await.unwrap().0;
         assert_eq!(token.name, "init-token");
     }

--- a/reductstore/src/http_frontend/token_api/remove.rs
+++ b/reductstore/src/http_frontend/token_api/remove.rs
@@ -3,14 +3,14 @@
 
 use crate::auth::policy::FullAccessPolicy;
 use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{HttpError, HttpServerState};
+use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
 
 // DELETE /tokens/:name
 pub async fn remove_token(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
@@ -33,14 +33,14 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_token(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_remove_token(components: Arc<Componentes>, headers: HeaderMap) {
         let token = remove_token(State(components), Path("test".to_string()), headers).await;
         assert!(token.is_ok());
     }
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_token_not_found(components: Arc<HttpServerState>, headers: HeaderMap) {
+    async fn test_remove_token_not_found(components: Arc<Componentes>, headers: HeaderMap) {
         let err = remove_token(State(components), Path("not-found".to_string()), headers)
             .await
             .err()

--- a/reductstore/src/http_frontend/ui_api.rs
+++ b/reductstore/src/http_frontend/ui_api.rs
@@ -2,8 +2,8 @@
 // Licensed under the Business Source License 1.1
 //
 
+use crate::http_frontend::Componentes;
 use crate::http_frontend::HttpError;
-use crate::http_frontend::HttpServerState;
 use axum::extract::State;
 
 use axum::headers::HeaderMap;
@@ -17,9 +17,7 @@ use mime_guess::mime;
 use reduct_base::error::ErrorCode;
 use std::sync::Arc;
 
-pub async fn redirect_to_index(
-    State(components): State<Arc<HttpServerState>>,
-) -> impl IntoResponse {
+pub async fn redirect_to_index(State(components): State<Arc<Componentes>>) -> impl IntoResponse {
     let base_path = components.base_path.clone();
     let mut headers = HeaderMap::new();
     headers.insert(LOCATION, format!("{}ui/", base_path).parse().unwrap());
@@ -27,7 +25,7 @@ pub async fn redirect_to_index(
 }
 
 pub async fn show_ui(
-    State(components): State<Arc<HttpServerState>>,
+    State(components): State<Arc<Componentes>>,
     request: Request<Body>,
 ) -> Result<impl IntoResponse, HttpError> {
     let base_path = components.base_path.clone();
@@ -79,7 +77,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_img_decoding(components: Arc<HttpServerState>) {
+    async fn test_img_decoding(components: Arc<Componentes>) {
         let request = Request::get("/ui/favicon.png").body(Body::empty()).unwrap();
         let response = show_ui(State(components), request)
             .await

--- a/reductstore/src/lib.rs
+++ b/reductstore/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the Business Source License 1.1
 pub mod asset;
 pub mod auth;
+pub mod cfg;
 pub mod core;
 pub mod http_frontend;
 pub mod storage;

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use reductstore::cfg::Cfg;
+use reductstore::core::env::{Env, StdEnvGetter};
 
 use reductstore::core::logger::Logger;
 use reductstore::http_frontend::create_axum_app;
@@ -38,7 +39,7 @@ async fn main() {
         git_ref
     );
 
-    let cfg = Cfg::from_env();
+    let cfg = Cfg::from_env(StdEnvGetter::default());
     Logger::init(&cfg.log_level);
 
     info!("Configuration: \n {}", cfg);

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -41,10 +41,9 @@ async fn main() {
 
     let cfg = Cfg::from_env(StdEnvGetter::default());
     Logger::init(&cfg.log_level);
-
     info!("Configuration: \n {}", cfg);
 
-    let components = cfg.build().await;
+    let components = cfg.build();
 
     let scheme = if cfg.cert_path.is_empty() {
         "http"

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -2,7 +2,6 @@
 // Licensed under the Business Source License 1.1
 
 use std::net::{IpAddr, SocketAddr};
-use std::path::PathBuf;
 
 use axum_server::tls_rustls::RustlsConfig;
 
@@ -10,16 +9,11 @@ use axum_server::Handle;
 use log::info;
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
-use reductstore::asset::asset_manager::ZipAssetManager;
-use reductstore::auth::token_auth::TokenAuthorization;
-use reductstore::auth::token_repository::create_token_repository;
 use reductstore::cfg::Cfg;
-use reductstore::core::env::Env;
+
 use reductstore::core::logger::Logger;
-use reductstore::http_frontend::{create_axum_app, Componentes};
-use reductstore::storage::storage::Storage;
+use reductstore::http_frontend::create_axum_app;
 
 #[tokio::main]
 async fn main() {

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -66,6 +66,7 @@ async fn main() {
     } else {
         "https"
     };
+
     info!(
         "Run HTTP reductstore on {}://{}:{}{}",
         scheme, cfg.host, cfg.port, cfg.api_base_path

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use reductstore::cfg::Cfg;
-use reductstore::core::env::{Env, StdEnvGetter};
+use reductstore::core::env::StdEnvGetter;
 
 use reductstore::core::logger::Logger;
 use reductstore::http_frontend::create_axum_app;

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -1,12 +1,6 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
-pub mod asset;
-pub mod auth;
-pub mod core;
-pub mod http_frontend;
-pub mod storage;
-
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 
@@ -18,15 +12,14 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use crate::asset::asset_manager::ZipAssetManager;
-use crate::auth::token_auth::TokenAuthorization;
-use crate::auth::token_repository::create_token_repository;
-use crate::storage::storage::Storage;
-
-use crate::core::env::Env;
-use crate::core::logger::Logger;
-
-use crate::http_frontend::{create_axum_app, HttpServerState};
+use reductstore::asset::asset_manager::ZipAssetManager;
+use reductstore::auth::token_auth::TokenAuthorization;
+use reductstore::auth::token_repository::create_token_repository;
+use reductstore::cfg::Cfg;
+use reductstore::core::env::Env;
+use reductstore::core::logger::Logger;
+use reductstore::http_frontend::{create_axum_app, HttpServerState};
+use reductstore::storage::storage::Storage;
 
 #[tokio::main]
 async fn main() {
@@ -39,63 +32,64 @@ async fn main() {
         env!("COMMIT"),
         env!("BUILD_TIME")
     );
-    info!("License: BUSL-1.1");
+
+    let git_ref = if version.ends_with("-dev") {
+        env!("COMMIT").to_string()
+    } else {
+        format!("v{}", version)
+    };
+
+    info!(
+        "License: BUSL-1.1 [https://github.com/reductstore/reductstore/blob/{}/LICENSE]",
+        git_ref
+    );
 
     let mut env = Env::new();
-
-    let log_level = env.get::<String>("RS_LOG_LEVEL", "INFO".to_string(), false);
-    let host = env.get::<String>("RS_HOST", "0.0.0.0".to_string(), false);
-    let port = env.get::<i32>("RS_PORT", 8383, false);
-    let api_base_path = env.get::<String>("RS_API_BASE_PATH", "/".to_string(), false);
-    let data_path = env.get::<String>("RS_DATA_PATH", "/data".to_string(), false);
-    let api_token = env.get::<String>("RS_API_TOKEN", "".to_string(), true);
-    let cert_path = env.get::<String>("RS_CERT_PATH", "".to_string(), true);
-    let cert_key_path = env.get::<String>("RS_CERT_KEY_PATH", "".to_string(), true);
-
-    Logger::init(&log_level);
+    let cfg = Cfg::from_env(&mut env);
+    Logger::init(&cfg.log_level);
 
     info!("Configuration: \n {}", env.message());
 
     let components = HttpServerState {
-        storage: RwLock::new(Storage::new(PathBuf::from(data_path.clone()))),
-        auth: TokenAuthorization::new(&api_token),
+        storage: RwLock::new(Storage::new(PathBuf::from(cfg.data_path.clone()))),
+        auth: TokenAuthorization::new(&cfg.api_token),
         token_repo: RwLock::new(create_token_repository(
-            PathBuf::from(data_path),
-            &api_token,
+            PathBuf::from(cfg.data_path),
+            &cfg.api_token,
         )),
         console: ZipAssetManager::new(include_bytes!(concat!(env!("OUT_DIR"), "/console.zip"))),
-        base_path: api_base_path.clone(),
+        base_path: cfg.api_base_path.clone(),
     };
 
-    let scheme = if cert_path.is_empty() {
+    let scheme = if cfg.cert_path.is_empty() {
         "http"
     } else {
         "https"
     };
     info!(
         "Run HTTP reductstore on {}://{}:{}{}",
-        scheme, host, port, api_base_path
+        scheme, cfg.host, cfg.port, cfg.api_base_path
     );
 
     let addr = SocketAddr::new(
-        IpAddr::from_str(&host).expect("Invalid host address"),
-        port as u16,
+        IpAddr::from_str(&cfg.host).expect("Invalid host address"),
+        cfg.port as u16,
     );
 
-    let app = create_axum_app(&api_base_path, Arc::new(components));
+    let app = create_axum_app(&cfg.api_base_path, Arc::new(components));
 
     let handle = Handle::new();
     tokio::spawn(shutdown_ctrl_c(handle.clone()));
     tokio::spawn(shutdown_signal(handle.clone()));
 
-    if cert_path.is_empty() {
+    if cfg.cert_path.is_empty() {
         axum_server::bind(addr)
             .handle(handle)
             .serve(app.into_make_service())
             .await
             .unwrap();
     } else {
-        let config = RustlsConfig::from_pem_file(cert_path, cert_key_path)
+        let config = RustlsConfig::from_pem_file(cfg.cert_path, cfg.cert_key_path)
             .await
             .unwrap();
         axum_server::bind_rustls(addr, config)

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -611,7 +611,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_provisioned_info(mut provisioned_bucket: Bucket) {
+    fn test_provisioned_info(provisioned_bucket: Bucket) {
         let info = provisioned_bucket.info().unwrap().info;
         assert_eq!(info.is_provisioned, true);
     }

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -3,6 +3,7 @@
 
 use log::info;
 use std::collections::BTreeMap;
+use std::fmt::format;
 use std::fs::remove_dir_all;
 use std::path::PathBuf;
 
@@ -151,6 +152,15 @@ impl Storage {
     ///
     /// * HTTPError - An error if the bucket doesn't exist
     pub fn remove_bucket(&mut self, name: &str) -> Result<(), ReductError> {
+        if let Some(bucket) = self.buckets.get(name) {
+            if bucket.is_provisioned() {
+                return Err(ReductError::conflict(&format!(
+                    "Can't remove provisioned bucket '{}'",
+                    bucket.name()
+                )));
+            }
+        }
+
         match self.buckets.remove(name) {
             Some(_) => {
                 remove_dir_all(&self.data_path.join(name))?;
@@ -179,14 +189,13 @@ mod tests {
     use crate::storage::writer::Chunk;
     use bytes::Bytes;
     use reduct_base::msg::bucket_api::QuotaType;
+    use rstest::{fixture, rstest};
     use std::thread::sleep;
     use std::time::Duration;
     use tempfile::tempdir;
 
-    #[test]
-    fn test_info() {
-        let storage = Storage::new(tempdir().unwrap().into_path());
-
+    #[rstest]
+    fn test_info(storage: Storage) {
         sleep(Duration::from_secs(1)); // uptime is 1 second
 
         let info = storage.info().unwrap();
@@ -206,11 +215,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_recover_from_fs() {
-        let path = tempdir().unwrap().into_path();
-        let mut storage = Storage::new(path.clone());
-
+    #[rstest]
+    fn test_recover_from_fs(mut storage: Storage) {
         let bucket_settings = BucketSettings {
             quota_size: Some(100),
             quota_type: Some(QuotaType::FIFO),
@@ -255,7 +261,7 @@ mod tests {
                 .unwrap();
         }
 
-        let storage = Storage::new(path);
+        let storage = Storage::new(storage.data_path);
         assert_eq!(
             storage.info().unwrap(),
             ServerInfo {
@@ -276,18 +282,16 @@ mod tests {
         assert_eq!(bucket.settings(), &bucket_settings);
     }
 
-    #[test]
-    fn test_create_bucket() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
+    #[rstest]
+    fn test_create_bucket(mut storage: Storage) {
         let bucket = storage
             .create_bucket("test", BucketSettings::default())
             .unwrap();
         assert_eq!(bucket.name(), "test");
     }
 
-    #[test]
-    fn test_create_bucket_with_invalid_name() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
+    #[rstest]
+    fn test_create_bucket_with_invalid_name(mut storage: Storage) {
         let result = storage.create_bucket("test$", BucketSettings::default());
         assert_eq!(
             result.err(),
@@ -297,9 +301,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_create_bucket_with_existing_name() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
+    #[rstest]
+    fn test_create_bucket_with_existing_name(mut storage: Storage) {
         let bucket = storage
             .create_bucket("test", BucketSettings::default())
             .unwrap();
@@ -312,9 +315,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_get_bucket() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
+    #[rstest]
+    fn test_get_bucket(mut storage: Storage) {
         let bucket = storage
             .create_bucket("test", BucketSettings::default())
             .unwrap();
@@ -324,9 +326,8 @@ mod tests {
         assert_eq!(bucket.name(), "test");
     }
 
-    #[test]
-    fn test_get_bucket_with_non_existing_name() {
-        let storage = Storage::new(tempdir().unwrap().into_path());
+    #[rstest]
+    fn test_get_bucket_with_non_existing_name(storage: Storage) {
         let result = storage.get_bucket("test");
         assert_eq!(
             result.err(),
@@ -334,9 +335,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_remove_bucket() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
+    #[rstest]
+    fn test_remove_bucket(mut storage: Storage) {
         let bucket = storage
             .create_bucket("test", BucketSettings::default())
             .unwrap();
@@ -352,9 +352,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_remove_bucket_with_non_existing_name() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
+    #[rstest]
+    fn test_remove_bucket_with_non_existing_name(mut storage: Storage) {
         let result = storage.remove_bucket("test");
         assert_eq!(
             result,
@@ -362,10 +361,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_remove_bucket_persistent() {
-        let path = tempdir().unwrap().into_path();
-        let mut storage = Storage::new(path.clone());
+    #[rstest]
+    fn test_remove_bucket_persistent(path: PathBuf, mut storage: Storage) {
         let bucket = storage
             .create_bucket("test", BucketSettings::default())
             .unwrap();
@@ -382,10 +379,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_get_bucket_list() {
-        let mut storage = Storage::new(tempdir().unwrap().into_path());
-
+    #[rstest]
+    fn test_get_bucket_list(mut storage: Storage) {
         storage.create_bucket("test1", Bucket::defaults()).unwrap();
         storage.create_bucket("test2", Bucket::defaults()).unwrap();
 
@@ -393,5 +388,28 @@ mod tests {
         assert_eq!(bucket_list.buckets.len(), 2);
         assert_eq!(bucket_list.buckets[0].name, "test1");
         assert_eq!(bucket_list.buckets[1].name, "test2");
+    }
+
+    #[rstest]
+    fn test_provisioned_remove(mut storage: Storage) {
+        let bucket = storage
+            .create_bucket("test", BucketSettings::default())
+            .unwrap();
+        bucket.set_provisioned(true);
+        let err = storage.remove_bucket("test").err().unwrap();
+        assert_eq!(
+            err,
+            ReductError::conflict("Can't remove provisioned bucket 'test'")
+        );
+    }
+
+    #[fixture]
+    fn path() -> PathBuf {
+        tempdir().unwrap().into_path()
+    }
+
+    #[fixture]
+    fn storage(path: PathBuf) -> Storage {
+        Storage::new(path)
     }
 }

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -3,7 +3,7 @@
 
 use log::info;
 use std::collections::BTreeMap;
-use std::fmt::format;
+
 use std::fs::remove_dir_all;
 use std::path::PathBuf;
 


### PR DESCRIPTION
Closes #329 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #329 

### What is the new behavior?

A user can provision buckets and tokens by using environment variables. For example:


```
RS_BUCKET_A_NAME=bucket-1
RS_BUCKET_A_QUOTA_TYPE=FIFO
RS_BUCKET_A_QUOTA_SIZE=1Tb

RS_BUCKET_B_NAME=bucket-2

RS_TOKEN_A_NAME=token
RS_TOKEN_A_VALUE=somesecret
RS_TOKEN_A_READ=bucket-1,bucket-2
```

### Does this PR introduce a breaking change?

No

### Other information:
