### PR TITLE
Always discard a transaction from replication log if remote bucket is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Discard replication for any storage errors, [PR-382](https://github.com/reductstore/reductstore/pull/382)
 - reductstore: CPU consumption for replication, [PR-383](https://github.com/reductstore/reductstore/pull/383)
 - reductstore: GET /api/v1/replications/:replication_name empty diagnostics, [PR-384](https://github.com/reductstore/reductstore/pull/384)
-- reductstore: Fix error counting in replication diagnostics, [PR-385](https://github.com/reductstore/reductstore/pull/385)
+- reductstore: Error counting in replication diagnostics, [PR-385](https://github.com/reductstore/reductstore/pull/385)
+- reductstore: Discard transaction from replication log if remote bucket is available, [PR-386](https://github.com/reductstore/reductstore/pull/386)
 
 ### Changed
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

If a remote bucket is available, but the replication engine fails to write the record e.g 409 error, it doesn't remove it from the log and infinitely tries to repeat the write operation. 
 
### What is the new behavior?

We discard the transaction always, even if an error happens. 

### Does this PR introduce a breaking change?

No

### Other information:
