### PR TITLE
Fix CI actions after Ubuntu update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
           sleep 5
 
       - name: Build API tests
-        run: docker build -t api ./integration_tests/api
+        run:  |
+          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
+          docker build -t api ./integration_tests/api
 
       - name: Run API tests
         run: docker run --network=host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
 
       - name: Run latest stable ReductStore
         run: |
+          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
           docker run --network=host -v ./data:/data --env RS_API_TOKEN=${RS_API_TOKEN} --name latest -d reduct/store:${{matrix.version}}
           sleep 5
           docker logs latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,9 @@ jobs:
       RS_API_TOKEN: XXXX
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
       - name: Run latest stable ReductStore
         run: |
@@ -252,6 +255,9 @@ jobs:
       RS_API_TOKEN: XXXX
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -314,6 +320,9 @@ jobs:
       RS_API_TOKEN: XXXX
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- Fix CI actions after Ubuntu update, [PR-604](https://github.com/reductstore/reductstore/pull/604)
+
 ## [1.12.0] - 2024-10-04
 
 ### Added


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Fix CI

### What was changed?

GitHub actions moved to ubuntu-24.04 and pip install command stopped working, we now use `actions/setup-python@v5`.  Also, I've added `docker login` command to get around the pull limit.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
