### PR TITLE
Fix status for unfinished record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Stop downloading Web Console at docs.rs build, [PR-366](https://github.com/reductstore/reductstore/pull/366)
 - reductstore: Sync write tasks with HTTP API to avoid unfinished records, [PR-374](https://github.com/reductstore/reductstore/pull/374)
 - reductstore: Re-create a transaction log of replication if it is broken, [PR-379](https://github.com/reductstore/reductstore/pull/379)
+- reductstore: Status for unfinished records, [PR-381](https://github.com/reductstore/reductstore/pull/381)
 
 ### Changed
 

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -90,10 +90,7 @@ impl IntoResponse for HttpError {
 
 impl From<axum::Error> for HttpError {
     fn from(err: axum::Error) -> Self {
-        HttpError::from(BaseHttpError::internal_server_error(&format!(
-            "Internal reductstore error: {}",
-            err
-        )))
+        HttpError::from(BaseHttpError::bad_request(&format!("HTTP layer: {}", err)))
     }
 }
 

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -90,7 +90,7 @@ impl IntoResponse for HttpError {
 
 impl From<axum::Error> for HttpError {
     fn from(err: axum::Error) -> Self {
-        HttpError::from(BaseHttpError::bad_request(&format!("HTTP layer: {}", err)))
+        HttpError::from(BaseHttpError::bad_request(&format!("{}", err)))
     }
 }
 

--- a/reductstore/src/api/middleware.rs
+++ b/reductstore/src/api/middleware.rs
@@ -39,7 +39,6 @@ pub async fn print_statuses<B>(
         request.uri().path_and_query().unwrap()
     );
 
-    info!("{} - started", msg);
     let response = next.run(request).await;
     let err_msg = match response.headers().get("x-reduct-error") {
         Some(msg) => msg.to_str().unwrap(),

--- a/reductstore/src/api/middleware.rs
+++ b/reductstore/src/api/middleware.rs
@@ -5,7 +5,7 @@ use axum::http::{HeaderMap, Request};
 
 use axum::middleware::Next;
 use axum::response::IntoResponse;
-use log::{debug, error, info};
+use log::{debug, error};
 
 use crate::api::{Components, HttpError};
 use crate::auth::policy::Policy;

--- a/reductstore/src/api/middleware.rs
+++ b/reductstore/src/api/middleware.rs
@@ -5,7 +5,7 @@ use axum::http::{HeaderMap, Request};
 
 use axum::middleware::Next;
 use axum::response::IntoResponse;
-use log::{debug, error};
+use log::{debug, error, info};
 
 use crate::api::{Components, HttpError};
 use crate::auth::policy::Policy;
@@ -39,6 +39,7 @@ pub async fn print_statuses<B>(
         request.uri().path_and_query().unwrap()
     );
 
+    info!("{} - started", msg);
     let response = next.run(request).await;
     let err_msg = match response.headers().get("x-reduct-error") {
         Some(msg) => msg.to_str().unwrap(),


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

If during a write operation the HTTP request was interrupted, the unfinished record might be written with the Finished status.

### What is the new behavior?

I've fixed a check for content length to avoid this situation. 

### Does this PR introduce a breaking change?

No

### Other information:
