### PR TITLE
Fix empty diagnostics in GET /api/vi/replications/:name endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Status for unfinished records, [PR-381](https://github.com/reductstore/reductstore/pull/381)
 - reductstore: Discard replication for any storage errors, [PR-382](https://github.com/reductstore/reductstore/pull/382)
 - reductstore: CPU consumption for replication, [PR-383](https://github.com/reductstore/reductstore/pull/383)
+- reductstore: GET /api/v1/replications/:replication_name empty diagnostics, [PR-384](https://github.com/reductstore/reductstore/pull/384)
 
 ### Changed
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix 

### What is the current behavior?

The `GET /api/v1/replications/:replication_name`  returns the diagnostics with zeros instead of data:

```json
{
   "info":{
      "name":"stress_test",
      "is_active":true,
      "is_provisioned":true,
      "pending_records":0
   },
   "settings":{
      "src_bucket":"stress_test",
      "dst_bucket":"demo",
      "dst_host":"https://play.reduct.store/",
      "dst_token":"reductstore",
      "entries":[
         
      ],
      "include":{
         
      },
      "exclude":{
         
      }
   },
   "diagnostics":{
      "hourly":{
         "ok":0,
         "errored":0,
         "errors":{
            
         }
      }
   }
}
```

### What is the new behavior?

The ReplicationRepo.get_info method returns a default value instead of real data. I've fixed this and added a test.

### Does this PR introduce a breaking change?

No

### Other information:
