### PR TITLE
RS-20: Stop downloading Web Console at `docs.rs` build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - reductstore: Cargo feature `web-console` to build without Web Console, [PR-365](https://github.com/reductstore/reductstore/pull/365)
 
+### Fixed
+
+- reductstore: Stop downloading Web Console at docs.rs build, [PR-366](https://github.com/reductstore/reductstore/pull/366)
+
 ## [1.7.0] - 2023-10-06
 
 ### Added

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -64,3 +64,7 @@ chrono = "0.4.26"
 [dev-dependencies]
 mockall = "0.11.4"
 rstest = "0.18.2"
+
+
+[package.metadata.docs.rs]
+no-default-features = true


### PR DESCRIPTION
Closes #353 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #353 

### What is the new behavior?

Now, Web Console is a feature which is disabled for docs.rs.

### Does this PR introduce a breaking change?

No

### Other information:
