### PR TITLE
RS-380: Send uncompleted batch when query is timed out 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-411: Refactor FileCache, [PR-551](https://github.com/reductstore/reductstore/pull/551)
 - RS-412: Refactor BlockCache, [PR-556](https://github.com/reductstore/reductstore/pull/556)
-
+- RS-380: Send uncompleted batch when query is timed out, [PR-558](https://github.com/reductstore/reductstore/pull/558)
 
 ### Fixed
 

--- a/integration_tests/api/entry_api/read_write_record_test.py
+++ b/integration_tests/api/entry_api/read_write_record_test.py
@@ -307,8 +307,6 @@ def test_read_batched_continuous_query(base_url, session, bucket):
     resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 204
 
-    sleep(1.1)
-
     resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 404
 

--- a/integration_tests/api/entry_api/read_write_record_test.py
+++ b/integration_tests/api/entry_api/read_write_record_test.py
@@ -307,6 +307,7 @@ def test_read_batched_continuous_query(base_url, session, bucket):
     resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 204
 
+    sleep(1.1)
     resp = session.get(f"{base_url}/b/{bucket}/entry/batch?q={query_id}")
     assert resp.status_code == 404
 

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -216,6 +216,15 @@ impl ReductError {
         }
     }
 }
+#[macro_export]
+macro_rules! no_content {
+    ($msg:expr, $($arg:tt)*) => {
+        ReductError::no_content(&format!($msg, $($arg)*))
+    };
+    ($msg:expr) => {
+        ReductError::no_content($msg)
+    };
+}
 
 #[macro_export]
 macro_rules! unprocessable_entity {

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -198,7 +198,7 @@ mod tests {
         ]);
 
         let sender = storage
-            .get_mut_bucket("bucket-1")
+            .get_bucket_mut("bucket-1")
             .unwrap()
             .write_record("entry-1", 0, 6, "text/plain".to_string(), labels)
             .await

--- a/reductstore/src/api/bucket/get.rs
+++ b/reductstore/src/api/bucket/get.rs
@@ -21,7 +21,7 @@ pub(crate) async fn get_bucket(
         .storage
         .write()
         .await
-        .get_mut_bucket(&bucket_name)?
+        .get_bucket_mut(&bucket_name)?
         .info()
         .await?;
     Ok(FullBucketInfoAxum::from(bucket_info))

--- a/reductstore/src/api/bucket/update.rs
+++ b/reductstore/src/api/bucket/update.rs
@@ -20,7 +20,7 @@ pub(crate) async fn update_bucket(
     let mut storage = components.storage.write().await;
 
     Ok(storage
-        .get_mut_bucket(&bucket_name)?
+        .get_bucket_mut(&bucket_name)?
         .set_settings(settings.into())?)
 }
 

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -475,11 +475,11 @@ mod tests {
             .get_mut_entry("entry-1")
             .unwrap();
 
-        let reader = entry.next(query.id).await.unwrap();
-        assert!(reader.last());
+        let rx = entry.get_query_receiver(query.id).await.unwrap();
+        assert!(rx.recv().await.unwrap().unwrap().last());
 
         assert_eq!(
-            entry.next(query.id).await.err().unwrap().status,
+            rx.recv().await.unwrap().err().unwrap().status,
             ErrorCode::NoContent
         );
     }

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -52,7 +52,7 @@ pub(crate) async fn query(
     let limit = parse_limit(params)?;
 
     let mut storage = components.storage.write().await;
-    let bucket = storage.get_mut_bucket(bucket_name)?;
+    let bucket = storage.get_bucket_mut(bucket_name)?;
     let entry = bucket.get_or_create_entry(entry_name)?;
     let id = entry.query(
         start,
@@ -470,9 +470,9 @@ mod tests {
 
         let mut storage = components.storage.write().await;
         let entry = storage
-            .get_mut_bucket("bucket-1")
+            .get_bucket_mut("bucket-1")
             .unwrap()
-            .get_mut_entry("entry-1")
+            .get_entry_mut("entry-1")
             .unwrap();
 
         let rx = entry.get_query_receiver(query.id).await.unwrap();

--- a/reductstore/src/api/entry/query.rs
+++ b/reductstore/src/api/entry/query.rs
@@ -97,9 +97,9 @@ fn parse_continuous_flag(params: &HashMap<String, String>) -> Result<bool, HttpE
     Ok(continuous)
 }
 
-fn parse_limit(params: HashMap<String, String>) -> Result<Option<usize>, HttpError> {
+fn parse_limit(params: HashMap<String, String>) -> Result<Option<u64>, HttpError> {
     let limit = match params.get("limit") {
-        Some(limit) => Some(limit.parse::<usize>().map_err(|_| {
+        Some(limit) => Some(limit.parse::<u64>().map_err(|_| {
             HttpError::new(
                 ErrorCode::UnprocessableEntity,
                 "'limit' must unsigned integer",

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -121,7 +121,7 @@ async fn fetch_and_response_batched_records(
         let result = if readers.is_empty() {
             rx.recv().await
         } else {
-            if let Ok(result) = timeout(Duration::from_millis(5), rx.recv()).await {
+            if let Ok(result) = timeout(Duration::from_secs(1), rx.recv()).await {
                 result
             } else {
                 debug!(
@@ -172,12 +172,6 @@ async fn fetch_and_response_batched_records(
                 } else {
                     if err.status() == ErrorCode::NoContent {
                         last = true;
-                        debug!(
-                            "Last record in query {}/{}/{}",
-                            bucket.name(),
-                            entry_name,
-                            query_id
-                        );
                         break;
                     } else {
                         return Err(HttpError::from(err));

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -361,4 +361,18 @@ mod tests {
             );
         }
     }
+
+    mod stram_wrapper {
+        use super::*;
+        use crate::storage::proto::Record;
+
+        #[rstest]
+        fn test_size_hint() {
+            let wrapper = ReadersWrapper {
+                readers: vec![],
+                empty_body: false,
+            };
+            assert_eq!(wrapper.size_hint(), (0, None));
+        }
+    }
 }

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -18,7 +18,6 @@ use crate::storage::query::QueryRx;
 use log::{debug, warn};
 use reduct_base::error::ReductError;
 use std::collections::HashMap;
-use std::fmt::format;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -322,7 +321,7 @@ mod tests {
         #[rstest]
         #[tokio::test]
         async fn test_next_record_reader_timeout() {
-            let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+            let (_tx, mut rx) = tokio::sync::mpsc::channel(1);
             assert!(
                 timeout(
                     Duration::from_secs(1),
@@ -364,7 +363,6 @@ mod tests {
 
     mod stram_wrapper {
         use super::*;
-        use crate::storage::proto::Record;
 
         #[rstest]
         fn test_size_hint() {

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -111,7 +111,7 @@ async fn fetch_and_response_batched_records(
     let mut readers = Vec::new();
     let mut last = false;
 
-    let mut rx = bucket
+    let rx = bucket
         .get_mut_entry(entry_name)
         .unwrap()
         .get_query_receiver(query_id)

--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -46,7 +46,7 @@ pub(crate) async fn read_single_record(
     drop(storage); // Release the lock
 
     let mut storage = components.storage.write().await;
-    let bucket = storage.get_mut_bucket(bucket_name)?;
+    let bucket = storage.get_bucket_mut(bucket_name)?;
     fetch_and_response_single_record(bucket, entry_name, ts, query_id, method.name() == "HEAD")
         .await
 }
@@ -94,7 +94,7 @@ async fn fetch_and_response_single_record(
         bucket.begin_read(entry_name, ts).await?
     } else {
         let rx = bucket
-            .get_mut_entry(entry_name)?
+            .get_entry_mut(entry_name)?
             .get_query_receiver(query_id.unwrap())
             .await?;
         if let Some(reader) = rx.recv().await {
@@ -216,9 +216,9 @@ mod tests {
                 .storage
                 .write()
                 .await
-                .get_mut_bucket(path_to_entry_1.get("bucket_name").unwrap())
+                .get_bucket_mut(path_to_entry_1.get("bucket_name").unwrap())
                 .unwrap()
-                .get_mut_entry(path_to_entry_1.get("entry_name").unwrap())
+                .get_entry_mut(path_to_entry_1.get("entry_name").unwrap())
                 .unwrap()
                 .query(0, u64::MAX, QueryOptions::default())
                 .unwrap()

--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -385,7 +385,7 @@ mod tests {
 
         #[rstest]
         fn test_size_hint() {
-            let (tx, rx) = tokio::sync::mpsc::channel(1);
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
 
             let wrapper = ReaderWrapper {
                 reader: RecordReader::new(

--- a/reductstore/src/api/entry/remove.rs
+++ b/reductstore/src/api/entry/remove.rs
@@ -33,7 +33,7 @@ pub(crate) async fn remove_entry(
         .storage
         .write()
         .await
-        .get_mut_bucket(bucket_name)?
+        .get_bucket_mut(bucket_name)?
         .remove_entry(entry_name)?;
     Ok(())
 }

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -65,8 +65,8 @@ pub(crate) async fn update_batched_records(
 
         let mut storage = components.storage.write().await;
         let entry = storage
-            .get_mut_bucket(bucket_name)?
-            .get_mut_entry(entry_name)?;
+            .get_bucket_mut(bucket_name)?
+            .get_entry_mut(entry_name)?;
         match entry
             .update_labels(time, labels_to_update.clone(), labels_to_remove)
             .await
@@ -233,7 +233,7 @@ mod tests {
         {
             let mut storage = components.storage.write().await;
             let tx = storage
-                .get_mut_bucket("bucket-1")
+                .get_bucket_mut("bucket-1")
                 .unwrap()
                 .write_record("entry-1", 2, 20, "text/plain".to_string(), HashMap::new())
                 .await

--- a/reductstore/src/api/entry/update_single.rs
+++ b/reductstore/src/api/entry/update_single.rs
@@ -74,8 +74,8 @@ pub(crate) async fn update_record(
         .storage
         .write()
         .await
-        .get_mut_bucket(bucket)?
-        .get_mut_entry(entry_name)?
+        .get_bucket_mut(bucket)?
+        .get_entry_mut(entry_name)?
         .update_labels(ts, labels_to_update.clone(), labels_to_remove)
         .await?;
 

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -227,7 +227,7 @@ async fn start_writing(
 ) -> RecordTx {
     let get_tx = async move {
         let mut storage = components.storage.write().await;
-        let bucket = storage.get_mut_bucket(bucket_name)?;
+        let bucket = storage.get_bucket_mut(bucket_name)?;
 
         bucket
             .write_record(
@@ -421,7 +421,7 @@ mod tests {
         {
             let mut storage = components.storage.write().await;
             let tx = storage
-                .get_mut_bucket("bucket-1")
+                .get_bucket_mut("bucket-1")
                 .unwrap()
                 .write_record("entry-1", 2, 20, "text/plain".to_string(), HashMap::new())
                 .await

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -68,7 +68,7 @@ pub(crate) async fn write_record(
 
         let sender = {
             let mut storage = components.storage.write().await;
-            let bucket = storage.get_mut_bucket(bucket)?;
+            let bucket = storage.get_bucket_mut(bucket)?;
             bucket
                 .write_record(
                     path.get("entry_name").unwrap(),

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -128,7 +128,7 @@ impl<EnvGetter: GetEnv> Cfg<EnvGetter> {
                 }
                 Err(e) => {
                     if e.status() == ErrorCode::Conflict {
-                        let bucket = storage.get_mut_bucket(&name).unwrap();
+                        let bucket = storage.get_bucket_mut(&name).unwrap();
                         bucket.set_provisioned(false);
                         bucket.set_settings(settings.clone()).unwrap();
                         bucket.set_provisioned(true);

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -341,7 +341,7 @@ mod tests {
             .storage
             .write()
             .await
-            .get_mut_bucket("src")
+            .get_bucket_mut("src")
             .unwrap()
             .remove_entry("test")
             .unwrap();
@@ -591,7 +591,7 @@ mod tests {
         let mut storage = sender.storage.write().await;
         let bucket = match storage.create_bucket("src", BucketSettings::default()) {
             Ok(bucket) => bucket,
-            Err(_err) => storage.get_mut_bucket("src").unwrap(),
+            Err(_err) => storage.get_bucket_mut("src").unwrap(),
         };
 
         let tx = bucket

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -345,23 +345,6 @@ impl Bucket {
         entry.begin_read(time).await
     }
 
-    /// Get the next record from the entry
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Entry name.
-    /// * `time` - The timestamp of the record.
-    ///
-    /// # Returns
-    ///
-    /// * `RecordReader` - The record reader to read the record content in chunks.
-    /// * `bool` - True if the record is the last one.
-    /// * `HTTPError` - The error if any.
-    pub async fn next(&mut self, name: &str, time: u64) -> Result<RecordReader, ReductError> {
-        let entry = self.get_mut_entry(name)?;
-        entry.next(time).await
-    }
-
     /// Remove entry from the bucket
     ///
     /// # Arguments

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -100,7 +100,7 @@ impl RecordReader {
 }
 
 /// Bucket is a single storage bucket.
-pub struct Bucket {
+pub(crate) struct Bucket {
     name: String,
     path: PathBuf,
     entries: BTreeMap<String, Entry>,
@@ -152,7 +152,7 @@ impl Bucket {
     /// # Returns
     ///
     /// * `Bucket` - The bucket or an HTTPError
-    pub(crate) async fn restore(path: PathBuf) -> Result<Bucket, ReductError> {
+    pub async fn restore(path: PathBuf) -> Result<Bucket, ReductError> {
         let buf: Vec<u8> = std::fs::read(path.join(SETTINGS_NAME))?;
         let settings = ProtoBucketSettings::decode(&mut Bytes::from(buf)).map_err(|e| {
             ReductError::internal_server_error(format!("Failed to decode settings: {}", e).as_str())

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -263,7 +263,7 @@ impl Bucket {
     /// # Returns
     ///
     /// * `&mut Entry` - The entry or an HTTPError
-    pub fn get_mut_entry(&mut self, name: &str) -> Result<&mut Entry, ReductError> {
+    pub fn get_entry_mut(&mut self, name: &str) -> Result<&mut Entry, ReductError> {
         let entry = self.entries.get_mut(name).ok_or_else(|| {
             ReductError::not_found(&format!(
                 "Entry '{}' not found in bucket '{}'",

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -12,12 +12,10 @@ use crate::storage::bucket::RecordReader;
 use crate::storage::entry::entry_loader::EntryLoader;
 use crate::storage::proto::record::Label;
 use crate::storage::proto::{record, ts_to_us, us_to_ts, Record};
-use crate::storage::query::base::{Query, QueryOptions, QueryState};
+use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::{build_query, spawn_query_task};
-use crate::storage::storage::IO_OPERATION_TIMEOUT;
-use log::{debug, warn};
-use reduct_base::error::ErrorCode::NoContent;
-use reduct_base::error::{ErrorCode, ReductError};
+use log::debug;
+use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::EntryInfo;
 use reduct_base::{internal_server_error, too_early, Labels};
 use std::collections::{HashMap, HashSet};
@@ -25,11 +23,9 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use tokio::time::{sleep, timeout};
 use tokio_stream::StreamExt;
 
 pub(super) type QueryRx = Receiver<Result<RecordReader, ReductError>>;
@@ -365,7 +361,7 @@ impl Entry {
     /// * `HTTPError` - The error if any.
     pub async fn get_query_receiver(&mut self, query_id: u64) -> Result<&mut QueryRx, ReductError> {
         self.remove_expired_query();
-        let mut query = self
+        let query = self
             .queries
             .get_mut(&query_id)
             .ok_or_else(||

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -13,7 +13,7 @@ use crate::storage::entry::entry_loader::EntryLoader;
 use crate::storage::proto::record::Label;
 use crate::storage::proto::{record, ts_to_us, us_to_ts, Record};
 use crate::storage::query::base::{Query, QueryOptions};
-use crate::storage::query::{build_query, spawn_query_task};
+use crate::storage::query::{build_query, spawn_query_task, QueryRx};
 use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::EntryInfo;
@@ -27,8 +27,6 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
-
-pub(super) type QueryRx = Receiver<Result<RecordReader, ReductError>>;
 
 struct QueryHandle {
     rx: QueryRx,

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -12,7 +12,7 @@ use crate::storage::bucket::RecordReader;
 use crate::storage::entry::entry_loader::EntryLoader;
 use crate::storage::proto::record::Label;
 use crate::storage::proto::{record, ts_to_us, us_to_ts, Record};
-use crate::storage::query::base::{Query, QueryOptions};
+use crate::storage::query::base::QueryOptions;
 use crate::storage::query::{build_query, spawn_query_task, QueryRx};
 use log::debug;
 use reduct_base::error::ReductError;
@@ -23,10 +23,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::mpsc::Receiver;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use tokio_stream::StreamExt;
 
 struct QueryHandle {
     rx: QueryRx,

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -132,9 +132,18 @@ impl EntryLoader {
 
         block_index.save().await?;
         let name = path.file_name().unwrap().to_str().unwrap().to_string();
+        let bucket_name = path
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
 
         Ok(Entry {
             name,
+            bucket_name,
             settings: options,
             block_manager: Arc::new(RwLock::new(BlockManager::new(path, block_index))),
             queries: HashMap::new(),
@@ -149,8 +158,17 @@ impl EntryLoader {
         let block_index = BlockIndex::try_load(path.join(BLOCK_INDEX_FILE)).await?;
 
         let name = path.file_name().unwrap().to_str().unwrap().to_string();
+        let bucket_name = path
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
         Ok(Entry {
             name,
+            bucket_name,
             settings: options,
             block_manager: Arc::new(RwLock::new(BlockManager::new(path, block_index))),
             queries: HashMap::new(),

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -11,7 +11,7 @@ use crate::storage::block_manager::BlockManager;
 use crate::storage::bucket::RecordReader;
 use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::storage::IO_OPERATION_TIMEOUT;
-use log::{debug, trace, warn};
+use log::{trace, warn};
 use reduct_base::error::ErrorCode::NoContent;
 use reduct_base::error::ReductError;
 use std::sync::Arc;

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -7,8 +7,21 @@ pub mod filters;
 mod historical;
 mod limited;
 
-use crate::storage::query::base::{Query, QueryOptions};
+use crate::storage::block_manager::BlockManager;
+use crate::storage::bucket::RecordReader;
+use crate::storage::query::base::{Query, QueryOptions, QueryState};
+use crate::storage::storage::IO_OPERATION_TIMEOUT;
+use log::warn;
+use reduct_base::error::ErrorCode::NoContent;
 use reduct_base::error::ReductError;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout};
+
+const QUERY_BUFFER_SIZE: usize = 64;
 
 /// Build a query.
 pub(in crate::storage) fn build_query(
@@ -31,10 +44,53 @@ pub(in crate::storage) fn build_query(
     })
 }
 
+pub(super) fn spawn_query_task(
+    mut query: Box<dyn Query + Send + Sync>,
+    block_manager: Arc<RwLock<BlockManager>>,
+) -> (Receiver<Result<RecordReader, ReductError>>, JoinHandle<()>) {
+    let (tx, rx) = tokio::sync::mpsc::channel(QUERY_BUFFER_SIZE);
+
+    let handle = tokio::spawn(async move {
+        loop {
+            if query.state() == &QueryState::Expired {
+                break;
+            }
+
+            let next_result = query.next(block_manager.clone()).await;
+            let query_err = next_result.as_ref().err().cloned();
+
+            let send_result = timeout(IO_OPERATION_TIMEOUT, tx.send(next_result)).await;
+
+            if let Err(err) = send_result {
+                warn!("Error sending query result: {}", err);
+                break;
+            }
+
+            if let Some(err) = query_err {
+                if err.status == NoContent && query.state() != &QueryState::Done {
+                    // continuous query will never be done
+                    // but we don't want to flood the channel and wait for the receiver
+                    while tx.capacity() < tx.max_capacity() && query.state() != &QueryState::Expired
+                    {
+                        sleep(Duration::from_millis(10)).await;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+    });
+    (rx, handle)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rstest::rstest;
+    use crate::storage::block_manager::block_index::BlockIndex;
+    use crate::storage::block_manager::ManageBlock;
+    use crate::storage::proto::Record;
+    use prost_wkt_types::Timestamp;
+    use rstest::*;
 
     #[rstest]
     fn test_bad_start_stop() {
@@ -55,5 +111,118 @@ mod tests {
             ..Default::default()
         };
         assert!(build_query(10, 5, options.clone()).is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_query_task_expired(#[future] block_manager: Arc<RwLock<BlockManager>>) {
+        let options = QueryOptions {
+            ttl: Duration::from_millis(50),
+            ..Default::default()
+        };
+
+        let query = build_query(0, 5, options.clone()).unwrap();
+        sleep(Duration::from_millis(100)).await;
+
+        let (rx, handle) = spawn_query_task(query, block_manager.await.clone());
+        assert!(rx.is_empty());
+        assert!(handle.await.is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_query_task_ok(#[future] block_manager: Arc<RwLock<BlockManager>>) {
+        let query = build_query(0, 5, QueryOptions::default()).unwrap();
+
+        let (mut rx, handle) = spawn_query_task(query, block_manager.await.clone());
+        assert_eq!(rx.recv().await.unwrap().unwrap().timestamp(), 0);
+        assert_eq!(rx.recv().await.unwrap().unwrap().timestamp(), 1);
+        assert_eq!(rx.recv().await.unwrap().err().unwrap().status, NoContent);
+        assert!(timeout(Duration::from_millis(1000), handle).await.is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_query_task_continuous_ok(#[future] block_manager: Arc<RwLock<BlockManager>>) {
+        let options = QueryOptions {
+            ttl: Duration::from_millis(50),
+            continuous: true,
+            ..Default::default()
+        };
+        let query = build_query(0, 5, options).unwrap();
+        let block_manager = block_manager.await;
+        let (mut rx, handle) = spawn_query_task(query, block_manager.clone());
+        assert_eq!(rx.recv().await.unwrap().unwrap().timestamp(), 0);
+        assert_eq!(rx.recv().await.unwrap().unwrap().timestamp(), 1);
+        assert_eq!(rx.recv().await.unwrap().err().unwrap().status, NoContent);
+
+        block_manager
+            .write()
+            .await
+            .load(0)
+            .await
+            .unwrap()
+            .write()
+            .await
+            .insert_or_update_record(Record {
+                timestamp: Some(Timestamp {
+                    seconds: 0,
+                    nanos: 2000,
+                }),
+                begin: 0,
+                end: 10,
+                state: 1,
+                labels: vec![],
+                content_type: "".to_string(),
+            });
+
+        assert_eq!(rx.recv().await.unwrap().unwrap().timestamp(), 2);
+        assert_eq!(rx.recv().await.unwrap().err().unwrap().status, NoContent);
+        assert!(timeout(Duration::from_millis(1000), handle).await.is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_query_task_err(#[future] block_manager: Arc<RwLock<BlockManager>>) {
+        let query = build_query(0, 10, QueryOptions::default()).unwrap();
+
+        let (mut rx, handle) = spawn_query_task(query, block_manager.await.clone());
+        drop(rx); // drop the receiver to simulate a closed channel
+        assert!(timeout(Duration::from_millis(1000), handle).await.is_ok());
+    }
+
+    #[fixture]
+    async fn block_manager() -> Arc<RwLock<BlockManager>> {
+        let path = tempfile::tempdir().unwrap().into_path();
+
+        let mut block_manager =
+            BlockManager::new(path.clone(), BlockIndex::new(path.join("index")));
+        let block_ref = block_manager.start(0, 10).await.unwrap();
+        block_ref.write().await.insert_or_update_record(Record {
+            timestamp: Some(Timestamp {
+                seconds: 0,
+                nanos: 0,
+            }),
+            begin: 0,
+            end: 10,
+            state: 1,
+            labels: vec![],
+            content_type: "".to_string(),
+        });
+
+        block_ref.write().await.insert_or_update_record(Record {
+            timestamp: Some(Timestamp {
+                seconds: 0,
+                nanos: 1000,
+            }),
+            begin: 0,
+            end: 10,
+            state: 1,
+            labels: vec![],
+            content_type: "".to_string(),
+        });
+
+        block_manager.finish(block_ref).await.unwrap();
+        Arc::new(RwLock::new(block_manager))
     }
 }

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -186,7 +186,7 @@ mod tests {
     async fn test_query_task_err(#[future] block_manager: Arc<RwLock<BlockManager>>) {
         let query = build_query(0, 10, QueryOptions::default()).unwrap();
 
-        let (mut rx, handle) = spawn_query_task(query, block_manager.await.clone());
+        let (rx, handle) = spawn_query_task(query, block_manager.await.clone());
         drop(rx); // drop the receiver to simulate a closed channel
         assert!(timeout(Duration::from_millis(1000), handle).await.is_ok());
     }

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -21,6 +21,8 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
 
+pub(crate) type QueryRx = Receiver<Result<RecordReader, ReductError>>;
+
 const QUERY_BUFFER_SIZE: usize = 64;
 
 /// Build a query.
@@ -47,7 +49,7 @@ pub(in crate::storage) fn build_query(
 pub(super) fn spawn_query_task(
     mut query: Box<dyn Query + Send + Sync>,
     block_manager: Arc<RwLock<BlockManager>>,
-) -> (Receiver<Result<RecordReader, ReductError>>, JoinHandle<()>) {
+) -> (QueryRx, JoinHandle<()>) {
     let (tx, rx) = tokio::sync::mpsc::channel(QUERY_BUFFER_SIZE);
 
     let handle = tokio::spawn(async move {

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -14,16 +14,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-#[derive(PartialEq, Debug)]
-pub enum QueryState {
-    /// The query is running.
-    Running(usize),
-    /// The query is done.
-    Done,
-    /// The query is outdated.
-    Expired,
-}
-
 /// Query is used to iterate over the records among multiple blocks.
 #[async_trait]
 pub(in crate::storage) trait Query {
@@ -47,9 +37,6 @@ pub(in crate::storage) trait Query {
         &mut self,
         block_manager: Arc<RwLock<BlockManager>>,
     ) -> Result<RecordReader, ReductError>;
-
-    /// Get the state of the query.
-    fn state(&self) -> &QueryState;
 }
 
 /// QueryOptions is used to specify the options for a query.
@@ -64,7 +51,7 @@ pub struct QueryOptions {
     /// If true, the query will never be done
     pub continuous: bool,
     /// The maximum number of records to return only for non-continuous queries.
-    pub limit: Option<usize>,
+    pub limit: Option<u64>,
     /// Return each N records
     pub each_n: Option<u64>,
     /// Return a record every S seconds

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::block_manager::BlockManager;
-use crate::storage::query::base::{Query, QueryOptions, QueryState};
+use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::historical::HistoricalQuery;
 use reduct_base::error::{ErrorCode, ReductError};
 
@@ -53,7 +53,6 @@ impl Query for ContinuousQuery {
                 ..
             }) => {
                 self.query = HistoricalQuery::new(self.next_start, u64::MAX, self.options.clone());
-                self.query.state = QueryState::Running(self.count);
                 Err(ReductError {
                     status: ErrorCode::NoContent,
                     message: "No content".to_string(),
@@ -61,10 +60,6 @@ impl Query for ContinuousQuery {
             }
             Err(err) => Err(err),
         }
-    }
-
-    fn state(&self) -> &QueryState {
-        self.query.state()
     }
 }
 
@@ -108,9 +103,5 @@ mod tests {
                 message: "No content".to_string(),
             })
         );
-        assert_eq!(query.state(), &QueryState::Running(1));
-
-        sleep(std::time::Duration::from_millis(100)).await;
-        assert_eq!(query.state(), &QueryState::Expired);
     }
 }

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -69,7 +69,6 @@ mod tests {
 
     use reduct_base::error::ErrorCode;
     use rstest::rstest;
-    use tokio::time::sleep;
 
     use crate::storage::query::base::tests::block_manager;
 

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -165,7 +165,6 @@ impl HistoricalQuery {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::time::Duration;
 
     use rstest::rstest;
 

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -14,7 +14,7 @@ use crate::storage::block_manager::{spawn_read_task, BlockManager, BlockRef, Man
 use crate::storage::bucket::RecordReader;
 use crate::storage::proto::record::Label;
 use crate::storage::proto::{record::State as RecordState, ts_to_us, Record};
-use crate::storage::query::base::{Query, QueryOptions, QueryState};
+use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::filters::{
     EachNFilter, EachSecondFilter, ExcludeLabelFilter, FilterPoint, IncludeLabelFilter,
     RecordFilter, RecordStateFilter, TimeRangeFilter,
@@ -50,7 +50,6 @@ pub struct HistoricalQuery {
 
     /// Filters
     filters: Vec<Box<dyn RecordFilter<Record> + Send + Sync>>,
-    pub(in crate::storage::query) state: QueryState,
 }
 
 impl HistoricalQuery {
@@ -84,7 +83,6 @@ impl HistoricalQuery {
             last_update: Instant::now(),
             options,
             filters,
-            state: QueryState::Running(0),
         }
     }
 }
@@ -136,16 +134,11 @@ impl Query for HistoricalQuery {
         }
 
         if self.records_from_current_block.is_empty() {
-            self.state = QueryState::Done;
             return Err(ReductError::no_content("No content"));
         }
 
         let record = self.records_from_current_block.pop_front().unwrap();
         let block = self.current_block.as_ref().unwrap();
-
-        if let QueryState::Running(idx) = &mut self.state {
-            *idx += 1;
-        }
 
         let rx = spawn_read_task(
             Arc::clone(&block_manager),
@@ -154,14 +147,6 @@ impl Query for HistoricalQuery {
         )
         .await?;
         Ok(RecordReader::new(rx, record.clone(), false))
-    }
-
-    fn state(&self) -> &QueryState {
-        if self.last_update.elapsed() > self.options.ttl {
-            &QueryState::Expired
-        } else {
-            &self.state
-        }
     }
 }
 
@@ -193,14 +178,6 @@ mod tests {
     use super::*;
 
     #[rstest]
-    fn test_state() {
-        let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
-        assert_eq!(query.state(), &QueryState::Running(0));
-        query.last_update = Instant::now() - Duration::from_secs(61);
-        assert_eq!(query.state(), &QueryState::Expired);
-    }
-
-    #[rstest]
     #[tokio::test]
     async fn test_query_ok_1_rec(#[future] block_manager: Arc<RwLock<BlockManager>>) {
         let mut query = HistoricalQuery::new(0, 5, QueryOptions::default());
@@ -209,7 +186,6 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].0.timestamp, Some(us_to_ts(&0)));
         assert_eq!(records[0].1, "0123456789");
-        assert_eq!(query.state(), &QueryState::Done);
     }
 
     #[rstest]
@@ -223,7 +199,6 @@ mod tests {
         assert_eq!(records[0].1, "0123456789");
         assert_eq!(records[1].0.timestamp, Some(us_to_ts(&5)));
         assert_eq!(records[1].1, "0123456789");
-        assert_eq!(query.state(), &QueryState::Done);
     }
 
     #[rstest]
@@ -239,7 +214,6 @@ mod tests {
         assert_eq!(records[1].1, "0123456789");
         assert_eq!(records[2].0.timestamp, Some(us_to_ts(&1000)));
         assert_eq!(records[2].1, "0123456789");
-        assert_eq!(query.state(), &QueryState::Done);
     }
 
     #[rstest]
@@ -274,7 +248,6 @@ mod tests {
             ]
         );
         assert_eq!(records[0].1, "0123456789");
-        assert_eq!(query.state(), &QueryState::Done);
     }
 
     #[rstest]
@@ -310,7 +283,6 @@ mod tests {
             ]
         );
         assert_eq!(records[0].1, "0123456789");
-        assert_eq!(query.state(), &QueryState::Done);
     }
 
     #[rstest]
@@ -354,7 +326,6 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].0.timestamp, Some(us_to_ts(&0)));
         assert_eq!(records[1].0.timestamp, Some(us_to_ts(&1000)));
-        assert_eq!(query.state(), &QueryState::Done);
     }
 
     #[rstest]
@@ -373,7 +344,6 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].0.timestamp, Some(us_to_ts(&0)));
         assert_eq!(records[1].0.timestamp, Some(us_to_ts(&1000)));
-        assert_eq!(query.state(), &QueryState::Done);
     }
 
     async fn read_to_vector(

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -42,7 +42,7 @@ impl Query for LimitedQuery {
         self.limit_count -= 1;
         let reader = self.query.next(block_manager).await;
         if self.limit_count == 0 {
-            reader.map(|mut r| {
+            reader.map(|r| {
                 let record = r.record().clone();
                 RecordReader::new(r.into_rx(), record, true)
             })

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -156,7 +156,7 @@ impl Storage {
     /// # Returns
     ///
     /// * `Bucket` - The bucket or an HTTPError
-    pub fn get_mut_bucket(&mut self, name: &str) -> Result<&mut Bucket, ReductError> {
+    pub fn get_bucket_mut(&mut self, name: &str) -> Result<&mut Bucket, ReductError> {
         match self.buckets.get_mut(name) {
             Some(bucket) => Ok(bucket),
             None => Err(ReductError::not_found(

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -105,7 +105,7 @@ impl Storage {
     }
 
     /// Creat a new bucket.
-    pub fn create_bucket(
+    pub(crate) fn create_bucket(
         &mut self,
         name: &str,
         settings: BucketSettings,
@@ -138,7 +138,7 @@ impl Storage {
     /// # Returns
     ///
     /// * `Bucket` - The bucket or an HTTPError
-    pub fn get_bucket(&self, name: &str) -> Result<&Bucket, ReductError> {
+    pub(crate) fn get_bucket(&self, name: &str) -> Result<&Bucket, ReductError> {
         match self.buckets.get(name) {
             Some(bucket) => Ok(bucket),
             None => Err(ReductError::not_found(
@@ -156,7 +156,7 @@ impl Storage {
     /// # Returns
     ///
     /// * `Bucket` - The bucket or an HTTPError
-    pub fn get_bucket_mut(&mut self, name: &str) -> Result<&mut Bucket, ReductError> {
+    pub(crate) fn get_bucket_mut(&mut self, name: &str) -> Result<&mut Bucket, ReductError> {
         match self.buckets.get_mut(name) {
             Some(bucket) => Ok(bucket),
             None => Err(ReductError::not_found(
@@ -174,7 +174,7 @@ impl Storage {
     /// # Returns
     ///
     /// * HTTPError - An error if the bucket doesn't exist
-    pub fn remove_bucket(&mut self, name: &str) -> Result<(), ReductError> {
+    pub(crate) fn remove_bucket(&mut self, name: &str) -> Result<(), ReductError> {
         if let Some(bucket) = self.buckets.get(name) {
             if bucket.is_provisioned() {
                 return Err(ReductError::conflict(&format!(
@@ -195,7 +195,7 @@ impl Storage {
         }
     }
 
-    pub async fn get_bucket_list(&self) -> Result<BucketInfoList, ReductError> {
+    pub(crate) async fn get_bucket_list(&self) -> Result<BucketInfoList, ReductError> {
         let mut buckets = Vec::new();
         for bucket in self.buckets.values() {
             buckets.push(bucket.info().await?.info);


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Now a client doesn't have to wait until the entire batch is ready to send. If processing the next record in the query takes more than a second, the unfinished batch is sent. I've also refactored the query. Now the query is run in a task and pushes new records asynchronously into a channel so that the records can be prepared in advance.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
