### PR TITLE
Fix replication crash if bucket is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-544: Fix keeping quota error, [PR-654](https://github.com/reductstore/reductstore/pull/654)
+- Fix replication crash if bucket is removed, [PR-664](https://github.com/reductstore/reductstore/pull/664)
 
 ### Internal
 

--- a/reduct_base/src/msg/entry_api.rs
+++ b/reduct_base/src/msg/entry_api.rs
@@ -80,7 +80,7 @@ pub struct QueryEntry {
     pub ttl: Option<u64>,
     /// Retrieve only metadata
     pub only_metadata: Option<bool>,
-    /// Continue query from last result
+    /// Continuous query, it doesn't stop until the TTL is reached
     pub continuous: Option<bool>,
 
     /// Conditional query

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -450,7 +450,6 @@ mod tests {
         notification: TransactionNotification,
         settings: ReplicationSettings,
     ) {
-        Logger::init("DEBUG");
         remote_bucket
             .expect_write_batch()
             .return_const(Ok(ErrorRecordMap::new()));

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -137,13 +137,19 @@ impl ReplicationTask {
                         }
 
                         info!("Creating a new transaction log: {:?}", path);
-                        thr_log_map.write().unwrap().insert(
-                            entry_name,
-                            RwLock::new(
-                                TransactionLog::try_load_or_create(path, TRANSACTION_LOG_SIZE)
-                                    .unwrap(),
-                            ),
-                        );
+                        match TransactionLog::try_load_or_create(path, TRANSACTION_LOG_SIZE) {
+                            Ok(log) => {
+                                thr_log_map
+                                    .write()
+                                    .unwrap()
+                                    .insert(entry_name, RwLock::new(log));
+                            }
+
+                            Err(err) => {
+                                error!("Failed to create transaction log: {:?}", err);
+                                sleep(Duration::from_secs(10));
+                            }
+                        }
                     }
                 }
             }

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -304,7 +304,7 @@ mod tests {
     use rstest::*;
 
     use crate::core::file_cache::FILE_CACHE;
-    use crate::core::logger::Logger;
+
     use crate::replication::remote_bucket::ErrorRecordMap;
     use crate::replication::Transaction;
     use crate::storage::entry::io::record_reader::RecordReader;

--- a/reductstore/src/storage/bucket/quotas.rs
+++ b/reductstore/src/storage/bucket/quotas.rs
@@ -55,7 +55,7 @@ impl Bucket {
                         break;
                     }
                     Err(e) => {
-                        warn!("Failed to remove oldest block from entry '{}': {}", name, e);
+                        debug!("Failed to remove oldest block from entry '{}': {}", name, e);
                     }
                 }
             }

--- a/reductstore/src/storage/bucket/quotas.rs
+++ b/reductstore/src/storage/bucket/quotas.rs
@@ -3,7 +3,7 @@
 
 use crate::storage::bucket::Bucket;
 use crate::storage::entry::Entry;
-use log::{debug, warn};
+use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::msg::bucket_api::QuotaType;
 use reduct_base::{bad_request, internal_server_error};


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

This PR fixes a crash that occurs when a user removes a source bucket for a replication task. Now, the task without the source bucket prints an error message without crashing.
### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
