### PR TITLE
RS-111: Remove a transaction for any storage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Sync write tasks with HTTP API to avoid unfinished records, [PR-374](https://github.com/reductstore/reductstore/pull/374)
 - reductstore: Re-create a transaction log of replication if it is broken, [PR-379](https://github.com/reductstore/reductstore/pull/379)
 - reductstore: Status for unfinished records, [PR-381](https://github.com/reductstore/reductstore/pull/381)
-
+- reductstore: Remove a transaction for any storage errors, [PR-382](https://github.com/reductstore/reductstore/pull/382)
+-
 ### Changed
 
 - reductstore: Refactor read and write operation with tokio channels, [PR-370](https://github.com/reductstore/reductstore/pull/370)

--- a/reductstore/src/replication/replication.rs
+++ b/reductstore/src/replication/replication.rs
@@ -105,11 +105,8 @@ impl Replication {
                             let read_record = match get_record.await {
                                 Ok(record) => record,
                                 Err(err) => {
-                                    if err.status == ErrorCode::NotFound {
-                                        log.write().await.pop_front().await.unwrap();
-                                    }
-
-                                    error!("Failed to read record: {:?}", err);
+                                    log.write().await.pop_front().await.unwrap();
+                                    error!("Failed to read record: {}", err);
                                     thr_hourly_diagnostics.write().await.count(Err(err));
                                     break;
                                 }
@@ -310,7 +307,7 @@ mod tests {
                 hourly: DiagnosticsItem {
                     ok: 60,
                     errored: 0,
-                    errors: HashMap::new()
+                    errors: HashMap::new(),
                 }
             }
         )
@@ -391,9 +388,9 @@ mod tests {
                         404,
                         DiagnosticsError {
                             count: 1,
-                            last_message: "No record with timestamp 100".to_string()
+                            last_message: "No record with timestamp 100".to_string(),
                         }
-                    )])
+                    )]),
                 }
             }
         )

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -606,7 +606,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_unfinished_writting(
+    async fn test_unfinished_writing(
         #[future] block_manager: BlockManager,
         #[future] block: Block,
         block_id: u64,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

When a record  has the Errored status, the replication engine keeps it in a transaction log. However, this is not a recoverable problem.

### What is the new behavior?

The engine removes a record  from a transaction log if it fails to read it.

### Does this PR introduce a breaking change?

(What changes might users need to make in their application due to this PR?)

### Other information:
