### PR TITLE
Add `POST /api/v1/b/:bucket/:entry/batch` endpoint for batched writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reduct-rs: `ReductClient.url`, `ReductClient.token`, `ReductCientBuilder.try_build` [PR-350](https://github.com/reductstore/reductstore/pull/350)
 - reductstore: `healthcheck` to buildx.Dockerfile, [PR-350](https://github.com/reductstore/reductstore/pull/350)
 - reductstore: provisioning with environment variables, [PR-352](https://github.com/reductstore/reductstore/pull/352)
+- reductstore,reduct-rs: batched write API, [PR-355](https://github.com/reductstore/reductstore/pull/355)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ name = "reduct-base"
 version = "1.7.0-dev"
 dependencies = [
  "chrono",
+ "http",
  "int-enum",
  "rstest",
  "serde",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It guarantees that your data will not overflow your hard disk and batches record
 - Optimized for small objects (less than 1 MB)
 - Labeling data for annotation and filtering
 - Iterative data querying
-- Batching records in an HTTP response
+- Batching records in an HTTP response for write and read operations
 - Embedded Web Console
 - Token authorization for managing data access
 

--- a/docs/http-api/entry-api.md
+++ b/docs/http-api/entry-api.md
@@ -70,6 +70,44 @@ A value of a label assigned to the record
 {% endswagger-response %}
 {% endswagger %}
 
+{% swagger method="post" path="" baseUrl="/api/v1/b/:bucket_name/:entry_name/batch" summary="Write batched entries" %}
+{% swagger-description %}
+This method allows multiple records to be written in a single request. A client should describe the records in headers in the following format:
+
+`x-reduct-time-: <CONTENT_LENGTH>,<CONTENT_TYPE>, [LABEL=VALUE]`
+
+For example: `x-reduct-time-192312381273: 100,text/plain,x=y,a="[a,b]"`&#x20;
+
+The body must contain the concatenated records sorted by timestamp. The method returns an HTTP error if the header format or data length is incorrect. It also returns an individual status and error message for each record if the write operation fails:
+
+&#x20;`x-reduct-error-: <STATUS_CODE>,<ERROR_MESSAGE>.`
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="The request was valid. However, some records may not be written. Check headers." %}
+
+{% endswagger-response %}
+
+{% swagger-response status="400: Bad Request" description="Posted content bigger or smaller than content-length" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="401: Unauthorized" description="Access token is invalid or empty" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="403: Forbidden" description="Access token does not have write permissions" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="404: Not Found" description="Bucket is not found" %}
+
+{% endswagger-response %}
+
+{% swagger-response status="422: Unprocessable Entity" description="Bad timestamp or header format" %}
+
+{% endswagger-response %}
+{% endswagger %}
+
 {% swagger method="get" path=" " baseUrl="/api/v1/b/:bucket_name/:entry_name " summary="Get a record from an entry" fullWidth="false" %}
 {% swagger-description %}
 The method finds a record for the given timestamp and sends its content in the HTTP response body. It also sends additional information in headers:
@@ -119,7 +157,7 @@ A UNIX timestamp in microseconds. If it is empty, the latest record is returned.
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn" %}
 
 {% endswagger-response %}
 
@@ -177,7 +215,7 @@ Name of entry
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn't have enough permissions" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn" %}
 
 {% endswagger-response %}
 
@@ -279,11 +317,11 @@ Maximum number of records in the query. Default: unlimited.
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn't have read permissions" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn" %}
 
 {% endswagger-response %}
 
-{% swagger-response status="404: Not Found" description="The bucket or entry doesn't exist" %}
+{% swagger-response status="404: Not Found" description="The bucket or entry doesn" %}
 
 {% endswagger-response %}
 
@@ -291,8 +329,6 @@ Maximum number of records in the query. Default: unlimited.
 
 {% endswagger-response %}
 {% endswagger %}
-
-
 
 {% swagger method="delete" path="" baseUrl="/api/v1/b/:bucket_name/:entry_name  " summary="Remove entry" %}
 {% swagger-description %}
@@ -307,11 +343,11 @@ Since v1.6, you can remove a specific entry from a bucket with the entire histor
 
 {% endswagger-response %}
 
-{% swagger-response status="403: Forbidden" description="Access token doesn't have write permissions" %}
+{% swagger-response status="403: Forbidden" description="Access token doesn" %}
 
 {% endswagger-response %}
 
-{% swagger-response status="404: Not Found" description="The bucket or entry doesn't exist" %}
+{% swagger-response status="404: Not Found" description="The bucket or entry doesn" %}
 
 {% endswagger-response %}
 {% endswagger %}

--- a/reduct_base/Cargo.toml
+++ b/reduct_base/Cargo.toml
@@ -22,7 +22,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 int-enum = "0.5.0"
 chrono = { version = "0.4.11", features = ["serde"] }
-url = "2.4.1"
+url = "2.4.0"
+http = "0.2.9"
 
 [dev-dependencies]
-rstest="0.18"
+rstest = "0.18"

--- a/reduct_base/src/batch.rs
+++ b/reduct_base/src/batch.rs
@@ -9,6 +9,12 @@ use std::collections::HashMap;
 
 pub type Labels = HashMap<String, String>;
 
+pub struct RecordHeader {
+    pub content_length: usize,
+    pub content_type: String,
+    pub labels: Labels,
+}
+
 /// Parse a batched header into a content length, content type, and labels.
 ///
 /// # Arguments
@@ -20,7 +26,7 @@ pub type Labels = HashMap<String, String>;
 /// * `content_length` - The content length of the batched header.
 /// * `content_type` - The content type of the batched header.
 /// * `labels` - The labels of the batched header.
-pub fn parse_batched_header(header: &str) -> Result<(usize, String, Labels), ReductError> {
+pub fn parse_batched_header(header: &str) -> Result<RecordHeader, ReductError> {
     let (content_length, rest) = header
         .split_once(',')
         .ok_or(ReductError::unprocessable_entity("Invalid batched header"))?;
@@ -60,7 +66,11 @@ pub fn parse_batched_header(header: &str) -> Result<(usize, String, Labels), Red
         };
     }
 
-    Ok((content_length, content_type, labels))
+    Ok(RecordHeader {
+        content_length,
+        content_type,
+        labels,
+    })
 }
 
 pub fn sort_headers_by_name(headers: &HeaderMap) -> Vec<(String, HeaderValue)> {

--- a/reduct_base/src/batch.rs
+++ b/reduct_base/src/batch.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use http::{HeaderMap, HeaderValue};
+use std::collections::HashMap;
+
+pub type Labels = HashMap<String, String>;
+
+/// Parse a batched header into a content length, content type, and labels.
+///
+/// # Arguments
+///
+/// * `header` - The batched header to parse.
+///
+/// # Returns
+///
+/// * `content_length` - The content length of the batched header.
+/// * `content_type` - The content type of the batched header.
+/// * `labels` - The labels of the batched header.
+pub fn parse_batched_header(header: &str) -> (usize, String, Labels) {
+    let (content_length, rest) = header.split_once(',').unwrap();
+    let content_length = content_length.trim().parse::<usize>().unwrap();
+
+    let (content_type, rest) = rest.split_once(',').unwrap_or((rest, ""));
+    let content_type = content_type.trim().to_string();
+
+    let mut labels = Labels::new();
+    let mut rest = rest.to_string();
+    while let Some(pair) = rest.split_once('=') {
+        let (key, value) = pair;
+        rest = if value.starts_with('\"') {
+            let value = value[1..].to_string();
+            let (value, rest) = value.split_once('\"').unwrap();
+            labels.insert(key.trim().to_string(), value.trim().to_string());
+            rest.trim_start_matches(',').trim().to_string()
+        } else if let Some(ret) = value.split_once(',') {
+            let (value, rest) = ret;
+            labels.insert(key.trim().to_string(), value.trim().to_string());
+            rest.trim().to_string()
+        } else {
+            labels.insert(key.trim().to_string(), value.trim().to_string());
+            break;
+        };
+    }
+
+    (content_length, content_type, labels)
+}
+
+pub fn sort_headers_by_name(headers: &HeaderMap) -> Vec<(String, HeaderValue)> {
+    let mut sorted_headers: Vec<_> = headers
+        .clone()
+        .into_iter()
+        .map(|(key, value)| (key.unwrap().as_str().to_string(), value))
+        .collect();
+    sorted_headers.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
+    sorted_headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    fn test_parse_batched_header_row() {
+        let header = "123, text/plain, label1=value1, label2=value2";
+        let (content_length, content_type, labels) = parse_batched_header(header);
+        assert_eq!(content_length, 123);
+        assert_eq!(content_type, "text/plain");
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels.get("label1"), Some(&"value1".to_string()));
+        assert_eq!(labels.get("label2"), Some(&"value2".to_string()));
+    }
+
+    #[rstest]
+    fn test_parse_batched_header_row_quotes() {
+        let header = "123, text/plain, label1=\"[1, 2, 3]\", label2=\"value2\"";
+        let (content_length, content_type, labels) = parse_batched_header(header);
+        assert_eq!(content_length, 123);
+        assert_eq!(content_type, "text/plain");
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels.get("label1"), Some(&"[1, 2, 3]".to_string()));
+        assert_eq!(labels.get("label2"), Some(&"value2".to_string()));
+    }
+
+    #[rstest]
+    fn test_parse_header_no_labels() {
+        let header = "123, text/plain";
+        let (content_length, content_type, labels) = parse_batched_header(header);
+        assert_eq!(content_length, 123);
+        assert_eq!(content_type, "text/plain");
+        assert_eq!(labels.len(), 0);
+    }
+}

--- a/reduct_base/src/batch.rs
+++ b/reduct_base/src/batch.rs
@@ -91,7 +91,11 @@ mod tests {
     #[rstest]
     fn test_parse_batched_header_row() {
         let header = "123, text/plain, label1=value1, label2=value2";
-        let (content_length, content_type, labels) = parse_batched_header(header).unwrap();
+        let RecordHeader {
+            content_length,
+            content_type,
+            labels,
+        } = parse_batched_header(header).unwrap();
         assert_eq!(content_length, 123);
         assert_eq!(content_type, "text/plain");
         assert_eq!(labels.len(), 2);
@@ -102,7 +106,11 @@ mod tests {
     #[rstest]
     fn test_parse_batched_header_row_quotes() {
         let header = "123, text/plain, label1=\"[1, 2, 3]\", label2=\"value2\"";
-        let (content_length, content_type, labels) = parse_batched_header(header).unwrap();
+        let RecordHeader {
+            content_length,
+            content_type,
+            labels,
+        } = parse_batched_header(header).unwrap();
         assert_eq!(content_length, 123);
         assert_eq!(content_type, "text/plain");
         assert_eq!(labels.len(), 2);
@@ -113,7 +121,11 @@ mod tests {
     #[rstest]
     fn test_parse_header_no_labels() {
         let header = "123, text/plain";
-        let (content_length, content_type, labels) = parse_batched_header(header).unwrap();
+        let RecordHeader {
+            content_length,
+            content_type,
+            labels,
+        } = parse_batched_header(header).unwrap();
         assert_eq!(content_length, 123);
         assert_eq!(content_type, "text/plain");
         assert_eq!(labels.len(), 0);

--- a/reduct_base/src/batch.rs
+++ b/reduct_base/src/batch.rs
@@ -32,7 +32,12 @@ pub fn parse_batched_header(header: &str) -> Result<(usize, String, Labels), Red
     let (content_type, rest) = rest
         .split_once(',')
         .unwrap_or((rest, "application/octet-stream"));
-    let content_type = content_type.trim().to_string();
+
+    let content_type = if content_type.is_empty() {
+        "application/octet-stream".to_string()
+    } else {
+        content_type.trim().to_string()
+    };
 
     let mut labels = Labels::new();
     let mut rest = rest.to_string();

--- a/reduct_base/src/batch.rs
+++ b/reduct_base/src/batch.rs
@@ -54,7 +54,7 @@ pub fn sort_headers_by_name(headers: &HeaderMap) -> Vec<(String, HeaderValue)> {
         .into_iter()
         .map(|(key, value)| (key.unwrap().as_str().to_string(), value))
         .collect();
-    sorted_headers.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
+    sorted_headers.sort_by(|(name1, _), (name2, _)| name2.cmp(name1));
     sorted_headers
 }
 

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Display, Error as FmtError, Formatter};
 use std::time::SystemTimeError;
 use url::ParseError;
 
-/// HTTP status codes + communication errors.
+/// HTTP status codes + client errors (negative).
 #[repr(i16)]
 #[derive(Debug, PartialEq, PartialOrd, Copy, Clone, IntEnum)]
 pub enum ErrorCode {
@@ -17,6 +17,7 @@ pub enum ErrorCode {
     ConnectionError = -3,
     Timeout = -2,
     Unknown = -1,
+
     Continue = 100,
     OK = 200,
     Created = 201,

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -78,6 +78,12 @@ impl Display for ReductError {
     }
 }
 
+impl Display for ErrorCode {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        write!(f, "{}", self.int_value())
+    }
+}
+
 impl From<std::io::Error> for ReductError {
     fn from(err: std::io::Error) -> Self {
         // An IO error is an internal reductstore error

--- a/reduct_base/src/lib.rs
+++ b/reduct_base/src/lib.rs
@@ -3,5 +3,6 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+pub mod batch;
 pub mod error;
 pub mod msg;

--- a/reduct_rs/README.md
+++ b/reduct_rs/README.md
@@ -1,12 +1,14 @@
 # ReductStore Client SDK for Rust
 
+![Crates.io](https://img.shields.io/crates/v/reductstore)
+![Crates.io](https://img.shields.io/crates/l/reduct-rs)
 
 This package provides an HTTP client for interacting with the [ReductStore](https://www.reduct.store), time-series
 database for unstructured data.
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.6](https://docs.reduct.store/http-api)
+* Supports the [ReductStore HTTP API v1.7](https://docs.reduct.store/http-api)
 * Built on top of [reqwest](https://github.com/seanmonstar/reqwest)
 * Asynchronous API
 
@@ -54,5 +56,5 @@ async fn main() -> Result<(), HttpError> {
 
 ## References
 
-* Documentation - TODO
+* [Documentation](https://docs.rs/reduct-rs/latest/reduct_rs/)
 * [ReductStore HTTP API](https://docs.reduct.store/http-api)

--- a/reduct_rs/src/bucket.rs
+++ b/reduct_rs/src/bucket.rs
@@ -215,7 +215,6 @@ mod tests {
     use crate::client::tests::{bucket_settings, client};
     use crate::client::ReductClient;
 
-    use crate::record::Record;
     use reduct_base::error::ErrorCode;
     use rstest::{fixture, rstest};
 
@@ -356,7 +355,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_head_record(#[future] bucket: Bucket) {
-        let record: Record = bucket
+        let record = bucket
             .await
             .read_record("entry-1")
             .timestamp_us(1000)

--- a/reduct_rs/src/bucket.rs
+++ b/reduct_rs/src/bucket.rs
@@ -522,7 +522,7 @@ mod tests {
     #[tokio::test]
     async fn test_batched_write(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
-        let mut batch = bucket.write_batch("test");
+        let batch = bucket.write_batch("test");
 
         let record1 = RecordBuilder::new()
             .timestamp_us(1000)

--- a/reduct_rs/src/lib.rs
+++ b/reduct_rs/src/lib.rs
@@ -12,5 +12,5 @@ pub use bucket::Bucket;
 pub use client::ReductClient;
 pub use record::read_record::ReadRecordBuilder;
 pub use record::write_record::WriteRecordBuilder;
-pub use record::{Labels, Record, RecordStream};
+pub use record::{Labels, Record, RecordMut, RecordStream};
 pub use reduct_base::error::{ErrorCode, ReductError};

--- a/reduct_rs/src/lib.rs
+++ b/reduct_rs/src/lib.rs
@@ -11,6 +11,7 @@ mod record;
 pub use bucket::Bucket;
 pub use client::ReductClient;
 pub use record::read_record::ReadRecordBuilder;
+pub use record::write_batched_records::WriteBatchBuilder;
 pub use record::write_record::WriteRecordBuilder;
-pub use record::{Labels, Record, RecordMut, RecordStream};
+pub use record::{Labels, Record, RecordStream};
 pub use reduct_base::error::{ErrorCode, ReductError};

--- a/reduct_rs/src/record.rs
+++ b/reduct_rs/src/record.rs
@@ -5,6 +5,7 @@
 
 pub mod query;
 pub mod read_record;
+mod write_batched_records;
 pub mod write_record;
 
 use bytes::{Bytes, BytesMut};
@@ -20,9 +21,48 @@ use std::pin::Pin;
 use std::time::SystemTime;
 
 pub use reduct_base::batch::Labels;
+
 pub type RecordStream = Pin<Box<dyn Stream<Item = Result<Bytes, ReductError>>>>;
 
 pub use write_record::WriteRecordBuilder;
+
+pub trait RecordMut {
+    /// Set the timestamp of the record to write as a unix timestamp in microseconds.
+    fn set_timestamp_us(&mut self, timestamp: u64);
+
+    /// Set the timestamp of the record to write.
+    fn set_timestamp(&mut self, timestamp: SystemTime);
+
+    /// Set the labels of the record to write.
+    /// This replaces all existing labels.
+    fn set_labels(&mut self, labels: Labels);
+
+    /// Add a label to the record to write.
+    fn add_label(&mut self, key: String, value: String);
+
+    /// Set the content type of the record to write.
+    fn set_content_type(&mut self, content_type: String);
+
+    /// Set the content length of the record to write
+    fn set_content_length(&mut self, content_length: usize);
+
+    /// Set the content of the record
+    fn set_bytes(&mut self, bytes: Bytes);
+
+    /// Set the content of the record as a stream
+    fn set_stream_bytes(&mut self, stream: RecordStream);
+}
+
+impl Debug for Record {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Record")
+            .field("timestamp", &self.timestamp())
+            .field("labels", &self.labels())
+            .field("content_type", &self.content_type())
+            .field("content_length", &self.content_length())
+            .finish()
+    }
+}
 
 /// A record is a timestamped piece of data with labels
 pub struct Record {
@@ -31,17 +71,6 @@ pub struct Record {
     content_type: String,
     content_length: usize,
     data: Option<RecordStream>,
-}
-
-impl Debug for Record {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Record")
-            .field("timestamp", &self.timestamp)
-            .field("labels", &self.labels)
-            .field("content_type", &self.content_type)
-            .field("content_length", &self.content_length)
-            .finish()
-    }
 }
 
 impl Record {
@@ -73,24 +102,70 @@ impl Record {
     /// Content of the record
     ///
     /// This consumes the record and returns bytes
-    pub async fn bytes(mut self) -> Result<Bytes, ReductError> {
-        if let Some(data) = &mut self.data {
-            let mut bytes = BytesMut::new();
-            while let Some(chunk) = data.next().await {
-                bytes.extend_from_slice(&chunk?);
+    pub fn bytes(mut self) -> Pin<Box<dyn futures::Future<Output = Result<Bytes, ReductError>>>> {
+        Box::pin(async move {
+            if let Some(mut data) = self.data {
+                let mut bytes = BytesMut::new();
+                while let Some(chunk) = data.next().await {
+                    bytes.extend_from_slice(&chunk?);
+                }
+                Ok(bytes.into())
+            } else {
+                panic!("Record has no data");
             }
-            Ok(bytes.into())
-        } else {
-            panic!("Record has no data");
-        }
+        })
     }
 
+    /// Content of the record as a stream
     pub fn stream_bytes(self) -> Pin<Box<dyn Stream<Item = Result<Bytes, ReductError>>>> {
         if let Some(data) = self.data {
             data
         } else {
             panic!("Record has no data");
         }
+    }
+}
+
+impl RecordMut for Record {
+    /// Set the timestamp of the record to write as a unix timestamp in microseconds.
+    fn set_timestamp_us(&mut self, timestamp: u64) {
+        self.timestamp = timestamp;
+    }
+
+    /// Set the timestamp of the record to write.
+    fn set_timestamp(&mut self, timestamp: SystemTime) {
+        self.timestamp = from_system_time(timestamp);
+    }
+
+    /// Set the labels of the record to write.
+    /// This replaces all existing labels.
+    fn set_labels(&mut self, labels: Labels) {
+        self.labels = labels;
+    }
+
+    /// Add a label to the record to write.
+    fn add_label(&mut self, key: String, value: String) {
+        self.labels.insert(key, value);
+    }
+
+    /// Set the content type of the record to write.
+    fn set_content_type(&mut self, content_type: String) {
+        self.content_type = content_type;
+    }
+
+    /// Set the content length of the record to write
+    fn set_content_length(&mut self, content_length: usize) {
+        self.content_length = content_length;
+    }
+
+    /// Set the content of the record
+    fn set_bytes(&mut self, bytes: Bytes) {
+        self.data = Some(Box::pin(futures::stream::once(async move { Ok(bytes) })));
+    }
+
+    /// Set the content of the record as a stream
+    fn set_stream_bytes(&mut self, stream: RecordStream) {
+        self.data = Some(stream);
     }
 }
 

--- a/reduct_rs/src/record.rs
+++ b/reduct_rs/src/record.rs
@@ -14,7 +14,6 @@ use futures::stream::Stream;
 use futures_util::StreamExt;
 use reduct_base::error::ReductError;
 
-use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 

--- a/reduct_rs/src/record.rs
+++ b/reduct_rs/src/record.rs
@@ -20,7 +20,7 @@ use std::pin::Pin;
 
 use std::time::SystemTime;
 
-pub type Labels = HashMap<String, String>;
+pub use reduct_base::batch::Labels;
 pub type RecordStream = Pin<Box<dyn Stream<Item = Result<Bytes, ReductError>>>>;
 
 pub use write_record::WriteRecordBuilder;

--- a/reduct_rs/src/record.rs
+++ b/reduct_rs/src/record.rs
@@ -13,14 +13,13 @@ use bytes::{Bytes, BytesMut};
 use futures::stream::Stream;
 
 use futures_util::StreamExt;
-use reduct_base::error::{ErrorCode, ReductError};
+use reduct_base::error::ReductError;
 
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
 use async_stream::stream;
-use futures::TryStream;
-use futures_util::future::err;
+
 use std::time::SystemTime;
 
 pub use reduct_base::batch::Labels;
@@ -82,7 +81,7 @@ impl Record {
     /// Content of the record
     ///
     /// This consumes the record and returns bytes
-    pub fn bytes(mut self) -> Pin<Box<dyn futures::Future<Output = Result<Bytes, ReductError>>>> {
+    pub fn bytes(self) -> Pin<Box<dyn futures::Future<Output = Result<Bytes, ReductError>>>> {
         Box::pin(async move {
             if let Some(mut data) = self.data {
                 let mut bytes = BytesMut::new();

--- a/reduct_rs/src/record/query.rs
+++ b/reduct_rs/src/record/query.rs
@@ -241,7 +241,7 @@ async fn parse_batched_records(
         for (name, value) in sorted_headers {
             if name.starts_with("x-reduct-time-") {
                 let timestamp = name[14..].parse::<u64>().unwrap();
-                let (content_length, content_type, labels) = parse_batched_header(value.to_str().unwrap());
+                let (content_length, content_type, labels) = parse_batched_header(value.to_str().unwrap()).unwrap();
                 let last =  headers.get("x-reduct-last") == Some(&HeaderValue::from_str("true").unwrap());
 
                 records_count += 1;

--- a/reduct_rs/src/record/query.rs
+++ b/reduct_rs/src/record/query.rs
@@ -13,13 +13,12 @@ use bytes::BytesMut;
 use chrono::Duration;
 use futures::Stream;
 use futures_util::{pin_mut, StreamExt};
+use reduct_base::batch::{parse_batched_header, sort_headers_by_name};
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::QueryInfo;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Method;
-
 use std::sync::Arc;
-
 use std::time::SystemTime;
 
 /// Builder for a query request.
@@ -229,12 +228,7 @@ async fn parse_batched_records(
     head_only: bool,
 ) -> Result<impl Stream<Item = Result<(Record, bool), ReductError>>, ReductError> {
     //sort headers by names
-    let mut sorted_headers: Vec<_> = headers
-        .clone()
-        .into_iter()
-        .map(|(key, value)| (key.unwrap().as_str().to_string(), value))
-        .collect();
-    sorted_headers.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
+    let sorted_headers = sort_headers_by_name(&headers);
 
     let records_total = sorted_headers
         .iter()
@@ -247,7 +241,7 @@ async fn parse_batched_records(
         for (name, value) in sorted_headers {
             if name.starts_with("x-reduct-time-") {
                 let timestamp = name[14..].parse::<u64>().unwrap();
-                let (content_length, content_type, labels) = parse_header_as_csv_row(value.to_str().unwrap());
+                let (content_length, content_type, labels) = parse_batched_header(value.to_str().unwrap());
                 let last =  headers.get("x-reduct-last") == Some(&HeaderValue::from_str("true").unwrap());
 
                 records_count += 1;
@@ -297,70 +291,4 @@ async fn parse_batched_records(
             }
         }
     })
-}
-
-fn parse_header_as_csv_row(header: &str) -> (usize, String, Labels) {
-    let (content_length, rest) = header.split_once(',').unwrap();
-    let content_length = content_length.trim().parse::<usize>().unwrap();
-
-    let (content_type, rest) = rest.split_once(',').unwrap_or((rest, ""));
-    let content_type = content_type.trim().to_string();
-
-    let mut labels = Labels::new();
-    let mut rest = rest.to_string();
-    while let Some(pair) = rest.split_once('=') {
-        let (key, value) = pair;
-        rest = if value.starts_with('\"') {
-            let value = value[1..].to_string();
-            let (value, rest) = value.split_once('\"').unwrap();
-            labels.insert(key.trim().to_string(), value.trim().to_string());
-            rest.trim_start_matches(',').trim().to_string()
-        } else if let Some(ret) = value.split_once(',') {
-            let (value, rest) = ret;
-            labels.insert(key.trim().to_string(), value.trim().to_string());
-            rest.trim().to_string()
-        } else {
-            labels.insert(key.trim().to_string(), value.trim().to_string());
-            break;
-        };
-    }
-
-    (content_length, content_type, labels)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::*;
-
-    #[rstest]
-    fn test_parse_header_as_csv_row() {
-        let header = "123, text/plain, label1=value1, label2=value2";
-        let (content_length, content_type, labels) = parse_header_as_csv_row(header);
-        assert_eq!(content_length, 123);
-        assert_eq!(content_type, "text/plain");
-        assert_eq!(labels.len(), 2);
-        assert_eq!(labels.get("label1"), Some(&"value1".to_string()));
-        assert_eq!(labels.get("label2"), Some(&"value2".to_string()));
-    }
-
-    #[rstest]
-    fn test_parse_header_as_csv_row_quotes() {
-        let header = "123, text/plain, label1=\"[1, 2, 3]\", label2=\"value2\"";
-        let (content_length, content_type, labels) = parse_header_as_csv_row(header);
-        assert_eq!(content_length, 123);
-        assert_eq!(content_type, "text/plain");
-        assert_eq!(labels.len(), 2);
-        assert_eq!(labels.get("label1"), Some(&"[1, 2, 3]".to_string()));
-        assert_eq!(labels.get("label2"), Some(&"value2".to_string()));
-    }
-
-    #[rstest]
-    fn test_parse_header_no_labels() {
-        let header = "123, text/plain";
-        let (content_length, content_type, labels) = parse_header_as_csv_row(header);
-        assert_eq!(content_length, 123);
-        assert_eq!(content_type, "text/plain");
-        assert_eq!(labels.len(), 0);
-    }
 }

--- a/reduct_rs/src/record/query.rs
+++ b/reduct_rs/src/record/query.rs
@@ -13,7 +13,7 @@ use bytes::BytesMut;
 use chrono::Duration;
 use futures::Stream;
 use futures_util::{pin_mut, StreamExt};
-use reduct_base::batch::{parse_batched_header, sort_headers_by_name};
+use reduct_base::batch::{parse_batched_header, sort_headers_by_name, RecordHeader};
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::QueryInfo;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -241,7 +241,7 @@ async fn parse_batched_records(
         for (name, value) in sorted_headers {
             if name.starts_with("x-reduct-time-") {
                 let timestamp = name[14..].parse::<u64>().unwrap();
-                let (content_length, content_type, labels) = parse_batched_header(value.to_str().unwrap()).unwrap();
+                let RecordHeader{content_length, content_type, labels} = parse_batched_header(value.to_str().unwrap()).unwrap();
                 let last =  headers.get("x-reduct-last") == Some(&HeaderValue::from_str("true").unwrap());
 
                 records_count += 1;

--- a/reduct_rs/src/record/query.rs
+++ b/reduct_rs/src/record/query.rs
@@ -4,8 +4,8 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::http_client::HttpClient;
-use crate::record::from_system_time;
-use crate::{Labels, Record, RecordStream};
+use crate::record::{from_system_time, Record};
+use crate::{Labels, RecordStream};
 use async_channel::{unbounded, Receiver};
 use async_stream::stream;
 use bytes::Bytes;

--- a/reduct_rs/src/record/read_record.rs
+++ b/reduct_rs/src/record/read_record.rs
@@ -8,7 +8,7 @@ use crate::record::{from_system_time, Labels, Record};
 use futures_util::StreamExt;
 use reduct_base::error::ReductError;
 use reqwest::Method;
-use std::fmt::Debug;
+
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/reduct_rs/src/record/read_record.rs
+++ b/reduct_rs/src/record/read_record.rs
@@ -8,6 +8,7 @@ use crate::record::{from_system_time, Labels, Record};
 use futures_util::StreamExt;
 use reduct_base::error::ReductError;
 use reqwest::Method;
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/reduct_rs/src/record/write_batched_records.rs
+++ b/reduct_rs/src/record/write_batched_records.rs
@@ -1,0 +1,4 @@
+// Copyright 2023 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/reduct_rs/src/record/write_batched_records.rs
+++ b/reduct_rs/src/record/write_batched_records.rs
@@ -2,3 +2,102 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::http_client::HttpClient;
+use crate::Record;
+use async_stream::stream;
+use futures_util::StreamExt;
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
+use reqwest::{Body, Method};
+use std::collections::VecDeque;
+use std::pin::pin;
+use std::sync::Arc;
+
+/// Builder for writing multiple records in a single request.
+pub struct WriteBatchBuilder {
+    bucket: String,
+    entry: String,
+    records: VecDeque<Record>,
+    client: Arc<HttpClient>,
+}
+
+impl WriteBatchBuilder {
+    pub(crate) fn new(bucket: String, entry: String, client: Arc<HttpClient>) -> Self {
+        Self {
+            bucket,
+            entry,
+            records: VecDeque::new(),
+            client,
+        }
+    }
+
+    /// Add a record to the batch.
+    pub fn add_record(mut self, record: Record) -> Self {
+        self.records.push_back(record);
+        self
+    }
+
+    /// Add records to the batch.
+    pub fn add_records(mut self, records: Vec<Record>) -> Self {
+        self.records.extend(records);
+        self
+    }
+
+    /// Build the request and send it to the server.
+    pub async fn send(mut self) -> Result<(), crate::ReductError> {
+        let mut request = self.client.request(
+            Method::POST,
+            &format!("/b/{}/{}/batch", self.bucket, self.entry),
+        );
+
+        let content_length: usize = self.records.iter().map(|r| r.content_length()).sum();
+
+        let mut request = request
+            .header(
+                CONTENT_TYPE,
+                HeaderValue::from_str("application/octet-stream").unwrap(),
+            )
+            .header(
+                CONTENT_LENGTH,
+                HeaderValue::from_str(&content_length.to_string()).unwrap(),
+            );
+
+        for record in &self.records {
+            let mut header_values = Vec::new();
+            header_values.push(record.content_length().to_string());
+            header_values.push(record.content_type().to_string());
+            if !record.labels().is_empty() {
+                for (key, value) in record.labels() {
+                    if value.contains(',') {
+                        header_values.push(format!("{}=\"{}\"", key, value));
+                    } else {
+                        header_values.push(format!("{}={}", key, value));
+                    }
+                }
+            }
+
+            request = request.header(
+                &format!("x-reduct-time-{}", record.timestamp_us()),
+                HeaderValue::from_str(&header_values.join(",").to_string()).unwrap(),
+            );
+        }
+
+        let client = Arc::clone(&self.client);
+
+        let stream = stream! {
+             while let Some(record) = self.records.pop_front() {
+                 let mut stream = record.stream_bytes();
+                 while let Some(bytes) = stream.next().await {
+                     yield bytes;
+                 }
+             }
+        };
+
+        let _ = client
+            .send_request(request.body(Body::wrap_stream(stream)))
+            .await?;
+        // todo: check response
+
+        Ok(())
+    }
+}

--- a/reduct_rs/src/record/write_batched_records.rs
+++ b/reduct_rs/src/record/write_batched_records.rs
@@ -7,10 +7,10 @@ use crate::http_client::HttpClient;
 use crate::Record;
 use async_stream::stream;
 use futures_util::StreamExt;
-use reqwest::header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
+use reqwest::header::{HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
 use reqwest::{Body, Method};
 use std::collections::VecDeque;
-use std::pin::pin;
+
 use std::sync::Arc;
 
 /// Builder for writing multiple records in a single request.
@@ -45,7 +45,7 @@ impl WriteBatchBuilder {
 
     /// Build the request and send it to the server.
     pub async fn send(mut self) -> Result<(), crate::ReductError> {
-        let mut request = self.client.request(
+        let request = self.client.request(
             Method::POST,
             &format!("/b/{}/{}/batch", self.bucket, self.entry),
         );

--- a/reduct_rs/src/record/write_record.rs
+++ b/reduct_rs/src/record/write_record.rs
@@ -28,14 +28,6 @@ pub struct WriteRecordBuilder {
     client: Arc<HttpClient>,
 }
 
-pub struct WritableRecord {
-    pub timestamp: u64,
-    pub labels: Labels,
-    pub content_type: String,
-    pub content_length: Option<u64>,
-    pub data: Option<Body>,
-}
-
 impl WriteRecordBuilder {
     pub(crate) fn new(bucket: String, entry: String, client: Arc<HttpClient>) -> Self {
         Self {

--- a/reduct_rs/src/record/write_record.rs
+++ b/reduct_rs/src/record/write_record.rs
@@ -12,7 +12,7 @@ use futures::TryStream;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use reqwest::{Body, Method};
 
-use reduct_base::error::ReductError;
+use reduct_base::error::{ErrorCode, ReductError};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -119,11 +119,10 @@ impl WriteRecordBuilder {
 
         if let Some(data) = self.data {
             request = request.body(data);
+            self.client.send_request(request).await?;
+            Ok(())
         } else {
-            request = request.header(CONTENT_LENGTH, 0);
+            Err(ReductError::new(ErrorCode::BadRequest, "No data provided"))
         }
-
-        self.client.send_request(request).await?;
-        Ok(())
     }
 }

--- a/reduct_rs/src/record/write_record.rs
+++ b/reduct_rs/src/record/write_record.rs
@@ -28,6 +28,14 @@ pub struct WriteRecordBuilder {
     client: Arc<HttpClient>,
 }
 
+pub struct WritableRecord {
+    pub timestamp: u64,
+    pub labels: Labels,
+    pub content_type: String,
+    pub content_length: Option<u64>,
+    pub data: Option<Body>,
+}
+
 impl WriteRecordBuilder {
     pub(crate) fn new(bucket: String, entry: String, client: Arc<HttpClient>) -> Self {
         Self {

--- a/reductstore/build.rs
+++ b/reductstore/build.rs
@@ -42,10 +42,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn download_web_console() {
-    if Path::exists(Path::new(&format!(
-        "{}/console.zip",
-        env::var("OUT_DIR").unwrap()
-    ))) {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    if Path::exists(Path::new(&format!("{}/console.zip", out_dir))) {
         return;
     }
 
@@ -62,9 +60,6 @@ fn download_web_console() {
             panic!("Failed to download Web Console: {}", resp.status());
         }
     }
-    fs::write(
-        format!("{}/console.zip", env::var("OUT_DIR").unwrap()),
-        resp.bytes().unwrap(),
-    )
-    .expect("Failed to write console.zip");
+    fs::write(format!("{}/console.zip", out_dir), resp.bytes().unwrap())
+        .expect("Failed to write console.zip");
 }

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -34,7 +34,7 @@ mod server;
 mod token;
 mod ui;
 
-pub struct Componentes {
+pub struct Components {
     pub storage: RwLock<Storage>,
     pub auth: TokenAuthorization,
     pub token_repo: RwLock<Box<dyn ManageTokens + Send + Sync>>,
@@ -102,7 +102,7 @@ impl From<serde_json::Error> for HttpError {
     }
 }
 
-pub fn create_axum_app(api_base_path: &String, components: Arc<Componentes>) -> Router {
+pub fn create_axum_app(api_base_path: &String, components: Arc<Components>) -> Router {
     let b_route = create_bucket_api_routes().merge(create_entry_api_routes());
 
     let app = Router::new()
@@ -144,7 +144,7 @@ mod tests {
     use rstest::fixture;
 
     #[fixture]
-    pub(crate) fn components() -> Arc<Componentes> {
+    pub(crate) fn components() -> Arc<Components> {
         let data_path = tempfile::tempdir().unwrap().into_path();
 
         let mut storage = Storage::new(data_path.clone());
@@ -179,7 +179,7 @@ mod tests {
 
         token_repo.generate_token("test", permissions).unwrap();
 
-        let components = Componentes {
+        let components = Components {
             storage: RwLock::new(storage),
             auth: TokenAuthorization::new("inti-token"),
             token_repo: RwLock::new(token_repo),

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -130,12 +130,14 @@ pub fn create_axum_app(api_base_path: &String, components: Arc<Componentes>) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Empty;
     use std::collections::HashMap;
 
     use crate::auth::token_repository::create_token_repository;
     use crate::storage::writer::Chunk;
-    use axum::extract::Path;
+    use axum::extract::{BodyStream, FromRequest, Path};
     use axum::headers::{Authorization, HeaderMap, HeaderMapExt};
+    use axum::http::Request;
     use bytes::Bytes;
     use reduct_base::msg::bucket_api::BucketSettings;
     use reduct_base::msg::token_api::Permissions;
@@ -202,5 +204,12 @@ mod tests {
             ("entry_name".to_string(), "entry-1".to_string()),
         ]));
         path
+    }
+
+    #[fixture]
+    pub async fn empty_body() -> BodyStream {
+        let emtpy_stream: Empty<Bytes> = Empty::new();
+        let request = Request::builder().body(emtpy_stream).unwrap();
+        BodyStream::from_request(request, &()).await.unwrap()
     }
 }

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -134,7 +134,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::auth::token_repository::create_token_repository;
-    use crate::storage::writer::Chunk;
+    use crate::storage::writer::{Chunk, WriteChunk};
     use axum::extract::{BodyStream, FromRequest, Path};
     use axum::headers::{Authorization, HeaderMap, HeaderMapExt};
     use axum::http::Request;

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -12,27 +12,27 @@ use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::api::bucket::create_bucket_api_routes;
+use crate::api::entry::create_entry_api_routes;
+use crate::api::middleware::{default_headers, print_statuses};
+use crate::api::server::create_server_api_routes;
+use crate::api::token::create_token_api_routes;
+use crate::api::ui::{redirect_to_index, show_ui};
 use crate::asset::asset_manager::ZipAssetManager;
 use crate::auth::token_auth::TokenAuthorization;
 use crate::auth::token_repository::ManageTokens;
-use crate::http_frontend::bucket_api::create_bucket_api_routes;
-use crate::http_frontend::entry_api::create_entry_api_routes;
-use crate::http_frontend::middleware::{default_headers, print_statuses};
-use crate::http_frontend::server_api::create_server_api_routes;
-use crate::http_frontend::token_api::create_token_api_routes;
-use crate::http_frontend::ui_api::{redirect_to_index, show_ui};
 use crate::storage::storage::Storage;
 use reduct_base::error::ReductError as BaseHttpError;
 use reduct_macros::Twin;
 
 pub use reduct_base::error::ErrorCode;
 
-mod bucket_api;
-mod entry_api;
+mod bucket;
+mod entry;
 mod middleware;
-mod server_api;
-mod token_api;
-mod ui_api;
+mod server;
+mod token;
+mod ui;
 
 pub struct Componentes {
     pub storage: RwLock<Storage>,

--- a/reductstore/src/api/bucket.rs
+++ b/reductstore/src/api/bucket.rs
@@ -24,7 +24,7 @@ use crate::api::bucket::head::head_bucket;
 use crate::api::bucket::remove::remove_bucket;
 use crate::api::bucket::update::update_bucket;
 
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use reduct_base::msg::bucket_api::{BucketSettings, FullBucketInfo};
 use reduct_macros::{IntoResponse, Twin};
 //
@@ -66,7 +66,7 @@ where
     }
 }
 
-pub fn create_bucket_api_routes() -> axum::Router<Arc<Componentes>> {
+pub fn create_bucket_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
         .route("/:bucket_name", get(get_bucket))
         .route("/:bucket_name", head(head_bucket))

--- a/reductstore/src/api/bucket.rs
+++ b/reductstore/src/api/bucket.rs
@@ -18,13 +18,13 @@ use axum::{async_trait, headers};
 use bytes::Bytes;
 use hyper::HeaderMap;
 
-use crate::http_frontend::bucket_api::create::create_bucket;
-use crate::http_frontend::bucket_api::get::get_bucket;
-use crate::http_frontend::bucket_api::head::head_bucket;
-use crate::http_frontend::bucket_api::remove::remove_bucket;
-use crate::http_frontend::bucket_api::update::update_bucket;
+use crate::api::bucket::create::create_bucket;
+use crate::api::bucket::get::get_bucket;
+use crate::api::bucket::head::head_bucket;
+use crate::api::bucket::remove::remove_bucket;
+use crate::api::bucket::update::update_bucket;
 
-use crate::http_frontend::{Componentes, HttpError};
+use crate::api::{Componentes, HttpError};
 use reduct_base::msg::bucket_api::{BucketSettings, FullBucketInfo};
 use reduct_macros::{IntoResponse, Twin};
 //

--- a/reductstore/src/api/bucket/create.rs
+++ b/reductstore/src/api/bucket/create.rs
@@ -1,42 +1,49 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::bucket::BucketSettingsAxum;
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::FullAccessPolicy;
-use crate::http_frontend::bucket_api::BucketSettingsAxum;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, HttpError};
+
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
 
-// PUT /b/:bucket_name
-pub async fn update_bucket(
+// POST /b/:bucket_name
+pub async fn create_bucket(
     State(components): State<Arc<Componentes>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
     settings: BucketSettingsAxum,
 ) -> Result<(), HttpError> {
     check_permissions(&components, headers, FullAccessPolicy {}).await?;
-    let mut storage = components.storage.write().await;
-
-    Ok(storage
-        .get_mut_bucket(&bucket_name)?
-        .set_settings(settings.into())?)
+    components
+        .storage
+        .write()
+        .await
+        .create_bucket(&bucket_name, settings.into())?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_frontend::tests::{components, headers};
-    use reduct_base::error::ErrorCode;
+
+    use crate::api::tests::{components, headers};
+    use crate::api::Componentes;
+
     use rstest::rstest;
+
+    use reduct_base::error::ErrorCode;
+    use std::sync::Arc;
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket(components: Arc<Componentes>, headers: HeaderMap) {
-        update_bucket(
+    async fn test_create_bucket(components: Arc<Componentes>, headers: HeaderMap) {
+        create_bucket(
             State(components),
-            Path("bucket-1".to_string()),
+            Path("bucket-3".to_string()),
             headers,
             BucketSettingsAxum::default(),
         )
@@ -46,10 +53,10 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
-        let err = update_bucket(
+    async fn test_create_bucket_already_exists(components: Arc<Componentes>, headers: HeaderMap) {
+        let err = create_bucket(
             State(components),
-            Path("not-found".to_string()),
+            Path("bucket-1".to_string()),
             headers,
             BucketSettingsAxum::default(),
         )
@@ -58,7 +65,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             err,
-            HttpError::new(ErrorCode::NotFound, "Bucket 'not-found' is not found",)
+            HttpError::new(ErrorCode::Conflict, "Bucket 'bucket-1' already exists",)
         )
     }
 }

--- a/reductstore/src/api/bucket/create.rs
+++ b/reductstore/src/api/bucket/create.rs
@@ -3,7 +3,7 @@
 
 use crate::api::bucket::BucketSettingsAxum;
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::FullAccessPolicy;
 
 use axum::extract::{Path, State};
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // POST /b/:bucket_name
 pub async fn create_bucket(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
     settings: BucketSettingsAxum,
@@ -31,7 +31,7 @@ mod tests {
     use super::*;
 
     use crate::api::tests::{components, headers};
-    use crate::api::Componentes;
+    use crate::api::Components;
 
     use rstest::rstest;
 
@@ -40,7 +40,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_bucket(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_create_bucket(components: Arc<Components>, headers: HeaderMap) {
         create_bucket(
             State(components),
             Path("bucket-3".to_string()),
@@ -53,7 +53,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_bucket_already_exists(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_create_bucket_already_exists(components: Arc<Components>, headers: HeaderMap) {
         let err = create_bucket(
             State(components),
             Path("bucket-1".to_string()),

--- a/reductstore/src/api/bucket/get.rs
+++ b/reductstore/src/api/bucket/get.rs
@@ -3,7 +3,7 @@
 
 use crate::api::bucket::FullBucketInfoAxum;
 use crate::api::middleware::check_permissions;
-use crate::api::Componentes;
+use crate::api::Components;
 use crate::api::HttpError;
 use crate::auth::policy::AuthenticatedPolicy;
 use axum::extract::{Path, State};
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // GET /b/:bucket_name
 pub async fn get_bucket(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<FullBucketInfoAxum, HttpError> {
@@ -30,7 +30,7 @@ pub async fn get_bucket(
 mod tests {
     use super::*;
 
-    use crate::api::Componentes;
+    use crate::api::Components;
 
     use crate::api::tests::{components, headers};
 
@@ -41,7 +41,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_bucket(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_get_bucket(components: Arc<Components>, headers: HeaderMap) {
         let info = get_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();
@@ -50,7 +50,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_get_bucket_not_found(components: Arc<Components>, headers: HeaderMap) {
         let err = get_bucket(State(components), Path("not-found".to_string()), headers)
             .await
             .err()

--- a/reductstore/src/api/bucket/get.rs
+++ b/reductstore/src/api/bucket/get.rs
@@ -1,11 +1,11 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::bucket::FullBucketInfoAxum;
+use crate::api::middleware::check_permissions;
+use crate::api::Componentes;
+use crate::api::HttpError;
 use crate::auth::policy::AuthenticatedPolicy;
-use crate::http_frontend::bucket_api::FullBucketInfoAxum;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::Componentes;
-use crate::http_frontend::HttpError;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
@@ -30,9 +30,9 @@ pub async fn get_bucket(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::Componentes;
+    use crate::api::Componentes;
 
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
 
     use rstest::rstest;
 

--- a/reductstore/src/api/bucket/head.rs
+++ b/reductstore/src/api/bucket/head.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
 
 use axum::extract::{Path, State};
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 // HEAD /b/:bucket_name
 pub async fn head_bucket(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
@@ -24,7 +24,7 @@ pub async fn head_bucket(
 mod tests {
     use super::*;
 
-    use crate::api::Componentes;
+    use crate::api::Components;
 
     use crate::api::tests::{components, headers};
 
@@ -34,7 +34,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_head_bucket(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_head_bucket(components: Arc<Components>, headers: HeaderMap) {
         head_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();

--- a/reductstore/src/api/bucket/head.rs
+++ b/reductstore/src/api/bucket/head.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, HttpError};
 
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -24,9 +24,9 @@ pub async fn head_bucket(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::Componentes;
+    use crate::api::Componentes;
 
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
 
     use rstest::rstest;
 

--- a/reductstore/src/api/bucket/remove.rs
+++ b/reductstore/src/api/bucket/remove.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::FullAccessPolicy;
 
 use axum::extract::{Path, State};
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // DELETE /b/:bucket_name
 pub async fn remove_bucket(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
@@ -34,7 +34,7 @@ pub async fn remove_bucket(
 mod tests {
     use super::*;
 
-    use crate::api::Componentes;
+    use crate::api::Components;
 
     use crate::api::tests::{components, headers};
 
@@ -45,7 +45,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_bucket(components: Arc<Components>, headers: HeaderMap) {
         remove_bucket(State(components), Path("bucket-1".to_string()), headers)
             .await
             .unwrap();
@@ -53,7 +53,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_bucket_not_found(components: Arc<Components>, headers: HeaderMap) {
         let err = remove_bucket(State(components), Path("not-found".to_string()), headers)
             .await
             .err()
@@ -66,7 +66,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket_from_permission(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_bucket_from_permission(components: Arc<Components>, headers: HeaderMap) {
         let token = components
             .token_repo
             .read()

--- a/reductstore/src/api/bucket/remove.rs
+++ b/reductstore/src/api/bucket/remove.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::FullAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, HttpError};
 
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -34,9 +34,9 @@ pub async fn remove_bucket(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::Componentes;
+    use crate::api::Componentes;
 
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
 
     use rstest::rstest;
 

--- a/reductstore/src/api/bucket/update.rs
+++ b/reductstore/src/api/bucket/update.rs
@@ -3,7 +3,7 @@
 
 use crate::api::bucket::BucketSettingsAxum;
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 // PUT /b/:bucket_name
 pub async fn update_bucket(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
     settings: BucketSettingsAxum,
@@ -33,7 +33,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_update_bucket(components: Arc<Components>, headers: HeaderMap) {
         update_bucket(
             State(components),
             Path("bucket-1".to_string()),
@@ -46,7 +46,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_update_bucket_not_found(components: Arc<Components>, headers: HeaderMap) {
         let err = update_bucket(
             State(components),
             Path("not-found".to_string()),

--- a/reductstore/src/api/bucket/update.rs
+++ b/reductstore/src/api/bucket/update.rs
@@ -1,49 +1,42 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::bucket::BucketSettingsAxum;
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::FullAccessPolicy;
-use crate::http_frontend::bucket_api::BucketSettingsAxum;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, HttpError};
-
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
 
-// POST /b/:bucket_name
-pub async fn create_bucket(
+// PUT /b/:bucket_name
+pub async fn update_bucket(
     State(components): State<Arc<Componentes>>,
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
     settings: BucketSettingsAxum,
 ) -> Result<(), HttpError> {
     check_permissions(&components, headers, FullAccessPolicy {}).await?;
-    components
-        .storage
-        .write()
-        .await
-        .create_bucket(&bucket_name, settings.into())?;
-    Ok(())
+    let mut storage = components.storage.write().await;
+
+    Ok(storage
+        .get_mut_bucket(&bucket_name)?
+        .set_settings(settings.into())?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::http_frontend::tests::{components, headers};
-    use crate::http_frontend::Componentes;
-
-    use rstest::rstest;
-
+    use crate::api::tests::{components, headers};
     use reduct_base::error::ErrorCode;
-    use std::sync::Arc;
+    use rstest::rstest;
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_bucket(components: Arc<Componentes>, headers: HeaderMap) {
-        create_bucket(
+    async fn test_update_bucket(components: Arc<Componentes>, headers: HeaderMap) {
+        update_bucket(
             State(components),
-            Path("bucket-3".to_string()),
+            Path("bucket-1".to_string()),
             headers,
             BucketSettingsAxum::default(),
         )
@@ -53,10 +46,10 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_bucket_already_exists(components: Arc<Componentes>, headers: HeaderMap) {
-        let err = create_bucket(
+    async fn test_update_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+        let err = update_bucket(
             State(components),
-            Path("bucket-1".to_string()),
+            Path("not-found".to_string()),
             headers,
             BucketSettingsAxum::default(),
         )
@@ -65,7 +58,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             err,
-            HttpError::new(ErrorCode::Conflict, "Bucket 'bucket-1' already exists",)
+            HttpError::new(ErrorCode::NotFound, "Bucket 'not-found' is not found",)
         )
     }
 }

--- a/reductstore/src/api/entry.rs
+++ b/reductstore/src/api/entry.rs
@@ -27,13 +27,13 @@ use reduct_base::msg::entry_api::QueryInfo;
 use reduct_macros::{IntoResponse, Twin};
 use std::sync::Arc;
 
-use crate::http_frontend::entry_api::read_batched::read_batched_records;
-use crate::http_frontend::entry_api::read_single::read_single_record;
-use crate::http_frontend::entry_api::remove::remove_entry;
-use crate::http_frontend::entry_api::write::write_record;
-use crate::http_frontend::HttpError;
+use crate::api::entry::read_batched::read_batched_records;
+use crate::api::entry::read_single::read_single_record;
+use crate::api::entry::remove::remove_entry;
+use crate::api::entry::write::write_record;
+use crate::api::HttpError;
 
-use crate::http_frontend::Componentes;
+use crate::api::Componentes;
 
 pub struct MethodExtractor {
     name: String,

--- a/reductstore/src/api/entry.rs
+++ b/reductstore/src/api/entry.rs
@@ -8,33 +8,27 @@ mod remove;
 mod write_batched;
 mod write_single;
 
-use axum::async_trait;
-
-use axum::extract::FromRequest;
-use axum::http::header::HeaderMap;
-use axum::http::{Request, StatusCode};
-use axum::response::{IntoResponse, Response};
-
-use std::collections::HashMap;
-
-use axum::headers;
-use axum::headers::HeaderMapExt;
-
-use axum::routing::{delete, get, head, post};
-
-use crate::storage::storage::Storage;
-use reduct_base::error::ErrorCode;
-use reduct_base::msg::entry_api::QueryInfo;
-use reduct_macros::{IntoResponse, Twin};
-use std::sync::Arc;
-
 use crate::api::entry::read_batched::read_batched_records;
 use crate::api::entry::read_single::read_single_record;
 use crate::api::entry::remove::remove_entry;
+use crate::api::entry::write_batched::write_batched_records;
 use crate::api::entry::write_single::write_record;
+use crate::api::Components;
 use crate::api::HttpError;
-
-use crate::api::Componentes;
+use crate::storage::storage::Storage;
+use axum::async_trait;
+use axum::extract::FromRequest;
+use axum::headers;
+use axum::headers::HeaderMapExt;
+use axum::http::header::HeaderMap;
+use axum::http::{Request, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get, head, post};
+use reduct_base::error::ErrorCode;
+use reduct_base::msg::entry_api::QueryInfo;
+use reduct_macros::{IntoResponse, Twin};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 pub struct MethodExtractor {
     name: String,
@@ -107,9 +101,13 @@ fn check_and_extract_ts_or_query_id(
 #[derive(IntoResponse, Twin)]
 pub struct QueryInfoAxum(QueryInfo);
 
-pub fn create_entry_api_routes() -> axum::Router<Arc<Componentes>> {
+pub fn create_entry_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
         .route("/:bucket_name/:entry_name", post(write_record))
+        .route(
+            "/:bucket_name/:entry_name/batch",
+            post(write_batched_records),
+        )
         .route("/:bucket_name/:entry_name", get(read_single_record))
         .route("/:bucket_name/:entry_name", head(read_single_record))
         .route("/:bucket_name/:entry_name/batch", get(read_batched_records))

--- a/reductstore/src/api/entry.rs
+++ b/reductstore/src/api/entry.rs
@@ -5,7 +5,8 @@ mod query;
 mod read_batched;
 mod read_single;
 mod remove;
-mod write;
+mod write_batched;
+mod write_single;
 
 use axum::async_trait;
 
@@ -30,7 +31,7 @@ use std::sync::Arc;
 use crate::api::entry::read_batched::read_batched_records;
 use crate::api::entry::read_single::read_single_record;
 use crate::api::entry::remove::remove_entry;
-use crate::api::entry::write::write_record;
+use crate::api::entry::write_single::write_record;
 use crate::api::HttpError;
 
 use crate::api::Componentes;

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::ReadAccessPolicy;
 use crate::storage::query::base::QueryOptions;
 
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 // GET /:bucket/:entry/q?start=<number>&stop=<number>&continue=<number>&exclude-<label>=<value>&include-<label>=<value>&ttl=<number>
 pub async fn query(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -131,7 +131,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_limited_query(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {
@@ -167,7 +167,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_bad_limit(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::ReadAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, HttpError};
 use crate::storage::query::base::QueryOptions;
 
 use axum::extract::{Path, Query, State};
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use std::sync::Arc;
 
-use crate::http_frontend::entry_api::QueryInfoAxum;
+use crate::api::entry::QueryInfoAxum;
 use reduct_base::error::ErrorCode;
 use reduct_base::msg::entry_api::QueryInfo;
 use std::time::Duration;
@@ -125,7 +125,7 @@ pub async fn query(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_frontend::tests::{components, headers, path_to_entry_1};
+    use crate::api::tests::{components, headers, path_to_entry_1};
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -3,7 +3,7 @@
 
 use crate::api::entry::MethodExtractor;
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, ErrorCode, HttpError};
+use crate::api::{Components, ErrorCode, HttpError};
 use crate::auth::policy::ReadAccessPolicy;
 use crate::storage::bucket::Bucket;
 
@@ -24,7 +24,7 @@ use std::task::{Context, Poll};
 
 // GET /:bucket/:entry/batch?q=<number>
 pub async fn read_batched_records(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -207,7 +207,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_batched_read(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::entry::MethodExtractor;
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, ErrorCode, HttpError};
 use crate::auth::policy::ReadAccessPolicy;
-use crate::http_frontend::entry_api::MethodExtractor;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, ErrorCode, HttpError};
 use crate::storage::bucket::Bucket;
 
 use crate::storage::reader::RecordReader;
@@ -198,7 +198,7 @@ mod tests {
 
     use axum::body::HttpBody;
 
-    use crate::http_frontend::tests::{components, headers, path_to_entry_1};
+    use crate::api::tests::{components, headers, path_to_entry_1};
     use crate::storage::query::base::QueryOptions;
     use rstest::*;
 

--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -1,11 +1,11 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::entry::{check_and_extract_ts_or_query_id, MethodExtractor};
+use crate::api::middleware::check_permissions;
+use crate::api::Componentes;
+use crate::api::HttpError;
 use crate::auth::policy::ReadAccessPolicy;
-use crate::http_frontend::entry_api::{check_and_extract_ts_or_query_id, MethodExtractor};
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::Componentes;
-use crate::http_frontend::HttpError;
 use crate::storage::bucket::Bucket;
 
 use crate::storage::reader::RecordReader;
@@ -137,7 +137,7 @@ mod tests {
 
     use axum::body::HttpBody;
 
-    use crate::http_frontend::tests::{components, headers, path_to_entry_1};
+    use crate::api::tests::{components, headers, path_to_entry_1};
     use crate::storage::query::base::QueryOptions;
     use reduct_base::error::ErrorCode;
     use reduct_base::error::ErrorCode::NotFound;

--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -3,7 +3,7 @@
 
 use crate::api::entry::{check_and_extract_ts_or_query_id, MethodExtractor};
 use crate::api::middleware::check_permissions;
-use crate::api::Componentes;
+use crate::api::Components;
 use crate::api::HttpError;
 use crate::auth::policy::ReadAccessPolicy;
 use crate::storage::bucket::Bucket;
@@ -24,7 +24,7 @@ use std::task::{Context, Poll};
 
 // GET /:bucket/:entry?ts=<number>|q=<number>|
 pub async fn read_single_record(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(path): Path<HashMap<String, String>>,
     Query(params): Query<HashMap<String, String>>,
     headers: HeaderMap,
@@ -148,7 +148,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_single_read_ts(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,
@@ -184,7 +184,7 @@ mod tests {
     #[case("HEAD", "")]
     #[tokio::test]
     async fn test_single_read_query(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
         #[case] method: String,
@@ -230,7 +230,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_single_read_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_single_read_bucket_not_found(components: Arc<Components>, headers: HeaderMap) {
         let path = Path(HashMap::from_iter(vec![
             ("bucket_name".to_string(), "XXX".to_string()),
             ("entry_name".to_string(), "entru-1".to_string()),
@@ -255,7 +255,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_single_read_ts_not_found(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {
@@ -279,7 +279,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_single_read_bad_ts(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {
@@ -309,7 +309,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_single_read_query_not_found(
-        components: Arc<Componentes>,
+        components: Arc<Components>,
         path_to_entry_1: Path<HashMap<String, String>>,
         headers: HeaderMap,
     ) {

--- a/reductstore/src/api/entry/remove.rs
+++ b/reductstore/src/api/entry/remove.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
 use std::collections::HashMap;
 
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 // DELETE /b/:bucket_name/:entry_name
 pub async fn remove_entry(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(path): Path<HashMap<String, String>>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
@@ -47,7 +47,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_entry(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_entry(components: Arc<Components>, headers: HeaderMap) {
         let path = HashMap::from_iter(vec![
             ("bucket_name".to_string(), "bucket-1".to_string()),
             ("entry_name".to_string(), "entry-1".to_string()),
@@ -73,7 +73,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_bucket_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_bucket_not_found(components: Arc<Components>, headers: HeaderMap) {
         let path = HashMap::from_iter(vec![
             ("bucket_name".to_string(), "XXX".to_string()),
             ("entry_name".to_string(), "entry-1".to_string()),
@@ -90,7 +90,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_entry_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_entry_not_found(components: Arc<Components>, headers: HeaderMap) {
         let path = HashMap::from_iter(vec![
             ("bucket_name".to_string(), "bucket-1".to_string()),
             ("entry_name".to_string(), "XXX".to_string()),

--- a/reductstore/src/api/entry/remove.rs
+++ b/reductstore/src/api/entry/remove.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, HttpError};
 use std::collections::HashMap;
 
 use axum::extract::{Path, State};
@@ -41,7 +41,7 @@ pub async fn remove_entry(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
     use reduct_base::error::ErrorCode;
     use rstest::rstest;
 

--- a/reductstore/src/api/entry/write.rs
+++ b/reductstore/src/api/entry/write.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, ErrorCode, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, ErrorCode, HttpError};
 use crate::storage::entry::Labels;
 use crate::storage::writer::Chunk;
 use axum::extract::{BodyStream, Path, Query, State};
@@ -142,7 +142,7 @@ mod tests {
     use axum::headers::{Authorization, HeaderMapExt};
     use rstest::*;
 
-    use crate::http_frontend::tests::{components, path_to_entry_1};
+    use crate::api::tests::{components, path_to_entry_1};
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -4,7 +4,7 @@
 use crate::api::middleware::check_permissions;
 use crate::api::{Components, ErrorCode, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
-use crate::storage::writer::{Chunk, RecordWriter, WriteChunk};
+use crate::storage::writer::{Chunk, WriteChunk};
 use axum::extract::{BodyStream, Path, State};
 use axum::headers::{Expect, Header, HeaderMap, HeaderValue};
 use axum::http::HeaderName;
@@ -15,7 +15,7 @@ use log::debug;
 use reduct_base::batch::{parse_batched_header, sort_headers_by_name, RecordHeader};
 use reduct_base::error::ReductError;
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::format;
+
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -132,7 +132,7 @@ pub async fn write_batched_records(
     error_map.iter().for_each(|(time, err)| {
         headers.insert(
             HeaderName::from_str(&format!("x-reduct-error-{}", time)).unwrap(),
-            HeaderValue::from_str(&format!("{},\"{}\"", err.status(), err.message())).unwrap(),
+            HeaderValue::from_str(&format!("{},{}", err.status(), err.message())).unwrap(),
         );
     });
 
@@ -415,7 +415,7 @@ mod tests {
         assert_eq!(headers.len(), 1);
         assert_eq!(
             headers.get("x-reduct-error-2").unwrap(),
-            &HeaderValue::from_static("409,\"A record with timestamp 2 already exists\"")
+            &HeaderValue::from_static("409,A record with timestamp 2 already exists")
         );
 
         let storage = components.storage.read().await;

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -1,0 +1,156 @@
+// Copyright 2023 ReductStore
+// Licensed under the Business Source License 1.1
+
+// Copyright 2023 ReductStore
+// Licensed under the Business Source License 1.1
+
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, ErrorCode, HttpError};
+use crate::auth::policy::WriteAccessPolicy;
+use crate::storage::entry::Labels;
+use crate::storage::writer::{Chunk, RecordWriter};
+use axum::extract::{BodyStream, Path, Query, State};
+use axum::headers::{Expect, Header, HeaderMap, HeaderValue};
+use bytes::{Bytes, BytesMut};
+use futures_util::StreamExt;
+use log::{debug, error};
+use reduct_base::batch::{parse_batched_header, sort_headers_by_name};
+use reduct_base::error::ReductError;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use zip::write;
+
+// POST /:bucket/:entry?ts=<number>
+pub async fn write_record(
+    State(components): State<Arc<Componentes>>,
+    headers: HeaderMap,
+    Path(path): Path<HashMap<String, String>>,
+    Query(params): Query<HashMap<String, String>>,
+    mut stream: BodyStream,
+) -> Result<(), HttpError> {
+    let bucket_name = path.get("bucket_name").unwrap();
+    check_permissions(
+        &components,
+        headers.clone(),
+        WriteAccessPolicy {
+            bucket: bucket_name.clone(),
+        },
+    )
+    .await?;
+    // TODO: drain if there is an error , parse_batched_header must return Result, check total size of content-length
+    let entry_name = path.get("entry_name").unwrap();
+    let record_headers: Vec<_> = sort_headers_by_name(&headers);
+    let mut record_headers: Vec<_> = record_headers
+        .iter()
+        .filter(|(k, _)| k.as_str().starts_with("x-reduct-time-"))
+        .collect();
+    let mut rest = BytesMut::new();
+    while let Some(header) = record_headers.pop() {
+        let writer = get_next_writer(
+            &components,
+            bucket_name,
+            entry_name,
+            header.0.as_str(),
+            &header.1,
+        )
+        .await;
+        match writer {
+            Ok(writer) => {
+                let mut writer = writer.write().unwrap();
+
+                if rest.len() > 0 {
+                    writer.write(Chunk::Data(rest.freeze()))?;
+                    rest = BytesMut::new();
+                }
+
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk.unwrap();
+                    let to_write = writer.content_length() - writer.written();
+                    if chunk.len() < to_write {
+                        writer.write(Chunk::Data(chunk))?;
+                    } else {
+                        let (to_write, for_next) = chunk.split_at(to_write);
+                        writer.write(Chunk::Last(Bytes::from(Vec::from(to_write))))?;
+                        rest = BytesMut::from(for_next);
+                        break;
+                    }
+                }
+            }
+            Err(e) => {
+                //todo: drain stream
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn get_next_writer(
+    components: &Arc<Componentes>,
+    bucket_name: &str,
+    entry_name: &str,
+    name: &str,
+    value: &HeaderValue,
+) -> Result<Arc<RwLock<RecordWriter>>, HttpError> {
+    let time = name.parse::<u64>().map_err(|_| {
+        HttpError::new(
+            ErrorCode::UnprocessableEntity,
+            &format!(
+                "Invalid header'{}': must be an unix timestamp in microseconds",
+                name
+            ),
+        )
+    })?;
+
+    let writer = {
+        let mut storage = components.storage.write().await;
+        let bucket = storage.get_mut_bucket(bucket_name)?;
+
+        let (content_length, content_type, labels) = parse_batched_header(value.to_str().unwrap());
+        bucket.begin_write(entry_name, time, content_length, content_type, labels)
+    };
+    Ok(writer?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::entry::write_batched::write_record;
+    use crate::api::tests::{components, empty_body, headers, path_to_entry_1};
+    use axum::body::Empty;
+    use axum::extract::FromRequest;
+    use axum::http::Request;
+    use rstest::{fixture, rstest};
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_write_record_bad_header(
+        components: Arc<Componentes>,
+        mut headers: HeaderMap,
+        path_to_entry_1: Path<HashMap<String, String>>,
+        #[future] empty_body: BodyStream,
+    ) {
+        headers.insert("content-length", "10".parse().unwrap());
+        headers.insert("x-reduct-time-xxx", "10".parse().unwrap());
+
+        let err = write_record(
+            State(components),
+            headers,
+            path_to_entry_1,
+            Query(HashMap::new()),
+            empty_body.await,
+        )
+        .await
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            err,
+            HttpError::new(
+                ErrorCode::UnprocessableEntity,
+                "Invalid header'x-reduct-time-xxx': must be an unix timestamp in microseconds",
+            )
+        );
+    }
+}

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -16,8 +16,8 @@ use futures_util::StreamExt;
 use log::{debug, error};
 use reduct_base::batch::{parse_batched_header, sort_headers_by_name};
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::{Arc, RwLock};
-use zip::write;
 
 // POST /:bucket/:entry?ts=<number>
 pub async fn write_records(
@@ -36,7 +36,7 @@ pub async fn write_records(
         },
     )
     .await?;
-    // TODO: drain if there is an error , parse_batched_header must return Result, check total size of content-length
+
     let entry_name = path.get("entry_name").unwrap();
     let record_headers: Vec<_> = sort_headers_by_name(&headers);
     let mut record_headers: Vec<_> = record_headers
@@ -44,58 +44,61 @@ pub async fn write_records(
         .filter(|(k, _)| k.as_str().starts_with("x-reduct-time-"))
         .collect();
     let mut rest = Bytes::new();
-    while let Some(header) = record_headers.pop() {
-        let writer = get_next_writer(
-            &components,
-            bucket_name,
-            entry_name,
-            header.0.as_str(),
-            &header.1,
-        )
-        .await;
-        match writer {
-            Ok(writer) => {
-                let mut writer = writer.write().unwrap();
-                let mut write_chunk = |chunk: Bytes| -> Result<Option<Bytes>, HttpError> {
-                    let to_write = writer.content_length() - writer.written();
-                    if chunk.len() < to_write {
-                        writer.write(Chunk::Data(chunk))?;
-                        Ok(None)
-                    } else {
-                        let (to_write, for_next) = chunk.split_at(to_write);
-                        writer.write(Chunk::Last(Bytes::copy_from_slice(to_write)))?;
-                        Ok(Some(Bytes::copy_from_slice(for_next)))
-                    }
-                };
 
-                if rest.is_empty() {
-                    match stream.next().await {
-                        Some(chunk) => {
-                            rest = chunk.unwrap();
-                        }
-                        None => {
-                            break;
-                        }
-                    }
+    let process_request = async {
+        for (name, value) in record_headers.iter() {
+            let writer =
+                get_next_writer(&components, bucket_name, entry_name, name.as_str(), value).await?;
+
+            let mut writer = writer.write().unwrap();
+            let mut write_chunk = |chunk: Bytes| -> Result<Option<Bytes>, HttpError> {
+                let to_write = writer.content_length() - writer.written();
+                if chunk.len() < to_write {
+                    writer.write(Chunk::Data(chunk))?;
+                    Ok(None)
+                } else {
+                    let (to_write, for_next) = chunk.split_at(to_write);
+                    writer.write(Chunk::Last(Bytes::copy_from_slice(to_write)))?;
+                    Ok(Some(Bytes::copy_from_slice(for_next)))
                 }
+            };
 
-                match write_chunk(rest)? {
-                    Some(data) => {
-                        rest = data;
+            if rest.is_empty() {
+                match stream.next().await {
+                    Some(chunk) => {
+                        rest = chunk.unwrap();
                     }
                     None => {
-                        rest = Bytes::new();
+                        break;
                     }
                 }
             }
-            Err(e) => {
-                //todo: drain stream
-                return Err(e);
+
+            match write_chunk(rest)? {
+                Some(data) => {
+                    rest = data;
+                }
+                None => {
+                    rest = Bytes::new();
+                }
             }
         }
-    }
 
-    Ok(())
+        Ok(())
+    };
+
+    match process_request.await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            // drain the stream in the case if a client doesn't support Expect: 100-continue
+            if !headers.contains_key(Expect::name()) {
+                debug!("draining the stream");
+                while let Some(_) = stream.next().await {}
+            }
+
+            Err(e)
+        }
+    }
 }
 
 async fn get_next_writer(
@@ -119,7 +122,7 @@ async fn get_next_writer(
         let mut storage = components.storage.write().await;
         let bucket = storage.get_mut_bucket(bucket_name)?;
 
-        let (content_length, content_type, labels) = parse_batched_header(value.to_str().unwrap());
+        let (content_length, content_type, labels) = parse_batched_header(value.to_str().unwrap())?;
         bucket.begin_write(entry_name, time, content_length, content_type, labels)
     };
     Ok(writer?)
@@ -137,7 +140,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_write_record_bad_header(
+    async fn test_write_record_bad_timestamp(
         components: Arc<Componentes>,
         mut headers: HeaderMap,
         path_to_entry_1: Path<HashMap<String, String>>,
@@ -163,6 +166,35 @@ mod tests {
                 ErrorCode::UnprocessableEntity,
                 "Invalid header'x-reduct-time-xxx': must be an unix timestamp in microseconds",
             )
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+
+    async fn test_write_batched_invalid_header(
+        components: Arc<Componentes>,
+        mut headers: HeaderMap,
+        path_to_entry_1: Path<HashMap<String, String>>,
+        #[future] empty_body: BodyStream,
+    ) {
+        headers.insert("content-length", "10".parse().unwrap());
+        headers.insert("x-reduct-time-1", "".parse().unwrap());
+
+        let err = write_records(
+            State(components),
+            headers,
+            path_to_entry_1,
+            Query(HashMap::new()),
+            empty_body.await,
+        )
+        .await
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            err,
+            HttpError::new(ErrorCode::UnprocessableEntity, "Invalid batched header",)
         );
     }
 

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -57,7 +57,7 @@ pub async fn write_record(
             ))?
             .to_str()
             .unwrap()
-            .parse::<u64>()
+            .parse::<usize>()
             .map_err(|_| {
                 HttpError::new(
                     ErrorCode::UnprocessableEntity,
@@ -120,7 +120,7 @@ pub async fn write_record(
             Ok(())
         }
         Err(e) => {
-            // drain the stream in the case if a reduct_rs doesn't support Expect: 100-continue
+            // drain the stream in the case if a client doesn't support Expect: 100-continue
             if !headers.contains_key(Expect::name()) {
                 debug!("draining the stream");
                 while let Some(_) = stream.next().await {}
@@ -142,7 +142,7 @@ mod tests {
     use axum::headers::{Authorization, HeaderMapExt};
     use rstest::*;
 
-    use crate::api::tests::{components, path_to_entry_1};
+    use crate::api::tests::{components, empty_body, path_to_entry_1};
 
     #[rstest]
     #[tokio::test]
@@ -250,12 +250,5 @@ mod tests {
         headers.typed_insert(Authorization::bearer("init-token").unwrap());
 
         headers
-    }
-
-    #[fixture]
-    async fn empty_body() -> BodyStream {
-        let emtpy_stream: Empty<Bytes> = Empty::new();
-        let request = Request::builder().body(emtpy_stream).unwrap();
-        BodyStream::from_request(request, &()).await.unwrap()
     }
 }

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -5,7 +5,7 @@ use crate::api::middleware::check_permissions;
 use crate::api::{Components, ErrorCode, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
 use crate::storage::entry::Labels;
-use crate::storage::writer::Chunk;
+use crate::storage::writer::{Chunk, WriteChunk};
 use axum::extract::{BodyStream, Path, Query, State};
 use axum::headers::{Expect, Header, HeaderMap, HeaderValue};
 use bytes::Bytes;

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -135,10 +135,6 @@ pub async fn write_record(
 mod tests {
     use super::*;
 
-    use axum::body::Empty;
-    use axum::extract::FromRequest;
-    use axum::http::Request;
-
     use axum::headers::{Authorization, HeaderMapExt};
     use rstest::*;
 

--- a/reductstore/src/api/middleware.rs
+++ b/reductstore/src/api/middleware.rs
@@ -7,8 +7,8 @@ use axum::middleware::Next;
 use axum::response::IntoResponse;
 use log::{debug, error};
 
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::Policy;
-use crate::http_frontend::{Componentes, HttpError};
 
 pub async fn default_headers<B>(
     request: Request<B>,

--- a/reductstore/src/api/middleware.rs
+++ b/reductstore/src/api/middleware.rs
@@ -5,9 +5,10 @@ use axum::http::{HeaderMap, Request};
 
 use axum::middleware::Next;
 use axum::response::IntoResponse;
+use futures_util::StreamExt;
 use log::{debug, error};
 
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::Policy;
 
 pub async fn default_headers<B>(
@@ -55,7 +56,7 @@ pub async fn print_statuses<B>(
 }
 
 pub async fn check_permissions<P>(
-    components: &Componentes,
+    components: &Components,
     headers: HeaderMap,
     policy: P,
 ) -> Result<(), HttpError>

--- a/reductstore/src/api/server.rs
+++ b/reductstore/src/api/server.rs
@@ -15,8 +15,8 @@ use axum::routing::{get, head};
 use reduct_base::msg::server_api::{BucketInfoList, ServerInfo};
 use reduct_macros::{IntoResponse, Twin};
 
-use crate::http_frontend::token_api::me::me;
-use crate::http_frontend::Componentes;
+use crate::api::token::me::me;
+use crate::api::Componentes;
 
 #[derive(IntoResponse, Twin)]
 pub struct ServerInfoAxum(ServerInfo);

--- a/reductstore/src/api/server.rs
+++ b/reductstore/src/api/server.rs
@@ -16,7 +16,7 @@ use reduct_base::msg::server_api::{BucketInfoList, ServerInfo};
 use reduct_macros::{IntoResponse, Twin};
 
 use crate::api::token::me::me;
-use crate::api::Componentes;
+use crate::api::Components;
 
 #[derive(IntoResponse, Twin)]
 pub struct ServerInfoAxum(ServerInfo);
@@ -24,7 +24,7 @@ pub struct ServerInfoAxum(ServerInfo);
 #[derive(IntoResponse, Twin)]
 pub struct BucketInfoListAxum(BucketInfoList);
 
-pub fn create_server_api_routes() -> axum::Router<Arc<Componentes>> {
+pub fn create_server_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
         .route("/list", get(list::list))
         .route("/info", get(info::info))

--- a/reductstore/src/api/server/info.rs
+++ b/reductstore/src/api/server/info.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::server::ServerInfoAxum;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::server_api::ServerInfoAxum;
-use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::State;
 use axum::headers::HeaderMap;
 
@@ -24,7 +24,7 @@ pub async fn info(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
     use rstest::rstest;
 
     #[rstest]

--- a/reductstore/src/api/server/info.rs
+++ b/reductstore/src/api/server/info.rs
@@ -3,7 +3,7 @@
 
 use crate::api::middleware::check_permissions;
 use crate::api::server::ServerInfoAxum;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
 use axum::extract::State;
 use axum::headers::HeaderMap;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // GET /info
 pub async fn info(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<ServerInfoAxum, HttpError> {
     check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
@@ -29,7 +29,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_info(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_info(components: Arc<Components>, headers: HeaderMap) {
         let info = info(State(components), headers).await.unwrap();
         assert_eq!(info.0.bucket_count, 2);
     }

--- a/reductstore/src/api/server/list.rs
+++ b/reductstore/src/api/server/list.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::server::BucketInfoListAxum;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::server_api::BucketInfoListAxum;
-use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::State;
 use axum::headers::HeaderMap;
 use std::sync::Arc;
@@ -23,7 +23,7 @@ pub async fn list(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
     use rstest::rstest;
 
     #[rstest]

--- a/reductstore/src/api/server/list.rs
+++ b/reductstore/src/api/server/list.rs
@@ -3,7 +3,7 @@
 
 use crate::api::middleware::check_permissions;
 use crate::api::server::BucketInfoListAxum;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
 use axum::extract::State;
 use axum::headers::HeaderMap;
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 // GET /list
 pub async fn list(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<BucketInfoListAxum, HttpError> {
     check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
@@ -28,7 +28,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_list(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_list(components: Arc<Components>, headers: HeaderMap) {
         let list = list(State(components), headers).await.unwrap();
         assert_eq!(list.0.buckets.len(), 2);
     }

--- a/reductstore/src/api/token.rs
+++ b/reductstore/src/api/token.rs
@@ -20,11 +20,11 @@ use axum::routing::{delete, get, post};
 use reduct_base::error::ErrorCode;
 use std::sync::Arc;
 
-use crate::http_frontend::token_api::create::create_token;
-use crate::http_frontend::token_api::get::get_token;
-use crate::http_frontend::token_api::list::list_tokens;
-use crate::http_frontend::token_api::remove::remove_token;
-use crate::http_frontend::{Componentes, HttpError};
+use crate::api::token::create::create_token;
+use crate::api::token::get::get_token;
+use crate::api::token::list::list_tokens;
+use crate::api::token::remove::remove_token;
+use crate::api::{Componentes, HttpError};
 
 use reduct_base::msg::token_api::{Permissions, Token, TokenCreateResponse, TokenList};
 use reduct_macros::{IntoResponse, Twin};

--- a/reductstore/src/api/token.rs
+++ b/reductstore/src/api/token.rs
@@ -24,7 +24,7 @@ use crate::api::token::create::create_token;
 use crate::api::token::get::get_token;
 use crate::api::token::list::list_tokens;
 use crate::api::token::remove::remove_token;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 
 use reduct_base::msg::token_api::{Permissions, Token, TokenCreateResponse, TokenList};
 use reduct_macros::{IntoResponse, Twin};
@@ -63,7 +63,7 @@ where
     }
 }
 
-pub fn create_token_api_routes() -> axum::Router<Arc<Componentes>> {
+pub fn create_token_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
         .route("/", get(list_tokens))
         .route("/:token_name", post(create_token))

--- a/reductstore/src/api/token/create.rs
+++ b/reductstore/src/api/token/create.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::token::{PermissionsAxum, TokenCreateResponseAxum};
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::FullAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::token_api::{PermissionsAxum, TokenCreateResponseAxum};
-use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 
@@ -32,7 +32,7 @@ pub async fn create_token(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
 
     use reduct_base::error::ErrorCode;
     use reduct_base::msg::token_api::Permissions;

--- a/reductstore/src/api/token/create.rs
+++ b/reductstore/src/api/token/create.rs
@@ -3,7 +3,7 @@
 
 use crate::api::middleware::check_permissions;
 use crate::api::token::{PermissionsAxum, TokenCreateResponseAxum};
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // POST /tokens/:token_name
 pub async fn create_token(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
     permissions: PermissionsAxum,
@@ -40,7 +40,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_token(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_create_token(components: Arc<Components>, headers: HeaderMap) {
         let token = create_token(
             State(components),
             Path("new-token".to_string()),
@@ -55,7 +55,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_token_already_exists(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_create_token_already_exists(components: Arc<Components>, headers: HeaderMap) {
         let err = create_token(
             State(components),
             Path("test".to_string()),

--- a/reductstore/src/api/token/get.rs
+++ b/reductstore/src/api/token/get.rs
@@ -3,7 +3,7 @@
 
 use crate::api::middleware::check_permissions;
 use crate::api::token::TokenAxum;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 // GET /tokens/:token_name
 pub async fn get_token(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<TokenAxum, HttpError> {
@@ -38,7 +38,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_token(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_get_token(components: Arc<Components>, headers: HeaderMap) {
         let token = get_token(State(components), Path("test".to_string()), headers)
             .await
             .unwrap()
@@ -49,7 +49,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_token_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_get_token_not_found(components: Arc<Components>, headers: HeaderMap) {
         let err = get_token(State(components), Path("not-found".to_string()), headers)
             .await
             .err()

--- a/reductstore/src/api/token/get.rs
+++ b/reductstore/src/api/token/get.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::token::TokenAxum;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::FullAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::token_api::TokenAxum;
-use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
@@ -31,7 +31,7 @@ pub async fn get_token(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
 
     use reduct_base::error::ErrorCode;
     use rstest::rstest;

--- a/reductstore/src/api/token/list.rs
+++ b/reductstore/src/api/token/list.rs
@@ -3,7 +3,7 @@
 
 use crate::api::middleware::check_permissions;
 use crate::api::token::TokenListAxum;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::State;
 use axum::headers::HeaderMap;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // GET /tokens
 pub async fn list_tokens(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<TokenListAxum, HttpError> {
     check_permissions(&components, headers, FullAccessPolicy {}).await?;
@@ -36,7 +36,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_token_list(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_token_list(components: Arc<Components>, headers: HeaderMap) {
         let list = list_tokens(State(components), headers).await.unwrap().0;
         assert_eq!(list.tokens.len(), 2);
         assert_eq!(list.tokens[0].name, "init-token");

--- a/reductstore/src/api/token/list.rs
+++ b/reductstore/src/api/token/list.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::token::TokenListAxum;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::FullAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::token_api::TokenListAxum;
-use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::State;
 use axum::headers::HeaderMap;
 
@@ -30,7 +30,7 @@ pub async fn list_tokens(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
 
     use rstest::rstest;
 

--- a/reductstore/src/api/token/me.rs
+++ b/reductstore/src/api/token/me.rs
@@ -3,7 +3,7 @@
 
 use crate::api::middleware::check_permissions;
 use crate::api::token::TokenAxum;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
 
 use axum::extract::State;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 // // GET /me
 pub async fn me(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<TokenAxum, HttpError> {
     check_permissions(&components, headers.clone(), AuthenticatedPolicy {}).await?;
@@ -34,7 +34,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_me(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_me(components: Arc<Components>, headers: HeaderMap) {
         let token = me(State(components), headers).await.unwrap().0;
         assert_eq!(token.name, "init-token");
     }

--- a/reductstore/src/api/token/me.rs
+++ b/reductstore/src/api/token/me.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::token::TokenAxum;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::AuthenticatedPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::token_api::TokenAxum;
-use crate::http_frontend::{Componentes, HttpError};
 
 use axum::extract::State;
 use axum::headers::HeaderMap;
@@ -29,7 +29,7 @@ pub async fn me(
 mod tests {
     use super::*;
 
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
     use rstest::rstest;
 
     #[rstest]

--- a/reductstore/src/api/token/remove.rs
+++ b/reductstore/src/api/token/remove.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::middleware::check_permissions;
+use crate::api::{Componentes, HttpError};
 use crate::auth::policy::FullAccessPolicy;
-use crate::http_frontend::middleware::check_permissions;
-use crate::http_frontend::{Componentes, HttpError};
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
 use std::sync::Arc;
@@ -26,7 +26,7 @@ pub async fn remove_token(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_frontend::tests::{components, headers};
+    use crate::api::tests::{components, headers};
 
     use reduct_base::error::ErrorCode;
     use rstest::rstest;

--- a/reductstore/src/api/token/remove.rs
+++ b/reductstore/src/api/token/remove.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::api::middleware::check_permissions;
-use crate::api::{Componentes, HttpError};
+use crate::api::{Components, HttpError};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::headers::HeaderMap;
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 // DELETE /tokens/:name
 pub async fn remove_token(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     Path(token_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
@@ -33,14 +33,14 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_token(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_token(components: Arc<Components>, headers: HeaderMap) {
         let token = remove_token(State(components), Path("test".to_string()), headers).await;
         assert!(token.is_ok());
     }
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_token_not_found(components: Arc<Componentes>, headers: HeaderMap) {
+    async fn test_remove_token_not_found(components: Arc<Components>, headers: HeaderMap) {
         let err = remove_token(State(components), Path("not-found".to_string()), headers)
             .await
             .err()

--- a/reductstore/src/api/ui.rs
+++ b/reductstore/src/api/ui.rs
@@ -2,8 +2,8 @@
 // Licensed under the Business Source License 1.1
 //
 
-use crate::http_frontend::Componentes;
-use crate::http_frontend::HttpError;
+use crate::api::Componentes;
+use crate::api::HttpError;
 use axum::extract::State;
 
 use axum::headers::HeaderMap;
@@ -72,7 +72,7 @@ mod tests {
     use super::*;
     use axum::body::HttpBody;
 
-    use crate::http_frontend::tests::components;
+    use crate::api::tests::components;
     use rstest::rstest;
 
     #[rstest]

--- a/reductstore/src/api/ui.rs
+++ b/reductstore/src/api/ui.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 //
 
-use crate::api::Componentes;
+use crate::api::Components;
 use crate::api::HttpError;
 use axum::extract::State;
 
@@ -17,7 +17,7 @@ use mime_guess::mime;
 use reduct_base::error::ErrorCode;
 use std::sync::Arc;
 
-pub async fn redirect_to_index(State(components): State<Arc<Componentes>>) -> impl IntoResponse {
+pub async fn redirect_to_index(State(components): State<Arc<Components>>) -> impl IntoResponse {
     let base_path = components.base_path.clone();
     let mut headers = HeaderMap::new();
     headers.insert(LOCATION, format!("{}ui/", base_path).parse().unwrap());
@@ -25,7 +25,7 @@ pub async fn redirect_to_index(State(components): State<Arc<Componentes>>) -> im
 }
 
 pub async fn show_ui(
-    State(components): State<Arc<Componentes>>,
+    State(components): State<Arc<Components>>,
     request: Request<Body>,
 ) -> Result<impl IntoResponse, HttpError> {
     let base_path = components.base_path.clone();
@@ -77,7 +77,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_img_decoding(components: Arc<Componentes>) {
+    async fn test_img_decoding(components: Arc<Components>) {
         let request = Request::get("/ui/favicon.png").body(Body::empty()).unwrap();
         let response = show_ui(State(components), request)
             .await

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
-use crate::api::Componentes;
+use crate::api::Components;
 use crate::asset::asset_manager::ZipAssetManager;
 use crate::auth::token_auth::TokenAuthorization;
 use crate::auth::token_repository::{create_token_repository, ManageTokens};
@@ -57,11 +57,11 @@ impl<EnvGetter: GetEnv> Cfg<EnvGetter> {
         cfg
     }
 
-    pub fn build(&self) -> Componentes {
+    pub fn build(&self) -> Components {
         let storage = self.provision_storage();
         let token_repo = self.provision_tokens();
 
-        Componentes {
+        Components {
             storage: RwLock::new(storage),
             token_repo: RwLock::new(token_repo),
             auth: TokenAuthorization::new(&self.api_token),

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -1,11 +1,11 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
+use crate::api::Componentes;
 use crate::asset::asset_manager::ZipAssetManager;
 use crate::auth::token_auth::TokenAuthorization;
 use crate::auth::token_repository::{create_token_repository, ManageTokens};
 use crate::core::env::{Env, GetEnv};
-use crate::http_frontend::Componentes;
 
 use crate::storage::storage::Storage;
 use bytesize::ByteSize;

--- a/reductstore/src/lib.rs
+++ b/reductstore/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
+pub mod api;
 pub mod asset;
 pub mod auth;
 pub mod cfg;
 pub mod core;
-pub mod http_frontend;
 pub mod storage;

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use reductstore::cfg::Cfg;
 use reductstore::core::env::StdEnvGetter;
 
+use reductstore::api::create_axum_app;
 use reductstore::core::logger::Logger;
-use reductstore::http_frontend::create_axum_app;
 
 #[tokio::main]
 async fn main() {

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, RwLock, Weak};
 
 use crate::storage::proto::*;
 use crate::storage::reader::RecordReader;
-use crate::storage::writer::RecordWriter;
+use crate::storage::writer::{RecordWriter, WriteChunk};
 use reduct_base::error::ReductError;
 
 pub const DEFAULT_MAX_READ_CHUNK: u64 = 1024 * 1024 * 512;

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -92,7 +92,7 @@ impl BlockManager {
             path,
             block,
             record_index,
-            content_length,
+            content_length as usize,
             Arc::clone(&block_manager),
         )?));
 

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -255,7 +255,7 @@ impl Bucket {
         &mut self,
         name: &str,
         time: u64,
-        content_size: u64,
+        content_size: usize,
         content_type: String,
         labels: Labels,
     ) -> Result<Arc<RwLock<RecordWriter>>, ReductError> {
@@ -323,11 +323,11 @@ impl Bucket {
         Ok(())
     }
 
-    fn keep_quota_for(&mut self, content_size: u64) -> Result<(), ReductError> {
+    fn keep_quota_for(&mut self, content_size: usize) -> Result<(), ReductError> {
         match self.settings.quota_type.clone().unwrap_or(QuotaType::NONE) {
             QuotaType::NONE => Ok(()),
             QuotaType::FIFO => {
-                let mut size = self.info()?.info.size + content_size;
+                let mut size = self.info()?.info.size + content_size as u64;
                 while size > self.settings.quota_size.unwrap_or(0) {
                     debug!(
                         "Need more space. Remove an oldest block from bucket '{}'",
@@ -377,7 +377,7 @@ impl Bucket {
                         ));
                     }
 
-                    size = self.info()?.info.size + content_size;
+                    size = self.info()?.info.size + content_size as u64;
                 }
 
                 // Remove empty entries
@@ -637,7 +637,7 @@ mod tests {
         let writer = bucket.begin_write(
             entry_name,
             time,
-            content.len() as u64,
+            content.len(),
             "".to_string(),
             Labels::new(),
         )?;

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -472,7 +472,7 @@ impl Bucket {
 mod tests {
     use super::*;
     use crate::storage::entry::Labels;
-    use crate::storage::writer::Chunk;
+    use crate::storage::writer::{Chunk, WriteChunk};
     use rstest::{fixture, rstest};
     use tempfile::tempdir;
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -126,7 +126,7 @@ impl Entry {
     pub fn begin_write(
         &mut self,
         time: u64,
-        content_size: u64,
+        content_size: usize,
         content_type: String,
         labels: Labels,
     ) -> Result<Arc<RwLock<RecordWriter>>, ReductError> {
@@ -179,6 +179,7 @@ impl Entry {
             (block, RecordType::Latest)
         };
 
+        let content_size = content_size as u64;
         let has_no_space = block.size + content_size > self.settings.max_block_size;
         let has_too_many_records =
             block.records.len() + 1 >= self.settings.max_block_records as usize;
@@ -198,7 +199,7 @@ impl Entry {
         let record = Record {
             timestamp: Some(us_to_ts(&time)),
             begin: block.size,
-            end: block.size + content_size as u64,
+            end: block.size + content_size,
             content_type,
             state: record::State::Started as i32,
             labels: labels
@@ -882,12 +883,8 @@ mod tests {
     }
 
     fn write_record(entry: &mut Entry, time: u64, data: Vec<u8>) -> Result<(), ReductError> {
-        let writer = entry.begin_write(
-            time,
-            data.len() as u64,
-            "text/plain".to_string(),
-            Labels::new(),
-        )?;
+        let writer =
+            entry.begin_write(time, data.len(), "text/plain".to_string(), Labels::new())?;
         let x = writer
             .write()
             .unwrap()

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -432,7 +432,7 @@ impl Entry {
 mod tests {
     use super::*;
     use crate::storage::block_manager::DEFAULT_MAX_READ_CHUNK;
-    use crate::storage::writer::Chunk;
+    use crate::storage::writer::{Chunk, WriteChunk};
     use std::fs::File;
 
     use rstest::{fixture, rstest};

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -81,7 +81,7 @@ pub(crate) mod tests {
     use crate::storage::block_manager::ManageBlock;
     use crate::storage::proto::record::{Label, State as RecordState};
     use crate::storage::proto::Record;
-    use crate::storage::writer::Chunk;
+    use crate::storage::writer::{Chunk, WriteChunk};
     use bytes::Bytes;
     use prost_wkt_types::Timestamp;
     use rstest::fixture;

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -186,7 +186,7 @@ impl Storage {
 mod tests {
     use super::*;
     use crate::storage::entry::Labels;
-    use crate::storage::writer::Chunk;
+    use crate::storage::writer::{Chunk, WriteChunk};
     use bytes::Bytes;
     use reduct_base::msg::bucket_api::QuotaType;
     use rstest::{fixture, rstest};

--- a/reductstore/src/storage/writer.rs
+++ b/reductstore/src/storage/writer.rs
@@ -14,8 +14,8 @@ use reduct_base::error::{ErrorCode, ReductError};
 /// RecordWriter is used to write a record to a file.
 pub struct RecordWriter {
     file: File,
-    written_bytes: u64,
-    content_length: u64,
+    written_bytes: usize,
+    content_length: usize,
     record_index: usize,
     block_id: u64,
     block_manager: Arc<RwLock<dyn ManageBlock>>,
@@ -40,7 +40,7 @@ impl RecordWriter {
         path: PathBuf,
         block: &Block,
         record_index: usize,
-        content_length: u64,
+        content_length: usize,
         block_manager: Arc<RwLock<T>>,
     ) -> Result<RecordWriter, ReductError>
     where
@@ -87,10 +87,18 @@ impl RecordWriter {
         Ok(())
     }
 
+    pub fn content_length(&self) -> usize {
+        self.content_length
+    }
+
+    pub fn written(&self) -> usize {
+        self.written_bytes
+    }
+
     fn write_impl(&mut self, buf: Bytes, last: bool) -> Result<(), ReductError> {
         let mut writer = &self.file;
 
-        self.written_bytes += buf.len() as u64;
+        self.written_bytes += buf.len();
         if self.written_bytes > self.content_length {
             return Err(ReductError::bad_request(
                 "Content is bigger than in content-length",


### PR DESCRIPTION
Closes #331

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #331 

### What is the new behavior?

I've added `POST /api/v1/b/:bucket/:entry/batch` endpoint which receives the batched records with their meta information in the headers. Reduct SDK was also updated.

### Does this PR introduce a breaking change?

No

### Other information:
