### PR TITLE
RS-429: Fix check for existing late record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-429: Fix check for existing late record, [PR-549](https://github.com/reductstore/reductstore/pull/549)
+
 ## [1.11.0] - 2024-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 1.11.0 - 2024-08-19
+## [1.11.0] - 2024-08-19
 
 ### Added
 

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -419,7 +419,7 @@ mod tests {
         });
 
         tx.send(Ok(Some(Bytes::from("xxxx")))).await.unwrap();
-        sleep(Duration::from_millis(15)).await;
+        sleep(Duration::from_millis(100)).await;
 
         let diagnostics = hourly_diagnostics.read().await.diagnostics();
         assert_eq!(


### PR DESCRIPTION
Closes #547 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

ReductStore allows to overwrite existing unfinished records, but the check had a bug and it didn't work for delayed records. Now it is fixed and covered by a test.

### Related issues

#547 

### Does this PR introduce a breaking change?

No

### Other information:
