### PR TITLE
RS-385: Add settings for CORS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           --env RS_CERT_PATH=${{matrix.cert_path}}
           --env RS_LICENSE_PATH=${{matrix.license_path}}
           --env RS_CERT_KEY_PATH=/misc/privateKey.key -d ${{github.repository}}
+          --env RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com"
 
       - name: Build API tests
         run: docker build -t api ./integration_tests/api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,9 @@ jobs:
         run: docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=${{matrix.token}}
           --env RS_CERT_PATH=${{matrix.cert_path}}
           --env RS_LICENSE_PATH=${{matrix.license_path}}
-          --env RS_CERT_KEY_PATH=/misc/privateKey.key -d ${{github.repository}}
+          --env RS_CERT_KEY_PATH=/misc/privateKey.key
           --env RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com"
+          -d ${{github.repository}}
 
       - name: Build API tests
         run: docker build -t api ./integration_tests/api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RS-31: Change labels via HTTP API, [PR-517](https://github.com/reductstore/reductstore/pull/517)
+- RS-385: Add support for CORS configuration, [PR-523](https://github.com/reductstore/reductstore/pull/523)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-http",
  "url",
  "zip",
 ]
@@ -2239,6 +2240,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/integration_tests/api/http_test.py
+++ b/integration_tests/api/http_test.py
@@ -1,5 +1,7 @@
 """Test basic HTTP things"""
 
+import requests
+
 
 def test_api_version(base_url, session):
     """Should get api version in header"""
@@ -7,3 +9,49 @@ def test_api_version(base_url, session):
 
     assert resp.status_code == 200
     assert resp.headers["x-reduct-api"] == "1.11"
+
+
+def test_cors_allows_first_allowed_origin(base_url):
+    """Should allow requests from the first allowed origin"""
+    headers = {"Origin": "https://first-allowed-origin.com"}
+    resp = requests.get(f"{base_url}/info", headers=headers)
+    assert resp.status_code == 200
+    assert (
+        resp.headers["Access-Control-Allow-Origin"]
+        == "https://first-allowed-origin.com"
+    )
+
+
+def test_cors_allows_second_allowed_origin(base_url):
+    """Should allow requests from the second allowed origin"""
+    headers = {"Origin": "https://second-allowed-origin.com"}
+    resp = requests.get(f"{base_url}/info", headers=headers)
+    assert resp.status_code == 200
+    assert (
+        resp.headers["Access-Control-Allow-Origin"]
+        == "https://second-allowed-origin.com"
+    )
+
+
+def test_cors_disallowed_origin(base_url):
+    """Should not allow requests from a disallowed origin"""
+    headers = {"Origin": "https://disallowed-origin.com"}
+    resp = requests.get(f"{base_url}/info", headers=headers)
+    assert resp.status_code == 200
+    assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+def test_cors_allowed_methods(base_url):
+    """Should allow requests with any method"""
+    headers = {"Origin": "https://first-allowed-origin.com"}
+    resp = requests.options(f"{base_url}/info", headers=headers)
+    assert resp.status_code == 200
+    assert resp.headers["Access-Control-Allow-Methods"] == "*"
+
+
+def test_cors_allowed_headers(base_url):
+    """Should allow requests with any headers"""
+    headers = {"Origin": "https://first-allowed-origin.com"}
+    resp = requests.options(f"{base_url}/info", headers=headers)
+    assert resp.status_code == 200
+    assert resp.headers["Access-Control-Allow-Headers"] == "*"

--- a/integration_tests/api/http_test.py
+++ b/integration_tests/api/http_test.py
@@ -1,7 +1,5 @@
 """Test basic HTTP things"""
 
-import requests
-
 
 def test_api_version(base_url, session):
     """Should get api version in header"""
@@ -11,10 +9,10 @@ def test_api_version(base_url, session):
     assert resp.headers["x-reduct-api"] == "1.11"
 
 
-def test_cors_allows_first_allowed_origin(base_url):
+def test_cors_allows_first_allowed_origin(base_url, session):
     """Should allow requests from the first allowed origin"""
     headers = {"Origin": "https://first-allowed-origin.com"}
-    resp = requests.get(f"{base_url}/info", headers=headers)
+    resp = session.get(f"{base_url}/info", headers=headers)
     assert resp.status_code == 200
     assert (
         resp.headers["Access-Control-Allow-Origin"]
@@ -22,10 +20,10 @@ def test_cors_allows_first_allowed_origin(base_url):
     )
 
 
-def test_cors_allows_second_allowed_origin(base_url):
+def test_cors_allows_second_allowed_origin(base_url, session):
     """Should allow requests from the second allowed origin"""
     headers = {"Origin": "https://second-allowed-origin.com"}
-    resp = requests.get(f"{base_url}/info", headers=headers)
+    resp = session.get(f"{base_url}/info", headers=headers)
     assert resp.status_code == 200
     assert (
         resp.headers["Access-Control-Allow-Origin"]
@@ -33,25 +31,25 @@ def test_cors_allows_second_allowed_origin(base_url):
     )
 
 
-def test_cors_disallowed_origin(base_url):
+def test_cors_disallowed_origin(base_url, session):
     """Should not allow requests from a disallowed origin"""
     headers = {"Origin": "https://disallowed-origin.com"}
-    resp = requests.get(f"{base_url}/info", headers=headers)
+    resp = session.get(f"{base_url}/info", headers=headers)
     assert resp.status_code == 200
     assert "Access-Control-Allow-Origin" not in resp.headers
 
 
-def test_cors_allowed_methods(base_url):
+def test_cors_allowed_methods(base_url, session):
     """Should allow requests with any method"""
     headers = {"Origin": "https://first-allowed-origin.com"}
-    resp = requests.options(f"{base_url}/info", headers=headers)
+    resp = session.options(f"{base_url}/info", headers=headers)
     assert resp.status_code == 200
     assert resp.headers["Access-Control-Allow-Methods"] == "*"
 
 
-def test_cors_allowed_headers(base_url):
+def test_cors_allowed_headers(base_url, session):
     """Should allow requests with any headers"""
     headers = {"Origin": "https://first-allowed-origin.com"}
-    resp = requests.options(f"{base_url}/info", headers=headers)
+    resp = session.options(f"{base_url}/info", headers=headers)
     assert resp.status_code == 200
     assert resp.headers["Access-Control-Allow-Headers"] == "*"

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -61,6 +61,7 @@ base64 = "0.22.1"
 ring = "0.17.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 async-stream = "0.3.5"
+tower-http = { version = "0.5.2", features = ["cors"] }
 
 [build-dependencies]
 prost-build = "0.12.6"

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -9,8 +9,10 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{middleware::from_fn, Router};
+use hyper::http::HeaderValue;
 use serde::de::StdError;
 use tokio::sync::RwLock;
+use tower_http::cors::{Any, CorsLayer};
 
 pub use reduct_base::error::ErrorCode;
 use reduct_base::error::ReductError as BaseHttpError;
@@ -103,8 +105,13 @@ impl From<serde_json::Error> for HttpError {
     }
 }
 
-pub fn create_axum_app(api_base_path: &String, components: Arc<Components>) -> Router {
+pub fn create_axum_app(
+    api_base_path: &String,
+    cors_allow_origin: &Vec<String>,
+    components: Arc<Components>,
+) -> Router {
     let b_route = create_bucket_api_routes().merge(create_entry_api_routes());
+    let cors = configure_cors(cors_allow_origin);
 
     let app = Router::new()
         // Server API
@@ -129,8 +136,28 @@ pub fn create_axum_app(api_base_path: &String, components: Arc<Components>) -> R
         .fallback(get(show_ui))
         .layer(from_fn(default_headers))
         .layer(from_fn(print_statuses))
+        .layer(cors)
         .with_state(components);
     app
+}
+
+fn configure_cors(cors_allow_origin: &Vec<String>) -> CorsLayer {
+    if cors_allow_origin.contains(&"*".to_string()) {
+        CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any)
+    } else {
+        let parsed_origins: Vec<HeaderValue> = cors_allow_origin
+            .iter()
+            .map(|origin| origin.parse::<HeaderValue>().unwrap())
+            .collect();
+
+        CorsLayer::new()
+            .allow_origin(parsed_origins)
+            .allow_methods(Any)
+            .allow_headers(Any)
+    }
 }
 
 #[cfg(test)]

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -141,22 +141,17 @@ pub fn create_axum_app(
     app
 }
 
-fn configure_cors(cors_allow_origin: &Vec<String>) -> CorsLayer {
+fn configure_cors(cors_allow_origin: &[String]) -> CorsLayer {
+    let cors_layer = CorsLayer::new().allow_methods(Any).allow_headers(Any);
+
     if cors_allow_origin.contains(&"*".to_string()) {
-        CorsLayer::new()
-            .allow_origin(Any)
-            .allow_methods(Any)
-            .allow_headers(Any)
+        cors_layer.allow_origin(Any)
     } else {
         let parsed_origins: Vec<HeaderValue> = cors_allow_origin
             .iter()
-            .map(|origin| origin.parse::<HeaderValue>().unwrap())
+            .filter_map(|origin| origin.parse().ok())
             .collect();
-
-        CorsLayer::new()
-            .allow_origin(parsed_origins)
-            .allow_methods(Any)
-            .allow_headers(Any)
+        cors_layer.allow_origin(parsed_origins)
     }
 }
 

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -71,7 +71,11 @@ async fn main() {
         cfg.port as u16,
     );
 
-    let app = create_axum_app(&cfg.api_base_path, Arc::new(components));
+    let app = create_axum_app(
+        &cfg.api_base_path,
+        &cfg.cors_allow_origin,
+        Arc::new(components),
+    );
 
     let handle = Handle::new();
     tokio::spawn(shutdown_ctrl_c(handle.clone()));


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

CORS configuration and testing:
- Parsing the RS_CORS_ALLOW_ORIGIN environment variable to support multiple origins and wildcard (*).
- Unit test for parsing the environment variable.
- Integration test to verify that CORS headers are correctly applied based on allowed origins.

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

No

### Other information:

The documentation is updated in [Website PR-76](https://github.com/reductstore/website/pull/76)