### PR TITLE
RS-422: Batch update records per block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-411: Refactor FileCache, [PR-551](https://github.com/reductstore/reductstore/pull/551)
 - RS-412: Refactor BlockCache, [PR-556](https://github.com/reductstore/reductstore/pull/556)
 - RS-380: Send uncompleted batch when query is timed out, [PR-558](https://github.com/reductstore/reductstore/pull/558)
+- RS-422: Batch update records per block, [PR-559](https://github.com/reductstore/reductstore/pull/559)
 
 ### Fixed
 

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -19,7 +19,6 @@ use crate::api::{Components, ErrorCode, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
 use crate::replication::{Transaction, TransactionNotification};
 use crate::storage::entry::update_labels::UpdateLabels;
-use crate::storage::proto::record::Label;
 
 // PATCH /:bucket/:entry/batch
 pub(crate) async fn update_batched_records(

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -18,6 +18,8 @@ use crate::api::middleware::check_permissions;
 use crate::api::{Components, ErrorCode, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
 use crate::replication::{Transaction, TransactionNotification};
+use crate::storage::entry::update_labels::UpdateLabels;
+use crate::storage::proto::record::Label;
 
 // PATCH /:bucket/:entry/batch
 pub(crate) async fn update_batched_records(
@@ -48,7 +50,7 @@ pub(crate) async fn update_batched_records(
 
     let entry_name = path.get("entry_name").unwrap();
     let record_headers: Vec<_> = sort_headers_by_time(&headers)?;
-    let mut error_map = BTreeMap::new();
+    let mut records_to_update = Vec::new();
 
     for (time, v) in record_headers {
         let header = parse_batched_header(v.to_str().unwrap())?;
@@ -63,19 +65,31 @@ pub(crate) async fn update_batched_records(
             }
         }
 
+        records_to_update.push(UpdateLabels {
+            time,
+            update: labels_to_update,
+            remove: labels_to_remove,
+        });
+    }
+
+    let result = {
         let mut storage = components.storage.write().await;
         let entry = storage
             .get_bucket_mut(bucket_name)?
             .get_entry_mut(entry_name)?;
-        match entry
-            .update_labels(time, labels_to_update.clone(), labels_to_remove)
-            .await
-        {
+        entry.update_labels(records_to_update).await?
+    };
+
+    let mut headers = HeaderMap::new();
+    for (time, result) in result {
+        match result {
             Err(err) => {
-                error_map.insert(time, err);
+                headers.insert(
+                    HeaderName::from_str(&format!("x-reduct-error-{}", time)).unwrap(),
+                    HeaderValue::from_str(&format!("{},{}", err.status(), err.message())).unwrap(),
+                );
             }
             Ok(new_labels) => {
-                drop(storage); // drop the lock because we may need to wait for the replication
                 let mut replication_repo = components.replication_repo.write().await;
                 replication_repo
                     .notify(TransactionNotification {
@@ -88,14 +102,6 @@ pub(crate) async fn update_batched_records(
             }
         };
     }
-
-    let mut headers = HeaderMap::new();
-    error_map.iter().for_each(|(time, err)| {
-        headers.insert(
-            HeaderName::from_str(&format!("x-reduct-error-{}", time)).unwrap(),
-            HeaderValue::from_str(&format!("{},{}", err.status(), err.message())).unwrap(),
-        );
-    });
 
     Ok(headers.into())
 }

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -23,7 +23,7 @@ use crate::storage::block_manager::block_cache::BlockCache;
 use crate::storage::block_manager::use_counter::UseCounter;
 use crate::storage::block_manager::wal::{Wal, WalEntry};
 use crate::storage::file_cache::{FileRef, FILE_CACHE};
-use crate::storage::proto::{record, Block as BlockProto, Record};
+use crate::storage::proto::{record, Block as BlockProto};
 use crate::storage::storage::{CHANNEL_BUFFER_SIZE, DEFAULT_MAX_READ_CHUNK, IO_OPERATION_TIMEOUT};
 use block_index::BlockIndex;
 use reduct_base::error::ReductError;

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -255,66 +255,8 @@ impl BlockManager {
     fn path_to_data(&self, block_id: u64) -> PathBuf {
         self.path.join(format!("{}{}", block_id, DATA_FILE_EXT))
     }
-}
 
-pub(in crate::storage) trait ManageBlock {
-    /// Load block descriptor from disk.
-    ///
-    /// # Arguments
-    /// * `block_id` - ID of the block to load (begin time of the block).
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(block)` - Block was loaded successfully.
-    async fn load(&self, block_id: u64) -> Result<BlockRef, ReductError>;
-
-    /// Save block descriptor in cache and on disk if needed.
-    ///
-    ///
-    /// # Arguments
-    ///
-    /// * `block` - Block to save.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(())` - Block was saved successfully.
-    async fn save(&mut self, block: BlockRef) -> Result<(), ReductError>;
-
-    /// Start a new block
-    ///
-    /// # Arguments
-    ///
-    /// * `begin_time` - Begin time of the block.
-    /// * `max_block_size` - Maximum size of the block.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(block)` - Block was created successfully.
-    async fn start(&mut self, block_id: u64, max_block_size: u64) -> Result<BlockRef, ReductError>;
-
-    /// Update a record in a block and save it to disk.
-    async fn update_record(&mut self, block: BlockRef, record: Record) -> Result<(), ReductError>;
-
-    /// Finish a block by truncating the file to the actual size.
-    ///
-    /// # Arguments
-    ///
-    /// * `block` - Block to finish.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(())` - Block was finished successfully.
-    async fn finish(&mut self, block: BlockRef) -> Result<(), ReductError>;
-
-    /// Remove a block from disk if there are no readers or writers.
-    async fn remove(&mut self, block_id: u64) -> Result<(), ReductError>;
-
-    /// Check if a block exists in the file system.
-    async fn exist(&self, block_id: u64) -> Result<bool, ReductError>;
-}
-
-impl ManageBlock for BlockManager {
-    async fn load(&self, block_id: u64) -> Result<BlockRef, ReductError> {
+    pub async fn load(&self, block_id: u64) -> Result<BlockRef, ReductError> {
         // first check if we have the block in write cache
         let mut cached_block = self.block_cache.get_read(&block_id).await;
         if cached_block.is_none() {
@@ -339,7 +281,7 @@ impl ManageBlock for BlockManager {
         Ok(cached_block)
     }
 
-    async fn save(&mut self, block: BlockRef) -> Result<(), ReductError> {
+    pub async fn save(&mut self, block: BlockRef) -> Result<(), ReductError> {
         // cache is empty, save the block there first
         for (_, block) in self
             .block_cache
@@ -352,7 +294,11 @@ impl ManageBlock for BlockManager {
         Ok(())
     }
 
-    async fn start(&mut self, block_id: u64, max_block_size: u64) -> Result<BlockRef, ReductError> {
+    pub async fn start(
+        &mut self,
+        block_id: u64,
+        max_block_size: u64,
+    ) -> Result<BlockRef, ReductError> {
         let block = Block::new(block_id);
 
         // create a block with data
@@ -371,18 +317,46 @@ impl ManageBlock for BlockManager {
         Ok(block_ref)
     }
 
-    async fn update_record(&mut self, block: BlockRef, record: Record) -> Result<(), ReductError> {
-        self.wal
-            .append(
-                block.read().await.block_id(),
-                WalEntry::UpdateRecord(record),
-            )
-            .await?;
+    /// Update records in a block and save it on disk.
+    ///
+    /// Make sure the records are in the block before calling this method.
+    ///
+    /// # Arguments
+    ///
+    /// * `block` - Block to update.
+    /// * `records` - Timestamps of the records to update.
+    ///
+    ///
+    /// # Panics
+    ///
+    /// * If the record is not in the block.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the records were updated successfully.
+    ///
+    /// # Errors
+    ///
+    /// * `ReductError` - If failed to append to WAL or save the block on disk.
+    pub async fn update_records(
+        &mut self,
+        block: BlockRef,
+        records: Vec<u64>,
+    ) -> Result<(), ReductError> {
+        for record in records {
+            let block = block.read().await;
+            self.wal
+                .append(
+                    block.block_id(),
+                    WalEntry::UpdateRecord(block.get_record(record).unwrap().clone()),
+                )
+                .await?;
+        }
 
         self.save_block_on_disk(block).await
     }
 
-    async fn finish(&mut self, block: BlockRef) -> Result<(), ReductError> {
+    pub async fn finish(&mut self, block: BlockRef) -> Result<(), ReductError> {
         let block = block.read().await;
         /* resize data block then sync descriptor and data */
         let path = self.path_to_data(block.block_id());
@@ -402,7 +376,7 @@ impl ManageBlock for BlockManager {
         Ok(())
     }
 
-    async fn remove(&mut self, block_id: u64) -> Result<(), ReductError> {
+    pub async fn remove(&mut self, block_id: u64) -> Result<(), ReductError> {
         if !self.use_counter.clean_stale_and_check(block_id) {
             return Err(internal_server_error!(
                 "Cannot remove block {} because it is still in use",
@@ -428,7 +402,7 @@ impl ManageBlock for BlockManager {
         Ok(())
     }
 
-    async fn exist(&self, block_id: u64) -> Result<bool, ReductError> {
+    pub async fn exist(&self, block_id: u64) -> Result<bool, ReductError> {
         let path = self.path_to_desc(block_id);
         Ok(path.try_exists()?)
     }
@@ -876,7 +850,7 @@ mod tests {
         };
 
         block.write().await.insert_or_update_record(record.clone());
-        bm.update_record(block, record).await.unwrap();
+        bm.update_records(block, vec![0]).await.unwrap();
         let block_index_proto = BlockIndexProto::decode(
             std::fs::read(bm.path.join(BLOCK_INDEX_FILE))
                 .unwrap()

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -10,7 +10,6 @@ use crate::storage::block_manager::{
 };
 use crate::storage::bucket::RecordReader;
 use crate::storage::entry::entry_loader::EntryLoader;
-use crate::storage::proto::record::Label;
 use crate::storage::proto::{record, ts_to_us, us_to_ts, Record};
 use crate::storage::query::base::QueryOptions;
 use crate::storage::query::{build_query, spawn_query_task, QueryRx};
@@ -18,7 +17,7 @@ use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::EntryInfo;
 use reduct_base::{internal_server_error, not_found, too_early, Labels};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -19,7 +19,7 @@ use reduct_base::error::ReductError;
 use crate::storage::block_manager::block_index::BlockIndex;
 use crate::storage::block_manager::wal::{create_wal, WalEntry};
 use crate::storage::block_manager::{
-    BlockManager, ManageBlock, BLOCK_INDEX_FILE, DATA_FILE_EXT, DESCRIPTOR_FILE_EXT,
+    BlockManager, BLOCK_INDEX_FILE, DATA_FILE_EXT, DESCRIPTOR_FILE_EXT,
 };
 use crate::storage::entry::{Entry, EntrySettings};
 use crate::storage::proto::{ts_to_us, Block, MinimalBlock};
@@ -260,7 +260,6 @@ impl EntryLoader {
 #[cfg(test)]
 mod tests {
     use crate::storage::block_manager::wal::WalEntry;
-    use crate::storage::block_manager::ManageBlock;
     use crate::storage::entry::tests::{entry, entry_settings, path, write_stub_record};
     use crate::storage::proto::{record, us_to_ts, BlockIndex as BlockIndexProto, Record};
 

--- a/reductstore/src/storage/entry/update_labels.rs
+++ b/reductstore/src/storage/entry/update_labels.rs
@@ -1,7 +1,6 @@
 use crate::storage::entry::Entry;
 use crate::storage::proto::record::Label;
 use crate::storage::proto::{ts_to_us, Record};
-use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::{not_found, Labels};
 use std::collections::{BTreeMap, HashSet};
@@ -24,7 +23,7 @@ impl Entry {
             let bm = self.block_manager.read().await;
             for UpdateLabels {
                 time,
-                mut update,
+                update,
                 remove,
             } in updates
             {
@@ -53,7 +52,7 @@ impl Entry {
         // Update blocks
         for (block_id, records) in records_per_block {
             let mut bm = self.block_manager.write().await;
-            let mut block_ref = bm.load(block_id).await?;
+            let block_ref = bm.load(block_id).await?;
 
             let record_times = {
                 let mut block = block_ref.write().await;
@@ -113,9 +112,8 @@ impl Entry {
 mod tests {
     use super::*;
     use crate::storage::entry::tests::{entry, write_record_with_labels};
-    use mockall::predicate::str::contains;
+
     use rstest::rstest;
-    use std::fmt::format;
 
     #[rstest]
     #[tokio::test]
@@ -126,7 +124,7 @@ mod tests {
         write_stub_record(&mut entry, 3).await.unwrap();
 
         // update, remove and add labels
-        let mut result = entry
+        let result = entry
             .update_labels(vec![
                 make_update(0),
                 make_update(1),

--- a/reductstore/src/storage/entry/update_labels.rs
+++ b/reductstore/src/storage/entry/update_labels.rs
@@ -1,0 +1,270 @@
+use crate::storage::entry::Entry;
+use crate::storage::proto::record::Label;
+use crate::storage::proto::{ts_to_us, Record};
+use log::debug;
+use reduct_base::error::ReductError;
+use reduct_base::{not_found, Labels};
+use std::collections::{BTreeMap, HashSet};
+
+pub(crate) struct UpdateLabels {
+    pub time: u64,
+    pub update: Labels,
+    pub remove: HashSet<String>,
+}
+
+impl Entry {
+    pub async fn update_labels(
+        &self,
+        updates: Vec<UpdateLabels>,
+    ) -> Result<BTreeMap<u64, Result<Vec<Label>, ReductError>>, ReductError> {
+        let mut result = BTreeMap::new();
+        let mut records_per_block = BTreeMap::new();
+
+        {
+            let bm = self.block_manager.read().await;
+            for UpdateLabels {
+                time,
+                mut update,
+                remove,
+            } in updates
+            {
+                // Find the block that contains the record
+                // TODO: Try to avoid the lookup for each record
+                match bm.find_block(time).await {
+                    Ok(block_ref) => {
+                        let block = block_ref.read().await;
+                        if let Some(record) = block.get_record(time) {
+                            records_per_block
+                                .entry(block.block_id())
+                                .or_insert_with(Vec::new)
+                                .push(Self::update_single_label(record.clone(), update, remove));
+                        } else {
+                            result
+                                .insert(time, Err(not_found!("No record with timestamp {}", time)));
+                        }
+                    }
+                    Err(err) => {
+                        result.insert(time, Err(err));
+                    }
+                }
+            }
+        }
+
+        // Update blocks
+        for (block_id, records) in records_per_block {
+            let mut bm = self.block_manager.write().await;
+            let mut block_ref = bm.load(block_id).await?;
+
+            let record_times = {
+                let mut block = block_ref.write().await;
+                let mut record_times = Vec::new();
+                for record in records.into_iter() {
+                    let time = ts_to_us(record.timestamp.as_ref().unwrap());
+                    record_times.push(time);
+                    block.insert_or_update_record(record.clone());
+                    result.insert(time, Ok(record.labels));
+                }
+                record_times
+            };
+
+            bm.update_records(block_ref.clone(), record_times).await?;
+        }
+
+        Ok(result)
+    }
+
+    fn update_single_label(
+        mut record: Record,
+        mut update: Labels,
+        remove: HashSet<String>,
+    ) -> Record {
+        let mut new_labels = Vec::new();
+        for label in &record.labels {
+            // remove labels
+            if remove.contains(label.name.as_str()) {
+                continue;
+            }
+
+            // update existing labels or add new labels
+            match update.remove(label.name.as_str()) {
+                Some(value) => {
+                    new_labels.push(Label {
+                        name: label.name.clone(),
+                        value,
+                    });
+                }
+                None => {
+                    new_labels.push(label.clone());
+                }
+            }
+        }
+
+        // add new labels
+        for (name, value) in update {
+            new_labels.push(Label { name, value });
+        }
+
+        record.labels = new_labels;
+        record
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::entry::tests::{entry, write_record_with_labels};
+    use mockall::predicate::str::contains;
+    use rstest::rstest;
+    use std::fmt::format;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_labels(mut entry: Entry) {
+        entry.settings.max_block_records = 2;
+        write_stub_record(&mut entry, 1).await.unwrap();
+        write_stub_record(&mut entry, 2).await.unwrap();
+        write_stub_record(&mut entry, 3).await.unwrap();
+
+        // update, remove and add labels
+        let mut result = entry
+            .update_labels(vec![
+                make_update(0),
+                make_update(1),
+                make_update(2),
+                make_update(3),
+                make_update(5),
+            ])
+            .await
+            .unwrap();
+
+        // check results
+        assert_eq!(result.len(), 5, "result contains entry for each update");
+        assert_eq!(
+            result[&0].as_ref().err().unwrap(),
+            &not_found!("No record with timestamp 0")
+        );
+        assert_eq!(
+            result[&5].as_ref().err().unwrap(),
+            &not_found!("No record with timestamp 5")
+        );
+
+        let updated_labels = result.get(&1).unwrap().as_ref().unwrap();
+        let expected_labels_1 = make_expected_labels(1);
+        assert_eq!(updated_labels.len(), 2);
+        assert!(updated_labels.contains(expected_labels_1.get(0).unwrap()));
+        assert!(updated_labels.contains(expected_labels_1.get(1).unwrap()));
+
+        let updated_labels = result.get(&2).unwrap().as_ref().unwrap();
+        let expected_labels_2 = make_expected_labels(2);
+        assert_eq!(updated_labels.len(), 2);
+        assert!(updated_labels.contains(expected_labels_2.get(0).unwrap()));
+        assert!(updated_labels.contains(expected_labels_2.get(1).unwrap()));
+
+        let updated_labels = result.get(&3).unwrap().as_ref().unwrap();
+        let expected_labels_3 = make_expected_labels(3);
+        assert_eq!(updated_labels.len(), 2);
+        assert!(updated_labels.contains(expected_labels_3.get(0).unwrap()));
+        assert!(updated_labels.contains(expected_labels_3.get(1).unwrap()));
+
+        // check if the records were updated
+        let block_ref = entry.block_manager.write().await.load(1).await.unwrap();
+
+        let block = block_ref.read().await;
+        assert_eq!(block.record_count(), 2);
+
+        let record = block.get_record(1).unwrap().clone();
+        assert_eq!(record.labels.len(), 2);
+        assert!(record.labels.contains(expected_labels_1.get(0).unwrap()));
+        assert!(record.labels.contains(expected_labels_1.get(1).unwrap()));
+
+        let record = block.get_record(2).unwrap().clone();
+        assert_eq!(record.labels.len(), 2);
+        assert!(record.labels.contains(expected_labels_2.get(0).unwrap()));
+        assert!(record.labels.contains(expected_labels_2.get(1).unwrap()));
+
+        let block_ref = entry.block_manager.write().await.load(3).await.unwrap();
+
+        let block = block_ref.read().await;
+        assert_eq!(block.record_count(), 1);
+
+        let record = block.get_record(3).unwrap().clone();
+        assert_eq!(record.labels.len(), 2);
+        assert!(record.labels.contains(expected_labels_3.get(0).unwrap()));
+        assert!(record.labels.contains(expected_labels_3.get(1).unwrap()));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_nothing(mut entry: Entry) {
+        write_stub_record(&mut entry, 1).await.unwrap();
+        let result = entry
+            .update_labels(vec![UpdateLabels {
+                time: 1,
+                update: Labels::new(),
+                remove: HashSet::new(),
+            }])
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+
+        let updated_labels = result.get(&1).unwrap().as_ref().unwrap();
+        let expected_labels = vec![
+            Label {
+                name: "a-1".to_string(),
+                value: "x-1".to_string(),
+            },
+            Label {
+                name: "c-1".to_string(),
+                value: "z-1".to_string(),
+            },
+        ];
+
+        assert_eq!(updated_labels.len(), 2);
+        assert!(updated_labels.contains(&expected_labels[0]));
+        assert!(updated_labels.contains(&expected_labels[1]));
+
+        let block = entry.block_manager.write().await.load(1).await.unwrap();
+        let record = block.read().await.get_record(1).unwrap().clone();
+        assert_eq!(record.labels.len(), 2);
+        assert!(updated_labels.contains(&expected_labels[0]));
+        assert!(updated_labels.contains(&expected_labels[1]));
+    }
+
+    fn make_update(time: u64) -> UpdateLabels {
+        UpdateLabels {
+            time: time,
+            update: Labels::from_iter(vec![
+                (format!("a-{}", time), format!("y-{}", time)),
+                (format!("b-{}", time), format!("f-{}", time)),
+            ]),
+            remove: HashSet::from_iter(vec![format!("c-{}", time), "".to_string()]),
+        }
+    }
+
+    fn make_expected_labels(time: u64) -> Vec<Label> {
+        vec![
+            Label {
+                name: format!("a-{}", time),
+                value: format!("y-{}", time),
+            },
+            Label {
+                name: format!("b-{}", time),
+                value: format!("f-{}", time),
+            },
+        ]
+    }
+
+    async fn write_stub_record(mut entry: &mut Entry, time: u64) -> Result<(), ReductError> {
+        write_record_with_labels(
+            &mut entry,
+            time,
+            vec![],
+            Labels::from_iter(vec![
+                (format!("a-{}", time), format!("x-{}", time)),
+                (format!("c-{}", time), format!("z-{}", time)),
+            ]),
+        )
+        .await
+    }
+}

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -91,7 +91,6 @@ pub(super) fn spawn_query_task(
 mod tests {
     use super::*;
     use crate::storage::block_manager::block_index::BlockIndex;
-    use crate::storage::block_manager::ManageBlock;
     use crate::storage::proto::Record;
     use prost_wkt_types::Timestamp;
     use rstest::*;

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -75,7 +75,6 @@ impl Default for QueryOptions {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::storage::block_manager::ManageBlock;
     use crate::storage::proto::record::{Label, State as RecordState};
     use crate::storage::proto::Record;
 

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 
 use reduct_base::error::ReductError;
 
-use crate::storage::block_manager::{spawn_read_task, BlockManager, BlockRef, ManageBlock};
+use crate::storage::block_manager::{spawn_read_task, BlockManager, BlockRef};
 use crate::storage::bucket::RecordReader;
 use crate::storage::proto::record::Label;
 use crate::storage::proto::{record::State as RecordState, ts_to_us, Record};

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -45,8 +45,6 @@ pub struct HistoricalQuery {
     current_block: Option<BlockRef>,
     /// The time of the last update. We use this to check if the query has expired.
     last_update: Instant,
-    /// The query options.
-    options: QueryOptions,
 
     /// Filters
     filters: Vec<Box<dyn RecordFilter<Record> + Send + Sync>>,
@@ -81,7 +79,6 @@ impl HistoricalQuery {
             records_from_current_block: VecDeque::new(),
             current_block: None,
             last_update: Instant::now(),
-            options,
             filters,
         }
     }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Refactoring

### What was changed?

The labels were updated one at a time, which caused  block descriptor and index update overhead. Now the records are batched per block and each block is updated once.


### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
