### PR TITLE
Fix deadlock in continuous query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server shutdown, [PR-557](https://github.com/reductstore/reductstore/pull/557)
 - Internal 500 error after removing bucket or entry, [PR-565](https://github.com/reductstore/reductstore/pull/565)
 - RS-479: Channel synchronization during write operation in HTTP API, [PR-594](https://github.com/reductstore/reductstore/pull/594)
+- Deadlock in continuous query, [PR-598](https://github.com/reductstore/reductstore/pull/598)
 
 ### Internal
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -27,9 +27,7 @@ use tokio::sync::RwLock as AsyncRwLock;
 
 pub(crate) use io::record_writer::{RecordDrainer, RecordWriter, WriteRecordContent};
 
-use crate::core::thread_pool::{
-    shared, shared_child, shared_isolated, try_unique, unique_child, TaskHandle,
-};
+use crate::core::thread_pool::{shared, try_unique, unique_child, TaskHandle};
 use crate::core::weak::Weak;
 pub(crate) use io::record_reader::RecordReader;
 use reduct_base::internal_server_error;
@@ -411,6 +409,8 @@ mod tests {
                     Some(no_content!("No content"))
                 );
             }
+
+            sleep(Duration::from_millis(100)); // let query task finish
 
             assert_eq!(
                 entry.get_query_receiver(id).err(),

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -172,13 +172,7 @@ impl Entry {
     ) -> Result<Weak<AsyncRwLock<QueryRx>>, ReductError> {
         let entry_path = format!("{}/{}", self.bucket_name, self.name);
         let queries = Arc::clone(&self.queries);
-        let (tx, rx) = std::sync::mpsc::sync_channel(1);
-        shared(&self.task_group(), "remove expired query", move || {
-            Self::remove_expired_query(queries, entry_path);
-            tx.send(()).unwrap();
-        });
-
-        rx.recv().unwrap();
+        Self::remove_expired_query(queries, entry_path);
 
         let mut queries = self.queries.write()?;
 
@@ -312,9 +306,9 @@ mod tests {
     use bytes::Bytes;
     use reduct_base::Labels;
     use rstest::{fixture, rstest};
+    use std::thread::sleep;
     use std::time::Duration;
     use tempfile;
-    use tokio::time::sleep;
 
     mod restore {
         use super::*;
@@ -324,8 +318,8 @@ mod tests {
         #[tokio::test]
         async fn test_restore(entry_settings: EntrySettings, path: PathBuf) {
             let mut entry = entry(entry_settings.clone(), path.clone());
-            write_stub_record(&mut entry, 1).await.unwrap();
-            write_stub_record(&mut entry, 2000010).await.unwrap();
+            write_stub_record(&mut entry, 1);
+            write_stub_record(&mut entry, 2000010);
 
             let mut bm = entry.block_manager.write().unwrap();
             let records = bm
@@ -376,13 +370,14 @@ mod tests {
         use super::*;
         use reduct_base::error::ErrorCode;
         use reduct_base::{no_content, not_found};
+        use std::thread::sleep;
 
         #[rstest]
         #[tokio::test]
         async fn test_historical_query(mut entry: Entry) {
-            write_stub_record(&mut entry, 1000000).await.unwrap();
-            write_stub_record(&mut entry, 2000000).await.unwrap();
-            write_stub_record(&mut entry, 3000000).await.unwrap();
+            write_stub_record(&mut entry, 1000000);
+            write_stub_record(&mut entry, 2000000);
+            write_stub_record(&mut entry, 3000000);
 
             let id = entry
                 .query(0, 4000000, QueryOptions::default())
@@ -420,9 +415,8 @@ mod tests {
         }
 
         #[rstest]
-        #[tokio::test]
-        async fn test_continuous_query(mut entry: Entry) {
-            write_stub_record(&mut entry, 1000000).await.unwrap();
+        fn test_continuous_query(mut entry: Entry) {
+            write_stub_record(&mut entry, 1000000);
 
             let id = entry
                 .query(
@@ -434,26 +428,26 @@ mod tests {
                         ..QueryOptions::default()
                     },
                 )
-                .await
+                .wait()
                 .unwrap();
 
             {
                 let rx = entry.get_query_receiver(id).unwrap().upgrade_and_unwrap();
-                let mut rx = rx.write().await;
-                let reader = rx.recv().await.unwrap().unwrap();
+                let mut rx = rx.blocking_write();
+                let reader = rx.blocking_recv().unwrap().unwrap();
                 assert_eq!(reader.timestamp(), 1000000);
                 assert_eq!(
-                    rx.recv().await.unwrap().err(),
+                    rx.blocking_recv().unwrap().err(),
                     Some(no_content!("No content"))
                 );
             }
 
-            write_stub_record(&mut entry, 2000000).await.unwrap();
+            write_stub_record(&mut entry, 2000000);
             {
                 let rx = entry.get_query_receiver(id).unwrap().upgrade_and_unwrap();
-                let mut rx = rx.write().await;
+                let mut rx = rx.blocking_write();
                 let reader = loop {
-                    let reader = rx.recv().await.unwrap();
+                    let reader = rx.blocking_recv().unwrap();
                     match reader {
                         Ok(reader) => break reader,
                         Err(ReductError {
@@ -466,7 +460,7 @@ mod tests {
                 assert_eq!(reader.timestamp(), 2000000);
             }
 
-            sleep(Duration::from_millis(700)).await;
+            sleep(Duration::from_millis(700));
             assert_eq!(
                 entry.get_query_receiver(id).err(),
                 Some(not_found!("Query {} not found and it might have expired. Check TTL in your query request. Default value 60 sec.", id))
@@ -475,8 +469,7 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_info(path: PathBuf) {
+    fn test_info(path: PathBuf) {
         let mut entry = entry(
             EntrySettings {
                 max_block_size: 10000,
@@ -485,9 +478,9 @@ mod tests {
             path,
         );
 
-        write_stub_record(&mut entry, 1000000).await.unwrap();
-        write_stub_record(&mut entry, 2000000).await.unwrap();
-        write_stub_record(&mut entry, 3000000).await.unwrap();
+        write_stub_record(&mut entry, 1000000);
+        write_stub_record(&mut entry, 2000000);
+        write_stub_record(&mut entry, 3000000);
 
         let info = entry.info().unwrap();
         assert_eq!(info.name, "entry");
@@ -500,6 +493,7 @@ mod tests {
 
     mod try_remove_oldest_block {
         use super::*;
+        use std::thread::sleep;
 
         use crate::storage::storage::{CHANNEL_BUFFER_SIZE, MAX_IO_BUFFER_SIZE};
 
@@ -512,17 +506,14 @@ mod tests {
         }
 
         #[rstest]
-        #[tokio::test]
-        async fn test_entry_which_has_reader(mut entry: Entry) {
+        fn test_entry_which_has_reader(mut entry: Entry) {
             write_record(
                 &mut entry,
                 1000000,
                 vec![0; MAX_IO_BUFFER_SIZE * CHANNEL_BUFFER_SIZE + 1],
-            )
-            .await
-            .unwrap();
+            );
             let _rx = entry.begin_read(1000000).wait().unwrap();
-            sleep(Duration::from_millis(100)).await;
+            sleep(Duration::from_millis(100));
 
             assert_eq!(
                 entry.try_remove_oldest_block().wait(),
@@ -546,7 +537,7 @@ mod tests {
                 .blocking_send(Ok(Some(Bytes::from_static(b"456789"))))
                 .unwrap();
 
-            std::thread::sleep(Duration::from_millis(100));
+            sleep(Duration::from_millis(100));
             assert_eq!(
                 entry.try_remove_oldest_block().wait(),
                 Err(internal_server_error!(
@@ -559,8 +550,7 @@ mod tests {
         }
 
         #[rstest]
-        #[tokio::test]
-        async fn test_size_counting(path: PathBuf) {
+        fn test_size_counting(path: PathBuf) {
             let mut entry = Entry::try_new(
                 "entry",
                 path.clone(),
@@ -571,21 +561,21 @@ mod tests {
             )
             .unwrap();
 
-            write_stub_record(&mut entry, 1000000).await.unwrap();
-            write_stub_record(&mut entry, 2000000).await.unwrap();
-            write_stub_record(&mut entry, 3000000).await.unwrap();
-            write_stub_record(&mut entry, 4000000).await.unwrap();
+            write_stub_record(&mut entry, 1000000);
+            write_stub_record(&mut entry, 2000000);
+            write_stub_record(&mut entry, 3000000);
+            write_stub_record(&mut entry, 4000000);
 
             assert_eq!(entry.info().unwrap().block_count, 2);
             assert_eq!(entry.info().unwrap().record_count, 4);
             assert_eq!(entry.info().unwrap().size, 138);
 
-            entry.try_remove_oldest_block().await.unwrap();
+            entry.try_remove_oldest_block().wait().unwrap();
             assert_eq!(entry.info().unwrap().block_count, 1);
             assert_eq!(entry.info().unwrap().record_count, 2);
             assert_eq!(entry.info().unwrap().size, 58);
 
-            entry.try_remove_oldest_block().await.unwrap();
+            entry.try_remove_oldest_block().wait().unwrap();
             assert_eq!(entry.info().unwrap().block_count, 0);
             assert_eq!(entry.info().unwrap().record_count, 0);
             assert_eq!(entry.info().unwrap().size, 0);
@@ -610,53 +600,40 @@ mod tests {
         tempfile::tempdir().unwrap().into_path().join("bucket")
     }
 
-    pub async fn write_record(
-        entry: &mut Entry,
-        time: u64,
-        data: Vec<u8>,
-    ) -> Result<(), ReductError> {
+    pub fn write_record(entry: &mut Entry, time: u64, data: Vec<u8>) {
         let sender = entry
             .begin_write(time, data.len(), "text/plain".to_string(), Labels::new())
-            .await?;
-        let x = sender.tx().send(Ok(Some(Bytes::from(data)))).await;
+            .wait()
+            .unwrap();
         sender
             .tx()
-            .send(Ok(None))
-            .await
+            .blocking_send(Ok(Some(Bytes::from(data))))
+            .unwrap();
+        sender
+            .tx()
+            .blocking_send(Ok(None))
             .expect("Failed to send None");
-        sender.tx().closed().await;
         drop(sender);
-        sleep(Duration::from_millis(10)).await; // let the record be written
-        match x {
-            Ok(_) => Ok(()),
-            Err(_) => Err(ReductError::internal_server_error("Error sending data")),
-        }
+        sleep(Duration::from_millis(10)); // let the record be written
     }
 
-    pub async fn write_record_with_labels(
-        entry: &mut Entry,
-        time: u64,
-        data: Vec<u8>,
-        labels: Labels,
-    ) -> Result<(), ReductError> {
+    pub fn write_record_with_labels(entry: &mut Entry, time: u64, data: Vec<u8>, labels: Labels) {
         let sender = entry
             .begin_write(time, data.len(), "text/plain".to_string(), labels)
-            .await?;
-        let x = sender.tx().send(Ok(Some(Bytes::from(data)))).await;
+            .wait()
+            .unwrap();
         sender
             .tx()
-            .send(Ok(None))
-            .await
+            .blocking_send(Ok(Some(Bytes::from(data))))
+            .unwrap();
+        sender
+            .tx()
+            .blocking_send(Ok(None))
             .expect("Failed to send None");
-        sender.tx().closed().await;
-        match x {
-            Ok(_) => Ok(()),
-            Err(_) => Err(internal_server_error!("Error sending data")),
-        }
     }
 
-    pub(super) async fn write_stub_record(entry: &mut Entry, time: u64) -> Result<(), ReductError> {
-        write_record(entry, time, b"0123456789".to_vec()).await
+    pub(super) fn write_stub_record(entry: &mut Entry, time: u64) {
+        write_record(entry, time, b"0123456789".to_vec());
     }
 
     pub fn get_task_group(entry_path: &PathBuf, time: u64) -> String {

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -282,11 +282,10 @@ mod tests {
     use rstest::{fixture, rstest};
 
     #[rstest]
-    #[tokio::test]
-    async fn test_restore(entry_settings: EntrySettings, path: PathBuf) {
+    fn test_restore(entry_settings: EntrySettings, path: PathBuf) {
         let mut entry = entry(entry_settings.clone(), path.clone());
-        write_stub_record(&mut entry, 1).await.unwrap();
-        write_stub_record(&mut entry, 2000010).await.unwrap();
+        write_stub_record(&mut entry, 1);
+        write_stub_record(&mut entry, 2000010);
 
         let mut bm = entry.block_manager.write().unwrap();
         let records = bm
@@ -330,23 +329,23 @@ mod tests {
         assert_eq!(info.record_count, 2);
         assert_eq!(info.size, 88);
 
-        let mut rec = entry.begin_read(1).await.unwrap();
+        let mut rec = entry.begin_read(1).wait().unwrap();
         assert_eq!(rec.timestamp(), 1);
         assert_eq!(rec.content_length(), 10);
         assert_eq!(rec.content_type(), "text/plain");
 
         assert_eq!(
-            rec.rx().recv().await.unwrap().unwrap(),
+            rec.rx().blocking_recv().unwrap().unwrap(),
             Bytes::from_static(b"0123456789")
         );
 
-        let mut rec = entry.begin_read(2000010).await.unwrap();
+        let mut rec = entry.begin_read(2000010).wait().unwrap();
         assert_eq!(rec.timestamp(), 2000010);
         assert_eq!(rec.content_length(), 10);
         assert_eq!(rec.content_type(), "text/plain");
 
         assert_eq!(
-            rec.rx().recv().await.unwrap().unwrap(),
+            rec.rx().blocking_recv().unwrap().unwrap(),
             Bytes::from_static(b"0123456789")
         );
     }
@@ -428,11 +427,10 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_create_block_index(path: PathBuf, entry_settings: EntrySettings) {
+    fn test_create_block_index(path: PathBuf, entry_settings: EntrySettings) {
         let mut entry = entry(entry_settings.clone(), path.clone());
-        write_stub_record(&mut entry, 1).await.unwrap();
-        write_stub_record(&mut entry, 2000010).await.unwrap();
+        write_stub_record(&mut entry, 1);
+        write_stub_record(&mut entry, 2000010);
         entry
             .block_manager
             .write()
@@ -455,11 +453,10 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_check_integrity_block_index(path: PathBuf, entry_settings: EntrySettings) {
+    fn test_check_integrity_block_index(path: PathBuf, entry_settings: EntrySettings) {
         let mut entry = entry(entry_settings.clone(), path.clone());
-        write_stub_record(&mut entry, 1).await.unwrap();
-        write_stub_record(&mut entry, 2000010).await.unwrap();
+        write_stub_record(&mut entry, 1);
+        write_stub_record(&mut entry, 2000010);
         let _ = entry.block_manager.write().unwrap().save_cache_on_disk();
 
         EntryLoader::restore_entry(path.join(entry.name.clone()), entry_settings.clone()).unwrap();
@@ -495,8 +492,7 @@ mod tests {
         use super::*;
 
         #[rstest]
-        #[tokio::test]
-        async fn test_new_block(entry_fix: (Entry, PathBuf), record2: Record) {
+        fn test_new_block(entry_fix: (Entry, PathBuf), record2: Record) {
             let (entry, path) = entry_fix;
             let mut wal = create_wal(path.clone());
             // Block #3 was created
@@ -530,8 +526,7 @@ mod tests {
         }
 
         #[rstest]
-        #[tokio::test]
-        async fn test_update_block(entry_fix: (Entry, PathBuf), mut record2: Record) {
+        fn test_update_block(entry_fix: (Entry, PathBuf), mut record2: Record) {
             let (entry, path) = entry_fix;
             let mut wal = create_wal(path.clone());
 
@@ -558,8 +553,7 @@ mod tests {
         }
 
         #[rstest]
-        #[tokio::test]
-        async fn test_remove_record(entry_fix: (Entry, PathBuf)) {
+        fn test_remove_record(entry_fix: (Entry, PathBuf)) {
             let (entry, path) = entry_fix;
             let mut wal = create_wal(path.clone());
 
@@ -576,8 +570,7 @@ mod tests {
         }
 
         #[rstest]
-        #[tokio::test]
-        async fn test_remove_block(entry_fix: (Entry, PathBuf)) {
+        fn test_remove_block(entry_fix: (Entry, PathBuf)) {
             let (entry, path) = entry_fix;
             let mut wal = create_wal(path.clone());
 
@@ -590,8 +583,7 @@ mod tests {
         }
 
         #[rstest]
-        #[tokio::test]
-        async fn test_corrupted_wal(entry_fix: (Entry, PathBuf)) {
+        fn test_corrupted_wal(entry_fix: (Entry, PathBuf)) {
             let (entry, path) = entry_fix;
 
             fs::write(path.join("wal/1.wal"), b"bad data").unwrap();

--- a/reductstore/src/storage/entry/remove_records.rs
+++ b/reductstore/src/storage/entry/remove_records.rs
@@ -249,10 +249,10 @@ mod tests {
             ..entry.settings()
         });
 
-        write_stub_record(&mut entry, 1).await.unwrap();
-        write_stub_record(&mut entry, 2).await.unwrap();
-        write_stub_record(&mut entry, 3).await.unwrap();
-        write_stub_record(&mut entry, 4).await.unwrap();
+        write_stub_record(&mut entry, 1);
+        write_stub_record(&mut entry, 2);
+        write_stub_record(&mut entry, 3);
+        write_stub_record(&mut entry, 4);
         entry
     }
 }

--- a/reductstore/src/storage/entry/remove_records.rs
+++ b/reductstore/src/storage/entry/remove_records.rs
@@ -195,7 +195,7 @@ mod tests {
     use rstest::{fixture, rstest};
 
     #[rstest]
-    fn test_remove_records(mut entry_with_data: Entry) {
+    fn test_remove_records(entry_with_data: Entry) {
         let timestamps = vec![0, 2, 4, 5];
         let error_map = entry_with_data.remove_records(timestamps).wait().unwrap();
 
@@ -219,7 +219,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_query_remove_records(mut entry_with_data: Entry) {
+    fn test_query_remove_records(entry_with_data: Entry) {
         let removed_records = entry_with_data
             .query_remove_records(2, 4, QueryOptions::default())
             .wait()

--- a/reductstore/src/storage/entry/update_labels.rs
+++ b/reductstore/src/storage/entry/update_labels.rs
@@ -275,7 +275,7 @@ mod tests {
         ]
     }
 
-    async fn write_stub_record(mut entry: &mut Entry, time: u64) {
+    fn write_stub_record(mut entry: &mut Entry, time: u64) {
         write_record_with_labels(
             &mut entry,
             time,

--- a/reductstore/src/storage/entry/update_labels.rs
+++ b/reductstore/src/storage/entry/update_labels.rs
@@ -147,15 +147,14 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[tokio::test]
-    async fn test_update_labels(mut entry: Entry) {
+    fn test_update_labels(mut entry: Entry) {
         entry.set_settings(EntrySettings {
             max_block_records: 2,
             ..entry.settings()
         });
-        write_stub_record(&mut entry, 1).await.unwrap();
-        write_stub_record(&mut entry, 2).await.unwrap();
-        write_stub_record(&mut entry, 3).await.unwrap();
+        write_stub_record(&mut entry, 1);
+        write_stub_record(&mut entry, 2);
+        write_stub_record(&mut entry, 3);
 
         // update, remove and add labels
         let result = entry
@@ -166,7 +165,7 @@ mod tests {
                 make_update(3),
                 make_update(5),
             ])
-            .await
+            .wait()
             .unwrap();
 
         // check results
@@ -199,33 +198,32 @@ mod tests {
         assert!(updated_labels.contains(&expected_labels_3[1]));
 
         // check if the records were updated
-        let record = entry.begin_read(1).await.unwrap().record().clone();
+        let record = entry.begin_read(1).wait().unwrap().record().clone();
         assert_eq!(record.labels.len(), 2);
         assert!(record.labels.contains(&expected_labels_1[0]));
         assert!(record.labels.contains(&expected_labels_1[1]));
 
-        let record = entry.begin_read(2).await.unwrap().record().clone();
+        let record = entry.begin_read(2).wait().unwrap().record().clone();
         assert_eq!(record.labels.len(), 2);
         assert!(record.labels.contains(&expected_labels_2[0]));
         assert!(record.labels.contains(&expected_labels_2[1]));
 
-        let record = entry.begin_read(3).await.unwrap().record().clone();
+        let record = entry.begin_read(3).wait().unwrap().record().clone();
         assert_eq!(record.labels.len(), 2);
         assert!(record.labels.contains(&expected_labels_3[0]));
         assert!(record.labels.contains(&expected_labels_3[1]));
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_update_nothing(mut entry: Entry) {
-        write_stub_record(&mut entry, 1).await.unwrap();
+    fn test_update_nothing(mut entry: Entry) {
+        write_stub_record(&mut entry, 1);
         let result = entry
             .update_labels(vec![UpdateLabels {
                 time: 1,
                 update: Labels::new(),
                 remove: HashSet::new(),
             }])
-            .await
+            .wait()
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -277,7 +275,7 @@ mod tests {
         ]
     }
 
-    async fn write_stub_record(mut entry: &mut Entry, time: u64) -> Result<(), ReductError> {
+    async fn write_stub_record(mut entry: &mut Entry, time: u64) {
         write_record_with_labels(
             &mut entry,
             time,
@@ -286,7 +284,6 @@ mod tests {
                 (format!("a-{}", time), format!("x-{}", time)),
                 (format!("c-{}", time), format!("z-{}", time)),
             ]),
-        )
-        .await
+        );
     }
 }

--- a/reductstore/src/storage/entry/write_record.rs
+++ b/reductstore/src/storage/entry/write_record.rs
@@ -177,8 +177,7 @@ mod tests {
     use std::path::PathBuf;
 
     #[rstest]
-    #[tokio::test]
-    async fn test_begin_write_new_block_size(path: PathBuf) {
+    fn test_begin_write_new_block_size(path: PathBuf) {
         let mut entry = entry(
             EntrySettings {
                 max_block_size: 10,
@@ -187,9 +186,8 @@ mod tests {
             path,
         );
 
-        write_stub_record(&mut entry, 1).await.unwrap();
-        write_stub_record(&mut entry, 2000010).await.unwrap();
-
+        write_stub_record(&mut entry, 1);
+        write_stub_record(&mut entry, 2000010);
         let bm = entry.block_manager.read().unwrap();
 
         assert_eq!(
@@ -230,8 +228,7 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_begin_write_new_block_records(path: PathBuf) {
+    fn test_begin_write_new_block_records(path: PathBuf) {
         let mut entry = entry(
             EntrySettings {
                 max_block_size: 10000,
@@ -240,9 +237,9 @@ mod tests {
             path,
         );
 
-        write_stub_record(&mut entry, 1).await.unwrap();
-        write_stub_record(&mut entry, 2).await.unwrap();
-        write_stub_record(&mut entry, 2000010).await.unwrap();
+        write_stub_record(&mut entry, 1);
+        write_stub_record(&mut entry, 2);
+        write_stub_record(&mut entry, 2000010);
 
         let bm = entry.block_manager.read().unwrap();
         let records = bm
@@ -285,11 +282,10 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_begin_write_belated_record(mut entry: Entry) {
-        write_stub_record(&mut entry, 1000000).await.unwrap();
-        write_stub_record(&mut entry, 3000000).await.unwrap();
-        write_stub_record(&mut entry, 2000000).await.unwrap();
+    fn test_begin_write_belated_record(mut entry: Entry) {
+        write_stub_record(&mut entry, 1000000);
+        write_stub_record(&mut entry, 3000000);
+        write_stub_record(&mut entry, 2000000);
 
         let bm = entry.block_manager.read().unwrap();
         let records = bm
@@ -315,10 +311,9 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_begin_write_belated_first(mut entry: Entry) {
-        write_stub_record(&mut entry, 3000000).await.unwrap();
-        write_stub_record(&mut entry, 1000000).await.unwrap();
+    fn test_begin_write_belated_first(mut entry: Entry) {
+        write_stub_record(&mut entry, 3000000);
+        write_stub_record(&mut entry, 1000000);
 
         let bm = entry.block_manager.read().unwrap();
         let records = bm
@@ -336,11 +331,12 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_begin_write_existing_record(mut entry: Entry) {
-        write_stub_record(&mut entry, 1000000).await.unwrap();
-        write_stub_record(&mut entry, 2000000).await.unwrap();
-        let err = write_stub_record(&mut entry, 1000000).await;
+    fn test_begin_write_existing_record(mut entry: Entry) {
+        write_stub_record(&mut entry, 1000000);
+        write_stub_record(&mut entry, 2000000);
+        let err = entry
+            .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
+            .wait();
         assert_eq!(
             err.err(),
             Some(ReductError::conflict(
@@ -350,11 +346,12 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_begin_write_existing_record_belated(mut entry: Entry) {
-        write_stub_record(&mut entry, 2000000).await.unwrap();
-        write_stub_record(&mut entry, 1000000).await.unwrap();
-        let err = write_stub_record(&mut entry, 1000000).await;
+    fn test_begin_write_existing_record_belated(mut entry: Entry) {
+        write_stub_record(&mut entry, 2000000);
+        write_stub_record(&mut entry, 1000000);
+        let err = entry
+            .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
+            .wait();
         assert_eq!(
             err.err(),
             Some(ReductError::conflict(

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -7,7 +7,7 @@ pub mod filters;
 mod historical;
 mod limited;
 
-use crate::core::thread_pool::{shared_isolated, TaskHandle};
+use crate::core::thread_pool::{shared, shared_isolated, TaskHandle};
 use crate::storage::block_manager::BlockManager;
 use crate::storage::entry::RecordReader;
 use crate::storage::query::base::{Query, QueryOptions};
@@ -15,9 +15,9 @@ use log::{trace, warn};
 use reduct_base::error::ErrorCode::NoContent;
 use reduct_base::error::ReductError;
 use reduct_base::unprocessable_entity;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc::Receiver;
 
 pub(crate) type QueryRx = Receiver<Result<RecordReader, ReductError>>;
@@ -45,40 +45,57 @@ pub(in crate::storage) fn build_query(
 
 pub(super) fn spawn_query_task(
     task_group: String,
-    mut query: Box<dyn Query + Send + Sync>,
+    query: Box<dyn Query + Send + Sync>,
     options: QueryOptions,
     block_manager: Arc<RwLock<BlockManager>>,
 ) -> (QueryRx, TaskHandle<()>) {
     let (tx, rx) = tokio::sync::mpsc::channel(QUERY_BUFFER_SIZE);
 
-    let handle = shared_isolated(&task_group.clone(), "spawn query task", move || {
+    // we spawn a new task to run the query outside of hierarchical task group to avoid deadlocks
+    let query = Arc::new(Mutex::new(query));
+    let handle = shared_isolated("spawn_query_task", "spawn query task", move || {
+        trace!("Query task for '{}' running", task_group);
+
         loop {
-            let next_result = query.next(block_manager.clone());
-            let query_err = next_result.as_ref().err().cloned();
+            let group = task_group.clone();
+            let query = query.clone();
+            let block_manager = block_manager.clone();
+            let tx = tx.clone();
 
-            if tx.is_closed() {
-                trace!("Query '{}' task channel closed", task_group);
-                break;
-            }
+            let task = shared(&group.clone(), "query iteration", move || {
+                let next_result = query.lock().unwrap().next(block_manager.clone());
+                let query_err = next_result.as_ref().err().cloned();
 
-            let send_result = tx.blocking_send(next_result);
-
-            if let Err(err) = send_result {
-                warn!("Error sending query '{}' result: {}", task_group, err);
-                break;
-            }
-
-            if let Some(err) = query_err {
-                if err.status == NoContent && options.continuous {
-                    // continuous query will never be done
-                    // but we don't want to flood the channel and wait for the receiver
-                    while tx.capacity() < tx.max_capacity() {
-                        sleep(Duration::from_millis(10));
-                    }
-                } else {
-                    trace!("Query task done for '{}'", task_group);
-                    break;
+                if tx.is_closed() {
+                    trace!("Query '{}' task channel closed", group);
+                    return None;
                 }
+
+                let send_result = tx.blocking_send(next_result);
+
+                if let Err(err) = send_result {
+                    warn!("Error sending query '{}' result: {}", group, err);
+                    return None;
+                }
+
+                if let Some(err) = query_err {
+                    if err.status == NoContent && options.continuous {
+                        // continuous query will never be done
+                        // but we don't want to flood the channel and wait for the receiver
+                        let now = Instant::now();
+                        while tx.capacity() < tx.max_capacity() && now.elapsed() < options.ttl {
+                            sleep(Duration::from_millis(10));
+                        }
+                    } else {
+                        trace!("Query task done for '{}'", group);
+                        return None;
+                    }
+                }
+                Some(())
+            });
+
+            if task.wait().is_none() {
+                break;
             }
         }
     });
@@ -88,6 +105,7 @@ pub(super) fn spawn_query_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::logger::Logger;
     use crate::storage::block_manager::block_index::BlockIndex;
     use crate::storage::proto::Record;
     use prost_wkt_types::Timestamp;
@@ -158,6 +176,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_query_task_continuous_ok(block_manager: Arc<RwLock<BlockManager>>) {
+        Logger::init("TRACE");
         let options = QueryOptions {
             ttl: Duration::from_millis(50),
             continuous: true,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Instead of running an isolated task with a loop inside, I'm spanning shared tasks in the loop so that the continuous query can't hold bucket forever.

### Related issues

#573 

### Does this PR introduce a breaking change?

No

### Other information:
