### PR TITLE
RS-261:  Add `eacn_n` and `each_s` query options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "chrono",
  "http",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "quote",
  "syn 2.0.60",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.9.5"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.9.5"
+version = "1.10.0"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -286,6 +286,34 @@ def test_query_limit(base_url, session, bucket):
     assert resp.status_code == 204
 
 
+def test_query_each_n(base_url, session, bucket):
+    """Should return each 2d record"""
+    ts = 1000
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
+    assert resp.status_code == 200
+
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 1000}", data="some_data")
+    assert resp.status_code == 200
+
+    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 2000}", data="some_data")
+    assert resp.status_code == 200
+
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?each_n=2")
+    assert resp.status_code == 200
+
+    query_id = int(json.loads(resp.content)["id"])
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
+    assert resp.status_code == 200
+    assert resp.headers["x-reduct-time"] == "1000"
+
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
+    assert resp.status_code == 200
+    assert resp.headers["x-reduct-time"] == "3000"
+
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
+    assert resp.status_code == 204
+
+
 def test_query_with_include_and_exclude(base_url, session, bucket):
     """Should handle include and exclude labels"""
     resp = session.post(

--- a/api_tests/entry_api_test.py
+++ b/api_tests/entry_api_test.py
@@ -266,14 +266,25 @@ def test_query_ttl(base_url, session, bucket):
     assert resp.status_code == 404
 
 
-def test_query_limit(base_url, session, bucket):
-    """Should limit number of records returned"""
+def _make_bucket_with_records(base_url, session, bucket_name):
     ts = 1000
-    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
+    resp = session.post(f"{base_url}/b/{bucket_name}/entry?ts={ts}", data="some_data")
     assert resp.status_code == 200
 
-    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 1000}", data="some_data")
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/entry?ts={ts + 1000}", data="some_data"
+    )
     assert resp.status_code == 200
+
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/entry?ts={ts + 2000}", data="some_data"
+    )
+    assert resp.status_code == 200
+
+
+def test_query_limit(base_url, session, bucket):
+    """Should limit number of records returned"""
+    _make_bucket_with_records(base_url, session, bucket)
 
     resp = session.get(f"{base_url}/b/{bucket}/entry/q?limit=1")
     assert resp.status_code == 200
@@ -288,17 +299,28 @@ def test_query_limit(base_url, session, bucket):
 
 def test_query_each_n(base_url, session, bucket):
     """Should return each 2d record"""
-    ts = 1000
-    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts}", data="some_data")
-    assert resp.status_code == 200
-
-    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 1000}", data="some_data")
-    assert resp.status_code == 200
-
-    resp = session.post(f"{base_url}/b/{bucket}/entry?ts={ts + 2000}", data="some_data")
-    assert resp.status_code == 200
+    _make_bucket_with_records(base_url, session, bucket)
 
     resp = session.get(f"{base_url}/b/{bucket}/entry/q?each_n=2")
+    assert resp.status_code == 200
+
+    query_id = int(json.loads(resp.content)["id"])
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
+    assert resp.status_code == 200
+    assert resp.headers["x-reduct-time"] == "1000"
+
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
+    assert resp.status_code == 200
+    assert resp.headers["x-reduct-time"] == "3000"
+
+    resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
+    assert resp.status_code == 204
+
+
+def test_query_each_s(base_url, session, bucket):
+    """Should return a record each 2ms"""
+    _make_bucket_with_records(base_url, session, bucket)
+    resp = session.get(f"{base_url}/b/{bucket}/entry/q?each_s=0.002")
     assert resp.status_code == 200
 
     query_id = int(json.loads(resp.content)["id"])

--- a/api_tests/http_test.py
+++ b/api_tests/http_test.py
@@ -6,4 +6,4 @@ def test_api_version(base_url, session):
     resp = session.get(f"{base_url}/info")
 
     assert resp.status_code == 200
-    assert resp.headers["x-reduct-api"] == "1.9"
+    assert resp.headers["x-reduct-api"] == "1.10"

--- a/api_tests/server_api_test.py
+++ b/api_tests/server_api_test.py
@@ -10,7 +10,7 @@ def test__get_info(base_url, session):
 
     assert resp.status_code == 200
     data = json.loads(resp.content)
-    assert data["version"] >= "1.5.0"
+    assert data["version"] >= "1.10.0"
     assert int(data["bucket_count"]) > 0
     assert int(data["uptime"]) >= 0
     assert int(data["latest_record"]) >= 0

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -112,6 +112,7 @@ pub(crate) async fn query(
             include,
             exclude,
             ttl: Duration::from_secs(ttl),
+            each_n: None,
             limit,
         },
     )?;

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -10,7 +10,7 @@ use crate::storage::query::base::QueryOptions;
 use axum::extract::{Path, Query, State};
 use axum_extra::headers::HeaderMap;
 use reduct_base::error::ErrorCode;
-use reduct_base::msg::entry_api::QueryInfo;
+use reduct_base::msg::entry_api::{EntryInfo, QueryInfo};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -40,6 +40,116 @@ pub(crate) async fn query(
         bucket.get_entry(entry_name)?.info().await?
     };
 
