### PR TITLE
Fix bad file descriptor error in replication log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bad file descriptor error in replication log, [PR-606](https://github.com/reductstore/reductstore/pull/606)
+
 ## [1.12.1] - 2024-10-17
 
 ### Fixed

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -136,7 +136,7 @@ impl ReplicationTask {
                             error!("Failed to remove transaction log: {:?}", err);
                         }
 
-                        info!("Creating a new transaction log");
+                        info!("Creating a new transaction log: {:?}", path);
                         thr_log_map.write().unwrap().insert(
                             entry_name,
                             RwLock::new(

--- a/reductstore/src/replication/transaction_log.rs
+++ b/reductstore/src/replication/transaction_log.rs
@@ -115,7 +115,7 @@ impl TransactionLog {
     ) -> Result<Option<Transaction>, ReductError> {
         {
             let file = FILE_CACHE
-                .read(&self.file_path, SeekFrom::Start(self.write_pos as u64))?
+                .write_or_create(&self.file_path, SeekFrom::Start(self.write_pos as u64))?
                 .upgrade()?;
             let mut file = file.write()?;
 

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -449,8 +449,8 @@ impl BlockManager {
         self.save_block(block_ref)?;
 
         debug!(
-            "Finished writing record {}/{}/{} with state {:?}",
-            self.bucket, self.entry, block_id, state
+            "Finished writing record {} to block {}/{}/{}.meta with state {:?}",
+            record_timestamp, self.bucket, self.entry, block_id, state
         );
 
         Ok(())


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

When the storage engine appends a record to the replication log, it gets it from the file cache with the read access, which is wrong and causes the bad file descriptor (OS error 9) after the database is restarted.

Fixed by changing the access level.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
