### PR TITLE
RS-419: Rename bucket API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,12 +162,15 @@ jobs:
         run: echo '${{secrets.LICENSE_KEY}}' > ./misc/license.lic
 
       - name: Run Database
-        run: docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=${{matrix.token}}
-          --env RS_CERT_PATH=${{matrix.cert_path}}
-          --env RS_LICENSE_PATH=${{matrix.license_path}}
-          --env RS_CERT_KEY_PATH=/misc/privateKey.key
-          --env RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com"
-          -d ${{github.repository}}
+        run: |
+          docker run --network=host -v ${PWD}/misc:/misc --env RS_API_TOKEN=${{matrix.token}}  \
+            --name reduct                                     \
+            --env RS_CERT_PATH=${{matrix.cert_path}}          \
+            --env RS_LICENSE_PATH=${{matrix.license_path}}    \
+            --env RS_CERT_KEY_PATH=/misc/privateKey.key       \
+            --env RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com"
+            -d ${{github.repository}}
+          sleep 5
 
       - name: Build API tests
         run: docker build -t api ./integration_tests/api
@@ -177,6 +180,11 @@ jobs:
           --env API_TOKEN=${{matrix.token}}
           --env LICENSE_PATH=${{matrix.license_path}}
           --env STORAGE_URL=${{matrix.url}} api
+
+
+      - name: Print docker logs
+        if: always()
+        run: docker logs reduct
 
   migration_test:
     name: Migration Tests
@@ -553,31 +561,6 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
-
-  update_azure_marketplace:
-    runs-on: ubuntu-latest
-    name: Update Azure Marketplace
-    needs:
-      - merge_digests
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: Update Azure Marketplace
-        uses: azure/CLI@v1
-        with:
-          azcliversion: 2.30.0
-          inlineScript: |
-            # import standard images
-            VERSION=${GITHUB_REF#refs/*/}
-            az acr import --name reduct --source docker.io/reduct/store:$VERSION --image reduct/store:$VERSION
-            az acr import --name reduct --source docker.io/reduct/store:$VERSION --image reduct/store:latest --force
-
-            # import enterprise images
-            az acr import --name reduct --source docker.io/reduct/store:$VERSION --image reduct/store-enterprise:$VERSION
-            az acr import --name reduct --source docker.io/reduct/store:$VERSION --image reduct/store-enterprise:latest --force
 
   publish_crate:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
             --env RS_CERT_PATH=${{matrix.cert_path}}          \
             --env RS_LICENSE_PATH=${{matrix.license_path}}    \
             --env RS_CERT_KEY_PATH=/misc/privateKey.key       \
-            --env RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com"
+            --env RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com"  \
             -d ${{github.repository}}
           sleep 5
 
@@ -194,7 +194,7 @@ jobs:
       - build
     strategy:
       matrix:
-        version: [ 'latest', 'v1.10.1', 'v1.9.5', 'v1.8.2', 'v1.7.3']
+        version: [ 'latest', 'v1.10.1', 'v1.9.5', 'v1.8.2', 'v1.7.3' ]
     env:
       RS_API_TOKEN: XXXX
     steps:

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+reorder_imports = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-413: Block CRC to block index for integrity check, [PR-584](https://github.com/reductstore/reductstore/pull/584)
 - RS-454: Check at least one query param to delete records, [PR-595](https://github.com/reductstore/reductstore/pull/595)
 - RS-388: Rename entry API, [PR-596](https://github.com/reductstore/reductstore/pull/596)
+- RS-419: Rename bucket API, [PR-597](https://github.com/reductstore/reductstore/pull/597)
 
 ### Changed
 

--- a/integration_tests/api/bucket_api_test.py
+++ b/integration_tests/api/bucket_api_test.py
@@ -270,3 +270,64 @@ def test__head_bucket_with_full_access_token(
         f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
     )
     assert resp.status_code == 200
+
+
+def test__rename_bucket_ok(base_url, session, bucket_name):
+    """Should rename a bucket"""
+    resp = session.post(f"{base_url}/b/{bucket_name}")
+    assert resp.status_code == 200
+
+    new_bucket_name = "new_bucket_name"
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/rename", json={"name": new_bucket_name}
+    )
+    assert resp.status_code == 200
+
+    resp = session.get(f"{base_url}/b/{bucket_name}")
+    assert resp.status_code == 404
+
+    resp = session.get(f"{base_url}/b/{new_bucket_name}")
+    assert resp.status_code == 200
+
+
+@requires_env("API_TOKEN")
+def test__rename_bucket_with_full_access_token(
+    base_url,
+    session,
+    bucket_name,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
+):
+    """Needs full access to rename bucket"""
+    resp = session.post(f"{base_url}/b/{bucket_name}")
+    assert resp.status_code == 200
+
+    new_bucket_name = "new_bucket_name"
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/rename",
+        json={"name": new_bucket_name},
+        headers=auth_headers(""),
+    )
+    assert resp.status_code == 401
+
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/rename",
+        json={"name": new_bucket_name},
+        headers=auth_headers(token_without_permissions),
+    )
+    assert resp.status_code == 403
+
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/rename",
+        json={"name": new_bucket_name},
+        headers=auth_headers(token_read_bucket),
+    )
+    assert resp.status_code == 403
+
+    resp = session.post(
+        f"{base_url}/b/{bucket_name}/rename",
+        json={"name": new_bucket_name},
+        headers=auth_headers(token_write_bucket),
+    )
+    assert resp.status_code == 403

--- a/integration_tests/api/bucket_api_test.py
+++ b/integration_tests/api/bucket_api_test.py
@@ -278,8 +278,8 @@ def test__rename_bucket_ok(base_url, session, bucket_name):
     assert resp.status_code == 200
 
     new_bucket_name = "new_bucket_name"
-    resp = session.post(
-        f"{base_url}/b/{bucket_name}/rename", json={"name": new_bucket_name}
+    resp = session.put(
+        f"{base_url}/b/{bucket_name}/rename", json={"new_name": new_bucket_name}
     )
     assert resp.status_code == 200
 
@@ -304,30 +304,30 @@ def test__rename_bucket_with_full_access_token(
     assert resp.status_code == 200
 
     new_bucket_name = "new_bucket_name"
-    resp = session.post(
+    resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",
-        json={"name": new_bucket_name},
+        json={"new_name": new_bucket_name},
         headers=auth_headers(""),
     )
     assert resp.status_code == 401
 
-    resp = session.post(
+    resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",
-        json={"name": new_bucket_name},
+        json={"new_name": new_bucket_name},
         headers=auth_headers(token_without_permissions),
     )
     assert resp.status_code == 403
 
-    resp = session.post(
+    resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",
-        json={"name": new_bucket_name},
+        json={"new_name": new_bucket_name},
         headers=auth_headers(token_read_bucket),
     )
     assert resp.status_code == 403
 
-    resp = session.post(
+    resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",
-        json={"name": new_bucket_name},
+        json={"new_name": new_bucket_name},
         headers=auth_headers(token_write_bucket),
     )
     assert resp.status_code == 403

--- a/integration_tests/api/bucket_api_test.py
+++ b/integration_tests/api/bucket_api_test.py
@@ -300,9 +300,6 @@ def test__rename_bucket_with_full_access_token(
     token_write_bucket,
 ):
     """Needs full access to rename bucket"""
-    resp = session.post(f"{base_url}/b/{bucket_name}")
-    assert resp.status_code == 200
-
     new_bucket_name = "new_bucket_name"
     resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -307,3 +307,13 @@ macro_rules! internal_server_error {
         ReductError::internal_server_error($msg)
     };
 }
+
+#[macro_export]
+macro_rules! unauthorized {
+    ($msg:expr, $($arg:tt)*) => {
+        ReductError::unauthorized(&format!($msg, $($arg)*))
+    };
+    ($msg:expr) => {
+        ReductError::unauthorized($msg)
+    };
+}

--- a/reduct_base/src/msg/bucket_api.rs
+++ b/reduct_base/src/msg/bucket_api.rs
@@ -127,3 +127,9 @@ mod tests {
         assert_eq!(QuotaType::from_str(as_string).unwrap(), expected);
     }
 }
+
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct RenameBucket {
+    /// New bucket name
+    pub new_name: String,
+}

--- a/reduct_base/src/msg/entry_api.rs
+++ b/reduct_base/src/msg/entry_api.rs
@@ -36,7 +36,7 @@ pub struct RemoveQueryInfo {
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
-pub struct RenameEnry {
+pub struct RenameEntry {
     /// New entry name
     pub new_name: String,
 }

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -9,34 +9,31 @@ mod server;
 mod token;
 mod ui;
 
-use std::fmt::{Debug, Display, Formatter};
-use std::sync::Arc;
-
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::routing::get;
-use axum::{middleware::from_fn, Router};
-use hyper::http::HeaderValue;
-use serde::de::StdError;
-use tokio::sync::RwLock;
-use tower_http::cors::{Any, CorsLayer};
-
-pub use reduct_base::error::ErrorCode;
-use reduct_base::error::ReductError as BaseHttpError;
-use reduct_macros::Twin;
-
 use crate::api::ui::{redirect_to_index, show_ui};
 use crate::asset::asset_manager::ManageStaticAsset;
 use crate::auth::token_auth::TokenAuthorization;
 use crate::auth::token_repository::ManageTokens;
 use crate::replication::ManageReplications;
 use crate::storage::storage::Storage;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{middleware::from_fn, Router};
 use bucket::create_bucket_api_routes;
 use entry::create_entry_api_routes;
+use hyper::http::HeaderValue;
 use middleware::{default_headers, print_statuses};
+pub use reduct_base::error::ErrorCode;
+use reduct_base::error::ReductError as BaseHttpError;
+use reduct_macros::Twin;
 use replication::create_replication_api_routes;
+use serde::de::StdError;
 use server::create_server_api_routes;
+use std::fmt::{Debug, Display, Formatter};
+use std::sync::Arc;
 use token::create_token_api_routes;
+use tokio::sync::RwLock;
+use tower_http::cors::{Any, CorsLayer};
 
 pub struct Components {
     pub storage: Arc<Storage>,

--- a/reductstore/src/api/bucket.rs
+++ b/reductstore/src/api/bucket.rs
@@ -5,10 +5,16 @@ mod create;
 mod get;
 mod head;
 mod remove;
+mod rename;
 mod update;
 
-use std::sync::Arc;
-
+use crate::api::bucket::create::create_bucket;
+use crate::api::bucket::get::get_bucket;
+use crate::api::bucket::head::head_bucket;
+use crate::api::bucket::remove::remove_bucket;
+use crate::api::bucket::rename::rename_bucket;
+use crate::api::bucket::update::update_bucket;
+use crate::api::{Components, HttpError};
 use axum::async_trait;
 use axum::body::Body;
 use axum::extract::FromRequest;
@@ -17,16 +23,10 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, head, post, put};
 use axum_extra::headers::HeaderMapExt;
 use bytes::Bytes;
-
-use crate::api::bucket::create::create_bucket;
-use crate::api::bucket::get::get_bucket;
-use crate::api::bucket::head::head_bucket;
-use crate::api::bucket::remove::remove_bucket;
-use crate::api::bucket::update::update_bucket;
-
-use crate::api::{Components, HttpError};
 use reduct_base::msg::bucket_api::{BucketSettings, FullBucketInfo};
 use reduct_macros::{IntoResponse, Twin};
+use std::sync::Arc;
+
 //
 // BucketSettings wrapper
 //
@@ -72,12 +72,12 @@ pub(crate) fn create_bucket_api_routes() -> axum::Router<Arc<Components>> {
         .route("/:bucket_name", post(create_bucket))
         .route("/:bucket_name", put(update_bucket))
         .route("/:bucket_name", delete(remove_bucket))
+        .route("/:bucket_name/rename", put(rename_bucket))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use axum::http::Method;
 
     #[tokio::test]

--- a/reductstore/src/api/bucket/remove.rs
+++ b/reductstore/src/api/bucket/remove.rs
@@ -17,7 +17,7 @@ pub(crate) async fn remove_bucket(
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
     check_permissions(&components, headers, FullAccessPolicy {}).await?;
-    components.storage.remove_bucket(&bucket_name)?;
+    components.storage.remove_bucket(&bucket_name).await?;
     components
         .token_repo
         .write()

--- a/reductstore/src/api/bucket/rename.rs
+++ b/reductstore/src/api/bucket/rename.rs
@@ -1,0 +1,110 @@
+// Copyright 2023-2024 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::api::middleware::check_permissions;
+use crate::api::{Components, HttpError};
+use crate::auth::policy::FullAccessPolicy;
+use axum::extract::{Path, State};
+use axum::Json;
+use axum_extra::headers::HeaderMap;
+use reduct_base::msg::bucket_api::RenameBucket;
+use std::sync::Arc;
+
+// PUT /b/:bucket_name/rename
+pub(crate) async fn rename_bucket(
+    State(components): State<Arc<Components>>,
+    Path(bucket_name): Path<String>,
+    headers: HeaderMap,
+    request: Json<RenameBucket>,
+) -> Result<(), HttpError> {
+    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    components
+        .storage
+        .rename_bucket(&bucket_name, &request.new_name)
+        .await?;
+    components
+        .token_repo
+        .write()
+        .await
+        .rename_bucket(&bucket_name, &request.new_name)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::tests::{components, headers};
+    use crate::api::Components;
+    use reduct_base::error::ReductError;
+    use reduct_base::not_found;
+    use rstest::{fixture, rstest};
+    use std::sync::Arc;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_rename_bucket(
+        #[future] components: Arc<Components>,
+        headers: HeaderMap,
+        request: Json<RenameBucket>,
+    ) {
+        let components = components.await;
+        rename_bucket(
+            State(components.clone()),
+            Path("bucket-1".to_string()),
+            headers,
+            request,
+        )
+        .await
+        .unwrap();
+
+        let bucket = components
+            .storage
+            .get_bucket("new-bucket")
+            .unwrap()
+            .upgrade()
+            .unwrap();
+
+        assert_eq!(bucket.name(), "new-bucket");
+
+        let token = components
+            .token_repo
+            .read()
+            .await
+            .get_token("test")
+            .unwrap()
+            .clone();
+        assert_eq!(
+            token.permissions.unwrap().write,
+            vec!["new-bucket".to_string()]
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_rename_bucket_not_found(
+        #[future] components: Arc<Components>,
+        headers: HeaderMap,
+        request: Json<RenameBucket>,
+    ) {
+        let components = components.await;
+        let result = rename_bucket(
+            State(components.clone()),
+            Path("NOT_EXIST".to_string()),
+            headers,
+            request,
+        )
+        .await;
+
+        assert_eq!(
+            result.unwrap_err(),
+            not_found!("Bucket 'NOT_EXIST' is not found").into()
+        );
+    }
+
+    #[fixture]
+    fn request() -> Json<RenameBucket> {
+        Json(RenameBucket {
+            new_name: "new-bucket".to_string(),
+        })
+    }
+}

--- a/reductstore/src/api/bucket/rename.rs
+++ b/reductstore/src/api/bucket/rename.rs
@@ -36,6 +36,7 @@ mod tests {
     use crate::api::tests::{components, headers};
     use crate::api::Components;
     use reduct_base::error::ReductError;
+    use reduct_base::msg::token_api::Permissions;
     use reduct_base::not_found;
     use rstest::{fixture, rstest};
     use std::sync::Arc;
@@ -48,6 +49,20 @@ mod tests {
         request: Json<RenameBucket>,
     ) {
         let components = components.await;
+        components
+            .token_repo
+            .write()
+            .await
+            .generate_token(
+                "test-1",
+                Permissions {
+                    full_access: false,
+                    read: vec!["bucket-1".to_string()],
+                    write: vec!["bucket-1".to_string()],
+                },
+            )
+            .unwrap();
+
         rename_bucket(
             State(components.clone()),
             Path("bucket-1".to_string()),
@@ -70,7 +85,7 @@ mod tests {
             .token_repo
             .read()
             .await
-            .get_token("test")
+            .get_token("test-1")
             .unwrap()
             .clone();
         assert_eq!(

--- a/reductstore/src/api/entry/rename_entry.rs
+++ b/reductstore/src/api/entry/rename_entry.rs
@@ -4,13 +4,11 @@
 use crate::api::middleware::check_permissions;
 use crate::api::{Components, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
-use std::collections::HashMap;
-
 use axum::extract::{Path, State};
-use axum_extra::headers::HeaderMap;
-
 use axum::Json;
-use reduct_base::msg::entry_api::RenameEnry;
+use axum_extra::headers::HeaderMap;
+use reduct_base::msg::entry_api::RenameEntry;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 // PUT /b/:bucket_name/:entry_name
@@ -18,7 +16,7 @@ pub(crate) async fn rename_entry(
     State(components): State<Arc<Components>>,
     Path(path): Path<HashMap<String, String>>,
     headers: HeaderMap,
-    request: Json<RenameEnry>,
+    request: Json<RenameEntry>,
 ) -> Result<(), HttpError> {
     let bucket_name = path.get("bucket_name").unwrap();
     let entry_name = path.get("entry_name").unwrap();
@@ -53,7 +51,7 @@ mod tests {
     async fn test_rename_entry(
         #[future] components: Arc<Components>,
         headers: HeaderMap,
-        request: RenameEnry,
+        request: RenameEntry,
     ) {
         let components = components.await;
         let path = HashMap::from_iter(vec![
@@ -102,7 +100,7 @@ mod tests {
     async fn test_rename_bucket_not_found(
         #[future] components: Arc<Components>,
         headers: HeaderMap,
-        request: RenameEnry,
+        request: RenameEntry,
     ) {
         let components = components.await;
         let path = HashMap::from_iter(vec![
@@ -129,7 +127,7 @@ mod tests {
     async fn test_rename_entry_not_found(
         #[future] components: Arc<Components>,
         headers: HeaderMap,
-        request: RenameEnry,
+        request: RenameEntry,
     ) {
         let components = components.await;
         let path = HashMap::from_iter(vec![
@@ -155,8 +153,8 @@ mod tests {
     }
 
     #[fixture]
-    fn request() -> RenameEnry {
-        RenameEnry {
+    fn request() -> RenameEntry {
+        RenameEntry {
             new_name: "entry-2".to_string(),
         }
     }

--- a/reductstore/src/auth/token_repository.rs
+++ b/reductstore/src/auth/token_repository.rs
@@ -869,7 +869,6 @@ mod tests {
 
     mod rename_bucket {
         use super::*;
-        use std::ops::Deref;
 
         #[rstest]
         fn test_rename_bucket(mut repo: Box<dyn ManageTokens>) {

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -162,17 +162,7 @@ impl Storage {
     ///
     /// * HTTPError - An error if the bucket doesn't exist
     pub(crate) fn remove_bucket(&self, name: &str) -> TaskHandle<Result<(), ReductError>> {
-        let task_group = [
-            self.data_path
-                .parent()
-                .unwrap()
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            name,
-        ]
-        .join("/");
+        let task_group = [self.data_path.file_name().unwrap().to_str().unwrap(), name].join("/");
 
         let path = self.data_path.join(name);
         let buckets = self.buckets.clone();
@@ -205,13 +195,7 @@ impl Storage {
         new_name: &str,
     ) -> TaskHandle<Result<(), ReductError>> {
         let task_group = [
-            self.data_path
-                .parent()
-                .unwrap()
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap(),
+            self.data_path.file_name().unwrap().to_str().unwrap(),
             old_name,
         ]
         .join("/");


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

A new HTTP API endpoint introduced:

* PUT /b/:bucket//rename

with JSON payload:

```json
{
   "new_name": "bucket-2"
}
```

The Storage Engine renames the bucket's folder and reloads the block indexes. 

### Related issues

#596 

### Does this PR introduce a breaking change?

(What changes might users need to make in their application due to this PR?)

### Other information:
