### PR TITLE
RS-101: Support Replication API in Client SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - reduct-cli: `bucket` command to manage buckets, [PR-367](https://github.com/reductstore/reductstore/pull/367)
 - reductstore: Data replication, [PR-377](https://github.com/reductstore/reductstore/pull/377)
 - reductstore: CRUD API and diagnostics for replication, [PR-380](https://github.com/reductstore/reductstore/pull/380)
+- reduct-rs: Implement replication API, [PR-391](https://github.com/reductstore/reductstore/pull/391)
 
 ### Fixed
 

--- a/reduct_base/src/msg/replication_api.rs
+++ b/reduct_base/src/msg/replication_api.rs
@@ -51,7 +51,7 @@ pub struct ReplicationList {
 
 /// Replication settings
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct ReplicationFullInfo {
+pub struct FullReplicationInfo {
     /// Info
     pub info: ReplicationInfo,
     /// Settings

--- a/reduct_rs/src/client.rs
+++ b/reduct_rs/src/client.rs
@@ -12,7 +12,7 @@ use crate::bucket::BucketBuilder;
 use crate::http_client::HttpClient;
 use crate::Bucket;
 use reduct_base::error::{ErrorCode, ReductError};
-use reduct_base::msg::bucket_api::BucketSettings;
+
 use reduct_base::msg::replication_api::{
     FullReplicationInfo, ReplicationInfo, ReplicationList, ReplicationSettings,
 };

--- a/reduct_rs/src/client.rs
+++ b/reduct_rs/src/client.rs
@@ -319,7 +319,8 @@ impl ReductClient {
     /// async fn main() {
     ///     let client = ReductClient::builder()
     ///         .url("http://127.0.0.1:8383")
-    ///         .api_token("my-api-token");
+    ///         .api_token("my-api-token")
+    ///         .build();
     ///
     ///     client.create_replication("test-replication")
     ///         .src_bucket("test-bucket-1")
@@ -509,10 +510,10 @@ pub(crate) mod tests {
             let client = client.await;
             client
                 .create_replication("test-replication")
-                .src_bucket(settings.src_bucket.clone())
-                .dst_bucket(settings.dst_bucket.clone())
-                .dst_host(settings.dst_host.clone())
-                .dst_token(settings.dst_token.clone())
+                .src_bucket(settings.src_bucket.as_str())
+                .dst_bucket(settings.dst_bucket.as_str())
+                .dst_host(settings.dst_host.as_str())
+                .dst_token(settings.dst_token.as_str())
                 .entries(settings.entries.clone())
                 .include(settings.include.clone())
                 .exclude(settings.exclude.clone())

--- a/reduct_rs/src/lib.rs
+++ b/reduct_rs/src/lib.rs
@@ -7,6 +7,7 @@ mod bucket;
 mod client;
 mod http_client;
 mod record;
+mod replication;
 
 pub use bucket::Bucket;
 pub use client::ReductClient;

--- a/reduct_rs/src/replication.rs
+++ b/reduct_rs/src/replication.rs
@@ -5,7 +5,7 @@
 
 use crate::client::Result;
 use crate::http_client::HttpClient;
-use crate::Bucket;
+
 use reduct_base::msg::replication_api::ReplicationSettings;
 use reduct_base::Labels;
 use reqwest::Method;

--- a/reduct_rs/src/replication.rs
+++ b/reduct_rs/src/replication.rs
@@ -1,0 +1,130 @@
+// Copyright 2024 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::client::Result;
+use crate::http_client::HttpClient;
+use crate::Bucket;
+use reduct_base::msg::replication_api::ReplicationSettings;
+use reduct_base::Labels;
+use reqwest::Method;
+use std::sync::Arc;
+
+/// Replication builder.
+pub struct ReplicationBuilder {
+    name: String,
+    settings: ReplicationSettings,
+    http_client: Arc<HttpClient>,
+}
+
+impl ReplicationBuilder {
+    /// Create a new replication builder.
+    pub(super) fn new(name: String, http_client: Arc<HttpClient>) -> Self {
+        Self {
+            name,
+            settings: ReplicationSettings {
+                src_bucket: "".to_string(),
+                dst_bucket: "".to_string(),
+                dst_host: "".to_string(),
+                dst_token: "".to_string(),
+                entries: vec![],
+                include: Default::default(),
+                exclude: Default::default(),
+            },
+            http_client,
+        }
+    }
+
+    /// Set the source bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `bucket` - Source bucket. Required and must exist.
+    pub fn src_bucket(mut self, bucket: String) -> Self {
+        self.settings.src_bucket = bucket;
+        self
+    }
+
+    /// Set the destination bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `bucket` - Destination bucket. Required and must exist.
+    pub fn dst_bucket(mut self, bucket: String) -> Self {
+        self.settings.dst_bucket = bucket;
+        self
+    }
+
+    /// Set the destination host.
+    ///
+    /// # Arguments
+    ///
+    /// * `host` - Destination host. Required.
+    pub fn dst_host(mut self, host: String) -> Self {
+        self.settings.dst_host = host;
+        self
+    }
+
+    /// Set the destination token.
+    ///
+    /// # Arguments
+    ///
+    /// * `token` - Destination token.
+    pub fn dst_token(mut self, token: String) -> Self {
+        self.settings.dst_token = token;
+        self
+    }
+
+    /// Set the replication entries.
+    ///
+    /// # Arguments
+    /// * `entries` - Replication entries. If empty, all entries will be replicated. Wildcards are supported.
+    pub fn entries(mut self, entries: Vec<String>) -> Self {
+        self.settings.entries = entries;
+        self
+    }
+
+    /// Set the replication include.
+    ///
+    /// # Arguments
+    ///
+    /// * `include` - Replication include. If empty, all labels will be replicated.
+    ///         If a few labels are specified, records must have all of them to be replicated.
+    pub fn include(mut self, include: Labels) -> Self {
+        self.settings.include = include;
+        self
+    }
+
+    /// Set the replication exclude.
+    ///
+    /// # Arguments
+    ///
+    /// * `exclude` - Replication exclude. If empty, no labels will be excluded.
+    ///        If a few labels are specified, records must have none of them to be replicated.
+    pub fn exclude(mut self, exclude: Labels) -> Self {
+        self.settings.exclude = exclude;
+        self
+    }
+
+    /// Override all the replication settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `settings` - Replication settings.
+    pub fn set_settings(mut self, settings: ReplicationSettings) -> Self {
+        self.settings = settings;
+        self
+    }
+
+    /// Send request to create a new replication.
+    pub async fn send(self) -> Result<()> {
+        self.http_client
+            .send_json(
+                Method::POST,
+                &format!("/replications/{}", self.name),
+                self.settings,
+            )
+            .await
+    }
+}

--- a/reduct_rs/src/replication.rs
+++ b/reduct_rs/src/replication.rs
@@ -41,8 +41,8 @@ impl ReplicationBuilder {
     /// # Arguments
     ///
     /// * `bucket` - Source bucket. Required and must exist.
-    pub fn src_bucket(mut self, bucket: String) -> Self {
-        self.settings.src_bucket = bucket;
+    pub fn src_bucket(mut self, bucket: &str) -> Self {
+        self.settings.src_bucket = bucket.to_string();
         self
     }
 
@@ -51,8 +51,8 @@ impl ReplicationBuilder {
     /// # Arguments
     ///
     /// * `bucket` - Destination bucket. Required and must exist.
-    pub fn dst_bucket(mut self, bucket: String) -> Self {
-        self.settings.dst_bucket = bucket;
+    pub fn dst_bucket(mut self, bucket: &str) -> Self {
+        self.settings.dst_bucket = bucket.to_string();
         self
     }
 
@@ -61,8 +61,8 @@ impl ReplicationBuilder {
     /// # Arguments
     ///
     /// * `host` - Destination host. Required.
-    pub fn dst_host(mut self, host: String) -> Self {
-        self.settings.dst_host = host;
+    pub fn dst_host(mut self, host: &str) -> Self {
+        self.settings.dst_host = host.to_string();
         self
     }
 
@@ -71,8 +71,8 @@ impl ReplicationBuilder {
     /// # Arguments
     ///
     /// * `token` - Destination token.
-    pub fn dst_token(mut self, token: String) -> Self {
-        self.settings.dst_token = token;
+    pub fn dst_token(mut self, token: &str) -> Self {
+        self.settings.dst_token = token.to_string();
         self
     }
 

--- a/reductstore/src/api/replication.rs
+++ b/reductstore/src/api/replication.rs
@@ -20,7 +20,7 @@ use axum::http::Request;
 use axum::routing::{delete, get, post, put};
 use bytes::Bytes;
 use reduct_base::msg::replication_api::{
-    ReplicationFullInfo, ReplicationList, ReplicationSettings,
+    FullReplicationInfo, ReplicationList, ReplicationSettings,
 };
 use reduct_macros::{IntoResponse, Twin};
 use std::sync::Arc;
@@ -56,7 +56,7 @@ where
 pub struct ReplicationListAxum(ReplicationList);
 
 #[derive(IntoResponse, Twin)]
-pub struct ReplicationFullInfoAxum(ReplicationFullInfo);
+pub struct ReplicationFullInfoAxum(FullReplicationInfo);
 
 pub(crate) fn create_replication_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()

--- a/reductstore/src/api/replication/get.rs
+++ b/reductstore/src/api/replication/get.rs
@@ -33,7 +33,7 @@ mod tests {
     use crate::api::replication::tests::settings;
     use crate::api::tests::{components, headers};
     use reduct_base::error::ErrorCode::NotFound;
-    use reduct_base::msg::replication_api::{ReplicationFullInfo, ReplicationSettings};
+    use reduct_base::msg::replication_api::{FullReplicationInfo, ReplicationSettings};
     use rstest::rstest;
     use std::sync::Arc;
 
@@ -66,7 +66,7 @@ mod tests {
 
         assert_eq!(
             info.0,
-            ReplicationFullInfo {
+            FullReplicationInfo {
                 info: repl.info().await,
                 settings: repl.masked_settings().clone(),
                 diagnostics: repl.diagnostics().await,

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -5,7 +5,7 @@ use crate::replication::replication::Replication;
 use async_trait::async_trait;
 use reduct_base::error::ReductError;
 use reduct_base::msg::replication_api::{
-    ReplicationFullInfo, ReplicationInfo, ReplicationSettings,
+    FullReplicationInfo, ReplicationInfo, ReplicationSettings,
 };
 use reduct_base::Labels;
 
@@ -93,7 +93,7 @@ pub trait ManageReplications {
 
     async fn replications(&self) -> Vec<ReplicationInfo>;
 
-    async fn get_info(&self, name: &str) -> Result<ReplicationFullInfo, ReductError>;
+    async fn get_info(&self, name: &str) -> Result<FullReplicationInfo, ReductError>;
 
     fn get_replication(&self, name: &str) -> Result<&Replication, ReductError>;
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Reduct Client SDK doesn't support Replication HTTP API.

### What is the new behavior?

I've added CRUD functions into the Client class.

### Does this PR introduce a breaking change?

No

### Other information:
