### PR TITLE
RS-113: fix error counting in replication diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Discard replication for any storage errors, [PR-382](https://github.com/reductstore/reductstore/pull/382)
 - reductstore: CPU consumption for replication, [PR-383](https://github.com/reductstore/reductstore/pull/383)
 - reductstore: GET /api/v1/replications/:replication_name empty diagnostics, [PR-384](https://github.com/reductstore/reductstore/pull/384)
+- reductstore: Fix error counting in replication diagnostics, [PR-385](https://github.com/reductstore/reductstore/pull/385)
 
 ### Changed
 

--- a/reductstore/src/replication/remote_bucket.rs
+++ b/reductstore/src/replication/remote_bucket.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use reduct_base::error::ReductError;
+use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::Labels;
 
 struct RemoteBucketImpl {
@@ -73,10 +73,10 @@ impl RemoteBucket for RemoteBucketImpl {
         if self.is_active {
             Ok(())
         } else {
-            Err(ReductError::internal_server_error(&format!(
-                "Remote bucket {} is not available",
-                self.path
-            )))
+            Err(ReductError::new(
+                ErrorCode::ConnectionError,
+                &format!("Remote bucket {} is not available", self.path),
+            ))
         }
     }
 

--- a/reductstore/src/replication/remote_bucket/states.rs
+++ b/reductstore/src/replication/remote_bucket/states.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use reduct_base::Labels;
 
 pub(super) use initial_state::InitialState;
+use reduct_base::error::ReductError;
 
 /// A state of the remote bucket.
 #[async_trait]
@@ -23,5 +24,5 @@ pub(super) trait RemoteBucketState {
     ) -> Box<dyn RemoteBucketState + Sync + Send>;
 
     /// Is the bucket available?
-    fn ok(&self) -> bool;
+    fn last_result(&self) -> &Result<(), ReductError>;
 }

--- a/reductstore/src/replication/remote_bucket/states.rs
+++ b/reductstore/src/replication/remote_bucket/states.rs
@@ -24,5 +24,8 @@ pub(super) trait RemoteBucketState {
     ) -> Box<dyn RemoteBucketState + Sync + Send>;
 
     /// Is the bucket available?
+    fn is_available(&self) -> bool;
+
+    // Get the last result of the write operation.
     fn last_result(&self) -> &Result<(), ReductError>;
 }

--- a/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
@@ -76,7 +76,7 @@ impl BucketUnavailableState {
             client,
             bucket_name,
             init_time: Instant::now(),
-            timeout: Duration::new(60, 0),
+            timeout: Duration::new(5, 0),
             last_result: Err(error),
         }
     }

--- a/reductstore/src/replication/remote_bucket/states/initial_state.rs
+++ b/reductstore/src/replication/remote_bucket/states/initial_state.rs
@@ -8,6 +8,7 @@ use crate::replication::remote_bucket::states::RemoteBucketState;
 use crate::storage::bucket::RecordRx;
 use async_trait::async_trait;
 use log::error;
+use reduct_base::error::ReductError;
 use reduct_base::Labels;
 
 /// Initial state of the remote bucket.
@@ -55,13 +56,17 @@ impl RemoteBucketState for InitialState {
                     self.bucket_name,
                     err
                 );
-                Box::new(BucketUnavailableState::new(self.client, self.bucket_name))
+                Box::new(BucketUnavailableState::new(
+                    self.client,
+                    self.bucket_name,
+                    err,
+                ))
             }
         }
     }
 
-    fn ok(&self) -> bool {
-        false
+    fn last_result(&self) -> &Result<(), ReductError> {
+        &Ok(())
     }
 }
 

--- a/reductstore/src/replication/remote_bucket/states/initial_state.rs
+++ b/reductstore/src/replication/remote_bucket/states/initial_state.rs
@@ -68,6 +68,9 @@ impl RemoteBucketState for InitialState {
     fn last_result(&self) -> &Result<(), ReductError> {
         &Ok(())
     }
+    fn is_available(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -86,7 +89,7 @@ mod tests {
         let bucket_name = "test_bucket";
         let api_token = "test_token";
         let state = InitialState::new(url, bucket_name, api_token);
-        assert_eq!(state.ok(), false);
+        assert_eq!(state.last_result(), &Ok(()));
     }
 
     #[rstest]
@@ -120,7 +123,8 @@ mod tests {
             .write_record("test_entry", 0, Labels::new(), "text/plain", 0, rx)
             .await;
 
-        assert_eq!(state.ok(), true);
+        assert_eq!(state.last_result(), &Ok(()));
+        assert_eq!(state.is_available(), true);
     }
 
     #[rstest]
@@ -140,6 +144,10 @@ mod tests {
             .write_record("test_entry", 0, Labels::new(), "text/plain", 0, rx)
             .await;
 
-        assert_eq!(state.ok(), false);
+        assert_eq!(
+            state.last_result(),
+            &Err(ReductError::bad_request("test error"))
+        );
+        assert_eq!(state.is_available(), false);
     }
 }

--- a/reductstore/src/replication/replication.rs
+++ b/reductstore/src/replication/replication.rs
@@ -84,74 +84,71 @@ impl Replication {
             loop {
                 let mut no_transactions = true;
                 for (entry_name, log) in thr_log_map.read().await.iter() {
-                    loop {
-                        let tr = log.write().await.front().await;
-                        match tr {
-                            Ok(None) => {
-                                no_transactions = false;
-                                break;
-                            }
-                            Ok(Some(transaction)) => {
-                                debug!("Replicating transaction {}/{:?}", entry_name, transaction);
+                    let tr = log.write().await.front().await;
+                    match tr {
+                        Ok(None) => {
+                            no_transactions = false;
+                            break;
+                        }
+                        Ok(Some(transaction)) => {
+                            debug!("Replicating transaction {}/{:?}", entry_name, transaction);
 
-                                let get_record = async {
-                                    thr_storage
-                                        .read()
-                                        .await
-                                        .get_bucket(&config.src_bucket)?
-                                        .begin_read(&entry_name, *transaction.timestamp())
-                                        .await
-                                };
-
-                                let read_record = match get_record.await {
-                                    Ok(record) => record,
-                                    Err(err) => {
-                                        log.write().await.pop_front().await.unwrap();
-                                        error!("Failed to read record: {}", err);
-                                        thr_hourly_diagnostics.write().await.count(Err(err));
-                                        break;
-                                    }
-                                };
-
-                                match thr_bucket
-                                    .write()
+                            let get_record = async {
+                                thr_storage
+                                    .read()
                                     .await
-                                    .write_record(entry_name, read_record)
+                                    .get_bucket(&config.src_bucket)?
+                                    .begin_read(&entry_name, *transaction.timestamp())
                                     .await
-                                {
-                                    Ok(_) => {
-                                        log.write().await.pop_front().await.unwrap();
-                                        thr_hourly_diagnostics.write().await.count(Ok(()));
-                                    }
-                                    Err(err) => {
-                                        debug!("Failed to replicate transaction: {:?}", err);
-                                        thr_hourly_diagnostics.write().await.count(Err(err));
-                                        break;
-                                    }
+                            };
+
+                            let read_record = match get_record.await {
+                                Ok(record) => record,
+                                Err(err) => {
+                                    log.write().await.pop_front().await.unwrap();
+                                    error!("Failed to read record: {}", err);
+                                    thr_hourly_diagnostics.write().await.count(Err(err));
+                                    break;
+                                }
+                            };
+
+                            match thr_bucket
+                                .write()
+                                .await
+                                .write_record(entry_name, read_record)
+                                .await
+                            {
+                                Ok(_) => {
+                                    log.write().await.pop_front().await.unwrap();
+                                    thr_hourly_diagnostics.write().await.count(Ok(()));
+                                }
+                                Err(err) => {
+                                    debug!("Failed to replicate transaction: {:?}", err);
+                                    thr_hourly_diagnostics.write().await.count(Err(err));
+                                    break;
                                 }
                             }
+                        }
 
-                            Err(err) => {
-                                error!("Failed to read transaction: {:?}", err);
-                                info!("Transaction log is corrupted, dropping the whole log");
-                                let mut log = log.write().await;
+                        Err(err) => {
+                            error!("Failed to read transaction: {:?}", err);
+                            info!("Transaction log is corrupted, dropping the whole log");
+                            let mut log = log.write().await;
 
-                                let path = Self::build_path_to_transaction_log(
-                                    thr_storage.read().await.data_path(),
-                                    &config.src_bucket,
-                                    &entry_name,
-                                    &replication_name,
-                                );
-                                if let Err(err) = fs::remove_file(&path).await {
-                                    error!("Failed to remove transaction log: {:?}", err);
-                                }
-
-                                info!("Creating a new transaction log");
-                                *log =
-                                    TransactionLog::try_load_or_create(path, TRANSACTION_LOG_SIZE)
-                                        .await
-                                        .unwrap();
+                            let path = Self::build_path_to_transaction_log(
+                                thr_storage.read().await.data_path(),
+                                &config.src_bucket,
+                                &entry_name,
+                                &replication_name,
+                            );
+                            if let Err(err) = fs::remove_file(&path).await {
+                                error!("Failed to remove transaction log: {:?}", err);
                             }
+
+                            info!("Creating a new transaction log");
+                            *log = TransactionLog::try_load_or_create(path, TRANSACTION_LOG_SIZE)
+                                .await
+                                .unwrap();
                         }
                     }
                 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

The replication engine counts errors for calls of `RemoteBucket.write_record` but not real HTTP requests.

### What is the new behavior?

It is counting only errors for failed HTTP requests.

### Does this PR introduce a breaking change?

No

### Other information:
