### PR TITLE
Fix panic for a bad time interval in `GET /b/:bucket/:entry/q`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- reductstore: Panic for a bad time interval in `GET /b/:bucket/:entry/q`, [PR-357](https://github.com/reductstore/reductstore/pull/357)
+
 ## [1.6.1] - 2023-08-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "chrono",
  "int-enum",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,9 +711,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -1469,6 +1469,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "hermit-abi",
  "hex",
  "http_req",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.61.0"

--- a/reductstore/src/auth/token_repository.rs
+++ b/reductstore/src/auth/token_repository.rs
@@ -530,7 +530,7 @@ mod tests {
 
         assert_eq!(token.value.len(), 37);
         assert_eq!(token.value, "test-".to_string() + &token.value[5..]);
-        assert!(token.created_at.second() > 0);
+        assert!(token.created_at.timestamp() > 0);
     }
 
     #[test]

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -304,7 +304,7 @@ impl Entry {
 
         let id = QUERY_ID.fetch_add(1, Ordering::SeqCst);
         self.remove_expired_query();
-        self.queries.insert(id, build_query(start, end, options));
+        self.queries.insert(id, build_query(start, end, options)?);
 
         Ok(id)
     }

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -7,14 +7,52 @@ mod historical;
 mod limited;
 
 use crate::storage::query::base::{Query, QueryOptions};
+use reduct_base::error::HttpError;
 
 /// Build a query.
-pub fn build_query(start: u64, stop: u64, options: QueryOptions) -> Box<dyn Query + Send + Sync> {
-    if let Some(_) = options.limit {
+pub fn build_query(
+    start: u64,
+    stop: u64,
+    options: QueryOptions,
+) -> Result<Box<dyn Query + Send + Sync>, HttpError> {
+    if start > stop && !options.continuous {
+        return Err(HttpError::unprocessable_entity(
+            "Start time must be before stop time",
+        ));
+    }
+
+    Ok(if let Some(_) = options.limit {
         Box::new(limited::LimitedQuery::new(start, stop, options))
     } else if options.continuous {
         Box::new(continuous::ContinuousQuery::new(start, options))
     } else {
         Box::new(historical::HistoricalQuery::new(start, stop, options))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_bad_start_stop() {
+        let options = QueryOptions::default();
+        assert_eq!(
+            build_query(10, 5, options.clone()).err().unwrap(),
+            HttpError::unprocessable_entity("Start time must be before stop time")
+        );
+
+        assert!(build_query(10, 10, options.clone()).is_ok());
+        assert!(build_query(10, 11, options.clone()).is_ok());
+    }
+
+    #[rstest]
+    fn test_ignore_stop_for_continuous() {
+        let options = QueryOptions {
+            continuous: true,
+            ..Default::default()
+        };
+        assert!(build_query(10, 5, options.clone()).is_ok());
     }
 }


### PR DESCRIPTION
Closes #356 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #356 

### What is the new behavior?

The storage checks the wrong time interval and returns `422 Unprocessable Content` instead of panicking.

### Does this PR introduce a breaking change?

No

### Other information:
