### PR TITLE
RS-233: fix wrong order of timestamps in batched write request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.4] - 2024-03-22
+
+- RS-233: fix wrong order of timestamps in batched write request, [PR-421](https://github.com/reductstore/reductstore/pull/421)
+
 ## [1.9.3] - 2024-03-16
 
 ### Fixed
 
-- RS-221: Fix body draining in write a record and batch edpoints, [PR-418](https://github.com/reductstore/reductstore/pull/418)
+- RS-221: fix body draining in write a record and batch edpoints, [PR-418](https://github.com/reductstore/reductstore/pull/418)
 
 ## [1.9.2] - 2024-03-15
 
 ### Fixed
 
-- RS-218: Fix block migration, [PR-416](https://github.com/reductstore/reductstore/pull/416)
+- RS-218: fix block migration, [PR-416](https://github.com/reductstore/reductstore/pull/416)
 
 ## [1.9.1] - 2024-03-09
 


### PR DESCRIPTION
Closes #419 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The API layer sorted the timestamp headers as strings, so the timestamps [1, 2, 10] were ordered as [1, 10, 2]. I've parsed the them as integers before the sorting.

### Related issues

#419, reductstore/reduct-rs#5

### Does this PR introduce a breaking change?

No

### Other information:
