### PR TITLE
RS-198: improve error message for expired query id

### DIFF
--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -337,6 +337,6 @@ mod tests {
         .err()
         .unwrap();
 
-        assert_eq!(err, HttpError::new(NotFound, "Query 1 not found"));
+        assert_eq!(err, HttpError::new(NotFound, "Query 1 not found and it might have expired. Check TTL in your query request. Default value 60 sec."));
     }
 }

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -380,7 +380,9 @@ impl Entry {
         let query = self
             .queries
             .get_mut(&query_id)
-            .ok_or_else(|| ReductError::not_found(&format!("Query {} not found", query_id)))?;
+            .ok_or_else(||
+                ReductError::not_found(
+                    &format!("Query {} not found and it might have expired. Check TTL in your query request. Default value {} sec.", query_id, QueryOptions::default().ttl.as_secs())))?;
         query
             .next(&self.block_index, Arc::clone(&self.block_manager))
             .await
@@ -811,7 +813,7 @@ mod tests {
         );
         assert_eq!(
             entry.next(id).await.err(),
-            Some(ReductError::not_found(&format!("Query {} not found", id)))
+            Some(ReductError::not_found(&format!("Query {} not found and it might have expired. Check TTL in your query request. Default value 60 sec.", id)))
         );
     }
 
@@ -851,7 +853,7 @@ mod tests {
         sleep(Duration::from_millis(600));
         assert_eq!(
             entry.next(id).await.err(),
-            Some(ReductError::not_found(&format!("Query {} not found", id)))
+            Some(ReductError::not_found(&format!("Query {} not found and it might have expired. Check TTL in your query request. Default value 60 sec.", id)))
         );
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Update

### What was changed?

I've change the message `Query N not found` to `Query {} not found and it might have expired. Check TTL in your query request. Default value 60 sec.`.

### Related issues

#405 

### Does this PR introduce a breaking change?

Might be , if someone use the messages in code. However, users should use error codes.

### Other information:
