### PR TITLE
RS-107: Mask access token for remote instance in replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reductstore: Error counting in replication diagnostics, [PR-385](https://github.com/reductstore/reductstore/pull/385)
 - reductstore: Discard transaction from replication log if remote bucket is available, [PR-386](https://github.com/reductstore/reductstore/pull/386)
 - reductstore: Use only HTTP1 for replication engine, [PR-388](https://github.com/reductstore/reductstore/pull/388)
+- reductstore: Mask access token for remote instance in replication, [PR-390](https://github.com/reductstore/reductstore/pull/390)
 
 ### Changed
 

--- a/api_tests/replication_api_test.py
+++ b/api_tests/replication_api_test.py
@@ -37,7 +37,7 @@ def test__create_replication_ok(base_url, session, bucket_name, replication_name
         "settings": {
             "dst_bucket": "dst_bucket",
             "dst_host": "http://localhost:9000",
-            "dst_token": "",
+            "dst_token": "***",
             "entries": [],
             "exclude": {},
             "include": {},
@@ -103,7 +103,7 @@ def test__update_replication_ok(base_url, session, bucket_name, replication_name
         "settings": {
             "dst_bucket": bucket_name,
             "dst_host": "http://localhost:9001",
-            "dst_token": "",
+            "dst_token": "***",
             "entries": [],
             "exclude": {},
             "include": {},

--- a/reduct_cli/src/context.rs
+++ b/reduct_cli/src/context.rs
@@ -53,16 +53,18 @@ impl ContextBuilder {
         ContextBuilder { config }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn config_path(mut self, config_dir: &str) -> Self {
         self.config.config_path = config_dir.to_string();
         self
     }
-
+    #[allow(dead_code)]
     pub(crate) fn output(mut self, output: Box<dyn Output>) -> Self {
         self.config.output = output;
         self
     }
 
+    #[allow(dead_code)]
     pub(crate) fn input(mut self, input: Box<dyn Input>) -> Self {
         self.config.input = input;
         self

--- a/reduct_rs/src/http_client.rs
+++ b/reduct_rs/src/http_client.rs
@@ -7,7 +7,6 @@ use crate::client::Result;
 use reduct_base::error::{ErrorCode, IntEnum, ReductError};
 use reqwest::header::HeaderValue;
 use reqwest::{Method, RequestBuilder, Response, Url};
-use std::time::Duration;
 
 /// Internal HTTP client to wrap reqwest.
 pub(crate) struct HttpClient {

--- a/reductstore/src/api/replication/get.rs
+++ b/reductstore/src/api/replication/get.rs
@@ -68,7 +68,7 @@ mod tests {
             info.0,
             ReplicationFullInfo {
                 info: repl.info().await,
-                settings: repl.settings().clone(),
+                settings: repl.masked_settings().clone(),
                 diagnostics: repl.diagnostics().await,
             }
         );

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -15,6 +15,7 @@ use reduct_base::msg::bucket_api::BucketSettings;
 use reduct_base::msg::replication_api::ReplicationSettings;
 use reduct_base::msg::token_api::{Permissions, Token};
 use reduct_base::Labels;
+use regex::Replacer;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
@@ -164,7 +165,12 @@ impl<EnvGetter: GetEnv> Cfg<EnvGetter> {
 
             let replication = repo.get_mut_replication(&name).unwrap();
             replication.set_provisioned(true);
-            info!("Provisioned replication '{}' with {:?}", name, settings);
+
+            info!(
+                "Provisioned replication '{}' with {:?}",
+                name,
+                replication.masked_settings()
+            );
         }
         Ok(repo)
     }

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -15,7 +15,6 @@ use reduct_base::msg::bucket_api::BucketSettings;
 use reduct_base::msg::replication_api::ReplicationSettings;
 use reduct_base::msg::token_api::{Permissions, Token};
 use reduct_base::Labels;
-use regex::Replacer;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;

--- a/reductstore/src/replication/replication.rs
+++ b/reductstore/src/replication/replication.rs
@@ -220,9 +220,18 @@ impl Replication {
         &self.name
     }
 
+    /// Get the replication settings with the destination token masked.
+    pub fn masked_settings(&self) -> ReplicationSettings {
+        ReplicationSettings {
+            dst_token: "***".to_string(),
+            ..self.settings.clone()
+        }
+    }
+
     pub fn settings(&self) -> &ReplicationSettings {
         &self.settings
     }
+
     pub fn is_provisioned(&self) -> bool {
         self.is_provisioned
     }

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -132,7 +132,7 @@ impl ManageReplications for ReplicationRepository {
         let replication = self.get_replication(name)?;
         let info = ReplicationFullInfo {
             info: replication.info().await,
-            settings: replication.settings().clone(),
+            settings: replication.masked_settings().clone(),
             diagnostics: replication.diagnostics().await,
         };
         Ok(info)
@@ -474,7 +474,7 @@ mod tests {
 
         let info = repo.get_info("test").await.unwrap();
         let repl = repo.get_replication("test").unwrap();
-        assert_eq!(info.settings, settings);
+        assert_eq!(info.settings, repl.masked_settings().clone());
         assert_eq!(info.info, repl.info().await);
         assert_eq!(info.diagnostics, repl.diagnostics().await);
     }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix 

### What is the current behavior?

The database exposes the access token in logs and HTTP API. This isn't secure.

### What is the new behavior?

I've masked the token with "***".

### Does this PR introduce a breaking change?

No

### Other information:
