### PR TITLE
Update documentation link to new website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - reductstore: Refactor read and write operation with tokio channels, [PR-370](https://github.com/reductstore/reductstore/pull/370)
+- docs: update link to new website, [PR-375](https://github.com/reductstore/reductstore/pull/375)
 
 ## [1.7.3] - 2023-11-08
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cargo install reductstore
 RS_DATA_PATH=./data reductstore
 ```
 
-For a more in-depth guide, visit the **[Getting Started](https://docs.reduct.store/)** and **[Download](https://www.reduct.store/download)** sections.
+For a more in-depth guide, visit the **[Getting Started](https://reduct.store/docs/)** and **[Download](https://www.reduct.store/download)** sections.
 
 After initializing the instance, dive in with one of our **[Client SDKs](#client-sdks)** to write or retrieve data. To illustrate, here's a Python sample:
 
@@ -127,7 +127,7 @@ A1: ReductStore is specially designed for storing and managing large amounts of 
 
 **Q2: How do I get started with ReductStore?**
 
-A2: You can easily set up ReductStore using our Docker image or by using cargo. Detailed instructions are provided in the **[Getting Started](https://docs.reduct.store/)** section.
+A2: You can easily set up ReductStore using our Docker image or by using cargo. Detailed instructions are provided in the **[Getting Started](https://reduct.store/docs/)** section.
 
 **Q3: Is there any size limitation for the blob data?**
 
@@ -139,4 +139,4 @@ A4: Absolutely! With our variety of client SDKs and its adaptable HTTP API, Redu
 
 **Q5: I'm facing issues with the installation. Where can I get help?**
 
-A5: We recommend checking out our **[documentation](https://docs.reduct.store/)**. If you still face issues, feel free to join our Discord community or raise an issue on our GitHub repository.
+A5: We recommend checking out our **[documentation](https://reduct.store/docs/)**. If you still face issues, feel free to join our Discord community or raise an issue on our GitHub repository.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,4 +22,4 @@
 
 ## VERSIONS
 
-* [Latest](https://docs.reduct.store)
+* [Latest](https://reduct.store/docs)

--- a/reduct_rs/README.md
+++ b/reduct_rs/README.md
@@ -8,7 +8,7 @@ database for unstructured data.
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.7](https://docs.reduct.store/http-api)
+* Supports the [ReductStore HTTP API v1.7](https://reduct.store/docs/http-api)
 * Built on top of [reqwest](https://github.com/seanmonstar/reqwest)
 * Asynchronous API
 
@@ -57,4 +57,4 @@ async fn main() -> Result<(), HttpError> {
 ## References
 
 * [Documentation](https://docs.rs/reduct-rs/latest/reduct_rs/)
-* [ReductStore HTTP API](https://docs.reduct.store/http-api)
+* [ReductStore HTTP API](https://reduct.store/docs/http-api)

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 license = "BUSL-1.1"
 description = "ReductStore is a time series database designed specifically for storing and managing large amounts of blob data."
 homepage = "https://reduct.store"
-documentation = "https://docs.reduct.store"
+documentation = "https://reduct.store/docs"
 repository = "https://github.com/reductstore/reductstore"
 
 keywords = ["database", "time-series", "blob", "storage", "reductstore"]


### PR DESCRIPTION
With new website we need to change links from docs.reduct.store to reduct.store/docs