### PR TITLE
Bug fix: Remove bucket and entry folders through file cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Server shutdown, [PR-557](https://github.com/reductstore/reductstore/pull/557)
 - RS-446: Fix storage engine hanging during replication, [PR-564](https://github.com/reductstore/reductstore/pull/564)
+- Server shutdown, [PR-557](https://github.com/reductstore/reductstore/pull/557)
+- Internal 500 error after removing bucket or entry, [PR-565](https://github.com/reductstore/reductstore/pull/565)
 
 ### Internal
 

--- a/reductstore/src/api/bucket/remove.rs
+++ b/reductstore/src/api/bucket/remove.rs
@@ -21,7 +21,8 @@ pub(crate) async fn remove_bucket(
         .storage
         .write()
         .await
-        .remove_bucket(&bucket_name)?;
+        .remove_bucket(&bucket_name)
+        .await?;
     components
         .token_repo
         .write()

--- a/reductstore/src/api/entry/remove_entry.rs
+++ b/reductstore/src/api/entry/remove_entry.rs
@@ -34,7 +34,8 @@ pub(crate) async fn remove_entry(
         .write()
         .await
         .get_bucket_mut(bucket_name)?
-        .remove_entry(entry_name)?;
+        .remove_entry(entry_name)
+        .await?;
     Ok(())
 }
 

--- a/reductstore/src/core/cache.rs
+++ b/reductstore/src/core/cache.rs
@@ -118,7 +118,6 @@ impl<K: Eq + Hash + Clone, V> Cache<K, V> {
     ///
     /// A vector of references to all values in the cache.
     ///
-    /// # Examples
     pub fn values(&mut self) -> Vec<&V> {
         self.store
             .values_mut()
@@ -127,6 +126,16 @@ impl<K: Eq + Hash + Clone, V> Cache<K, V> {
                 &v.value
             })
             .collect()
+    }
+
+    /// Returns a vector of references to all keys in the cache.
+    ///
+    /// # Returns
+    ///
+    /// A vector of references to all keys in the cache.
+    ///
+    pub fn keys(&self) -> Vec<&K> {
+        self.store.keys().collect()
     }
 
     fn discard_old_descriptors(&mut self) -> Vec<(K, V)> {

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -343,6 +343,7 @@ mod tests {
             .get_bucket_mut("src")
             .unwrap()
             .remove_entry("test")
+            .await
             .unwrap();
 
         assert_eq!(sender.run().await, SyncState::SyncedOrRemoved);

--- a/reductstore/src/storage/block_manager/block_index.rs
+++ b/reductstore/src/storage/block_manager/block_index.rs
@@ -96,7 +96,10 @@ impl BlockIndex {
         }
 
         let block_index_proto = {
-            let file = FILE_CACHE.read(&path, SeekFrom::Start(0)).await?;
+            let file = FILE_CACHE
+                .read(&path, SeekFrom::Start(0))
+                .await?
+                .upgrade()?;
             let mut lock = file.write().await;
             let mut buf = Vec::new();
             if let Err(err) = lock.read_to_end(&mut buf).await {
@@ -189,7 +192,8 @@ impl BlockIndex {
 
         let file = FILE_CACHE
             .write_or_create(&self.path_buf, SeekFrom::Start(0))
-            .await?;
+            .await?
+            .upgrade()?;
         let mut lock = file.write().await;
         lock.set_len(0).await?;
         lock.write_all(&buf).await.map_err(|err| {

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -11,7 +11,6 @@ use reduct_base::msg::bucket_api::{BucketInfo, BucketSettings, FullBucketInfo, Q
 use reduct_base::msg::entry_api::EntryInfo;
 use reduct_base::Labels;
 use std::collections::BTreeMap;
-use std::fs::remove_dir_all;
 use std::io::Write;
 use std::path::PathBuf;
 use tokio::task::JoinSet;

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -603,7 +603,7 @@ mod tests {
     async fn test_remove_entry(mut bucket: Bucket) {
         write(&mut bucket, "test-1", 1, b"test").await.unwrap();
 
-        bucket.remove_entry("test-1").unwrap();
+        bucket.remove_entry("test-1").await.unwrap();
         assert_eq!(
             bucket.get_entry("test-1").err(),
             Some(ReductError::not_found(
@@ -613,9 +613,10 @@ mod tests {
     }
 
     #[rstest]
-    fn test_remove_entry_not_found(mut bucket: Bucket) {
+    #[tokio::test]
+    async fn test_remove_entry_not_found(mut bucket: Bucket) {
         assert_eq!(
-            bucket.remove_entry("test-1").err(),
+            bucket.remove_entry("test-1").await.err(),
             Some(ReductError::not_found(
                 "Entry 'test-1' not found in bucket 'test'"
             ))

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -255,7 +255,7 @@ pub async fn read_in_chunks(
     let mut buf = vec![0; chunk_size as usize];
 
     let seek_and_read = async {
-        let mut rc = file.upgrade()?;
+        let rc = file.upgrade()?;
         let mut lock = rc.write().await;
         lock.seek(SeekFrom::Start(offset + read_bytes)).await?;
         let read = lock.read(&mut buf).await?;
@@ -341,7 +341,7 @@ mod tests {
     mod reader {
         use super::*;
         use crate::storage::entry::Entry;
-        use std::thread::sleep;
+
         use std::time::Duration;
 
         #[rstest]
@@ -393,7 +393,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let mut reader = entry.begin_read(1000).await.unwrap();
+            let reader = entry.begin_read(1000).await.unwrap();
             tokio::time::sleep(IO_OPERATION_TIMEOUT).await;
             tokio::time::sleep(Duration::from_millis(100)).await; // Wait for the task to finish
 

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -133,7 +133,7 @@ impl RecordWriter {
                         }
 
                         {
-                            let mut rc = ctx.file_ref.upgrade()?;
+                            let rc = ctx.file_ref.upgrade()?;
                             let mut lock = rc.write().await;
                             lock.seek(SeekFrom::Start(
                                 ctx.offset + written_bytes - chunk.len() as u64,

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::block_manager::{BlockManager, BlockRef, RecordTx};
-use crate::storage::file_cache::FileRef;
+use crate::storage::file_cache::FileWeak;
 use crate::storage::proto::record;
 use crate::storage::storage::{CHANNEL_BUFFER_SIZE, IO_OPERATION_TIMEOUT};
 use bytes::Bytes;
@@ -40,7 +40,7 @@ struct WriteContext {
     entry_name: String,
     block_id: u64,
     record_timestamp: u64,
-    file_ref: FileRef,
+    file_ref: FileWeak,
     offset: u64,
     content_size: u64,
     block_manager: Arc<RwLock<BlockManager>>,
@@ -133,7 +133,8 @@ impl RecordWriter {
                         }
 
                         {
-                            let mut lock = ctx.file_ref.write().await;
+                            let mut rc = ctx.file_ref.upgrade()?;
+                            let mut lock = rc.write().await;
                             lock.seek(SeekFrom::Start(
                                 ctx.offset + written_bytes - chunk.len() as u64,
                             ))
@@ -162,7 +163,7 @@ impl RecordWriter {
                     "Content is smaller than in content-length",
                 ))
             } else {
-                ctx.file_ref.write().await.flush().await?;
+                ctx.file_ref.upgrade()?.write().await.flush().await?;
                 Ok(())
             }
         };

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -61,7 +61,6 @@ mod tests {
     use reduct_base::Labels;
     use rstest::rstest;
     use std::path::PathBuf;
-    use std::thread::sleep;
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/storage/file_cache.rs
+++ b/reductstore/src/storage/file_cache.rs
@@ -167,7 +167,28 @@ impl FileCache {
             tokio::fs::remove_file(path).await?;
         }
         let mut cache = self.cache.write().await;
+
         cache.remove(path);
+        Ok(())
+    }
+
+    pub async fn remove_dir(&self, path: &PathBuf) -> Result<(), ReductError> {
+        if path.try_exists()? {
+            tokio::fs::remove_dir_all(path).await?;
+        }
+
+        let mut cache = self.cache.write().await;
+
+        let files_to_remove = cache
+            .keys()
+            .iter()
+            .filter(|file_path| file_path.starts_with(path))
+            .map(|file_path| (*file_path).clone())
+            .collect::<Vec<PathBuf>>();
+        for file_path in files_to_remove {
+            cache.remove(&file_path);
+        }
+
         Ok(())
     }
 

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -149,7 +149,8 @@ pub(crate) mod tests {
                     .begin_write_record(&blk, $index)
                     .await
                     .unwrap();
-                let mut file = file.write().await;
+                let rc = file.upgrade().unwrap();
+                let mut file = rc.write().await;
                 file.write($content).await.unwrap();
                 file.flush().await.unwrap();
             }};

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -4,7 +4,6 @@
 use log::{debug, info};
 use std::collections::BTreeMap;
 
-use std::fs::remove_dir_all;
 use std::path::PathBuf;
 
 use std::time::{Duration, Instant};

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -401,7 +401,7 @@ mod tests {
             .unwrap();
         assert_eq!(bucket.name(), "test");
 
-        let result = storage.remove_bucket("test");
+        let result = storage.remove_bucket("test").await;
         assert_eq!(result, Ok(()));
 
         let result = storage.get_bucket("test");
@@ -414,7 +414,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_remove_bucket_with_non_existing_name(#[future] mut storage: Storage) {
-        let result = storage.await.remove_bucket("test");
+        let result = storage.await.remove_bucket("test").await;
         assert_eq!(
             result,
             Err(ReductError::not_found("Bucket 'test' is not found"))
@@ -430,7 +430,7 @@ mod tests {
             .unwrap();
         assert_eq!(bucket.name(), "test");
 
-        let result = storage.remove_bucket("test");
+        let result = storage.remove_bucket("test").await;
         assert_eq!(result, Ok(()));
 
         let storage = Storage::load(path, None).await;
@@ -462,7 +462,7 @@ mod tests {
             .create_bucket("test", BucketSettings::default())
             .unwrap();
         bucket.set_provisioned(true);
-        let err = storage.remove_bucket("test").err().unwrap();
+        let err = storage.remove_bucket("test").await.err().unwrap();
         assert_eq!(
             err,
             ReductError::conflict("Can't remove provisioned bucket 'test'")


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

When an entire bucket or entry is removed, the broken file descriptors get stuck in the FILE_CACHE and cause file system errors. The fix adds a `FileCache.remove_dir` method to safely remove the folder.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
