### PR TITLE
Fix truncating of a recovered block from WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-429: Fix check for existing late record, [PR-549](https://github.com/reductstore/reductstore/pull/549)
+- Fix truncating of a recovered block from WAL, [PR-550](https://github.com/reductstore/reductstore/pull/550)
 
 ## [1.11.0] - 2024-08-19
 

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -184,13 +184,14 @@ impl BlockManager {
         // overwrite the file
         let file = get_global_file_cache().write_or_create(&path).await?;
         let mut lock = file.write().await;
-        lock.set_len(buf.len() as u64).await?;
+        let len = buf.len() as u64;
+        lock.set_len(len).await?;
         lock.seek(SeekFrom::Start(0)).await?;
         lock.write_all(&buf).await?;
         lock.flush().await?;
 
         // update index
-        proto.metadata_size = buf.len() as u64; // update metadata size because it changed
+        proto.metadata_size = len; // update metadata size because it changed
         self.block_index.insert_or_update(proto);
         self.block_index.save().await?;
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The block created by WAL was not truncated after recovery to the real size and kept the maximum size from the bucket settings. 
Fixed and tested.
 
### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
