### PR TITLE
RS-155: Wait for incomplete records during replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-162: Fix locked block by read/write operation, [PR-398](https://github.com/reductstore/reductstore/pull/398)
+- RS-155: Wait for incomplete records during replication, [PR-399](https://github.com/reductstore/reductstore/pull/399)
 
 ## [1.8.1] - 2024-01-28
 

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -547,7 +547,6 @@ pub async fn spawn_write_task(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Buf;
     use rstest::{fixture, rstest};
     use tempfile::tempdir;
     use tokio::io::AsyncWriteExt;


### PR DESCRIPTION
Closes #396 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

See #396 

### What is the new behavior?

Now the replication engine waits a few milliseconds for an incomplete record before discarding the transaction.

### Does this PR introduce a breaking change?

No

### Other information:
