### PR TITLE
Fix crash when querying removed entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Crash when querying removed entry, [PR-605](https://github.com/reductstore/reductstore/pull/605)
+
 ## [1.12.0] - 2024-10-04
 
 ### Added


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The database crashed if an entry was removed during data queuing.  It was an unwrap() call instead of the ? operator. Fixed and covered with a test.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
