### PR TITLE
RS-413: Add block CRC to block index for integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-418: Remove record API, [PR-560](https://github.com/reductstore/reductstore/pull/560)
 - RS-389: Hard bucket quota, [PR-570](https://github.com/reductstore/reductstore/pull/570)
+- RS-413: Block CRC to block index for integrity check, [PR-584](https://github.com/reductstore/reductstore/pull/584)
 
 ### Changed
 

--- a/reductstore/src/proto/storage.proto
+++ b/reductstore/src/proto/storage.proto
@@ -55,7 +55,7 @@ message Block {
   google.protobuf.Timestamp latest_record_time = 2;    // the timestamp of the latest record
   uint64 size = 3;                                // size of block in bytes (with protobuf overhead)
   repeated Record records = 4;                    // stored records
-  bool invalid = 5;                               // mark block as invalid if some IO happened
+  // bool invalid = 5;                               // DEPRECATED: mark block as invalid if some IO happened
   uint64 record_count = 6;                       // number of records in the block
   uint64 metadata_size = 7;                       // size of metadata in bytes
 }
@@ -66,7 +66,7 @@ message MinimalBlock {
   google.protobuf.Timestamp begin_time = 1;           // when the block started being recorded
   google.protobuf.Timestamp latest_record_time = 2;    // the timestamp of the latest record
   uint64 size = 3;                                // size of block in bytes (with protobuf overhead)
-  bool invalid = 5;                               // mark block as invalid if some IO happened
+  // bool invalid = 5;                               // DEPRECATED: mark block as invalid if some IO happened
   uint64 record_count = 6;                       // number of records in the block
   uint64 metadata_size = 7;                       // size of metadata in bytes
 }
@@ -79,6 +79,7 @@ message BlockIndex {
     uint64 record_count = 3;  // number of records in the block
     uint64 metadata_size = 4;  // size of metadata in bytes
     google.protobuf.Timestamp latest_record_time = 5;  // the timestamp of the latest record
+    optional uint64 crc64 = 6;  // integrity check for a block
   }
 
   repeated Block blocks = 1;

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -118,12 +118,15 @@ impl BlockManager {
             let mut crc = Digest::new();
             crc.write(&buf);
 
-            if self.block_index.get_block(block_id).unwrap().crc64 != Some(crc.sum64()) {
-                error!("Block descriptor {:?} is corrupted. Remove it and its data block, then restart the database", path);
-                return Err(internal_server_error!(
-                    "Block descriptor {:?} is corrupted",
-                    path
-                ));
+            if let Some(block_crc) = self.block_index.get_block(block_id).unwrap().crc64 {
+                // we check crc if the crc is stored in the index for backward compatibility
+                if block_crc != crc.sum64() {
+                    error!("Block descriptor {:?} is corrupted. Remove it and its data block, then restart the database", path);
+                    return Err(internal_server_error!(
+                        "Block descriptor {:?} is corrupted",
+                        path
+                    ));
+                }
             }
 
             let block_from_disk = BlockProto::decode(Bytes::from(buf)).map_err(|e| {

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -118,7 +118,7 @@ impl BlockManager {
             let mut crc = Digest::new();
             crc.write(&buf);
 
-            if (self.block_index.get_block(block_id).unwrap().crc64 != Some(crc.sum64())) {
+            if self.block_index.get_block(block_id).unwrap().crc64 != Some(crc.sum64()) {
                 error!("Block descriptor {:?} is corrupted. Remove it and its data block, then restart the database", path);
                 return Err(internal_server_error!(
                     "Block descriptor {:?} is corrupted",

--- a/reductstore/src/storage/block_manager/block.rs
+++ b/reductstore/src/storage/block_manager/block.rs
@@ -50,7 +50,6 @@ impl From<Block> for BlockProto {
             record_count: block.record_count,
             metadata_size: block.metadata_size,
             records,
-            invalid: false,
         }
     }
 }
@@ -256,7 +255,6 @@ mod tests {
             record_count: 1,
             metadata_size: 4,
             records: vec![record],
-            invalid: false,
         }
     }
 }

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -374,7 +374,9 @@ mod tests {
 
     mod query {
         use super::*;
+        use reduct_base::error::ErrorCode;
         use reduct_base::{no_content, not_found};
+        use std::ptr::read;
 
         #[rstest]
         #[tokio::test]
@@ -451,7 +453,17 @@ mod tests {
             {
                 let rx = entry.get_query_receiver(id).unwrap().upgrade_and_unwrap();
                 let mut rx = rx.write().await;
-                let reader = rx.recv().await.unwrap().unwrap();
+                let reader = loop {
+                    let reader = rx.recv().await.unwrap();
+                    match reader {
+                        Ok(reader) => break reader,
+                        Err(ReductError {
+                            status: ErrorCode::NoContent,
+                            ..
+                        }) => continue,
+                        Err(e) => panic!("Unexpected error: {:?}", e),
+                    }
+                };
                 assert_eq!(reader.timestamp(), 2000000);
             }
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -376,7 +376,6 @@ mod tests {
         use super::*;
         use reduct_base::error::ErrorCode;
         use reduct_base::{no_content, not_found};
-        use std::ptr::read;
 
         #[rstest]
         #[tokio::test]

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -397,14 +397,23 @@ mod tests {
                 labels: vec![],
             });
         }
-        block_manager.save_cache_on_disk().unwrap();
+
+        let mut block_proto: Block = block_manager
+            .load_block(1)
+            .unwrap()
+            .read()
+            .unwrap()
+            .clone()
+            .into();
+        block_proto.record_count = 0;
+        fs::write(path.join("1.meta"), block_proto.encode_to_vec()).unwrap();
 
         // repack the block
         FILE_CACHE.remove(&path.join(BLOCK_INDEX_FILE)).unwrap();
         let entry = EntryLoader::restore_entry(path.clone(), entry_settings).unwrap();
         let info = entry.info().unwrap();
 
-        assert_eq!(info.size, 66);
+        assert_eq!(info.size, 88);
         assert_eq!(info.record_count, 2);
         assert_eq!(info.block_count, 1);
         assert_eq!(info.oldest_record, 1);
@@ -415,7 +424,7 @@ mod tests {
         let block_v19 = block_manager.load_block(1).unwrap().read().unwrap().clone();
         assert_eq!(block_v19.record_count(), 2);
         assert_eq!(block_v19.size(), 20);
-        assert_eq!(block_v19.metadata_size(), 46);
+        assert_eq!(block_v19.metadata_size(), 68);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The storage engine calculates a CRC64 for the contents of block descriptors and stores it in the block index. If the CRC in the index mismatches during block loading, the storage engine returns an error and print in logs message requesting that the corrupt block be deleted.

### Related issues

No

### Does this PR introduce a breaking change?

No, the CRC is an optional field and only works for blocks that are stored in the current version.

### Other information:
