### PR TITLE
Fix wrong size calculation if a block could not be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- reductstore: Wrong size calculation if a block could not be removed, [PR-371](https://github.com/reductstore/reductstore/pull/371)
+
 ## [1.7.0] - 2023-10-06
 
 ### Added


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

When the storage engine tries to keep a FIFO quota it removes the oldest block in a bucket. If the block has a reader or writer, it causes an error and the engine tries to remove the last block in another entry. However, it reduces the size of the entry anyway and the bucket has more data than the quota.


### What is the new behavior?

Now the `Entry` class changes the size only if the remove operation was successful. 

### Does this PR introduce a breaking change?

No

### Other information:
