### PR TITLE
RS-93: Re-create broken transaction log of replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - reductstore: Stop downloading Web Console at docs.rs build, [PR-366](https://github.com/reductstore/reductstore/pull/366)
 - reductstore: Sync write tasks with HTTP API to avoid unfinished records, [PR-374](https://github.com/reductstore/reductstore/pull/374)
+- reductstore: Re-create a transaction log of replication if it is broken, [PR-379](https://github.com/reductstore/reductstore/pull/379)
 
 ### Changed
 

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -811,7 +811,7 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_replications_needs_DST_BUCKET(mut env_with_replications: MockEnvGetter) {
+        async fn test_replications_needs_dst_bucket(mut env_with_replications: MockEnvGetter) {
             env_with_replications
                 .expect_get()
                 .with(eq("RS_REPLICATION_1_NAME"))
@@ -843,7 +843,7 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_replications_needs_DST_HOST(mut env_with_replications: MockEnvGetter) {
+        async fn test_replications_needs_dst_host(mut env_with_replications: MockEnvGetter) {
             env_with_replications
                 .expect_get()
                 .with(eq("RS_REPLICATION_1_NAME"))

--- a/reductstore/src/replication/remote_bucket.rs
+++ b/reductstore/src/replication/remote_bucket.rs
@@ -8,10 +8,9 @@ use crate::replication::remote_bucket::states::{InitialState, RemoteBucketState}
 use crate::storage::bucket::RecordReader;
 use crate::storage::proto::ts_to_us;
 use async_trait::async_trait;
-use futures_util::TryStream;
+
 use reduct_base::error::ReductError;
 use reduct_base::Labels;
-use url::Url;
 
 pub(super) struct RemoteBucketImpl {
     state: Option<Box<dyn RemoteBucketState + Send + Sync>>,
@@ -179,7 +178,7 @@ pub(super) mod tests {
             )
             .return_once(move |_, _, _, _, _, _| Box::new(second_state));
 
-        let remote_bucket = create_DST_BUCKET(first_state);
+        let remote_bucket = create_dst_bucket(first_state);
         write_record(remote_bucket).await.unwrap();
     }
 
@@ -194,11 +193,11 @@ pub(super) mod tests {
             .expect_write_record()
             .return_once(move |_, _, _, _, _, _| Box::new(second_state));
 
-        let remote_bucket = create_DST_BUCKET(first_state);
+        let remote_bucket = create_dst_bucket(first_state);
         write_record(remote_bucket).await.unwrap_err();
     }
 
-    fn create_DST_BUCKET(mut first_state: MockState) -> RemoteBucketImpl {
+    fn create_dst_bucket(first_state: MockState) -> RemoteBucketImpl {
         let mut remote_bucket = RemoteBucketImpl::new("http://localhost:8080", "test", "api_token");
         remote_bucket.state = Some(Box::new(first_state));
         remote_bucket

--- a/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
@@ -1,9 +1,7 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
-use crate::replication::remote_bucket::client_wrapper::{
-    BoxedClientApi, ReductBucketApi, ReductClientApi,
-};
+use crate::replication::remote_bucket::client_wrapper::BoxedClientApi;
 use crate::replication::remote_bucket::states::bucket_available::BucketAvailableState;
 use crate::replication::remote_bucket::states::RemoteBucketState;
 use crate::storage::bucket::RecordRx;

--- a/reductstore/src/replication/remote_bucket/states/initial_state.rs
+++ b/reductstore/src/replication/remote_bucket/states/initial_state.rs
@@ -1,9 +1,7 @@
 // Copyright 2023 ReductStore
 // Licensed under the Business Source License 1.1
 
-use crate::replication::remote_bucket::client_wrapper::{
-    create_client, BoxedClientApi, ReductClientApi,
-};
+use crate::replication::remote_bucket::client_wrapper::{create_client, BoxedClientApi};
 use crate::replication::remote_bucket::states::bucket_available::BucketAvailableState;
 use crate::replication::remote_bucket::states::bucket_unavailable::BucketUnavailableState;
 use crate::replication::remote_bucket::states::RemoteBucketState;
@@ -11,7 +9,6 @@ use crate::storage::bucket::RecordRx;
 use async_trait::async_trait;
 use log::error;
 use reduct_base::Labels;
-use url::Url;
 
 /// Initial state of the remote bucket.
 pub(in crate::replication::remote_bucket) struct InitialState {

--- a/reductstore/src/replication/replication.rs
+++ b/reductstore/src/replication/replication.rs
@@ -11,15 +11,12 @@ use log::{debug, error, info};
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::Labels;
 
-use crate::storage::entry::Entry;
-use bytes::Buf;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
-use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct ReplicationSettings {
@@ -51,7 +48,7 @@ const TRANSACTION_LOG_SIZE: usize = 1000_000;
 impl Replication {
     pub fn new(storage: Arc<RwLock<Storage>>, settings: ReplicationSettings) -> Self {
         let ReplicationSettings {
-            name,
+            name: _,
             src_bucket,
             dst_bucket: remote_bucket,
             dst_host: remote_host,
@@ -236,8 +233,6 @@ mod tests {
     use mockall::mock;
     use reduct_base::msg::bucket_api::BucketSettings;
     use rstest::*;
-    use tokio::fs::OpenOptions;
-    use tokio::io::AsyncWriteExt;
 
     mock! {
         RmBucket {}

--- a/reductstore/src/replication/replication.rs
+++ b/reductstore/src/replication/replication.rs
@@ -11,9 +11,12 @@ use log::{debug, error, info};
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::Labels;
 
+use crate::storage::entry::Entry;
+use bytes::Buf;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::fs;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 use url::Url;
@@ -42,6 +45,8 @@ struct ReplicationComponents {
     filter: TransactionFilter,
     storage: Arc<RwLock<Storage>>,
 }
+
+const TRANSACTION_LOG_SIZE: usize = 1000_000;
 
 impl Replication {
     pub fn new(storage: Arc<RwLock<Storage>>, settings: ReplicationSettings) -> Self {
@@ -88,42 +93,65 @@ impl Replication {
         tokio::spawn(async move {
             loop {
                 for (entry_name, log) in map_log.read().await.iter() {
-                    if log.read().await.is_empty() {
-                        sleep(std::time::Duration::from_micros(100)).await;
-                        continue;
-                    }
+                    match log.write().await.front().await {
+                        Ok(None) => {
+                            // empty log, nothing to do
+                            sleep(std::time::Duration::from_micros(100)).await;
+                            continue;
+                        }
+                        Ok(Some(transaction)) => {
+                            debug!("Replicating transaction {}/{:?}", entry_name, transaction);
 
-                    let transaction = log.write().await.front().await.unwrap().unwrap();
+                            let get_record = async {
+                                local_storage
+                                    .read()
+                                    .await
+                                    .get_bucket(&config.src_bucket)?
+                                    .begin_read(&entry_name, *transaction.timestamp())
+                                    .await
+                            };
 
-                    debug!("Replicating transaction {}/{:?}", entry_name, transaction);
+                            let read_record = match get_record.await {
+                                Ok(record) => record,
+                                Err(err) => {
+                                    if err.status == ErrorCode::NotFound {
+                                        log.write().await.pop_front().await.unwrap();
+                                    }
+                                    error!("Failed to read record: {:?}", err);
+                                    break;
+                                }
+                            };
 
-                    let get_record = async {
-                        local_storage
-                            .read()
-                            .await
-                            .get_bucket(&config.src_bucket)?
-                            .begin_read(&entry_name, *transaction.timestamp())
-                            .await
-                    };
-
-                    let read_record = match get_record.await {
-                        Ok(record) => record,
-                        Err(err) => {
-                            if err.status == ErrorCode::NotFound {
-                                log.write().await.pop_front().await.unwrap();
+                            match remote_bucket.write_record(entry_name, read_record).await {
+                                Ok(_) => {
+                                    log.write().await.pop_front().await.unwrap();
+                                }
+                                Err(err) => {
+                                    debug!("Failed to replicate transaction: {:?}", err);
+                                    break;
+                                }
                             }
-                            error!("Failed to read record: {:?}", err);
-                            break;
                         }
-                    };
 
-                    match remote_bucket.write_record(entry_name, read_record).await {
-                        Ok(_) => {
-                            log.write().await.pop_front().await.unwrap();
-                        }
                         Err(err) => {
-                            debug!("Failed to replicate transaction: {:?}", err);
-                            break;
+                            error!("Failed to read transaction: {:?}", err);
+                            info!("Transaction log is corrupted, dropping the whole log");
+                            let mut log = log.write().await;
+
+                            let path = Self::build_path_to_transaction_log(
+                                local_storage.read().await.data_path(),
+                                &config.src_bucket,
+                                &entry_name,
+                                &config.name,
+                            );
+                            if let Err(err) = fs::remove_file(&path).await {
+                                error!("Failed to remove transaction log: {:?}", err);
+                            }
+
+                            info!("Creating a new transaction log");
+                            *log = TransactionLog::try_load_or_create(path, TRANSACTION_LOG_SIZE)
+                                .await
+                                .unwrap();
                         }
                     }
                 }
@@ -151,11 +179,13 @@ impl Replication {
                 notification.entry.clone(),
                 RwLock::new(
                     TransactionLog::try_load_or_create(
-                        self.storage.read().await.data_path().join(format!(
-                            "{}/{}/{}.log",
-                            notification.bucket, notification.entry, self.settings.name
-                        )),
-                        1000_000,
+                        Self::build_path_to_transaction_log(
+                            self.storage.read().await.data_path(),
+                            &self.settings.src_bucket,
+                            &notification.entry,
+                            &self.settings.name,
+                        ),
+                        TRANSACTION_LOG_SIZE,
                     )
                     .await?,
                 ),
@@ -184,6 +214,15 @@ impl Replication {
     pub fn settings(&self) -> &ReplicationSettings {
         &self.settings
     }
+
+    fn build_path_to_transaction_log(
+        storage_path: &PathBuf,
+        bucket: &str,
+        entry: &str,
+        name: &str,
+    ) -> PathBuf {
+        storage_path.join(format!("{}/{}/{}.log", bucket, entry, name))
+    }
 }
 
 #[cfg(test)]
@@ -191,13 +230,13 @@ mod tests {
     use super::*;
     use crate::replication::Transaction;
     use crate::storage::bucket::RecordReader;
-    use crate::storage::proto::Record;
     use async_trait::async_trait;
-    use axum::extract::connect_info::MockConnectInfo;
     use bytes::Bytes;
     use mockall::mock;
     use reduct_base::msg::bucket_api::BucketSettings;
     use rstest::*;
+    use tokio::fs::OpenOptions;
+    use tokio::io::AsyncWriteExt;
 
     mock! {
         RmBucket {}

--- a/reductstore/src/replication/replication.rs
+++ b/reductstore/src/replication/replication.rs
@@ -93,7 +93,8 @@ impl Replication {
         tokio::spawn(async move {
             loop {
                 for (entry_name, log) in map_log.read().await.iter() {
-                    match log.write().await.front().await {
+                    let tr = log.write().await.front().await;
+                    match tr {
                         Ok(None) => {
                             // empty log, nothing to do
                             sleep(std::time::Duration::from_micros(100)).await;


### PR DESCRIPTION
Closes #378 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

If a transaction log of a replication got broken, the database crashed because of an unhandled error.

### What is the new behavior?

The database re-create the log if it is broken, so that it can continue working.  

### Does this PR introduce a breaking change?

No

### Other information:
