### PR TITLE
RS-109: sleep if no transaction to replicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Re-create a transaction log of replication if it is broken, [PR-379](https://github.com/reductstore/reductstore/pull/379)
 - reductstore: Status for unfinished records, [PR-381](https://github.com/reductstore/reductstore/pull/381)
 - reductstore: Discard replication for any storage errors, [PR-382](https://github.com/reductstore/reductstore/pull/382)
--
+- reductstore: CPU consumption for replication, [PR-383](https://github.com/reductstore/reductstore/pull/383)
+
 ### Changed
 
 - reductstore: Refactor read and write operation with tokio channels, [PR-370](https://github.com/reductstore/reductstore/pull/370)


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The replication thread doesn't sleep if there is no transaction to replicate.

### What is the new behavior?

I've added a global flag to check if there is no transaction and  sleep if it is true.

### Does this PR introduce a breaking change?

No

### Other information:
