### PR TITLE
RS-30: Move reduct-rs to separated repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Rust Linter
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check code
         run: cargo fmt --all -- --check
 
@@ -35,7 +35,7 @@ jobs:
     needs:
       - rust_fmt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and export
@@ -60,7 +60,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
@@ -89,7 +89,7 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
@@ -120,7 +120,7 @@ jobs:
           - cert_path: ""
             url: http://127.0.0.1:8383
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
@@ -144,7 +144,7 @@ jobs:
     needs:
       - rust_fmt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: snapcore/action-build@v1
         id: build-snap
         with:
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check tag
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -226,7 +226,7 @@ jobs:
             gcc_compiler: gcc-arm-linux-gnueabihf
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -370,7 +370,7 @@ jobs:
     name: Make release
     if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/create-release@v1
         id: create_release
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           cargo install cargo-get
-          for PKG_NAME in reduct_base reduct_macros reduct_rs reductstore; do
+          for PKG_NAME in reduct_base reduct_macros reductstore; do
             if [ "v$(cargo get package.version --entry $PKG_NAME/)" != "${GITHUB_REF#refs/*/}" ]; then
               echo "Tag does not match version in $PKG_NAME/Cargo.toml"
               exit 1
@@ -186,7 +186,6 @@ jobs:
     needs:
       - build_snap
       - api_tests
-      - sdk_tests
       - cli_tests
       - sdk_examples
       - check_tag
@@ -210,8 +209,6 @@ jobs:
     name: Push to DockerHub Registry
     needs:
       - api_tests
-      - sdk_tests
-      - sdk_examples
       - cli_tests
       - check_tag
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
@@ -340,8 +337,6 @@ jobs:
     name: Publish crate
     needs:
       - api_tests
-      - sdk_tests
-      - sdk_examples
       - cli_tests
       - check_tag # Only publish on tags
     if: startsWith(github.ref, 'refs/tags/')
@@ -371,8 +366,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - api_tests
-      - sdk_tests
-      - sdk_examples
       - cli_tests
       - check_tag # Only publish on tags
     name: Make release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,51 +83,6 @@ jobs:
           name: reductstore-${{ matrix.os }}
           path: target/release/reductstore${{ matrix.os == 'windows-latest' && '.exe' || '' }}
 
-  sdk_tests:
-    name: Client SDK Tests
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - uses: actions/checkout@v3
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: image
-          path: /tmp/
-      - name: Load image
-        run: |
-          docker load --input /tmp/image.tar
-          docker image ls -a
-      - name: Run Database
-        run: docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=TOKEN -d ${{github.repository}}
-      - name: Run Client SDK tests
-        run: RS_API_TOKEN=TOKEN cargo test --package reduct-rs -- --test-threads=1
-
-  sdk_examples:
-    name: Client SDK Examples
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    strategy:
-      matrix:
-        example: [ "hallo_world", "query" ]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: image
-          path: /tmp/
-      - name: Load image
-        run: |
-          docker load --input /tmp/image.tar
-          docker image ls -a
-      - name: Run Database
-        run: docker run --network=host -v ${PWD}/misc:/misc -d ${{github.repository}}
-      - name: Run Client SDK tests
-        run: cargo run --example ${{matrix.example}}
-
   cli_tests:
     name: Client CLI Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
       - build_snap
       - api_tests
       - cli_tests
-      - sdk_examples
       - check_tag
     steps:
       - uses: actions/download-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stuck last replication error, [PR-393](https://github.com/reductstore/reductstore/pull/393)
 
+### Changed
+
+- reduct-rs: Move `reduct-rs` to separated repository, [PR-395](https://github.com/reductstore/reductstore/pull/395)
+
 ## [1.8.0] - 2024-01-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,20 @@ dependencies = [
 [[package]]
 name = "reduct-base"
 version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911ade168313bead460ec5b5ffb8fec98e65a9335a89ca17cabcd2c2c7935e20"
+dependencies = [
+ "chrono",
+ "http",
+ "int-enum",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "reduct-base"
+version = "1.9.0-dev"
 dependencies = [
  "chrono",
  "http",
@@ -1591,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-cli"
-version = "1.8.1"
+version = "1.9.0-dev"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -1613,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.8.1"
+version = "1.9.0-dev"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1622,6 +1636,8 @@ dependencies = [
 [[package]]
 name = "reduct-rs"
 version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a949546006c37151f9823533679158e123428efda136d6e4b107337182b465"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1629,9 +1645,8 @@ dependencies = [
  "chrono",
  "futures",
  "futures-util",
- "reduct-base",
+ "reduct-base 1.8.1",
  "reqwest",
- "rstest",
  "rustls 0.21.10",
  "serde",
  "serde_json",
@@ -1640,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.8.1"
+version = "1.9.0-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -1661,7 +1676,7 @@ dependencies = [
  "prost-wkt-build",
  "prost-wkt-types",
  "rand",
- "reduct-base",
+ "reduct-base 1.9.0-dev",
  "reduct-macros",
  "reduct-rs",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@
 members = [
     "reductstore",
     "reduct_cli",
-    "reduct_rs",
     "reduct_base",
     "reduct_macros"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.1"
+version = "1.9.0-dev"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/api_tests/http_test.py
+++ b/api_tests/http_test.py
@@ -6,4 +6,4 @@ def test_api_version(base_url, session):
     resp = session.get(f"{base_url}/info")
 
     assert resp.status_code == 200
-    assert resp.headers["x-reduct-api"] == "1.8"
+    assert resp.headers["x-reduct-api"] == "1.9"

--- a/reduct_cli/Cargo.toml
+++ b/reduct_cli/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 description = "A CLI client for ReductStore written in Rust"
 
 [dependencies]
-reduct-rs = { path = "../reduct_rs", version = "1.8.0-dev" }
+reduct-rs = "1.8.1"
 clap = { version = "4.3.23", features = ["cargo"] }
 dirs = "5.0.1"
 toml = "0.8.0"

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["lib"]
 [dependencies]
 reduct-base =  { path = "../reduct_base", version = "1.8.1" }
 reduct-macros = { path = "../reduct_macros", version = "1.8.1" }
-reduct-rs = { path = "../reduct_rs", version = "1.8.1" }
+reduct-rs = "1.8.1"
 
 log = "0.4.20"
 chrono = { version = "0.4.31", features = ["serde"] }

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -26,8 +26,8 @@ crate-type = ["lib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reduct-base =  { path = "../reduct_base", version = "1.8.1" }
-reduct-macros = { path = "../reduct_macros", version = "1.8.1" }
+reduct-base =  { path = "../reduct_base", version = "1.9.0-dev" }
+reduct-macros = { path = "../reduct_macros", version = "1.9.0-dev" }
 reduct-rs = "1.8.1"
 
 log = "0.4.20"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

reduct-rs is a part of the workspace. We publish a new version even if we don't change anything in the library.

### What is the new behavior?

Now it has a separated repository - https://github.com/reductstore/reduct-rs 

### Does this PR introduce a breaking change?

No

### Other information:
