### PR TITLE
RS-212: add `--ignore-ssl` flag to `reduct-cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-18: implement token management commands in `reduct-cli`, [PR-413](https://github.com/reductstore/reductstore/pull/413)
 - RS-181: add support for commercial license in `reduct-cli`, [PR-414](https://github.com/reductstore/reductstore/pull/414)
+- RS-212: add --ignore-ssl flag to reduct-cli, [PR-415](https://github.com/reductstore/reductstore/pull/415)
 
 ## [1.9.1] - 2024-03-09
 

--- a/reduct_cli/src/context.rs
+++ b/reduct_cli/src/context.rs
@@ -11,6 +11,7 @@ pub(crate) struct CliContext {
     config_path: String,
     output: Box<dyn Output>,
     input: Box<dyn Input>,
+    ignore_ssl: bool,
 }
 
 impl CliContext {
@@ -24,6 +25,10 @@ impl CliContext {
     pub(crate) fn stdin(&self) -> &dyn Input {
         &*self.input
     }
+
+    pub(crate) fn ignore_ssl(&self) -> bool {
+        self.ignore_ssl
+    }
 }
 
 pub(crate) struct ContextBuilder {
@@ -36,6 +41,7 @@ impl ContextBuilder {
             config_path: String::new(),
             output: Box::new(StdOutput::new()),
             input: Box::new(StdInput::new()),
+            ignore_ssl: false,
         };
         config.config_path = match home_dir() {
             Some(path) => path
@@ -67,6 +73,11 @@ impl ContextBuilder {
     #[allow(dead_code)]
     pub(crate) fn input(mut self, input: Box<dyn Input>) -> Self {
         self.config.input = input;
+        self
+    }
+
+    pub(crate) fn ignore_ssl(mut self, ignore_ssl: bool) -> Self {
+        self.config.ignore_ssl = ignore_ssl;
         self
     }
 

--- a/reduct_cli/src/io/reduct.rs
+++ b/reduct_cli/src/io/reduct.rs
@@ -31,6 +31,7 @@ pub(crate) async fn build_client(
     let client = ReductClient::builder()
         .url(url.as_str())
         .api_token(token.as_str())
+        .verify_ssl(!ctx.ignore_ssl())
         .try_build()?;
 
     let status = client.server_info().await?;

--- a/reduct_cli/src/main.rs
+++ b/reduct_cli/src/main.rs
@@ -16,7 +16,7 @@ use crate::context::ContextBuilder;
 use crate::cmd::bucket::{bucket_cmd, bucket_handler};
 use crate::cmd::server::{server_cmd, server_handler};
 use crate::cmd::token::{token_cmd, token_handler};
-use clap::ArgAction::{SetFalse, SetTrue};
+use clap::ArgAction::SetTrue;
 use clap::{crate_description, crate_name, crate_version, Arg, Command};
 
 fn cli() -> Command {

--- a/reduct_cli/src/main.rs
+++ b/reduct_cli/src/main.rs
@@ -16,13 +16,23 @@ use crate::context::ContextBuilder;
 use crate::cmd::bucket::{bucket_cmd, bucket_handler};
 use crate::cmd::server::{server_cmd, server_handler};
 use crate::cmd::token::{token_cmd, token_handler};
-use clap::{crate_description, crate_name, crate_version, Command};
+use clap::ArgAction::{SetFalse, SetTrue};
+use clap::{crate_description, crate_name, crate_version, Arg, Command};
 
 fn cli() -> Command {
     Command::new(crate_name!())
         .version(crate_version!())
         .arg_required_else_help(true)
         .about(crate_description!())
+        .arg(
+            Arg::new("ignore-ssl")
+                .long("ignore-ssl")
+                .short('i')
+                .help("Ignore SSL certificate verification")
+                .required(false)
+                .action(SetFalse)
+                .global(true),
+        )
         .subcommand(alias_cmd())
         .subcommand(server_cmd())
         .subcommand(bucket_cmd())

--- a/reduct_cli/src/main.rs
+++ b/reduct_cli/src/main.rs
@@ -30,7 +30,7 @@ fn cli() -> Command {
                 .short('i')
                 .help("Ignore SSL certificate verification")
                 .required(false)
-                .action(SetFalse)
+                .action(SetTrue)
                 .global(true),
         )
         .subcommand(alias_cmd())
@@ -41,8 +41,11 @@ fn cli() -> Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let ctx = ContextBuilder::new().build();
     let matches = cli().get_matches();
+    let ctx = ContextBuilder::new()
+        .ignore_ssl(matches.get_flag("ignore-ssl"))
+        .build();
+
     match matches.subcommand() {
         Some(("alias", args)) => alias_handler(&ctx, args.subcommand()),
         Some(("server", args)) => server_handler(&ctx, args.subcommand()).await,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

I've added the global `--ignore-ssl` to ignore SSL issues. It's needed for self-signed certificates. 

### Does this PR introduce a breaking change?

No

### Other information:
