### PR TITLE
RS-540: Fix synchronization of a new block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-539: Fix transaction log file descriptor, [PR-643](https://github.com/reductstore/reductstore/pull/643)
+- RS-540: Fix synchronization of a new block, [PR-652](https://github.com/reductstore/reductstore/pull/652)
 
 ## [1.12.3] - 2024-10-26
 

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -536,7 +536,7 @@ impl BlockManager {
             let len = buf.len() as u64;
             lock.set_len(len)?;
             lock.write_all(&buf)?;
-            lock.flush()?;
+            lock.sync_all()?; // fix https://github.com/reductstore/reductstore/issues/642
             len
         };
 


### PR DESCRIPTION
Closes #642 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR calls `sync_all` for the file descriptor avoid to read it empty after it's discarded from the cache.

### Related issues

#642 

### Does this PR introduce a breaking change?

No

### Other information:
