### PR TITLE
RS-524: Check naming convention before creating or renaming entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-415: Check to prevent replication to the same bucket, [PR-629](https://github.com/reductstore/reductstore/pull/629)
 - RS-527: POST /:bucket/:entry/q endpoint to query with JSON request, [PR-635](https://github.com/reductstore/reductstore/pull/635)
 - RS-528: Conditional query engine, [PR-640](https://github.com/reductstore/reductstore/pull/640)
+- RS-524: Check naming convention before creating or renaming entry, [PR-650](https://github.com/reductstore/reductstore/pull/650)
 
 ### Internal
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR applies to entry name the same restriction what we have for a bucket: only letters, digests and [-,_] symbols

### Related issues

No

### Does this PR introduce a breaking change?

It could be, but only for new entries.

### Other information:
