### PR TITLE
RS-470: Fix WAL overwrite due to infrequent writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-470: Fix WAL overwrite due to infrequent writing, [PR-576](https://github.com/reductstore/reductstore/pull/576)
+
 ## [1.11.1] - 2024-08-23
 
 ### Fixed

--- a/reductstore/src/storage/block_manager/wal.rs
+++ b/reductstore/src/storage/block_manager/wal.rs
@@ -146,7 +146,7 @@ impl Wal for WalImpl {
             self.file_positions.insert(block_id, 0);
             file
         } else {
-            let mut file = get_global_file_cache().write_or_create(&path).await?;
+            let file = get_global_file_cache().write_or_create(&path).await?;
             let pos = match self.file_positions.entry(block_id) {
                 Occupied(e) => e.get().clone(),
                 Vacant(e) => {

--- a/reductstore/src/storage/file_cache.rs
+++ b/reductstore/src/storage/file_cache.rs
@@ -122,6 +122,7 @@ impl FileCache {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub async fn discard(&self, path: &PathBuf) -> Result<(), ReductError> {
         let mut cache = self.cache.write().await;
         cache.remove(path);

--- a/reductstore/src/storage/file_cache.rs
+++ b/reductstore/src/storage/file_cache.rs
@@ -122,6 +122,12 @@ impl FileCache {
         Ok(())
     }
 
+    pub async fn discard(&self, path: &PathBuf) -> Result<(), ReductError> {
+        let mut cache = self.cache.write().await;
+        cache.remove(path);
+        Ok(())
+    }
+
     fn discard_old_descriptors(
         ttl: Duration,
         max_size: usize,


### PR DESCRIPTION
Closes #574 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

File descriptors of WALs are stored in the file cache and invalidated every 30 seconds. If records are written less frequently than once every 30 seconds, the WAL is reopened from position 0 and the previous records are lost.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