+    // system parameters
+    let continuous = parse_continuous_flag(&params)?;
+    let ttl = parse_ttl(&params)?;
+
+    // filter parameters in order of priority
+    let (start, stop) = parse_time_range(&params, entry_info)?;
+    let (include, exclude) = parse_include_exclude_filters(&params);
+    let each_n = parse_each_n(&params)?;
+    let limit = parse_limit(params)?;
+
+    let mut storage = components.storage.write().await;
+    let bucket = storage.get_mut_bucket(bucket_name)?;
+    let entry = bucket.get_or_create_entry(entry_name)?;
+    let id = entry.query(
+        start,
+        stop,
+        QueryOptions {
+            continuous,
+            include,
+            exclude,
+            ttl,
+            each_n,
+            limit,
+        },
+    )?;
+
+    Ok(QueryInfoAxum::from(QueryInfo { id }))
+}
+
+fn parse_ttl(params: &HashMap<String, String>) -> Result<Duration, HttpError> {
+    let ttl = match params.get("ttl") {
+        Some(ttl) => ttl.parse::<u64>().map_err(|_| {
+            HttpError::new(
+                ErrorCode::UnprocessableEntity,
+                "'ttl' must be in seconds as an unsigned integer",
+            )
+        })?,
+        None => QueryOptions::default().ttl.as_secs(),
+    };
+    Ok(Duration::from_secs(ttl))
+}
+
+fn parse_continuous_flag(params: &HashMap<String, String>) -> Result<bool, HttpError> {
+    let continuous = match params.get("continuous") {
+        Some(continue_) => continue_.parse::<bool>().map_err(|_| {
+            HttpError::new(
+                ErrorCode::UnprocessableEntity,
+                "'continue' must be a bool value",
+            )
+        })?,
+        None => false,
+    };
+    Ok(continuous)
+}
+
+fn parse_limit(params: HashMap<String, String>) -> Result<Option<usize>, HttpError> {
+    let limit = match params.get("limit") {
+        Some(limit) => Some(limit.parse::<usize>().map_err(|_| {
+            HttpError::new(
+                ErrorCode::UnprocessableEntity,
+                "'limit' must unsigned integer",
+            )
+        })?),
+        None => None,
+    };
+    Ok(limit)
+}
+
+fn parse_each_n(params: &HashMap<String, String>) -> Result<Option<usize>, HttpError> {
+    let each_n = match params.get("each_n") {
+        Some(each_n) => {
+            let value = each_n.parse::<usize>().map_err(|_| {
+                HttpError::new(
+                    ErrorCode::UnprocessableEntity,
+                    "'each_n' must unsigned integer",
+                )
+            })?;
+            if value == 0 {
+                return Err(HttpError::new(
+                    ErrorCode::UnprocessableEntity,
+                    "'each_n' must be greater than 0",
+                ));
+            }
+            Some(value)
+        }
+        None => None,
+    };
+    Ok(each_n)
+}
+
+fn parse_include_exclude_filters(
+    params: &HashMap<String, String>,
+) -> (HashMap<String, String>, HashMap<String, String>) {
+    let mut include = HashMap::new();
+    let mut exclude = HashMap::new();
+
+    for (k, v) in params.iter() {
+        if k.starts_with("include-") {
+            include.insert(k[8..].to_string(), v.to_string());
+        } else if k.starts_with("exclude-") {
+            exclude.insert(k[8..].to_string(), v.to_string());
+        }
+    }
+    (include, exclude)
+}
+
+fn parse_time_range(
+    params: &HashMap<String, String>,
+    entry_info: EntryInfo,
+) -> Result<(u64, u64), HttpError> {
     let start = match params.get("start") {
         Some(start) => start.parse::<u64>().map_err(|_| {
             HttpError::new(
@@ -60,64 +170,13 @@ pub(crate) async fn query(
         None => entry_info.latest_record + 1,
     };
 
-    let continuous = match params.get("continuous") {
-        Some(continue_) => continue_.parse::<bool>().map_err(|_| {
-            HttpError::new(
-                ErrorCode::UnprocessableEntity,
-                "'continue' must be an unix timestamp in microseconds",
-            )
-        })?,
-        None => false,
-    };
-
-    let ttl = match params.get("ttl") {
-        Some(ttl) => ttl.parse::<u64>().map_err(|_| {
-            HttpError::new(
-                ErrorCode::UnprocessableEntity,
-                "'ttl' must be an unix timestamp in microseconds",
-            )
-        })?,
-        None => 5,
-    };
-
-    let limit = match params.get("limit") {
-        Some(limit) => Some(limit.parse::<usize>().map_err(|_| {
-            HttpError::new(
-                ErrorCode::UnprocessableEntity,
-                "'limit' must unsigned integer",
-            )
-        })?),
-        None => None,
-    };
-
-    let mut include = HashMap::new();
-    let mut exclude = HashMap::new();
-
-    for (k, v) in params.iter() {
-        if k.starts_with("include-") {
-            include.insert(k[8..].to_string(), v.to_string());
-        } else if k.starts_with("exclude-") {
-            exclude.insert(k[8..].to_string(), v.to_string());
-        }
+    if start > stop {
+        return Err(HttpError::new(
+            ErrorCode::UnprocessableEntity,
+            "Start time must be before stop time",
+        ));
     }
-
-    let mut storage = components.storage.write().await;
-    let bucket = storage.get_mut_bucket(bucket_name)?;
-    let entry = bucket.get_or_create_entry(entry_name)?;
-    let id = entry.query(
-        start,
-        stop,
-        QueryOptions {
-            continuous,
-            include,
-            exclude,
-            ttl: Duration::from_secs(ttl),
-            each_n: None,
-            limit,
-        },
-    )?;
-
-    Ok(QueryInfoAxum::from(QueryInfo { id }))
+    Ok((start, stop))
 }
 
 #[cfg(test)]
@@ -125,6 +184,226 @@ mod tests {
     use super::*;
     use crate::api::tests::{components, headers, path_to_entry_1};
     use rstest::*;
+
+    mod parse_ttl {
+        use super::*;
+
+        #[rstest]
+        fn test_ok() {
+            let params = HashMap::from_iter(vec![("ttl".to_string(), "10".to_string())]);
+            let ttl = parse_ttl(&params).unwrap();
+            assert_eq!(ttl, Duration::from_secs(10));
+        }
+
+        #[rstest]
+        fn test_default() {
+            let params = HashMap::new();
+            let ttl = parse_ttl(&params).unwrap();
+            assert_eq!(ttl, Duration::from_secs(60));
+        }
+
+        #[rstest]
+        fn test_bad() {
+            let params = HashMap::from_iter(vec![("ttl".to_string(), "a".to_string())]);
+            let result = parse_ttl(&params);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] 'ttl' must be in seconds as an unsigned integer"
+            );
+        }
+    }
+
+    mod parse_continuous_flag {
+        use super::*;
+
+        #[rstest]
+        fn test_ok() {
+            let params = HashMap::from_iter(vec![("continuous".to_string(), "true".to_string())]);
+            let continuous = parse_continuous_flag(&params).unwrap();
+            assert_eq!(continuous, true);
+        }
+
+        #[rstest]
+        fn test_default() {
+            let params = HashMap::new();
+            let continuous = parse_continuous_flag(&params).unwrap();
+            assert_eq!(continuous, false);
+        }
+
+        #[rstest]
+        fn test_bad() {
+            let params = HashMap::from_iter(vec![("continuous".to_string(), "a".to_string())]);
+            let result = parse_continuous_flag(&params);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] 'continue' must be a bool value"
+            );
+        }
+    }
+
+    mod parse_time_range {
+        use super::*;
+
+        #[rstest]
+        fn test_ok() {
+            let params = HashMap::from_iter(vec![
+                ("start".to_string(), "0".to_string()),
+                ("stop".to_string(), "10".to_string()),
+            ]);
+            let entry_info = EntryInfo {
+                oldest_record: 0,
+                latest_record: 10,
+                ..EntryInfo::default()
+            };
+            let (start, stop) = parse_time_range(&params, entry_info).unwrap();
+            assert_eq!(start, 0);
+            assert_eq!(stop, 10);
+        }
+
+        #[rstest]
+        fn test_default() {
+            let params = HashMap::new();
+            let entry_info = EntryInfo {
+                oldest_record: 0,
+                latest_record: 10,
+                ..EntryInfo::default()
+            };
+            let (start, stop) = parse_time_range(&params, entry_info).unwrap();
+            assert_eq!(start, 0);
+            assert_eq!(stop, 11);
+        }
+
+        #[rstest]
+        fn test_start_bad() {
+            let params = HashMap::from_iter(vec![("start".to_string(), "a".to_string())]);
+            let entry_info = EntryInfo::default();
+            let result = parse_time_range(&params, entry_info);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] 'start' must be an unix timestamp in microseconds"
+            );
+        }
+
+        #[rstest]
+        fn test_stop_bad() {
+            let params = HashMap::from_iter(vec![("stop".to_string(), "a".to_string())]);
+            let entry_info = EntryInfo::default();
+            let result = parse_time_range(&params, entry_info);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] 'stop' must be an unix timestamp in microseconds"
+            );
+        }
+
+        #[rstest]
+        fn test_start_after_stop() {
+            let params = HashMap::from_iter(vec![
+                ("start".to_string(), "10".to_string()),
+                ("stop".to_string(), "5".to_string()),
+            ]);
+            let entry_info = EntryInfo::default();
+            let result = parse_time_range(&params, entry_info);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] Start time must be before stop time"
+            );
+        }
+    }
+
+    mod parse_include_exclude_filters {
+        use super::*;
+
+        #[rstest]
+        fn test_ok() {
+            let params = HashMap::from_iter(vec![
+                ("include-key".to_string(), "value".to_string()),
+                ("exclude-key".to_string(), "value".to_string()),
+            ]);
+            let (include, exclude) = parse_include_exclude_filters(&params);
+            assert_eq!(
+                include,
+                HashMap::from_iter(vec![("key".to_string(), "value".to_string())])
+            );
+            assert_eq!(
+                exclude,
+                HashMap::from_iter(vec![("key".to_string(), "value".to_string())])
+            );
+        }
+
+        #[rstest]
+        fn test_no_filters() {
+            let params = HashMap::new();
+            let (include, exclude) = parse_include_exclude_filters(&params);
+            assert_eq!(include, HashMap::new());
+            assert_eq!(exclude, HashMap::new());
+        }
+    }
+
+    mod parse_each_n {
+        use super::*;
+
+        #[rstest]
+        fn test_ok() {
+            let params = HashMap::from_iter(vec![("each_n".to_string(), "1".to_string())]);
+            let each_n = parse_each_n(&params).unwrap();
+            assert_eq!(each_n, Some(1));
+        }
+
+        #[rstest]
+        fn test_default() {
+            let params = HashMap::new();
+            let each_n = parse_each_n(&params).unwrap();
+            assert_eq!(each_n, None);
+        }
+
+        #[rstest]
+        fn test_bad() {
+            let params = HashMap::from_iter(vec![("each_n".to_string(), "a".to_string())]);
+            let result = parse_each_n(&params);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] 'each_n' must unsigned integer"
+            );
+        }
+
+        #[rstest]
+        fn test_zero() {
+            let params = HashMap::from_iter(vec![("each_n".to_string(), "0".to_string())]);
+            let result = parse_each_n(&params);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] 'each_n' must be greater than 0"
+            );
+        }
+    }
+
+    mod parse_limit {
+        use super::*;
+
+        #[rstest]
+        fn test_ok() {
+            let params = HashMap::from_iter(vec![("limit".to_string(), "1".to_string())]);
+            let limit = parse_limit(params).unwrap();
+            assert_eq!(limit, Some(1));
+        }
+
+        #[rstest]
+        fn test_default() {
+            let params = HashMap::new();
+            let limit = parse_limit(params).unwrap();
+            assert_eq!(limit, None);
+        }
+
+        #[rstest]
+        fn test_bad() {
+            let params = HashMap::from_iter(vec![("limit".to_string(), "a".to_string())]);
+            let result = parse_limit(params);
+            assert_eq!(
+                result.err().unwrap().0.to_string(),
+                "[UnprocessableEntity] 'limit' must unsigned integer"
+            );
+        }
+    }
 
     #[rstest]
     #[tokio::test]
@@ -160,31 +439,6 @@ mod tests {
         assert_eq!(
             entry.next(query.id).await.err().unwrap().status,
             ErrorCode::NoContent
-        );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_bad_limit(
-        #[future] components: Arc<Components>,
-        path_to_entry_1: Path<HashMap<String, String>>,
-        headers: HeaderMap,
-    ) {
-        let components = components.await;
-        let mut params = HashMap::new();
-        params.insert("limit".to_string(), "a".to_string());
-
-        let result = query(
-            State(Arc::clone(&components)),
-            path_to_entry_1,
-            Query(params),
-            headers,
-        )
-        .await;
-
-        assert_eq!(
-            result.err().unwrap().0.status,
-            ErrorCode::UnprocessableEntity
         );
     }
 }

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -3,6 +3,7 @@
 
 pub mod base;
 mod continuous;
+mod filters;
 mod historical;
 mod limited;
 

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 ReductStore
+// Copyright 2023-2024 ReductStore
 // Licensed under the Business Source License 1.1
 
 use crate::storage::block_manager::BlockManager;
@@ -67,6 +67,8 @@ pub struct QueryOptions {
     pub continuous: bool,
     /// The maximum number of records to return only for non-continuous queries.
     pub limit: Option<usize>,
+    // /// Return each N records
+    // pub each_n: Option<usize>,
 }
 
 impl Default for QueryOptions {

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -25,7 +25,6 @@ pub enum QueryState {
 }
 
 /// Query is used to iterate over the records among multiple blocks.
-
 #[async_trait]
 pub trait Query {
     ///  Get next record
@@ -69,6 +68,8 @@ pub struct QueryOptions {
     pub limit: Option<usize>,
     /// Return each N records
     pub each_n: Option<usize>,
+    /// Return a record every S seconds
+    pub each_s: Option<f64>,
 }
 
 impl Default for QueryOptions {
@@ -80,6 +81,7 @@ impl Default for QueryOptions {
             continuous: false,
             limit: None,
             each_n: None,
+            each_s: None,
         }
     }
 }

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -67,8 +67,8 @@ pub struct QueryOptions {
     pub continuous: bool,
     /// The maximum number of records to return only for non-continuous queries.
     pub limit: Option<usize>,
-    // /// Return each N records
-    // pub each_n: Option<usize>,
+    /// Return each N records
+    pub each_n: Option<usize>,
 }
 
 impl Default for QueryOptions {
@@ -79,6 +79,7 @@ impl Default for QueryOptions {
             exclude: HashMap::new(),
             continuous: false,
             limit: None,
+            each_n: None,
         }
     }
 }

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -9,6 +9,7 @@ mod time_range;
 
 use crate::storage::proto::Record;
 
+/// Trait for record filters in queries.
 pub(super) trait RecordFilter {
     /// Filter the record by condition.
     fn filter(&mut self, record: &Record) -> bool;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -1,0 +1,25 @@
+// Copyright 2023-2024 ReductStore
+// Licensed under the Business Source License 1.1
+
+mod each_n;
+mod exclude;
+mod include;
+mod record_state;
+mod time_range;
+
+use crate::storage::proto::Record;
+
+pub(super) trait RecordFilter {
+    /// Filter the record by condition.
+    fn filter(&self, record: &Record) -> bool;
+
+    /// Notify the filter that a record has been sent.
+    /// This is used to update the filter state.
+    fn last_sent(&mut self, record: &Record) -> ();
+}
+
+pub(super) use each_n::EachNFilter;
+pub(super) use exclude::ExcludeLabelFilter;
+pub(super) use include::IncludeLabelFilter;
+pub(super) use record_state::RecordStateFilter;
+pub(super) use time_range::TimeRangeFilter;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -15,6 +15,7 @@ pub(super) trait RecordFilter {
     fn filter(&mut self, record: &Record) -> bool;
 }
 
+pub(super) use each_n::EachNFilter;
 pub(super) use exclude::ExcludeLabelFilter;
 pub(super) use include::IncludeLabelFilter;
 pub(super) use record_state::RecordStateFilter;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -15,7 +15,6 @@ pub(super) trait RecordFilter {
     fn filter(&mut self, record: &Record) -> bool;
 }
 
-pub(super) use each_n::EachNFilter;
 pub(super) use exclude::ExcludeLabelFilter;
 pub(super) use include::IncludeLabelFilter;
 pub(super) use record_state::RecordStateFilter;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -2,6 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 mod each_n;
+mod each_s;
 mod exclude;
 mod include;
 mod record_state;
@@ -16,6 +17,7 @@ pub(super) trait RecordFilter {
 }
 
 pub(super) use each_n::EachNFilter;
+pub(super) use each_s::EachSecondFilter;
 pub(super) use exclude::ExcludeLabelFilter;
 pub(super) use include::IncludeLabelFilter;
 pub(super) use record_state::RecordStateFilter;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -11,11 +11,7 @@ use crate::storage::proto::Record;
 
 pub(super) trait RecordFilter {
     /// Filter the record by condition.
-    fn filter(&self, record: &Record) -> bool;
-
-    /// Notify the filter that a record has been sent.
-    /// This is used to update the filter state.
-    fn last_sent(&mut self, record: &Record) -> ();
+    fn filter(&mut self, record: &Record) -> bool;
 }
 
 pub(super) use each_n::EachNFilter;

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -1,0 +1,26 @@
+// Copyright 2023-2024 ReductStore
+// Licensed under the Business Source License 1.1
+
+use crate::storage::proto::Record;
+use crate::storage::query::filters::RecordFilter;
+
+pub struct EachNFilter {
+    n: usize,
+    count: usize,
+}
+
+impl EachNFilter {
+    pub fn new(n: usize) -> EachNFilter {
+        EachNFilter { n, count: 0 }
+    }
+}
+
+impl RecordFilter for EachNFilter {
+    fn filter(&self, _: &Record) -> bool {
+        self.count % self.n == 0
+    }
+
+    fn last_sent(&mut self, _: &Record) -> () {
+        self.count += 1;
+    }
+}

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -4,6 +4,7 @@
 use crate::storage::proto::Record;
 use crate::storage::query::filters::RecordFilter;
 
+/// Filter that passes every N-th record
 pub struct EachNFilter {
     n: usize,
     count: usize,

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -12,6 +12,9 @@ pub struct EachNFilter {
 
 impl EachNFilter {
     pub fn new(n: usize) -> EachNFilter {
+        if n == 0 {
+            panic!("N must be greater than 0");
+        }
         EachNFilter { n, count: 0 }
     }
 }

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -22,3 +22,21 @@ impl RecordFilter for EachNFilter {
         ret
     }
 }
+
+#[cfg(test)]
+
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    fn test_each_n_filter() {
+        let mut filter = EachNFilter::new(2);
+        let record = Record::default();
+
+        assert!(filter.filter(&record), "First time should pass");
+        assert!(!filter.filter(&record), "Second time should not pass");
+        assert!(filter.filter(&record), "Third time should pass");
+        assert!(!filter.filter(&record), "Fourth time should not pass");
+    }
+}

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -16,11 +16,9 @@ impl EachNFilter {
 }
 
 impl RecordFilter for EachNFilter {
-    fn filter(&self, _: &Record) -> bool {
-        self.count % self.n == 0
-    }
-
-    fn last_sent(&mut self, _: &Record) -> () {
+    fn filter(&mut self, _: &Record) -> bool {
+        let ret = self.count % self.n == 0;
         self.count += 1;
+        ret
     }
 }

--- a/reductstore/src/storage/query/filters/each_s.rs
+++ b/reductstore/src/storage/query/filters/each_s.rs
@@ -1,0 +1,71 @@
+// Copyright 2023-2024 ReductStore
+// Licensed under the Business Source License 1.1
+
+use crate::storage::proto::{ts_to_us, Record};
+use crate::storage::query::filters::RecordFilter;
+use prost_wkt_types::Timestamp;
+
+/// Filter that passes every N-th record
+pub struct EachSecondFilter {
+    s: f64,
+    last_time: i64,
+}
+
+impl EachSecondFilter {
+    pub fn new(s: f64) -> EachSecondFilter {
+        if s <= 0.0 {
+            panic!("Time must be greater than 0 seconds");
+        }
+        EachSecondFilter {
+            s,
+            last_time: -(s * 1_000_000.0) as i64, // take the first record
+        }
+    }
+}
+
+impl RecordFilter for EachSecondFilter {
+    fn filter(&mut self, record: &Record) -> bool {
+        let ts = ts_to_us(record.timestamp.as_ref().unwrap()) as i64;
+        let ret = ts - self.last_time >= (self.s * 1_000_000.0) as i64;
+        if ret {
+            self.last_time = ts;
+        }
+
+        ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost_wkt_types::Timestamp;
+    use rstest::*;
+
+    #[rstest]
+    fn test_each_s_filter() {
+        let mut filter = EachSecondFilter::new(2.0);
+        let mut record = Record::default();
+        record.timestamp = Some(Timestamp {
+            seconds: 1,
+            nanos: 0,
+        });
+
+        assert!(filter.filter(&record));
+        assert!(!filter.filter(&record));
+
+        record.timestamp = Some(Timestamp {
+            seconds: 2,
+            nanos: 0,
+        });
+
+        assert!(!filter.filter(&record));
+
+        record.timestamp = Some(Timestamp {
+            seconds: 3,
+            nanos: 0,
+        });
+
+        assert!(filter.filter(&record));
+        assert!(!filter.filter(&record));
+    }
+}

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -6,11 +6,21 @@ use reduct_base::Labels;
 use crate::storage::proto::Record;
 use crate::storage::query::filters::RecordFilter;
 
+/// Filter that excludes records with specific labels
 pub struct ExcludeLabelFilter {
     labels: Labels,
 }
 
 impl ExcludeLabelFilter {
+    /// Create a new filter that excludes records with the specified labels
+    ///
+    /// # Arguments
+    ///
+    /// * `labels` - The labels to exclude
+    ///
+    /// # Returns
+    ///
+    /// A new `ExcludeLabelFilter` instance
     pub fn new(labels: Labels) -> ExcludeLabelFilter {
         ExcludeLabelFilter { labels }
     }

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -17,16 +17,12 @@ impl ExcludeLabelFilter {
 }
 
 impl RecordFilter for ExcludeLabelFilter {
-    fn filter(&self, record: &Record) -> bool {
+    fn filter(&mut self, record: &Record) -> bool {
         !self.labels.iter().all(|(key, value)| {
             record
                 .labels
                 .iter()
                 .any(|label| label.name == *key && label.value == *value)
         })
-    }
-
-    fn last_sent(&mut self, _: &Record) -> () {
-        ()
     }
 }

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
     use crate::storage::proto::record::Label;
     use crate::storage::proto::Record;
-    use crate::storage::query::filters::IncludeLabelFilter;
+
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -26,3 +26,89 @@ impl RecordFilter for ExcludeLabelFilter {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::proto::record::Label;
+    use crate::storage::proto::Record;
+    use crate::storage::query::filters::IncludeLabelFilter;
+    use rstest::*;
+
+    #[rstest]
+    fn test_exclude_label_filter() {
+        let mut filter = ExcludeLabelFilter::new(Labels::from_iter(vec![(
+            "key".to_string(),
+            "value".to_string(),
+        )]));
+        let record = Record {
+            labels: vec![Label {
+                name: "key".to_string(),
+                value: "value".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        assert!(!filter.filter(&record), "Record should not pass");
+    }
+
+    #[rstest]
+    fn test_exclude_label_filter_no_records() {
+        let mut filter = ExcludeLabelFilter::new(Labels::from_iter(vec![(
+            "key".to_string(),
+            "value".to_string(),
+        )]));
+        let record = Record {
+            labels: vec![Label {
+                name: "key".to_string(),
+                value: "other".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        assert!(filter.filter(&record), "Record should pass");
+    }
+
+    #[rstest]
+    fn test_exclude_label_all() {
+        let mut filter = ExcludeLabelFilter::new(Labels::from_iter(vec![
+            ("key1".to_string(), "value1".to_string()),
+            ("key2".to_string(), "value2".to_string()),
+        ]));
+        let record = Record {
+            labels: vec![
+                Label {
+                    name: "key1".to_string(),
+                    value: "value1".to_string(),
+                },
+                Label {
+                    name: "key2".to_string(),
+                    value: "value2".to_string(),
+                },
+                Label {
+                    name: "key3".to_string(),
+                    value: "value3".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert!(
+            !filter.filter(&record),
+            "Record should not pass because it has key1=value1 and key2=value2"
+        );
+
+        let record = Record {
+            labels: vec![Label {
+                name: "key1".to_string(),
+                value: "value1".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        assert!(
+            filter.filter(&record),
+            "Record should pass because it has only key1=value1"
+        );
+    }
+}

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -1,0 +1,32 @@
+// Copyright 2023-2024 ReductStore
+// Licensed under the Business Source License 1.1
+
+use reduct_base::Labels;
+
+use crate::storage::proto::Record;
+use crate::storage::query::filters::RecordFilter;
+
+pub struct ExcludeLabelFilter {
+    labels: Labels,
+}
+
+impl ExcludeLabelFilter {
+    pub fn new(labels: Labels) -> ExcludeLabelFilter {
+        ExcludeLabelFilter { labels }
+    }
+}
+
+impl RecordFilter for ExcludeLabelFilter {
+    fn filter(&self, record: &Record) -> bool {
+        !self.labels.iter().all(|(key, value)| {
+            record
+                .labels
+                .iter()
+                .any(|label| label.name == *key && label.value == *value)
+        })
+    }
+
+    fn last_sent(&mut self, _: &Record) -> () {
+        ()
+    }
+}

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -1,0 +1,32 @@
+// Copyright 2023-2024 ReductStore
+// Licensed under the Business Source License 1.1
+
+use reduct_base::Labels;
+
+use crate::storage::proto::Record;
+use crate::storage::query::filters::RecordFilter;
+
+pub struct IncludeLabelFilter {
+    labels: Labels,
+}
+
+impl IncludeLabelFilter {
+    pub fn new(labels: Labels) -> IncludeLabelFilter {
+        IncludeLabelFilter { labels }
+    }
+}
+
+impl RecordFilter for IncludeLabelFilter {
+    fn filter(&self, record: &Record) -> bool {
+        self.labels.iter().all(|(key, value)| {
+            record
+                .labels
+                .iter()
+                .any(|label| label.name == *key && label.value == *value)
+        })
+    }
+
+    fn last_sent(&mut self, _: &Record) -> () {
+        ()
+    }
+}

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -17,16 +17,12 @@ impl IncludeLabelFilter {
 }
 
 impl RecordFilter for IncludeLabelFilter {
-    fn filter(&self, record: &Record) -> bool {
+    fn filter(&mut self, record: &Record) -> bool {
         self.labels.iter().all(|(key, value)| {
             record
                 .labels
                 .iter()
                 .any(|label| label.name == *key && label.value == *value)
         })
-    }
-
-    fn last_sent(&mut self, _: &Record) -> () {
-        ()
     }
 }

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -6,11 +6,21 @@ use reduct_base::Labels;
 use crate::storage::proto::Record;
 use crate::storage::query::filters::RecordFilter;
 
+/// Filter that excludes records with specific labels
 pub struct IncludeLabelFilter {
     labels: Labels,
 }
 
 impl IncludeLabelFilter {
+    /// Create a new filter that includes records with the specified labels
+    ///
+    /// # Arguments
+    ///
+    /// * `labels` - The labels to include
+    ///
+    /// # Returns
+    ///
+    /// A new `IncludeLabelFilter` instance
     pub fn new(labels: Labels) -> IncludeLabelFilter {
         IncludeLabelFilter { labels }
     }

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -26,3 +26,88 @@ impl RecordFilter for IncludeLabelFilter {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::proto::record::Label;
+    use crate::storage::proto::Record;
+    use rstest::*;
+
+    #[rstest]
+    fn test_include_label_filter() {
+        let mut filter = IncludeLabelFilter::new(Labels::from_iter(vec![(
+            "key".to_string(),
+            "value".to_string(),
+        )]));
+        let record = Record {
+            labels: vec![Label {
+                name: "key".to_string(),
+                value: "value".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        assert!(filter.filter(&record), "Record should pass");
+    }
+
+    #[rstest]
+    fn test_include_label_filter_no_records() {
+        let mut filter = IncludeLabelFilter::new(Labels::from_iter(vec![(
+            "key".to_string(),
+            "value".to_string(),
+        )]));
+        let record = Record {
+            labels: vec![Label {
+                name: "key".to_string(),
+                value: "other".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        assert!(!filter.filter(&record), "Record should not pass");
+    }
+
+    #[rstest]
+    fn test_include_label_all() {
+        let mut filter = IncludeLabelFilter::new(Labels::from_iter(vec![
+            ("key1".to_string(), "value1".to_string()),
+            ("key2".to_string(), "value2".to_string()),
+        ]));
+        let record = Record {
+            labels: vec![
+                Label {
+                    name: "key1".to_string(),
+                    value: "value1".to_string(),
+                },
+                Label {
+                    name: "key2".to_string(),
+                    value: "value2".to_string(),
+                },
+                Label {
+                    name: "key3".to_string(),
+                    value: "value3".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert!(
+            filter.filter(&record),
+            "Record should pass because it has key1=value1 and key2=value2"
+        );
+
+        let record = Record {
+            labels: vec![Label {
+                name: "key1".to_string(),
+                value: "value1".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        assert!(
+            !filter.filter(&record),
+            "Record should not pass because it has only key1=value1"
+        );
+    }
+}

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -5,11 +5,21 @@ use crate::storage::proto::record::State;
 use crate::storage::proto::Record;
 use crate::storage::query::filters::RecordFilter;
 
+/// Filter that passes records with a specific state
 pub struct RecordStateFilter {
     state: State,
 }
 
 impl RecordStateFilter {
+    /// Create a new filter that passes records with the specified state
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - The state to pass
+    ///
+    /// # Returns
+    ///
+    /// A new `RecordStateFilter` instance
     pub fn new(state: State) -> RecordStateFilter {
         RecordStateFilter { state }
     }

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -1,0 +1,26 @@
+// Copyright 2023-2024 ReductStore
+// Licensed under the Business Source License 1.1
+
+use crate::storage::proto::record::State;
+use crate::storage::proto::Record;
+use crate::storage::query::filters::RecordFilter;
+
+pub struct RecordStateFilter {
+    state: State,
+}
+
+impl RecordStateFilter {
+    pub fn new(state: State) -> RecordStateFilter {
+        RecordStateFilter { state }
+    }
+}
+
+impl RecordFilter for RecordStateFilter {
+    fn filter(&self, record: &Record) -> bool {
+        record.state == self.state as i32
+    }
+
+    fn last_sent(&mut self, _: &Record) -> () {
+        ()
+    }
+}

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -20,3 +20,33 @@ impl RecordFilter for RecordStateFilter {
         record.state == self.state as i32
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::proto::record::State;
+    use crate::storage::proto::Record;
+    use rstest::*;
+
+    #[rstest]
+    fn test_record_state_filter() {
+        let mut filter = RecordStateFilter::new(State::Finished);
+        let record = Record {
+            state: State::Finished as i32,
+            ..Default::default()
+        };
+
+        assert!(filter.filter(&record), "Record should pass");
+    }
+
+    #[rstest]
+    fn test_record_state_filter_no_records() {
+        let mut filter = RecordStateFilter::new(State::Finished);
+        let record = Record {
+            state: State::Started as i32,
+            ..Default::default()
+        };
+
+        assert!(!filter.filter(&record), "Record should not pass");
+    }
+}

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -16,11 +16,7 @@ impl RecordStateFilter {
 }
 
 impl RecordFilter for RecordStateFilter {
-    fn filter(&self, record: &Record) -> bool {
+    fn filter(&mut self, record: &Record) -> bool {
         record.state == self.state as i32
-    }
-
-    fn last_sent(&mut self, _: &Record) -> () {
-        ()
     }
 }

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -20,9 +20,65 @@ impl RecordFilter for TimeRangeFilter {
         let ts = ts_to_us(record.timestamp.as_ref().unwrap());
         let ret = ts >= self.start && ts < self.stop;
         if ret {
+            // Ensure that we don't return the same record twice
             self.start = ts + 1;
         }
 
         ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::proto::us_to_ts;
+    use rstest::*;
+
+    #[rstest]
+    fn test_time_range_filter() {
+        let mut filter = TimeRangeFilter::new(0, 10);
+        let record = Record {
+            timestamp: Some(us_to_ts(&5)),
+            ..Default::default()
+        };
+
+        assert!(filter.filter(&record), "First time should pass");
+        assert!(
+            !filter.filter(&record),
+            "Second time should not pass, as we have already returned the record"
+        );
+    }
+
+    #[rstest]
+    fn test_time_range_filter_no_records() {
+        let mut filter = TimeRangeFilter::new(0, 10);
+        let record = Record {
+            timestamp: Some(us_to_ts(&15)),
+            ..Default::default()
+        };
+
+        assert!(!filter.filter(&record), "Record should not pass");
+    }
+
+    #[rstest]
+    fn test_time_include_start() {
+        let mut filter = TimeRangeFilter::new(0, 10);
+        let record = Record {
+            timestamp: Some(us_to_ts(&0)),
+            ..Default::default()
+        };
+
+        assert!(filter.filter(&record), "Record should pass");
+    }
+
+    #[rstest]
+    fn test_time_exclude_end() {
+        let mut filter = TimeRangeFilter::new(0, 10);
+        let record = Record {
+            timestamp: Some(us_to_ts(&10)),
+            ..Default::default()
+        };
+
+        assert!(!filter.filter(&record), "Record should not pass");
     }
 }

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -4,12 +4,23 @@
 use crate::storage::proto::{ts_to_us, Record};
 use crate::storage::query::filters::RecordFilter;
 
+/// Filter that passes records with a timestamp within a specific range
 pub struct TimeRangeFilter {
     start: u64,
     stop: u64,
 }
 
 impl TimeRangeFilter {
+    /// Create a new filter that passes records with a timestamp within the specified range
+    ///
+    /// # Arguments
+    ///
+    /// * `start` - The start of the range (inclusive)
+    /// * `stop` - The end of the range (exclusive)
+    ///
+    /// # Returns
+    ///
+    /// A new `TimeRangeFilter` instance
     pub fn new(start: u64, stop: u64) -> TimeRangeFilter {
         TimeRangeFilter { start, stop }
     }

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -1,0 +1,27 @@
+// Copyright 2023-2024 ReductStore
+// Licensed under the Business Source License 1.1
+
+use crate::storage::proto::{ts_to_us, Record};
+use crate::storage::query::filters::RecordFilter;
+
+pub struct TimeRangeFilter {
+    start: u64,
+    stop: u64,
+}
+
+impl TimeRangeFilter {
+    pub fn new(start: u64, stop: u64) -> TimeRangeFilter {
+        TimeRangeFilter { start, stop }
+    }
+}
+
+impl RecordFilter for TimeRangeFilter {
+    fn filter(&self, record: &Record) -> bool {
+        let ts = ts_to_us(record.timestamp.as_ref().unwrap());
+        ts >= self.start && ts < self.stop
+    }
+
+    fn last_sent(&mut self, record: &Record) -> () {
+        self.start = ts_to_us(record.timestamp.as_ref().unwrap()) + 1;
+    }
+}

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -16,12 +16,13 @@ impl TimeRangeFilter {
 }
 
 impl RecordFilter for TimeRangeFilter {
-    fn filter(&self, record: &Record) -> bool {
+    fn filter(&mut self, record: &Record) -> bool {
         let ts = ts_to_us(record.timestamp.as_ref().unwrap());
-        ts >= self.start && ts < self.stop
-    }
+        let ret = ts >= self.start && ts < self.stop;
+        if ret {
+            self.start = ts + 1;
+        }
 
-    fn last_sent(&mut self, record: &Record) -> () {
-        self.start = ts_to_us(record.timestamp.as_ref().unwrap()) + 1;
+        ret
     }
 }

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -105,8 +105,6 @@ impl Query for HistoricalQuery {
         }
 
         let record = records.pop_front().unwrap();
-        self.update_filters(&record);
-
         let block = self.current_block.as_ref().unwrap();
         let record_idx = block
             .records
@@ -132,21 +130,15 @@ impl Query for HistoricalQuery {
 }
 
 impl HistoricalQuery {
-    fn filter_records_from_current_block(&self) -> Vec<Record> {
+    fn filter_records_from_current_block(&mut self) -> Vec<Record> {
         self.current_block
             .as_ref()
             .unwrap()
             .records
             .iter()
-            .filter(|record| self.filters.iter().all(|filter| filter.filter(record)))
+            .filter(|record| self.filters.iter_mut().all(|filter| filter.filter(record)))
             .map(|record| record.clone())
             .collect()
-    }
-
-    fn update_filters(&mut self, record: &Record) {
-        for filter in &mut self.filters {
-            filter.last_sent(record);
-        }
     }
 }
 

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -146,7 +146,6 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
-    use bytes::Bytes;
     use rstest::rstest;
 
     use reduct_base::error::ErrorCode;

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -15,7 +15,8 @@ use crate::storage::bucket::RecordReader;
 use crate::storage::proto::{record::State as RecordState, ts_to_us, Block, Record};
 use crate::storage::query::base::{Query, QueryOptions, QueryState};
 use crate::storage::query::filters::{
-    ExcludeLabelFilter, IncludeLabelFilter, RecordFilter, RecordStateFilter, TimeRangeFilter,
+    EachNFilter, ExcludeLabelFilter, IncludeLabelFilter, RecordFilter, RecordStateFilter,
+    TimeRangeFilter,
 };
 
 pub struct HistoricalQuery {
@@ -50,6 +51,10 @@ impl HistoricalQuery {
 
         if !options.exclude.is_empty() {
             filters.push(Box::new(ExcludeLabelFilter::new(options.exclude.clone())));
+        }
+
+        if let Some(each_n) = options.each_n {
+            filters.push(Box::new(EachNFilter::new(each_n)));
         }
 
         HistoricalQuery {
@@ -312,6 +317,29 @@ mod tests {
                 message: "No content".to_string(),
             })
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_each_n_records(
+        #[future] block_manager_and_index: (Arc<RwLock<BlockManager>>, BTreeSet<u64>),
+    ) {
+        let mut query = HistoricalQuery::new(
+            0,
+            1001,
+            QueryOptions {
+                each_n: Some(2),
+                ..QueryOptions::default()
+            },
+        );
+        let records = read_to_vector(&mut query, block_manager_and_index.await).await;
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].0.timestamp, Some(us_to_ts(&0)));
+        assert_eq!(records[0].1, "0123456789");
+        assert_eq!(records[1].0.timestamp, Some(us_to_ts(&1000)));
+        assert_eq!(records[1].1, "0123456789");
+        assert_eq!(query.state(), &QueryState::Done);
     }
 
     async fn read_to_vector(

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -74,8 +74,7 @@ impl Query for HistoricalQuery {
     ) -> Result<RecordReader, ReductError> {
         self.last_update = Instant::now();
 
-        let records = &mut self.records_from_current_block.clone();
-        if records.is_empty() {
+        if self.records_from_current_block.is_empty() {
             let start = if let Some(block) = &self.current_block {
                 ts_to_us(block.records.last().unwrap().timestamp.as_ref().unwrap())
             } else {
@@ -92,19 +91,19 @@ impl Query for HistoricalQuery {
                 self.current_block = Some(block);
                 let mut found_records = self.filter_records_from_current_block();
                 found_records.sort_by_key(|rec| ts_to_us(rec.timestamp.as_ref().unwrap()));
-                records.extend(found_records);
-                if !records.is_empty() {
+                self.records_from_current_block.extend(found_records);
+                if !self.records_from_current_block.is_empty() {
                     break;
                 }
             }
         }
 
-        if records.is_empty() {
+        if self.records_from_current_block.is_empty() {
             self.state = QueryState::Done;
             return Err(ReductError::no_content("No content"));
         }
 
-        let record = records.pop_front().unwrap();
+        let record = self.records_from_current_block.pop_front().unwrap();
         let block = self.current_block.as_ref().unwrap();
         let record_idx = block
             .records

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -35,7 +35,7 @@ impl Query for LimitedQuery {
         block_indexes: &BTreeSet<u64>,
         block_manager: Arc<RwLock<BlockManager>>,
     ) -> Result<RecordReader, ReductError> {
-        // TODO: It could be done better, maybe it make sense to move the limit into HistoricalQuery instead of manipulating the state here.
+        // TODO: It could be done better, maybe it make senses to move the limit into HistoricalQuery instead of manipulating the state here.
         if let Running(count) = self.state() {
             if *count == self.options.limit.unwrap() {
                 self.query.state = QueryState::Done;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Very often we need to query each N record or a record each X seconds. I've added two query options for this:

* `each_n` to get each N record
* `each_s` to get a record each X seconds, where X can be a float value.

### Related issues

No

### Does this PR introduce a breaking change?

Np

### Other information:
