### PR TITLE
Accept URL without slash at the end for dest server of replication task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-364: Mask replication token in logs, [PR-531](https://github.com/reductstore/reductstore/pull/531)
+- URL without slash at the end for dest server of replication task, [PR-540](https://github.com/reductstore/reductstore/pull/540)
 
 ### Infrastructure
 

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -218,6 +218,16 @@ impl ReductError {
 }
 
 #[macro_export]
+macro_rules! unprocessable_entity {
+    ($msg:expr, $($arg:tt)*) => {
+        ReductError::unprocessable_entity(&format!($msg, $($arg)*))
+    };
+    ($msg:expr) => {
+        ReductError::unprocessable_entity($msg)
+    };
+}
+
+#[macro_export]
 macro_rules! not_found {
     ($msg:expr, $($arg:tt)*) => {
         ReductError::not_found(&format!($msg, $($arg)*))

--- a/reductstore/src/replication/remote_bucket/states/bucket_available.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_available.rs
@@ -37,7 +37,7 @@ impl BucketAvailableState {
 
         if err.status.int_value() < 0 {
             error!(
-                "Failed to write record to remote bucket {}/{}: {}",
+                "Failed to write record to remote bucket {}{}: {}",
                 self.bucket.server_url(),
                 self.bucket.name(),
                 err

--- a/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
@@ -38,9 +38,10 @@ impl RemoteBucketState for BucketUnavailableState {
                 }
                 Err(err) => {
                     error!(
-                        "Failed to get remote bucket {}/{}",
+                        "Failed to get remote bucket {}{}: {}",
                         self.client.url(),
-                        self.bucket_name
+                        self.bucket_name,
+                        err
                     );
                     Box::new(BucketUnavailableState::new(
                         self.client,

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use log::{error, info, log};
+use log::{error, info};
 use tokio::fs;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
@@ -283,7 +283,7 @@ impl ReplicationTask {
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use axum::routing::patch;
+
     use bytes::Bytes;
 
     use mockall::mock;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Replication didn't work if a user used `http://example.com` without a slash at the end of the target host. 
The PR fixes this and also improves error handling when parsing batched headers from the remote server.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
