### PR TITLE
RS-545: Implement logical operators in conditional query

### DIFF
--- a/reductstore/src/storage/query/condition/operators/logical.rs
+++ b/reductstore/src/storage/query/condition/operators/logical.rs
@@ -1,4 +1,8 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-pub(crate) mod logical;
+mod and;
+mod or;
+
+pub(crate) use and::And;
+pub(crate) use or::Or;

--- a/reductstore/src/storage/query/condition/operators/logical.rs
+++ b/reductstore/src/storage/query/condition/operators/logical.rs
@@ -1,8 +1,12 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-mod and;
-mod or;
+mod all_of;
+mod any_of;
+mod none_of;
+mod only_one_of;
 
-pub(crate) use and::And;
-pub(crate) use or::Or;
+pub(crate) use all_of::AllOf;
+pub(crate) use any_of::AnyOf;
+pub(crate) use none_of::NoneOf;
+pub(crate) use only_one_of::OnlyOneOf;

--- a/reductstore/src/storage/query/condition/operators/logical/all_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/all_of.rs
@@ -52,18 +52,14 @@ mod tests {
             Constant::boxed(Value::Float(-2.0)),
             Constant::boxed(Value::String("xxxx".to_string())),
         ]);
-
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(true));
+        assert_eq!(and.apply(&Context::default()).unwrap(), Value::Bool(true));
 
         let and = AllOf::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(true)),
         ]);
-
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(false));
+        assert_eq!(and.apply(&Context::default()).unwrap(), Value::Bool(false));
     }
 
     #[rstest]
@@ -75,7 +71,6 @@ mod tests {
     #[rstest]
     fn print() {
         let and = AllOf::new(vec![Constant::boxed(Value::Bool(true))]);
-
         assert_eq!(and.print(), "AllOf([Bool(true)])");
     }
 }

--- a/reductstore/src/storage/query/condition/operators/logical/and.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/and.rs
@@ -1,0 +1,76 @@
+// Copyright 2024 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+
+/// A node representing a logical AND operation.
+pub(crate) struct And {
+    operands: Vec<BoxedNode>,
+}
+
+impl Node for And {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        for operand in self.operands.iter() {
+            let value = operand.apply(context)?;
+            if !value.as_bool()? {
+                return Ok(Value::Bool(false));
+            }
+        }
+
+        Ok(Value::Bool(true))
+    }
+
+    fn print(&self) -> String {
+        format!("And({:?})", self.operands)
+    }
+}
+
+impl And {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands }
+    }
+
+    pub fn boxed(operands: Vec<BoxedNode>) -> BoxedNode {
+        Box::new(Self::new(operands))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply() {
+        let and = And::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Float(-2.0)),
+            Constant::boxed(Value::String("xxxx".to_string())),
+        ]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(true));
+
+        let and = And::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(false)),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let and = And::new(vec![]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/logical/any_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/any_of.rs
@@ -46,38 +46,31 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let and = AnyOf::new(vec![
+        let or = AnyOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
             Constant::boxed(Value::String("xxxx".to_string())),
         ]);
+        assert_eq!(or.apply(&Context::default()).unwrap(), Value::Bool(true));
 
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(true));
-
-        let and = AnyOf::new(vec![
+        let or = AnyOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
         ]);
-
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(false));
+        assert_eq!(or.apply(&Context::default()).unwrap(), Value::Bool(false));
     }
 
     #[rstest]
     fn apply_empty() {
-        let and = AnyOf::new(vec![]);
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(false));
+        let or = AnyOf::new(vec![]);
+        assert_eq!(or.apply(&Context::default()).unwrap(), Value::Bool(false));
     }
 
     #[rstest]
     fn print() {
-        let and = AnyOf::new(vec![Constant::boxed(Value::Bool(true))]);
-
-        let result = and.print();
-        assert_eq!(result, "AnyOf([Bool(true)])");
+        let or = AnyOf::new(vec![Constant::boxed(Value::Bool(true))]);
+        assert_eq!(or.print(), "AnyOf([Bool(true)])");
     }
 }

--- a/reductstore/src/storage/query/condition/operators/logical/any_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/any_of.rs
@@ -1,0 +1,83 @@
+// Copyright 2024 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+
+/// A node representing a logical OR or ANY_OF operation.
+pub(crate) struct AnyOf {
+    operands: Vec<BoxedNode>,
+}
+
+impl Node for AnyOf {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        for operand in self.operands.iter() {
+            let value = operand.apply(context)?;
+            if value.as_bool()? {
+                return Ok(Value::Bool(true));
+            }
+        }
+
+        Ok(Value::Bool(false))
+    }
+
+    fn print(&self) -> String {
+        format!("AnyOf({:?})", self.operands)
+    }
+}
+
+impl AnyOf {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands }
+    }
+
+    pub fn boxed(operands: Vec<BoxedNode>) -> BoxedNode {
+        Box::new(Self::new(operands))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply() {
+        let and = AnyOf::new(vec![
+            Constant::boxed(Value::Bool(false)),
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Float(-2.0)),
+            Constant::boxed(Value::String("xxxx".to_string())),
+        ]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(true));
+
+        let and = AnyOf::new(vec![
+            Constant::boxed(Value::Bool(false)),
+            Constant::boxed(Value::Bool(false)),
+            Constant::boxed(Value::Bool(false)),
+        ]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let and = AnyOf::new(vec![]);
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[rstest]
+    fn print() {
+        let and = AnyOf::new(vec![Constant::boxed(Value::Bool(true))]);
+
+        let result = and.print();
+        assert_eq!(result, "AnyOf([Bool(true)])");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/logical/none_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/none_of.rs
@@ -46,39 +46,31 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let and = NoneOf::new(vec![
+        let not = NoneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
             Constant::boxed(Value::String("xxxx".to_string())),
         ]);
+        assert_eq!(not.apply(&Context::default()).unwrap(), Value::Bool(false));
 
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(false));
-
-        let and = NoneOf::new(vec![
+        let not = NoneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
         ]);
-
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(true));
+        assert_eq!(not.apply(&Context::default()).unwrap(), Value::Bool(true));
     }
 
     #[rstest]
     fn apply_empty() {
-        let and = NoneOf::new(vec![]);
-
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(true));
+        let not = NoneOf::new(vec![]);
+        assert_eq!(not.apply(&Context::default()).unwrap(), Value::Bool(true));
     }
 
     #[rstest]
     fn print() {
-        let and = NoneOf::new(vec![Constant::boxed(Value::Bool(false))]);
-
-        let result = and.print();
-        assert_eq!(result, "NoneOf([Bool(false)])");
+        let not = NoneOf::new(vec![Constant::boxed(Value::Bool(false))]);
+        assert_eq!(not.print(), "NoneOf([Bool(false)])");
     }
 }

--- a/reductstore/src/storage/query/condition/operators/logical/none_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/none_of.rs
@@ -1,0 +1,84 @@
+// Copyright 2024 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+
+/// A node representing a logical NOT or NONE_OF operation.
+pub(crate) struct NoneOf {
+    operands: Vec<BoxedNode>,
+}
+
+impl Node for NoneOf {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        for operand in self.operands.iter() {
+            let value = operand.apply(context)?;
+            if value.as_bool()? {
+                return Ok(Value::Bool(false));
+            }
+        }
+
+        Ok(Value::Bool(true))
+    }
+
+    fn print(&self) -> String {
+        format!("NoneOf({:?})", self.operands)
+    }
+}
+
+impl NoneOf {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands }
+    }
+
+    pub fn boxed(operands: Vec<BoxedNode>) -> BoxedNode {
+        Box::new(Self::new(operands))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply() {
+        let and = NoneOf::new(vec![
+            Constant::boxed(Value::Bool(false)),
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Float(-2.0)),
+            Constant::boxed(Value::String("xxxx".to_string())),
+        ]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(false));
+
+        let and = NoneOf::new(vec![
+            Constant::boxed(Value::Bool(false)),
+            Constant::boxed(Value::Bool(false)),
+            Constant::boxed(Value::Bool(false)),
+        ]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let and = NoneOf::new(vec![]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[rstest]
+    fn print() {
+        let and = NoneOf::new(vec![Constant::boxed(Value::Bool(false))]);
+
+        let result = and.print();
+        assert_eq!(result, "NoneOf([Bool(false)])");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/logical/only_one_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/only_one_of.rs
@@ -5,29 +5,30 @@ use crate::storage::query::condition::value::Value;
 use crate::storage::query::condition::{BoxedNode, Context, Node};
 use reduct_base::error::ReductError;
 
-/// A node representing a logical AND operation.
-pub(crate) struct And {
+/// A node representing a logical XOR or ONLY_ONE_OF operation.
+pub(crate) struct OnlyOneOf {
     operands: Vec<BoxedNode>,
 }
 
-impl Node for And {
+impl Node for OnlyOneOf {
     fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let mut count = 0;
         for operand in self.operands.iter() {
             let value = operand.apply(context)?;
-            if !value.as_bool()? {
-                return Ok(Value::Bool(false));
+            if value.as_bool()? {
+                count += 1;
             }
         }
 
-        Ok(Value::Bool(true))
+        Ok(Value::Bool(count == 1))
     }
 
     fn print(&self) -> String {
-        format!("And({:?})", self.operands)
+        format!("OnlyOneOf({:?})", self.operands)
     }
 }
 
-impl And {
+impl OnlyOneOf {
     pub fn new(operands: Vec<BoxedNode>) -> Self {
         Self { operands }
     }
@@ -46,31 +47,39 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let and = And::new(vec![
-            Constant::boxed(Value::Bool(true)),
+        let and = OnlyOneOf::new(vec![
+            Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
             Constant::boxed(Value::String("xxxx".to_string())),
         ]);
 
         let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(true));
+        assert_eq!(result, Value::Bool(false));
 
-        let and = And::new(vec![
-            Constant::boxed(Value::Bool(true)),
+        let and = OnlyOneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(false)),
         ]);
+
+        let result = and.apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let and = OnlyOneOf::new(vec![]);
 
         let result = and.apply(&Context::default()).unwrap();
         assert_eq!(result, Value::Bool(false));
     }
 
     #[rstest]
-    fn apply_empty() {
-        let and = And::new(vec![]);
+    fn print() {
+        let and = OnlyOneOf::new(vec![Constant::boxed(Value::Bool(false))]);
 
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(true));
+        let result = and.print();
+        assert_eq!(result, "OnlyOneOf([Bool(false)])");
     }
 }

--- a/reductstore/src/storage/query/condition/operators/logical/only_one_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/only_one_of.rs
@@ -47,39 +47,33 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let and = OnlyOneOf::new(vec![
+        let xor = OnlyOneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
             Constant::boxed(Value::String("xxxx".to_string())),
         ]);
 
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(false));
+        assert_eq!(xor.apply(&Context::default()).unwrap(), Value::Bool(false));
 
-        let and = OnlyOneOf::new(vec![
+        let xor = OnlyOneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Bool(false)),
         ]);
 
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(true));
+        assert_eq!(xor.apply(&Context::default()).unwrap(), Value::Bool(true));
     }
 
     #[rstest]
     fn apply_empty() {
-        let and = OnlyOneOf::new(vec![]);
-
-        let result = and.apply(&Context::default()).unwrap();
-        assert_eq!(result, Value::Bool(false));
+        let xor = OnlyOneOf::new(vec![]);
+        assert_eq!(xor.apply(&Context::default()).unwrap(), Value::Bool(false));
     }
 
     #[rstest]
     fn print() {
-        let and = OnlyOneOf::new(vec![Constant::boxed(Value::Bool(false))]);
-
-        let result = and.print();
-        assert_eq!(result, "OnlyOneOf([Bool(false)])");
+        let xor = OnlyOneOf::new(vec![Constant::boxed(Value::Bool(false))]);
+        assert_eq!(xor.print(), "OnlyOneOf([Bool(false)])");
     }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR implements logical operators in conditional queires:

* $and / $all_of
* $or / $any_of
* $not / $none_of
* $xor / $only_one_of

### Related issues

#640 

### Does this PR introduce a breaking change?

No

### Other information:
