### PR TITLE
RS-454: At least one query param to delete records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-418: Remove record API, [PR-560](https://github.com/reductstore/reductstore/pull/560)
 - RS-389: Hard bucket quota, [PR-570](https://github.com/reductstore/reductstore/pull/570)
 - RS-413: Block CRC to block index for integrity check, [PR-584](https://github.com/reductstore/reductstore/pull/584)
+- RS-454: Check at least one query param to delete records, [PR-595](https://github.com/reductstore/reductstore/pull/595)
 
 ### Changed
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

To avoid removing all records in an entry, we need at least one query parameter.

### Related issues

#560 

### Does this PR introduce a breaking change?

No

### Other information:
