### PR TITLE
RS-525: Fix recovering from empty block index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-519: Check bucket name convention when renaming bucket, [PR-616](https://github.com/reductstore/reductstore/pull/616)
 - RS-520: Check if bucket provisioned before renaming it, [PR-617](https://github.com/reductstore/reductstore/pull/617)
 - RS-521: Sync bucket and entry before renaming them, [PR-521](https://github.com/reductstore/reductstore/pull/618)
+- RS-525: Recovering from empty block index, [PR-620](https://github.com/reductstore/reductstore/pull/620)
 
 ## [1.12.2] - 2024-10-21
 

--- a/reductstore/src/storage/block_manager/block_index.rs
+++ b/reductstore/src/storage/block_manager/block_index.rs
@@ -133,6 +133,10 @@ impl BlockIndex {
                 ));
             };
 
+            if lock.metadata()?.len() == 0 {
+                return Err(internal_server_error!("Block index {:?} is empty", path));
+            }
+
             BlockIndexProto::decode(Bytes::from(buf))
         };
 

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -435,12 +435,12 @@ mod tests {
 
         {
             let block_file_index = path.join(&entry.name).join(BLOCK_INDEX_FILE);
-            let mut rc = FILE_CACHE
+            let rc = FILE_CACHE
                 .write_or_create(&block_file_index, SeekFrom::Current(0))
                 .unwrap()
                 .upgrade()
                 .unwrap();
-            let mut file = rc.write().unwrap();
+            let file = rc.write().unwrap();
             file.set_len(0).unwrap();
             file.sync_all().unwrap();
         }


### PR DESCRIPTION
Closes #619 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The storage engine recovers an entry from block descriptors when its block index is empty.

### Related issues

#619 

### Does this PR introduce a breaking change?

No

### Other information:
