### PR TITLE
Fix order of condition operands in object syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-544: Fix keeping quota error, [PR-654](https://github.com/reductstore/reductstore/pull/654)
 - Fix replication crash if bucket is removed, [PR-664](https://github.com/reductstore/reductstore/pull/664)
+- Fix order of condition operands in object syntax, [PR-670](https://github.com/reductstore/reductstore/pull/670)
 
 ### Internal
 

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -84,7 +84,7 @@ impl Parser {
 
         let (operator, operand) = op_right_operand.iter().next().unwrap();
         let right_operand = self.parse(operand)?;
-        let operands = vec![right_operand, left_operand];
+        let operands = vec![left_operand, right_operand];
         Self::parse_operator(operator, operands)
     }
 
@@ -130,16 +130,16 @@ mod tests {
 
     #[rstest]
     fn test_parser_array_syntax(parser: Parser, context: Context) {
-        let json = serde_json::from_str(r#"{"$and": [true, {"$and": [true, true]}]}"#).unwrap();
+        let json = serde_json::from_str(r#"{"$and": [true, {"$gt": [20, 10]}]}"#).unwrap();
         let node = parser.parse(&json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
     #[rstest]
     fn test_parser_object_syntax(parser: Parser) {
-        let json = serde_json::from_str(r#"{"&label": {"$and": true}}"#).unwrap();
+        let json = serde_json::from_str(r#"{"&label": {"$gt": 10}}"#).unwrap();
         let node = parser.parse(&json).unwrap();
-        let context = Context::new(HashMap::from_iter(vec![("label", "true")]));
+        let context = Context::new(HashMap::from_iter(vec![("label", "20")]));
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The parser parsed operands of the object syntax in a wrong order:

```
{ "&label": { "$gt": 10}} , was 10 > label
```

The PR fixes the bug and adds tests for the case.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
