### PR TITLE
Fix stuck last replication error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stuck last replication error, [PR-393](https://github.com/reductstore/reductstore/pull/393)
+
 ## [1.8.0] - 2024-01-24
 
 ### Added


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Last communication error is stuck in a replication and it can't continue anymore.

### What is the new behavior?

Now, the replication engine reset the last error if the replication synced a record successfully.

### Does this PR introduce a breaking change?

No

### Other information:
