### PR TITLE
RS-311: support downsampling parameters each_s and each_n in replication tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- RS-261: Add `eacn_n` and `each_s` query options, [PR-465](https://github.com/reductstore/reductstore/pull/465)
+- RS-261: Add `each_n` and `each_s` query options, [PR-465](https://github.com/reductstore/reductstore/pull/465)
 
 ### Removed
 
 - RS-213: `reduct-cli` and dependency from `reduct-rs`, [PR-426](https://github.com/reductstore/reductstore/pull/426)
 - Checking "stop before start" in query endpoint, [PR-466](https://github.com/reductstore/reductstore/pull/466)
-- RS-300: mark initial token as provisioned, [PR-479](https://github.com/reductstore/reductstore/pull/479)
 
 ### Security
 
@@ -29,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix removing invalid blocks at start, [PR-454](https://github.com/reductstore/reductstore/pull/454)
+- RS-300: mark initial token as provisioned, [PR-479](https://github.com/reductstore/reductstore/pull/479)
 
 ## [1.9.5] - 2024-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- RS-261: Add `each_n` and `each_s` query options, [PR-465](https://github.com/reductstore/reductstore/pull/465)
+- RS-261: support downsampling parameters `each_n` and `each_s` query options, [PR-465](https://github.com/reductstore/reductstore/pull/465)
+- RS-311: support downsampling parameters `each_n` and `each_s` in replication tasks, [PR-480](https://github.com/reductstore/reductstore/pull/480)
 
 ### Removed
 

--- a/api_tests/auth_test.py
+++ b/api_tests/auth_test.py
@@ -1,4 +1,5 @@
 """Test authorization"""
+
 from conftest import requires_env, auth_headers
 
 

--- a/api_tests/replication_api_test.py
+++ b/api_tests/replication_api_test.py
@@ -115,6 +115,8 @@ def test__update_replication_ok(base_url, session, bucket_name, replication_name
             "entries": [],
             "exclude": {},
             "include": {},
+            "each_n": None,
+            "each_s": None,
             "src_bucket": bucket_name,
         },
     }

--- a/api_tests/replication_api_test.py
+++ b/api_tests/replication_api_test.py
@@ -1,4 +1,5 @@
 """Replication Tests"""
+
 import pytest
 
 
@@ -19,6 +20,11 @@ def test__create_replication_ok(base_url, session, bucket_name, replication_name
             "src_bucket": bucket_name,
             "dst_bucket": "dst_bucket",
             "dst_host": "http://localhost:9000",
+            "entries": ["entry1", "entry2"],
+            "include": {"key1": "value1"},
+            "exclude": {"key2": "value2"},
+            "each_n": 10,
+            "each_s": 0.5,
         },
     )
 
@@ -35,13 +41,15 @@ def test__create_replication_ok(base_url, session, bucket_name, replication_name
             "pending_records": 0,
         },
         "settings": {
+            "src_bucket": bucket_name,
             "dst_bucket": "dst_bucket",
             "dst_host": "http://localhost:9000",
             "dst_token": "***",
-            "entries": [],
-            "exclude": {},
-            "include": {},
-            "src_bucket": bucket_name,
+            "entries": ["entry1", "entry2"],
+            "exclude": {"key2": "value2"},
+            "include": {"key1": "value1"},
+            "each_n": 10,
+            "each_s": 0.5,
         },
     }
 

--- a/api_tests/web_console.py
+++ b/api_tests/web_console.py
@@ -1,4 +1,5 @@
 """Test for WebConsole integration"""
+
 import os
 
 import pytest

--- a/reduct_base/src/msg/replication_api.rs
+++ b/reduct_base/src/msg/replication_api.rs
@@ -7,7 +7,7 @@ use crate::Labels;
 use serde::{Deserialize, Serialize};
 
 /// Replication settings
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct ReplicationSettings {
     /// Source bucket
     pub src_bucket: String,
@@ -27,6 +27,12 @@ pub struct ReplicationSettings {
     /// Labels to exclude
     #[serde(default)]
     pub exclude: Labels,
+    /// Replication each N-th record
+    #[serde(default)]
+    pub each_n: Option<u64>,
+    /// Replication a record every S seconds
+    #[serde(default)]
+    pub each_s: Option<f64>,
 }
 
 /// Replication info

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -110,10 +110,10 @@ fn parse_limit(params: HashMap<String, String>) -> Result<Option<usize>, HttpErr
     Ok(limit)
 }
 
-fn parse_each_n(params: &HashMap<String, String>) -> Result<Option<usize>, HttpError> {
+fn parse_each_n(params: &HashMap<String, String>) -> Result<Option<u64>, HttpError> {
     let each_n = match params.get("each_n") {
         Some(each_n) => {
-            let value = each_n.parse::<usize>().map_err(|_| {
+            let value = each_n.parse::<u64>().map_err(|_| {
                 HttpError::new(
                     ErrorCode::UnprocessableEntity,
                     "'each_n' must unsigned integer",

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -14,6 +14,7 @@ use futures_util::StreamExt;
 
 use crate::replication::{Transaction, TransactionNotification};
 use crate::storage::bucket::RecordTx;
+use crate::storage::proto::record::Label;
 use log::debug;
 use reduct_base::batch::{parse_batched_header, sort_headers_by_time, RecordHeader};
 use reduct_base::error::ReductError;
@@ -105,7 +106,15 @@ pub(crate) async fn write_batched_records(
                             .notify(TransactionNotification {
                                 bucket: bucket_name.clone(),
                                 entry: entry_name.clone(),
-                                labels: timed_headers[index].1.labels.clone(),
+                                labels: timed_headers[index]
+                                    .1
+                                    .labels
+                                    .iter()
+                                    .map(|(k, v)| Label {
+                                        name: k.clone(),
+                                        value: v.clone(),
+                                    })
+                                    .collect::<Vec<Label>>(), // TODO: find a way to avoid cloning
                                 event: Transaction::WriteRecord(timed_headers[index].0),
                             })
                             .await?;

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -10,6 +10,7 @@ use axum_extra::headers::{Expect, Header, HeaderMap};
 
 use crate::replication::Transaction::WriteRecord;
 use crate::replication::TransactionNotification;
+use crate::storage::proto::record::Label;
 use futures_util::StreamExt;
 use log::{debug, error};
 use reduct_base::error::ReductError;
@@ -148,7 +149,10 @@ pub(crate) async fn write_record(
                 .notify(TransactionNotification {
                     bucket: bucket.clone(),
                     entry: path.get("entry_name").unwrap().to_string(),
-                    labels,
+                    labels: labels
+                        .into_iter()
+                        .map(|(k, v)| Label { name: k, value: v })
+                        .collect(),
                     event: WriteRecord(ts),
                 })
                 .await?;

--- a/reductstore/src/api/replication.rs
+++ b/reductstore/src/api/replication.rs
@@ -83,6 +83,8 @@ mod tests {
             entries: vec![],
             include: Labels::default(),
             exclude: Labels::default(),
+            each_n: None,
+            each_s: None,
         }
     }
 }

--- a/reductstore/src/proto/replication.proto
+++ b/reductstore/src/proto/replication.proto
@@ -18,6 +18,8 @@ message  ReplicationSettings {
   repeated string entries = 6;// list of entries to replicate, empty means all. Wildcards are allowed.
   repeated Label include = 7; // list of labels to include
   repeated Label exclude = 8; // list of labels to exclude
+  uint64 each_n = 9;          // replicate each Nth record
+  double each_s = 10;      // replicate each record every N seconds
 }
 
 message ReplicationRepo {

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -164,8 +164,8 @@ impl ManageReplications for ReplicationRepository {
         self.save_repo()
     }
 
-    async fn notify(&self, notification: TransactionNotification) -> Result<(), ReductError> {
-        for (_, replication) in self.replications.iter() {
+    async fn notify(&mut self, notification: TransactionNotification) -> Result<(), ReductError> {
+        for (_, replication) in self.replications.iter_mut() {
             let _ = replication.notify(notification.clone()).await?;
         }
         Ok(())
@@ -484,7 +484,7 @@ mod tests {
             repl.notify(TransactionNotification {
                 bucket: "bucket-1".to_string(),
                 entry: "entry-1".to_string(),
-                labels: Labels::default(),
+                labels: Vec::new(),
                 event: WriteRecord(0),
             })
             .await

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -43,6 +43,8 @@ impl From<ReplicationSettings> for ProtoReplicationSettings {
                 .into_iter()
                 .map(|(k, v)| ProtoLabel { name: k, value: v })
                 .collect(),
+            each_s: settings.each_s.unwrap_or(0.0),
+            each_n: settings.each_n.unwrap_or(0),
         }
     }
 }
@@ -65,6 +67,16 @@ impl From<ProtoReplicationSettings> for ReplicationSettings {
                 .into_iter()
                 .map(|label| (label.name, label.value))
                 .collect(),
+            each_s: if settings.each_s > 0.0 {
+                Some(settings.each_s)
+            } else {
+                None
+            },
+            each_n: if settings.each_n > 0 {
+                Some(settings.each_n)
+            } else {
+                None
+            },
         }
     }
 }
@@ -509,6 +521,8 @@ mod tests {
             entries: vec!["entry-1".to_string()],
             include: Labels::default(),
             exclude: Labels::default(),
+            each_n: None,
+            each_s: None,
         }
     }
 

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -618,6 +618,8 @@ mod tests {
             entries: vec!["test".to_string()],
             include: Labels::new(),
             exclude: Labels::new(),
+            each_n: None,
+            each_s: None,
         }
     }
 }

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -1,6 +1,7 @@
 // Copyright 2023-2024 ReductStore
 // Licensed under the Business Source License 1.1
 
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -27,7 +28,7 @@ pub struct ReplicationTask {
     name: String,
     is_provisioned: bool,
     settings: ReplicationSettings,
-    filter: TransactionFilter,
+    filter_map: Arc<RwLock<HashMap<String, TransactionFilter>>>,
     log_map: Arc<RwLock<HashMap<String, RwLock<TransactionLog>>>>,
     storage: Arc<RwLock<Storage>>,
     remote_bucket: Arc<RwLock<dyn RemoteBucket + Send + Sync>>,
@@ -43,13 +44,10 @@ impl ReplicationTask {
         storage: Arc<RwLock<Storage>>,
     ) -> Self {
         let ReplicationSettings {
-            src_bucket,
             dst_bucket: remote_bucket,
             dst_host: remote_host,
             dst_token: remote_token,
-            entries,
-            include,
-            exclude,
+            ..
         } = settings.clone();
 
         let remote_bucket = create_remote_bucket(
@@ -58,16 +56,20 @@ impl ReplicationTask {
             remote_token.as_str(),
         );
 
-        let filter = TransactionFilter::new(src_bucket, entries, include, exclude);
-
-        Self::build(name, settings, remote_bucket, filter, storage)
+        Self::build(
+            name,
+            settings,
+            remote_bucket,
+            Arc::new(RwLock::new(HashMap::new())),
+            storage,
+        )
     }
 
     fn build(
         name: String,
         settings: ReplicationSettings,
         remote_bucket: Arc<RwLock<dyn RemoteBucket + Send + Sync>>,
-        filter: TransactionFilter,
+        filter: Arc<RwLock<HashMap<String, TransactionFilter>>>,
         storage: Arc<RwLock<Storage>>,
     ) -> Self {
         let log_map = Arc::new(RwLock::new(HashMap::<String, RwLock<TransactionLog>>::new()));
@@ -157,7 +159,7 @@ impl ReplicationTask {
             is_provisioned: false,
             settings,
             storage,
-            filter,
+            filter_map: filter,
             log_map,
             remote_bucket,
             hourly_diagnostics,
@@ -168,8 +170,20 @@ impl ReplicationTask {
         &mut self,
         notification: TransactionNotification,
     ) -> Result<(), ReductError> {
-        if !self.filter.filter(&notification) {
-            return Ok(());
+        // We need to have a filter for each entry
+        {
+            let mut lock = self.filter_map.write().await;
+            if !lock.contains_key(&notification.entry) {
+                lock.insert(
+                    notification.entry.clone(),
+                    TransactionFilter::new(self.settings.clone()),
+                );
+            }
+
+            let mut filter = lock.get_mut(&notification.entry).unwrap();
+            if !filter.filter(&notification) {
+                return Ok(());
+            }
         }
 
         // NOTE: very important not to lock the log_map for too long
@@ -266,6 +280,7 @@ impl ReplicationTask {
 mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
+    use futures_util::future::Remote;
     use mockall::mock;
     use rstest::*;
 
@@ -299,53 +314,15 @@ mod tests {
     #[tokio::test]
     async fn test_transaction_log_init(remote_bucket: MockRmBucket, settings: ReplicationSettings) {
         let replication = build_replication(remote_bucket, settings).await;
-        assert_eq!(replication.log_map.read().await.len(), 1);
+        assert_eq!(replication.log_map.read().await.len(), 2);
         assert!(
-            replication.log_map.read().await.contains_key("test"),
+            replication.log_map.read().await.contains_key("test1"),
             "Transaction log is initialized"
         );
-    }
-
-    async fn build_replication(
-        remote_bucket: MockRmBucket,
-        settings: ReplicationSettings,
-    ) -> ReplicationTask {
-        let tmp_dir = tempfile::tempdir().unwrap().into_path();
-
-        let filter = TransactionFilter::new(
-            settings.src_bucket.clone(),
-            settings.entries.clone(),
-            settings.include.clone(),
-            settings.exclude.clone(),
+        assert!(
+            replication.log_map.read().await.contains_key("test2"),
+            "Transaction log is initialized"
         );
-
-        let storage = Arc::new(RwLock::new(Storage::load(tmp_dir, None).await));
-
-        {
-            let mut lock = storage.write().await;
-
-            let bucket = lock
-                .create_bucket("src", BucketSettings::default())
-                .unwrap();
-
-            let tx = bucket
-                .write_record("test", 10, 4, "text/plain".to_string(), Labels::new())
-                .await
-                .unwrap();
-            tx.send(Ok(Some(Bytes::from("test")))).await.unwrap();
-            tx.send(Ok(None)).await.unwrap_or(());
-        }
-
-        let repl = ReplicationTask::build(
-            "test".to_string(),
-            settings,
-            Arc::new(RwLock::new(remote_bucket)),
-            filter,
-            storage,
-        );
-
-        sleep(Duration::from_millis(5)).await; // wait for the transaction log to be initialized in worker
-        repl
     }
 
     #[rstest]
@@ -385,6 +362,109 @@ mod tests {
         )
     }
 
+    #[rstest]
+    #[tokio::test]
+    async fn test_replication_filter_each_entry(
+        mut notification: TransactionNotification,
+        mut remote_bucket: MockRmBucket,
+        settings: ReplicationSettings,
+    ) {
+        remote_bucket
+            .expect_write_batch()
+            .return_const(Ok(ErrorRecordMap::new()));
+
+        let settings = ReplicationSettings {
+            each_n: Some(2),
+            ..settings
+        };
+
+        let mut replication = build_replication(MockRmBucket::new(), settings.clone()).await;
+
+        let mut time = 10;
+        for entry in &["test1", "test2"] {
+            for _ in 0..3 {
+                notification.entry = entry.to_string();
+                notification.event = Transaction::WriteRecord(time.clone());
+                replication.notify(notification.clone()).await.unwrap();
+                time += 10;
+            }
+        }
+
+        assert_eq!(replication.log_map.read().await.len(), 2);
+        assert_eq!(
+            replication
+                .log_map
+                .read()
+                .await
+                .get("test1")
+                .unwrap()
+                .read()
+                .await
+                .front(10)
+                .await
+                .unwrap(),
+            vec![Transaction::WriteRecord(10), Transaction::WriteRecord(30)]
+        );
+        assert_eq!(
+            replication
+                .log_map
+                .read()
+                .await
+                .get("test2")
+                .unwrap()
+                .read()
+                .await
+                .front(10)
+                .await
+                .unwrap(),
+            vec![Transaction::WriteRecord(40), Transaction::WriteRecord(60)]
+        );
+    }
+
+    async fn build_replication(
+        remote_bucket: MockRmBucket,
+        settings: ReplicationSettings,
+    ) -> ReplicationTask {
+        let tmp_dir = tempfile::tempdir().unwrap().into_path();
+
+        let storage = Arc::new(RwLock::new(Storage::load(tmp_dir, None).await));
+
+        {
+            let mut lock = storage.write().await;
+
+            let bucket = lock
+                .create_bucket("src", BucketSettings::default())
+                .unwrap();
+
+            let mut time = 10;
+            for entry in ["test1", "test2"] {
+                for _ in 0..3 {
+                    let tx = bucket
+                        .write_record(entry, time, 4, "text/plain".to_string(), Labels::new())
+                        .await
+                        .unwrap();
+                    tx.send(Ok(Some(Bytes::from("test")))).await.unwrap();
+                    tx.send(Ok(None)).await.unwrap_or(());
+                    tx.closed().await;
+                    time += 10;
+                }
+
+                time += 10;
+            }
+        }
+
+        let repl = ReplicationTask::build(
+            "test".to_string(),
+            settings,
+            Arc::new(RwLock::new(remote_bucket)),
+            Arc::new(RwLock::new(HashMap::new())),
+            storage,
+        );
+
+        sleep(Duration::from_millis(10)).await; // wait for the transaction log to be initialized in worker
+        repl
+    }
+
     #[fixture]
     fn remote_bucket() -> MockRmBucket {
         let bucket = MockRmBucket::new();
@@ -395,7 +475,7 @@ mod tests {
     fn notification() -> TransactionNotification {
         TransactionNotification {
             bucket: "src".to_string(),
-            entry: "test".to_string(),
+            entry: "test1".to_string(),
             labels: Vec::new(),
             event: Transaction::WriteRecord(10),
         }
@@ -408,9 +488,11 @@ mod tests {
             dst_bucket: "remote".to_string(),
             dst_host: "http://localhost:8383".to_string(),
             dst_token: "token".to_string(),
-            entries: vec!["test".to_string()],
+            entries: vec!["test1".to_string(), "test2".to_string()],
             include: Labels::new(),
             exclude: Labels::new(),
+            each_n: None,
+            each_s: None,
         }
     }
 
@@ -422,7 +504,7 @@ mod tests {
             .log_map
             .read()
             .await
-            .get("test")
+            .get("test1")
             .unwrap()
             .read()
             .await

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -164,7 +164,10 @@ impl ReplicationTask {
         }
     }
 
-    pub async fn notify(&self, notification: TransactionNotification) -> Result<(), ReductError> {
+    pub async fn notify(
+        &mut self,
+        notification: TransactionNotification,
+    ) -> Result<(), ReductError> {
         if !self.filter.filter(&notification) {
             return Ok(());
         }
@@ -356,7 +359,7 @@ mod tests {
             .expect_write_batch()
             .returning(|_, _| Ok(ErrorRecordMap::new()));
         remote_bucket.expect_is_active().return_const(true);
-        let replication = build_replication(remote_bucket, settings).await;
+        let mut replication = build_replication(remote_bucket, settings).await;
 
         replication.notify(notification).await.unwrap();
         sleep(Duration::from_millis(250)).await;
@@ -393,7 +396,7 @@ mod tests {
         TransactionNotification {
             bucket: "src".to_string(),
             entry: "test".to_string(),
-            labels: Labels::new(),
+            labels: Vec::new(),
             event: Transaction::WriteRecord(10),
         }
     }

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -279,7 +279,7 @@ impl ReplicationTask {
 mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
-    use futures_util::future::Remote;
+
     use mockall::mock;
     use rstest::*;
 

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -1,7 +1,6 @@
 // Copyright 2023-2024 ReductStore
 // Licensed under the Business Source License 1.1
 
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -180,7 +179,7 @@ impl ReplicationTask {
                 );
             }
 
-            let mut filter = lock.get_mut(&notification.entry).unwrap();
+            let filter = lock.get_mut(&notification.entry).unwrap();
             if !filter.filter(&notification) {
                 return Ok(());
             }

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -2,7 +2,6 @@
 // Licensed under the Business Source License 1.1
 
 use reduct_base::msg::replication_api::ReplicationSettings;
-use reduct_base::Labels;
 
 use crate::replication::TransactionNotification;
 use crate::storage::proto::record::Label;

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -112,6 +112,7 @@ impl TransactionFilter {
 
 #[cfg(test)]
 mod tests {
+    use reduct_base::Labels;
     use rstest::*;
 
     use crate::replication::Transaction;

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -3,7 +3,7 @@
 
 pub mod base;
 mod continuous;
-mod filters;
+pub mod filters;
 mod historical;
 mod limited;
 

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -67,7 +67,7 @@ pub struct QueryOptions {
     /// The maximum number of records to return only for non-continuous queries.
     pub limit: Option<usize>,
     /// Return each N records
-    pub each_n: Option<usize>,
+    pub each_n: Option<u64>,
     /// Return a record every S seconds
     pub each_s: Option<f64>,
 }

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -9,7 +9,6 @@ mod record_state;
 mod time_range;
 
 use crate::storage::proto::record::Label;
-use crate::storage::proto::Record;
 
 /// Trait for record filters in queries.
 pub(super) trait RecordFilter<P>

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -8,12 +8,22 @@ mod include;
 mod record_state;
 mod time_range;
 
+use crate::storage::proto::record::Label;
 use crate::storage::proto::Record;
 
 /// Trait for record filters in queries.
-pub(super) trait RecordFilter {
+pub(super) trait RecordFilter<P>
+where
+    P: FilterPoint,
+{
     /// Filter the record by condition.
-    fn filter(&mut self, record: &Record) -> bool;
+    fn filter(&mut self, record: &P) -> bool;
+}
+
+pub(super) trait FilterPoint {
+    fn timestamp(&self) -> i64;
+    fn labels(&self) -> &Vec<Label>;
+    fn state(&self) -> &i32;
 }
 
 pub(super) use each_n::EachNFilter;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -1,17 +1,17 @@
 // Copyright 2023-2024 ReductStore
 // Licensed under the Business Source License 1.1
 
-mod each_n;
-mod each_s;
-mod exclude;
-mod include;
-mod record_state;
-mod time_range;
+pub mod each_n;
+pub mod each_s;
+pub mod exclude;
+pub mod include;
+pub mod record_state;
+pub mod time_range;
 
 use crate::storage::proto::record::Label;
 
 /// Trait for record filters in queries.
-pub(super) trait RecordFilter<P>
+pub trait RecordFilter<P>
 where
     P: FilterPoint,
 {
@@ -19,15 +19,15 @@ where
     fn filter(&mut self, record: &P) -> bool;
 }
 
-pub(super) trait FilterPoint {
+pub trait FilterPoint {
     fn timestamp(&self) -> i64;
     fn labels(&self) -> &Vec<Label>;
     fn state(&self) -> &i32;
 }
 
-pub(super) use each_n::EachNFilter;
-pub(super) use each_s::EachSecondFilter;
-pub(super) use exclude::ExcludeLabelFilter;
-pub(super) use include::IncludeLabelFilter;
-pub(super) use record_state::RecordStateFilter;
-pub(super) use time_range::TimeRangeFilter;
+pub use each_n::EachNFilter;
+pub use each_s::EachSecondFilter;
+pub use exclude::ExcludeLabelFilter;
+pub use include::IncludeLabelFilter;
+pub use record_state::RecordStateFilter;
+pub use time_range::TimeRangeFilter;

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -2,15 +2,16 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::filters::{FilterPoint, RecordFilter};
+use log::debug;
 
 /// Filter that passes every N-th record
 pub struct EachNFilter {
-    n: usize,
-    count: usize,
+    n: u64,
+    count: u64,
 }
 
 impl EachNFilter {
-    pub fn new(n: usize) -> EachNFilter {
+    pub fn new(n: u64) -> EachNFilter {
         if n == 0 {
             panic!("N must be greater than 0");
         }
@@ -22,9 +23,14 @@ impl<P> RecordFilter<P> for EachNFilter
 where
     P: FilterPoint,
 {
-    fn filter(&mut self, _: &P) -> bool {
+    fn filter(&mut self, p: &P) -> bool {
         let ret = self.count % self.n == 0;
         self.count += 1;
+        if ret {
+            debug!("Point {:?} passed", p.timestamp());
+        } else {
+            debug!("Point {:?} did not pass", p.timestamp());
+        }
         ret
     }
 }

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::proto::Record;
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes every N-th record
 pub struct EachNFilter {
@@ -19,8 +19,11 @@ impl EachNFilter {
     }
 }
 
-impl RecordFilter for EachNFilter {
-    fn filter(&mut self, _: &Record) -> bool {
+impl<P> RecordFilter<P> for EachNFilter
+where
+    P: FilterPoint,
+{
+    fn filter(&mut self, _: &P) -> bool {
         let ret = self.count % self.n == 0;
         self.count += 1;
         ret

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -1,7 +1,6 @@
 // Copyright 2023-2024 ReductStore
 // Licensed under the Business Source License 1.1
 
-use crate::storage::proto::Record;
 use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes every N-th record
@@ -34,6 +33,7 @@ where
 
 mod tests {
     use super::*;
+    use crate::storage::proto::Record;
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/each_s.rs
+++ b/reductstore/src/storage/query/filters/each_s.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::proto::{ts_to_us, Record};
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes every N-th record
 pub struct EachSecondFilter {
@@ -22,12 +22,14 @@ impl EachSecondFilter {
     }
 }
 
-impl RecordFilter for EachSecondFilter {
-    fn filter(&mut self, record: &Record) -> bool {
-        let ts = ts_to_us(record.timestamp.as_ref().unwrap()) as i64;
-        let ret = ts - self.last_time >= (self.s * 1_000_000.0) as i64;
+impl<P> RecordFilter<P> for EachSecondFilter
+where
+    P: FilterPoint,
+{
+    fn filter(&mut self, point: &P) -> bool {
+        let ret = point.timestamp() - self.last_time >= (self.s * 1_000_000.0) as i64;
         if ret {
-            self.last_time = ts;
+            self.last_time = point.timestamp().clone();
         }
 
         ret

--- a/reductstore/src/storage/query/filters/each_s.rs
+++ b/reductstore/src/storage/query/filters/each_s.rs
@@ -1,7 +1,6 @@
 // Copyright 2023-2024 ReductStore
 // Licensed under the Business Source License 1.1
 
-use crate::storage::proto::{ts_to_us, Record};
 use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes every N-th record
@@ -39,6 +38,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::proto::Record;
     use prost_wkt_types::Timestamp;
     use rstest::*;
 

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -4,7 +4,7 @@
 use reduct_base::Labels;
 
 use crate::storage::proto::Record;
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that excludes records with specific labels
 pub struct ExcludeLabelFilter {
@@ -26,11 +26,14 @@ impl ExcludeLabelFilter {
     }
 }
 
-impl RecordFilter for ExcludeLabelFilter {
-    fn filter(&mut self, record: &Record) -> bool {
+impl<P> RecordFilter<P> for ExcludeLabelFilter
+where
+    P: FilterPoint,
+{
+    fn filter(&mut self, record: &P) -> bool {
         !self.labels.iter().all(|(key, value)| {
             record
-                .labels
+                .labels()
                 .iter()
                 .any(|label| label.name == *key && label.value == *value)
         })

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -3,7 +3,6 @@
 
 use reduct_base::Labels;
 
-use crate::storage::proto::Record;
 use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that excludes records with specific labels

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -4,7 +4,7 @@
 use reduct_base::Labels;
 
 use crate::storage::proto::Record;
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that excludes records with specific labels
 pub struct IncludeLabelFilter {
@@ -26,11 +26,14 @@ impl IncludeLabelFilter {
     }
 }
 
-impl RecordFilter for IncludeLabelFilter {
-    fn filter(&mut self, record: &Record) -> bool {
+impl<P> RecordFilter<P> for IncludeLabelFilter
+where
+    P: FilterPoint,
+{
+    fn filter(&mut self, record: &P) -> bool {
         self.labels.iter().all(|(key, value)| {
             record
-                .labels
+                .labels()
                 .iter()
                 .any(|label| label.name == *key && label.value == *value)
         })

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -3,7 +3,6 @@
 
 use reduct_base::Labels;
 
-use crate::storage::proto::Record;
 use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that excludes records with specific labels

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::proto::record::State;
-use crate::storage::proto::Record;
+
 use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes records with a specific state

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -3,7 +3,7 @@
 
 use crate::storage::proto::record::State;
 use crate::storage::proto::Record;
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes records with a specific state
 pub struct RecordStateFilter {
@@ -19,15 +19,18 @@ impl RecordStateFilter {
     ///
     /// # Returns
     ///
-    /// A new `RecordStateFilter` instance
+    /// A new `RecordSta()teFilter` instance
     pub fn new(state: State) -> RecordStateFilter {
         RecordStateFilter { state }
     }
 }
 
-impl RecordFilter for RecordStateFilter {
-    fn filter(&mut self, record: &Record) -> bool {
-        record.state == self.state as i32
+impl<P> RecordFilter<P> for RecordStateFilter
+where
+    P: FilterPoint,
+{
+    fn filter(&mut self, record: &P) -> bool {
+        *record.state() == self.state as i32
     }
 }
 

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -1,7 +1,6 @@
 // Copyright 2023-2024 ReductStore
 // Licensed under the Business Source License 1.1
 
-use crate::storage::proto::{ts_to_us, Record};
 use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes records with a timestamp within a specific range
@@ -45,7 +44,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::proto::us_to_ts;
+    use crate::storage::proto::{us_to_ts, Record};
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::proto::{ts_to_us, Record};
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{FilterPoint, RecordFilter};
 
 /// Filter that passes records with a timestamp within a specific range
 pub struct TimeRangeFilter {
@@ -26,9 +26,12 @@ impl TimeRangeFilter {
     }
 }
 
-impl RecordFilter for TimeRangeFilter {
-    fn filter(&mut self, record: &Record) -> bool {
-        let ts = ts_to_us(record.timestamp.as_ref().unwrap());
+impl<P> RecordFilter<P> for TimeRangeFilter
+where
+    P: FilterPoint,
+{
+    fn filter(&mut self, record: &P) -> bool {
+        let ts = record.timestamp() as u64;
         let ret = ts >= self.start && ts < self.stop;
         if ret {
             // Ensure that we don't return the same record twice


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

* Refactored query filters to reuse them in replications 
* Added `each_s` and `each_n` parameters to replication settings 
* Added the new parameters to provisioning and HTTP API

### Related issues

#465 

### Does this PR introduce a breaking change?

No

### Other information:

