### PR TITLE
RS-162:  Fix locked block by read/write operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,8 +407,6 @@ jobs:
         run: cargo publish -p reduct-base
       - name: Publish reduct-macros
         run: cargo publish -p reduct-macros
-      - name: Publish reduct-rs
-        run: cargo publish -p reduct-rs
       - name: Publish reductstore
         run: cargo publish -p reductstore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-162: Fix locked block by read/write operation, [PR-398](https://github.com/reductstore/reductstore/pull/398)
+
 ## [1.8.1] - 2024-01-28
 
 ### Fixed


### PR DESCRIPTION
Closes #397 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

A data block has  counters for writers and readers to prevent it from being removed while in use. These counters can have bad state if  an IO operation was interrupted. 

### What is the new behavior?

I've added timeouts to remove a block even if it has registered writers or readers. 

### Does this PR introduce a breaking change?

No

### Other information:
