### PR TITLE
RS-539: Fix transaction log file descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-539: Fix transaction log file descriptor, [PR-643](https://github.com/reductstore/reductstore/pull/643)
+
 ## [1.12.3] - 2024-10-26
 
 ### Fixed


### PR DESCRIPTION
Closes #641 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR has fixed the access level to ReadWrite for the file descriptor of the transaction log in the pop method. This place caused the bug when the transaction log had records for replications after restarting.

### Related issues

#641

### Does this PR introduce a breaking change?

No

### Other information:
