### PR TITLE
RS-239: Override errored records if they have the same size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- RS-239: Override errored records if they have the same size, [PR-428](https://github.com/reductstore/reductstore/pull/428)
 
 ## [1.9.4] - 2024-03-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,13 +1703,12 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd48afb3ef32fa64464ea40251be274b05f43bec366fa3bf30f35b92cae31fe0"
+version = "1.9.4"
 dependencies = [
  "chrono",
  "http 1.1.0",
  "int-enum",
+ "rstest",
  "serde",
  "serde_json",
  "url",
@@ -1718,11 +1717,12 @@ dependencies = [
 [[package]]
 name = "reduct-base"
 version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef7bce6118a32caea83f08d762d13d958bfa41dad310a4c64e99c1ce9215f51d"
 dependencies = [
  "chrono",
  "http 1.1.0",
  "int-enum",
- "rstest",
  "serde",
  "serde_json",
  "url",
@@ -1760,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "reduct-rs"
-version = "1.9.2"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a056038572689131de8b571a29dea6fa3478a0d2995f4aea6f668466300d885a"
+checksum = "104a9c4002ed78139aa06837a107b77fc036b7d573e5c75c63a0638872a096f8"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1771,7 +1771,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http 1.1.0",
- "reduct-base 1.9.0",
+ "reduct-base 1.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
  "rustls",
  "serde",

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -19,6 +19,7 @@ use reduct_base::Labels;
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::io::Write;
+use std::ops::Index;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -33,6 +34,13 @@ pub struct Entry {
     record_count: u64,
     size: u64,
     queries: HashMap<u64, Box<dyn Query + Send + Sync>>,
+}
+
+#[derive(PartialEq)]
+enum RecordType {
+    Latest,
+    Belated,
+    BelatedFirst,
 }
 
 /// EntryOptions is the options for creating a new entry.
@@ -165,13 +173,6 @@ impl Entry {
         content_type: String,
         labels: Labels,
     ) -> Result<RecordTx, ReductError> {
-        #[derive(PartialEq)]
-        enum RecordType {
-            Latest,
-            Belated,
-            BelatedFirst,
-        }
-
         // When we write, the likely case is that we are writing the latest record
         // in the entry. In this case, we can just append to the latest block.
         let block = if self.block_index.is_empty() {
@@ -193,19 +194,46 @@ impl Entry {
                 (self.start_new_block(time).await?, RecordType::BelatedFirst)
             } else {
                 let block_id = find_first_block(&self.block_index, &time);
-                let bm = self.block_manager.read().await;
-                let block = bm.load(block_id)?;
+                let mut block = async {
+                    let bm = self.block_manager.read().await;
+                    bm.load(block_id)
+                }
+                .await?;
+
                 // check if the record already exists
                 let proto_time = Some(us_to_ts(&time));
-                if block
+                if let Some(record) = block
                     .records
-                    .iter()
-                    .any(|record| record.timestamp == proto_time)
+                    .iter_mut()
+                    .filter(|record| record.timestamp == proto_time)
+                    .last()
                 {
-                    return Err(ReductError::conflict(&format!(
-                        "A record with timestamp {} already exists",
-                        time
-                    )));
+                    // We overwrite the record if it is errored and the size is the same.
+                    return if record.state != record::State::Errored as i32
+                        || record.end - record.begin != content_size as u64
+                    {
+                        Err(ReductError::conflict(&format!(
+                            "A record with timestamp {} already exists",
+                            time
+                        )))
+                    } else {
+                        record.labels = labels
+                            .into_iter()
+                            .map(|(name, value)| record::Label { name, value })
+                            .collect();
+                        record.state = record::State::Started as i32;
+                        record.content_type = content_type;
+
+                        let record_index = block
+                            .records
+                            .iter()
+                            .position(|r| r.timestamp == proto_time)
+                            .unwrap();
+                        let tx =
+                            spawn_write_task(Arc::clone(&self.block_manager), block, record_index)
+                                .await?;
+                        Ok(tx)
+                    };
                 }
                 (block, RecordType::Belated)
             }
@@ -214,7 +242,24 @@ impl Entry {
             (block, RecordType::Latest)
         };
 
-        let content_size = content_size;
+        let block = self
+            .prepare_block_for_writing(time, content_size, content_type, labels, block, record_type)
+            .await?;
+        let record_index = block.records.len() - 1;
+
+        let tx = spawn_write_task(Arc::clone(&self.block_manager), block, record_index).await?;
+        Ok(tx)
+    }
+
+    async fn prepare_block_for_writing(
+        &mut self,
+        time: u64,
+        content_size: usize,
+        content_type: String,
+        labels: Labels,
+        block: Block,
+        record_type: RecordType,
+    ) -> Result<Block, ReductError> {
         let has_no_space = block.size + content_size as u64 > self.settings.max_block_size;
         let has_too_many_records =
             block.records.len() + 1 > self.settings.max_block_records as usize;
@@ -261,10 +306,7 @@ impl Entry {
         if record_type != RecordType::Belated {
             block.latest_record_time = Some(us_to_ts(&time));
         }
-
-        let record_index = block.records.len() - 1;
-        let tx = spawn_write_task(Arc::clone(&self.block_manager), block, record_index).await?;
-        Ok(tx)
+        Ok(block)
     }
 
     /// Starts a new record read.
@@ -483,9 +525,9 @@ mod tests {
     use std::fs::File;
 
     use rstest::{fixture, rstest};
-    use std::thread::sleep;
     use std::time::Duration;
     use tempfile;
+    use tokio::time::sleep;
 
     #[rstest]
     #[tokio::test]
@@ -664,6 +706,73 @@ mod tests {
         let err = write_stub_record(&mut entry, 1000000).await;
         assert_eq!(
             err.err(),
+            Some(ReductError::conflict(
+                "A record with timestamp 1000000 already exists"
+            ))
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_begin_override_errored(mut entry: Entry) {
+        let sender = entry
+            .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
+            .await
+            .unwrap();
+
+        sender.send(Ok(None)).await.unwrap();
+        sender.closed().await;
+
+        let sender = entry
+            .begin_write(
+                1000000,
+                10,
+                "text/html".to_string(),
+                Labels::from_iter(vec![("a".to_string(), "b".to_string())]),
+            )
+            .await
+            .unwrap();
+        sender
+            .send(Ok(Some(Bytes::from(vec![0; 10]))))
+            .await
+            .unwrap();
+
+        let record = entry
+            .block_manager
+            .read()
+            .await
+            .load(1000000)
+            .unwrap()
+            .records[0]
+            .clone();
+        assert_eq!(record.content_type, "text/html");
+        assert_eq!(record.labels.len(), 1);
+        assert_eq!(record.labels[0].name, "a");
+        assert_eq!(record.labels[0].value, "b");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_begin_not_override_if_different_size(mut entry: Entry) {
+        let sender = entry
+            .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
+            .await
+            .unwrap();
+
+        sender.send(Ok(None)).await.unwrap();
+        sender.closed().await;
+
+        let err = entry
+            .begin_write(
+                1000000,
+                5,
+                "text/html".to_string(),
+                Labels::from_iter(vec![("a".to_string(), "b".to_string())]),
+            )
+            .await
+            .err();
+        assert_eq!(
+            err,
             Some(ReductError::conflict(
                 "A record with timestamp 1000000 already exists"
             ))
@@ -850,7 +959,7 @@ mod tests {
             assert_eq!(reader.timestamp(), 2000000);
         }
 
-        sleep(Duration::from_millis(600));
+        sleep(Duration::from_millis(600)).await;
         assert_eq!(
             entry.next(id).await.err(),
             Some(ReductError::not_found(&format!("Query {} not found and it might have expired. Check TTL in your query request. Default value 60 sec.", id)))


### PR DESCRIPTION
Closes #422

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Change

### What was changed?

We need to replicate records after communication error. Now,  we check during a write operation if the existing record is errored and has the same size. If it is true then overwrite the record.

### Related issues

#422 

### Does this PR introduce a breaking change?

No

### Other information:
