### PR TITLE
RS-538: Add strict mode for conditional query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-524: Check naming convention before creating or renaming entry, [PR-650](https://github.com/reductstore/reductstore/pull/650)
 - RS-545: Implement logical operators in conditional query, [PR-656](https://github.com/reductstore/reductstore/pull/656)
 - RS-529: Implement comparison operators in conditional query, [PR-662](https://github.com/reductstore/reductstore/pull/662)
+- RS-538: Add strict mode for conditional query, [PR-663](https://github.com/reductstore/reductstore/pull/663)
 
 ### Changed
 

--- a/reduct_base/src/msg/entry_api.rs
+++ b/reduct_base/src/msg/entry_api.rs
@@ -85,4 +85,7 @@ pub struct QueryEntry {
 
     /// Conditional query
     pub when: Option<Value>,
+    /// Strict conditional query
+    /// If true, the query returns an error if any condition cannot be evaluated
+    pub strict: Option<bool>,
 }

--- a/reductstore/src/api/entry/common.rs
+++ b/reductstore/src/api/entry/common.rs
@@ -71,6 +71,7 @@ pub(super) fn parse_query_params(
         ttl,
         only_metadata: Some(only_metadata),
         when: None,
+        strict: None,
     })
 }
 

--- a/reductstore/src/storage/query/base.rs
+++ b/reductstore/src/storage/query/base.rs
@@ -57,6 +57,8 @@ pub struct QueryOptions {
     pub only_metadata: bool,
     /// Condition
     pub when: Option<Value>,
+    /// Strict condition
+    pub strict: bool,
 }
 
 impl From<QueryEntry> for QueryOptions {
@@ -71,6 +73,7 @@ impl From<QueryEntry> for QueryOptions {
             each_s: query.each_s,
             only_metadata: query.only_metadata.unwrap_or(false),
             when: query.when,
+            strict: query.strict.unwrap_or(false),
         }
     }
 }
@@ -87,6 +90,7 @@ impl Default for QueryOptions {
             each_s: None,
             only_metadata: false,
             when: None,
+            strict: false,
         }
     }
 }

--- a/reductstore/src/storage/query/condition/reference.rs
+++ b/reductstore/src/storage/query/condition/reference.rs
@@ -16,7 +16,7 @@ impl Node for Reference {
         let label_value = context
             .labels
             .get(self.name.as_str())
-            .ok_or(not_found!("Reference '{}' not found"))?;
+            .ok_or(not_found!("Reference '{}' not found", self.name))?;
 
         let value = Value::parse(label_value);
         Ok(value)
@@ -56,7 +56,11 @@ mod tests {
         let reference = Reference::new("label".to_string());
         let context = Context::default();
         let result = reference.apply(&context);
-        assert!(result.is_err());
+        assert!(result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("Reference 'label' not found"));
     }
 
     #[test]

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -44,6 +44,8 @@ pub struct HistoricalQuery {
     filters: Vec<Box<dyn RecordFilter<Record> + Send + Sync>>,
     /// Request only metadata without the content.
     only_metadata: bool,
+    /// Strict mode
+    strict: bool,
 }
 
 impl HistoricalQuery {
@@ -86,6 +88,7 @@ impl HistoricalQuery {
             current_block: None,
             filters,
             only_metadata: options.only_metadata,
+            strict: options.strict,
         })
     }
 }
@@ -124,7 +127,7 @@ impl Query for HistoricalQuery {
                 let block_ref = bm.load_block(block_id)?;
 
                 self.current_block = Some(block_ref);
-                let mut found_records = self.filter_records_from_current_block();
+                let mut found_records = self.filter_records_from_current_block()?;
                 found_records.sort_by_key(|rec| ts_to_us(rec.timestamp.as_ref().unwrap()));
                 self.records_from_current_block.extend(found_records);
                 if !self.records_from_current_block.is_empty() {
@@ -154,18 +157,36 @@ impl Query for HistoricalQuery {
 }
 
 impl HistoricalQuery {
-    fn filter_records_from_current_block(&mut self) -> Vec<Record> {
-        let block = self.current_block.as_ref().unwrap().read().unwrap();
-        block
-            .record_index()
-            .values()
-            .filter(|record| {
-                self.filters
-                    .iter_mut()
-                    .all(|filter| filter.filter(record).unwrap_or(false))
-            }) // TODO: we need an option to make it strict
-            .map(|record| record.clone())
-            .collect()
+    fn filter_records_from_current_block(&mut self) -> Result<Vec<Record>, ReductError> {
+        let block = self.current_block.as_ref().unwrap().read()?;
+        let mut filtered_records = Vec::new();
+        for record in block.record_index().values() {
+            let mut include_record = true;
+            for filter in self.filters.iter_mut() {
+                match filter.filter(record) {
+                    Ok(false) => {
+                        include_record = false;
+                        break;
+                    }
+                    Ok(true) => {}
+                    Err(err) => {
+                        if self.strict {
+                            // in strict mode, we return an error if a filter fails
+                            return Err(err);
+                        }
+
+                        // in non-strict mode, we ignore the record with the failed filter
+                        include_record = false;
+                        break;
+                    }
+                }
+            }
+            if include_record {
+                filtered_records.push(record.clone());
+            }
+        }
+
+        Ok(filtered_records)
     }
 }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR introduced the strict flag to the POST /:bucket/:entry/q request. If set, the query will return an error during execution if any of the conditions can't be evaluated. If the flag is not set or is false, the failed conditions are considered false.

### Related issues

https://github.com/reductstore/website/pull/130

### Does this PR introduce a breaking change?

No

### Other information:
