### PR TITLE
RS-62: Fix entry size calculation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- reductstore: Fix entry size calculation, [PR-373](https://github.com/reductstore/reductstore/pull/373)
+
 ## [1.7.2] - 2023-11-01
 
 ## Fixed
@@ -554,7 +558,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release with basic HTTP API and FIFO bucket quota
 
-[Unreleased]: https://github.com/reductstore/reductstore/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/reductstore/reductstore/compare/v1.7.2...HEAD
+
+[1.7.2]: https://github.com/reductstore/reductstore/compare/v1.7.0...v1.7.2
 
 [1.7.1]: https://github.com/reductstore/reductstore/compare/v1.7.0...v1.7.1
 

--- a/api_tests/bucket_api_test.py
+++ b/api_tests/bucket_api_test.py
@@ -119,7 +119,7 @@ def test__get_bucket_stats(base_url, session, bucket_name):
             "name": "entry_1",
             "oldest_record": 1000000,
             "record_count": 1,
-            "size": 8,
+            "size": 40,
         },
         {
             "block_count": 1,
@@ -127,13 +127,13 @@ def test__get_bucket_stats(base_url, session, bucket_name):
             "name": "entry_2",
             "oldest_record": 2000000,
             "record_count": 1,
-            "size": 11,
+            "size": 43,
         },
     ]
     assert data["info"] == dict(
         name=bucket_name,
         entry_count=2,
-        size=19,
+        size=83,
         latest_record=2000000,
         oldest_record=1000000,
         is_provisioned=False,

--- a/reductstore/src/api/middleware.rs
+++ b/reductstore/src/api/middleware.rs
@@ -5,7 +5,6 @@ use axum::http::{HeaderMap, Request};
 
 use axum::middleware::Next;
 use axum::response::IntoResponse;
-use futures_util::StreamExt;
 use log::{debug, error};
 
 use crate::api::{Components, HttpError};

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -384,7 +384,7 @@ impl Bucket {
                 for name in self
                     .entries
                     .iter()
-                    .filter(|entry| entry.1.info().unwrap().size == 0)
+                    .filter(|entry| entry.1.info().unwrap().record_count == 0)
                     .map(|entry| entry.0.clone())
                     .collect::<Vec<String>>()
                 {
@@ -538,22 +538,24 @@ mod tests {
     fn test_quota_keeping(path: PathBuf) {
         let mut bucket = bucket(
             BucketSettings {
-                max_block_size: Some(5),
+                max_block_size: Some(20),
                 quota_type: Some(QuotaType::FIFO),
-                quota_size: Some(10),
+                quota_size: Some(100),
                 max_block_records: Some(100),
             },
             path,
         );
 
-        write(&mut bucket, "test-1", 0, b"test").unwrap();
-        assert_eq!(bucket.info().unwrap().info.size, 4);
+        let blob: &[u8] = &[0u8; 40];
 
-        write(&mut bucket, "test-2", 1, b"test").unwrap();
-        assert_eq!(bucket.info().unwrap().info.size, 8);
+        write(&mut bucket, "test-1", 0, blob.clone()).unwrap();
+        assert_eq!(bucket.info().unwrap().info.size, 44);
 
-        write(&mut bucket, "test-3", 2, b"test").unwrap();
-        assert_eq!(bucket.info().unwrap().info.size, 8);
+        write(&mut bucket, "test-2", 1, blob.clone()).unwrap();
+        assert_eq!(bucket.info().unwrap().info.size, 91);
+
+        write(&mut bucket, "test-3", 2, blob.clone()).unwrap();
+        assert_eq!(bucket.info().unwrap().info.size, 94);
 
         assert_eq!(
             read(&mut bucket, "test-1", 0).err(),
@@ -576,7 +578,7 @@ mod tests {
         );
 
         write(&mut bucket, "test-1", 0, b"test").unwrap();
-        assert_eq!(bucket.info().unwrap().info.size, 4);
+        assert_eq!(bucket.info().unwrap().info.size, 8);
 
         let result = write(&mut bucket, "test-2", 1, b"0123456789___");
         assert_eq!(

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -267,7 +267,7 @@ mod tests {
             ServerInfo {
                 version: env!("CARGO_PKG_VERSION").to_string(),
                 bucket_count: 1,
-                usage: 30,
+                usage: 134,
                 uptime: 0,
                 oldest_record: 1000,
                 latest_record: 5000,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The storage engine only uses the contents of records to calculate the size of records. It ignores protobuf overhead and labels, which can be a significant amount of data, especially for small blobs. Sometimes we could have much more data on disk than the FIFO quota.

### What is the new behavior?

We use information about the protobuf descriptor and labels to calculate the size more accurately. 

### Does this PR introduce a breaking change?

No

### Other information:
