### PR TITLE
RS-531: Support for arithmetical operators in conditional query 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RS-550: Add support for when condition on replication task, [PR-687](https://github.com/reductstore/reductstore/pull/687)
+- RS-531: Support for arithmetical operators in conditional query, [PR-696](https://github.com/reductstore/reductstore/pull/696)
 
 ## [1.13.1] - 2024-12-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,18 +98,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -138,16 +138,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8478a5c29ead3f3be14aff8a202ad965cf7da6856860041bfca271becf8ba48b"
+checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
  "paste",
 ]
 
@@ -239,7 +238,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -312,7 +311,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.93",
+ "syn 2.0.95",
  "which",
 ]
 
@@ -378,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",
@@ -552,7 +551,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -574,7 +573,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -735,7 +734,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -805,9 +804,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -1136,7 +1135,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1422,7 +1421,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1599,7 +1598,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1663,12 +1662,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
 dependencies = [
  "proc-macro2",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1725,7 +1724,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.93",
+ "syn 2.0.95",
  "tempfile",
 ]
 
@@ -1739,7 +1738,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1915,7 +1914,7 @@ name = "reduct-macros"
 version = "1.14.0"
 dependencies = [
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2008,9 +2007,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2093,7 +2092,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.93",
+ "syn 2.0.95",
  "unicode-ident",
 ]
 
@@ -2197,9 +2196,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scc"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b13f8ea6177672c49d12ed964cca44836f59621981b04a3e26b87e675181de"
+checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
 dependencies = [
  "sdd",
 ]
@@ -2239,7 +2238,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2298,7 +2297,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2401,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2427,17 +2426,18 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2475,7 +2475,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2643,7 +2643,7 @@ checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow 0.6.22",
 ]
 
 [[package]]
@@ -2762,7 +2762,7 @@ checksum = "d9d30226ac9cbd2d1ff775f74e8febdab985dab14fb14aa2582c29a92d5555dc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2855,7 +2855,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -2890,7 +2890,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3087,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -3126,7 +3126,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -3148,7 +3148,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3168,7 +3168,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -3189,7 +3189,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.95",
 ]
 
 [[package]]

--- a/reductstore/src/storage/query/condition/operators.rs
+++ b/reductstore/src/storage/query/condition/operators.rs
@@ -1,5 +1,6 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+pub(crate) mod arithmetic;
 pub(crate) mod comparison;
 pub(crate) mod logical;

--- a/reductstore/src/storage/query/condition/operators/arithmetic.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+mod abs;
 mod add;
 mod div;
 mod div_num;
@@ -8,6 +9,7 @@ mod mult;
 mod rem;
 mod sub;
 
+pub(crate) use abs::Abs;
 pub(crate) use add::Add;
 pub(crate) use div::Div;
 pub(crate) use div_num::DivNum;

--- a/reductstore/src/storage/query/condition/operators/arithmetic.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic.rs
@@ -3,10 +3,12 @@
 
 mod add;
 mod div;
+mod div_num;
 mod mult;
 mod sub;
 
 pub(crate) use add::Add;
 pub(crate) use div::Div;
+pub(crate) use div_num::DivNum;
 pub(crate) use mult::Mult;
 pub(crate) use sub::Sub;

--- a/reductstore/src/storage/query/condition/operators/arithmetic.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic.rs
@@ -1,0 +1,6 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+mod add;
+
+pub(crate) use add::Add;

--- a/reductstore/src/storage/query/condition/operators/arithmetic.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic.rs
@@ -2,7 +2,9 @@
 // Licensed under the Business Source License 1.1
 
 mod add;
+mod mult;
 mod sub;
 
 pub(crate) use add::Add;
+pub(crate) use mult::Mult;
 pub(crate) use sub::Sub;

--- a/reductstore/src/storage/query/condition/operators/arithmetic.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic.rs
@@ -2,5 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 mod add;
+mod sub;
 
 pub(crate) use add::Add;
+pub(crate) use sub::Sub;

--- a/reductstore/src/storage/query/condition/operators/arithmetic.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic.rs
@@ -5,10 +5,12 @@ mod add;
 mod div;
 mod div_num;
 mod mult;
+mod rem;
 mod sub;
 
 pub(crate) use add::Add;
 pub(crate) use div::Div;
 pub(crate) use div_num::DivNum;
 pub(crate) use mult::Mult;
+pub(crate) use rem::Rem;
 pub(crate) use sub::Sub;

--- a/reductstore/src/storage/query/condition/operators/arithmetic.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic.rs
@@ -2,9 +2,11 @@
 // Licensed under the Business Source License 1.1
 
 mod add;
+mod div;
 mod mult;
 mod sub;
 
 pub(crate) use add::Add;
+pub(crate) use div::Div;
 pub(crate) use mult::Mult;
 pub(crate) use sub::Sub;

--- a/reductstore/src/storage/query/condition/operators/arithmetic/abs.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/abs.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Abs as AbsTrait;
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an absolute value operation.
+pub(crate) struct Abs {
+    op: BoxedNode,
+}
+
+impl Node for Abs {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let value = self.op.apply(context)?;
+        value.abs()
+    }
+
+    fn print(&self) -> String {
+        format!("Abs({:?})", self.op)
+    }
+}
+
+impl Boxed for Abs {
+    fn boxed(mut operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 1 {
+            return Err(unprocessable_entity!("Abs requires exactly one operand"));
+        }
+
+        let op = operands.pop().unwrap();
+        Ok(Box::new(Self::new(op)))
+    }
+}
+
+impl Abs {
+    pub fn new(op: BoxedNode) -> Self {
+        Self { op }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use reduct_base::unprocessable_entity;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let op = Abs::new(Constant::boxed(Value::Int(-1)));
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Int(1));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let op = Abs::new(Constant::boxed(Value::String("foo".to_string())));
+        assert_eq!(
+            op.apply(&Context::default()).unwrap_err(),
+            unprocessable_entity!("Cannot calculate absolute value of a string")
+        );
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let result = Abs::boxed(vec![]);
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("Abs requires exactly one operand")
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let and = Abs::new(Constant::boxed(Value::Bool(true)));
+        assert_eq!(and.print(), "Abs(Bool(true))");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
@@ -1,10 +1,10 @@
 // Copyright 2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+use crate::storage::query::condition::value::Add as AddTrait;
 use crate::storage::query::condition::value::Value;
 use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
 use reduct_base::error::ReductError;
-use reduct_base::unprocessable_entity;
 
 /// A node representing an arithmetic addition operation.
 pub(crate) struct Add {
@@ -13,54 +13,12 @@ pub(crate) struct Add {
 
 impl Node for Add {
     fn apply(&self, context: &Context) -> Result<Value, ReductError> {
-        let mut sum = None;
+        let mut sum: Option<Value> = None;
 
         for operand in self.operands.iter() {
             let value = operand.apply(context)?;
             match sum {
-                Some(Value::Bool(s)) => match value {
-                    Value::Bool(v) => sum = Some(Value::Int(s as i64 + v as i64)),
-                    Value::Int(v) => sum = Some(Value::Int(s as i64 + v)),
-                    Value::Float(v) => sum = Some(Value::Float(s as i8 as f64 + v)),
-                    Value::String(_) => {
-                        return Err(unprocessable_entity!("Cannot add string to boolean"));
-                    }
-                },
-
-                Some(Value::Int(s)) => match value {
-                    Value::Bool(v) => sum = Some(Value::Int(s + v as i64)),
-                    Value::Int(v) => sum = Some(Value::Int(s + v)),
-                    Value::Float(v) => {
-                        sum = Some(Value::Float(s as f64 + v));
-                    }
-                    Value::String(_) => {
-                        return Err(unprocessable_entity!("Cannot add string to integer"));
-                    }
-                },
-
-                Some(Value::Float(s)) => match value {
-                    Value::Bool(v) => sum = Some(Value::Float(s + v as i8 as f64)),
-                    Value::Int(v) => sum = Some(Value::Float(s + v as f64)),
-                    Value::Float(v) => sum = Some(Value::Float(s + v)),
-                    Value::String(_) => {
-                        return Err(unprocessable_entity!("Cannot add string to float"));
-                    }
-                },
-
-                Some(Value::String(s)) => match value {
-                    Value::Bool(_) => {
-                        return Err(unprocessable_entity!("Cannot add boolean to string"));
-                    }
-                    Value::Int(_) => {
-                        return Err(unprocessable_entity!("Cannot add integer to string"));
-                    }
-
-                    Value::Float(_) => {
-                        return Err(unprocessable_entity!("Cannot add float to string"));
-                    }
-                    Value::String(v) => sum = Some(Value::String(format!("{}{}", s, v))),
-                },
-
+                Some(s) => sum = Some(s.add(value)?),
                 None => sum = Some(value),
             }
         }
@@ -90,141 +48,29 @@ mod tests {
     use super::*;
     use crate::storage::query::condition::constant::Constant;
     use crate::storage::query::condition::value::Value;
+    use reduct_base::unprocessable_entity;
     use rstest::rstest;
 
     #[rstest]
-    fn apply_bool() {
+    fn apply_ok() {
         let add = Add::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Bool(false)),
         ]);
+
         assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(1));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Bool(true)),
-            Constant::boxed(Value::Int(2)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(3));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Bool(true)),
-            Constant::boxed(Value::Float(2.0)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Bool(true)),
-            Constant::boxed(Value::String("xxx".to_string())),
-        ]);
-
-        assert_eq!(
-            add.apply(&Context::default()),
-            Err(unprocessable_entity!("Cannot add string to boolean"))
-        );
     }
 
     #[rstest]
-    fn apply_int() {
+    fn apply_bad() {
         let add = Add::new(vec![
-            Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Bool(true)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(2));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Int(1)),
-            Constant::boxed(Value::Int(2)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(3));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Int(1)),
-            Constant::boxed(Value::Float(2.0)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::String("xxx".to_string())),
-        ]);
-
-        assert_eq!(
-            add.apply(&Context::default()),
-            Err(unprocessable_entity!("Cannot add string to integer"))
-        );
-    }
-
-    #[rstest]
-    fn apply_float() {
-        let add = Add::new(vec![
-            Constant::boxed(Value::Float(1.0)),
-            Constant::boxed(Value::Bool(true)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(2.0));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Float(1.0)),
-            Constant::boxed(Value::Int(2)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Float(1.0)),
-            Constant::boxed(Value::Float(2.0)),
-        ]);
-        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::Float(1.0)),
-            Constant::boxed(Value::String("xxx".to_string())),
-        ]);
-
-        assert_eq!(
-            add.apply(&Context::default()),
-            Err(unprocessable_entity!("Cannot add string to float"))
-        );
-    }
-
-    #[rstest]
-    fn apply_string() {
-        let add = Add::new(vec![
-            Constant::boxed(Value::String("a".to_string())),
-            Constant::boxed(Value::Bool(true)),
         ]);
 
         assert_eq!(
             add.apply(&Context::default()),
             Err(unprocessable_entity!("Cannot add boolean to string"))
-        );
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::String("a".to_string())),
-            Constant::boxed(Value::Int(2)),
-        ]);
-
-        assert_eq!(
-            add.apply(&Context::default()),
-            Err(unprocessable_entity!("Cannot add integer to string"))
-        );
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::String("a".to_string())),
-            Constant::boxed(Value::Float(2.0)),
-        ]);
-
-        assert_eq!(
-            add.apply(&Context::default()),
-            Err(unprocessable_entity!("Cannot add float to string"))
-        );
-
-        let add = Add::new(vec![
-            Constant::boxed(Value::String("a".to_string())),
-            Constant::boxed(Value::String("b".to_string())),
-        ]);
-
-        assert_eq!(
-            add.apply(&Context::default()).unwrap(),
-            Value::String("ab".to_string())
         );
     }
 

--- a/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
@@ -33,7 +33,7 @@ impl Node for Add {
                     Value::Float(v) => {
                         sum = Some(Value::Float(s as f64 + v));
                     }
-                    Value::String(v) => {
+                    Value::String(_) => {
                         return Err(unprocessable_entity!("Cannot add string to integer"));
                     }
                 },
@@ -48,14 +48,14 @@ impl Node for Add {
                 },
 
                 Some(Value::String(s)) => match value {
-                    Value::Bool(v) => {
+                    Value::Bool(_) => {
                         return Err(unprocessable_entity!("Cannot add boolean to string"));
                     }
-                    Value::Int(v) => {
+                    Value::Int(_) => {
                         return Err(unprocessable_entity!("Cannot add integer to string"));
                     }
 
-                    Value::Float(v) => {
+                    Value::Float(_) => {
                         return Err(unprocessable_entity!("Cannot add float to string"));
                     }
                     Value::String(v) => sum = Some(Value::String(format!("{}{}", s, v))),

--- a/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
@@ -1,0 +1,242 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an arithmetic addition operation.
+pub(crate) struct Add {
+    operands: Vec<BoxedNode>,
+}
+
+impl Node for Add {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let mut sum = None;
+
+        for operand in self.operands.iter() {
+            let value = operand.apply(context)?;
+            match sum {
+                Some(Value::Bool(s)) => match value {
+                    Value::Bool(v) => sum = Some(Value::Int(s as i64 + v as i64)),
+                    Value::Int(v) => sum = Some(Value::Int(s as i64 + v)),
+                    Value::Float(v) => sum = Some(Value::Float(s as i8 as f64 + v)),
+                    Value::String(_) => {
+                        return Err(unprocessable_entity!("Cannot add string to boolean"));
+                    }
+                },
+
+                Some(Value::Int(s)) => match value {
+                    Value::Bool(v) => sum = Some(Value::Int(s + v as i64)),
+                    Value::Int(v) => sum = Some(Value::Int(s + v)),
+                    Value::Float(v) => {
+                        sum = Some(Value::Float(s as f64 + v));
+                    }
+                    Value::String(v) => {
+                        return Err(unprocessable_entity!("Cannot add string to integer"));
+                    }
+                },
+
+                Some(Value::Float(s)) => match value {
+                    Value::Bool(v) => sum = Some(Value::Float(s + v as i8 as f64)),
+                    Value::Int(v) => sum = Some(Value::Float(s + v as f64)),
+                    Value::Float(v) => sum = Some(Value::Float(s + v)),
+                    Value::String(_) => {
+                        return Err(unprocessable_entity!("Cannot add string to float"));
+                    }
+                },
+
+                Some(Value::String(s)) => match value {
+                    Value::Bool(v) => {
+                        return Err(unprocessable_entity!("Cannot add boolean to string"));
+                    }
+                    Value::Int(v) => {
+                        return Err(unprocessable_entity!("Cannot add integer to string"));
+                    }
+
+                    Value::Float(v) => {
+                        return Err(unprocessable_entity!("Cannot add float to string"));
+                    }
+                    Value::String(v) => sum = Some(Value::String(format!("{}{}", s, v))),
+                },
+
+                None => sum = Some(value),
+            }
+        }
+
+        Ok(sum.unwrap_or(Value::Int(0)))
+    }
+
+    fn print(&self) -> String {
+        format!("Add({:?})", self.operands)
+    }
+}
+
+impl Boxed for Add {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        Ok(Box::new(Self::new(operands)))
+    }
+}
+
+impl Add {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_bool() {
+        let add = Add::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(false)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(1));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Int(2)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(3));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::String("xxx".to_string())),
+        ]);
+
+        assert_eq!(
+            add.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot add string to boolean"))
+        );
+    }
+
+    #[rstest]
+    fn apply_int() {
+        let add = Add::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(2));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Int(2)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Int(3));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::String("xxx".to_string())),
+        ]);
+
+        assert_eq!(
+            add.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot add string to integer"))
+        );
+    }
+
+    #[rstest]
+    fn apply_float() {
+        let add = Add::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(2.0));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::Int(2)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+        assert_eq!(add.apply(&Context::default()).unwrap(), Value::Float(3.0));
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::String("xxx".to_string())),
+        ]);
+
+        assert_eq!(
+            add.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot add string to float"))
+        );
+    }
+
+    #[rstest]
+    fn apply_string() {
+        let add = Add::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+
+        assert_eq!(
+            add.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot add boolean to string"))
+        );
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::Int(2)),
+        ]);
+
+        assert_eq!(
+            add.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot add integer to string"))
+        );
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+
+        assert_eq!(
+            add.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot add float to string"))
+        );
+
+        let add = Add::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::String("b".to_string())),
+        ]);
+
+        assert_eq!(
+            add.apply(&Context::default()).unwrap(),
+            Value::String("ab".to_string())
+        );
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let result = Add::new(vec![]).apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Int(0));
+    }
+
+    #[rstest]
+    fn print() {
+        let and = Add::new(vec![Constant::boxed(Value::Bool(true))]);
+        assert_eq!(and.print(), "Add([Bool(true)])");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/arithmetic/div.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/div.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Div as DivTrait;
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an arithmetic division operation.
+pub(crate) struct Div {
+    op_1: BoxedNode,
+    op_2: BoxedNode,
+}
+
+impl Node for Div {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let value_1 = self.op_1.apply(context)?;
+        let value_2 = self.op_2.apply(context)?;
+        value_1.divide(value_2)
+    }
+
+    fn print(&self) -> String {
+        format!("Div({:?}, {:?})", self.op_1, self.op_2)
+    }
+}
+
+impl Boxed for Div {
+    fn boxed(mut operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 2 {
+            return Err(unprocessable_entity!("$div requires exactly two operands"));
+        }
+        let op_2 = operands.pop().unwrap();
+        let op_1 = operands.pop().unwrap();
+        Ok(Box::new(Div::new(op_1, op_2)))
+    }
+}
+
+impl Div {
+    pub fn new(op_1: BoxedNode, op_2: BoxedNode) -> Self {
+        Self { op_1, op_2 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let sub = Div::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Int(2)),
+        );
+        assert_eq!(sub.apply(&Context::default()).unwrap(), Value::Float(0.5));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let sub = Div::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::String("foo".to_string())),
+        );
+        assert_eq!(
+            sub.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot divide by string"))
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let op = Div::new(
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(true)),
+        );
+        assert_eq!(op.print(), "Div(Bool(true), Bool(true))");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/arithmetic/div.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/div.rs
@@ -71,6 +71,15 @@ mod tests {
     }
 
     #[rstest]
+    fn apply_empty() {
+        let op = Div::boxed(vec![]);
+        assert_eq!(
+            op.err(),
+            Some(unprocessable_entity!("$div requires exactly two operands"))
+        );
+    }
+
+    #[rstest]
     fn print() {
         let op = Div::new(
             Constant::boxed(Value::Bool(true)),

--- a/reductstore/src/storage/query/condition/operators/arithmetic/div_num.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/div_num.rs
@@ -73,6 +73,17 @@ mod tests {
     }
 
     #[rstest]
+    fn apply_empty() {
+        let op = DivNum::boxed(vec![]);
+        assert_eq!(
+            op.err(),
+            Some(unprocessable_entity!(
+                "$div_num requires exactly two operands"
+            ))
+        );
+    }
+
+    #[rstest]
     fn print() {
         let op = DivNum::new(
             Constant::boxed(Value::Bool(true)),

--- a/reductstore/src/storage/query/condition/operators/arithmetic/div_num.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/div_num.rs
@@ -1,0 +1,83 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::DivNum as DivNumTrait;
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an integer division operation.
+pub(crate) struct DivNum {
+    op_1: BoxedNode,
+    op_2: BoxedNode,
+}
+
+impl Node for DivNum {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let value_1 = self.op_1.apply(context)?;
+        let value_2 = self.op_2.apply(context)?;
+        value_1.divide_num(value_2)
+    }
+
+    fn print(&self) -> String {
+        format!("DivNum({:?}, {:?})", self.op_1, self.op_2)
+    }
+}
+
+impl Boxed for DivNum {
+    fn boxed(mut operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 2 {
+            return Err(unprocessable_entity!(
+                "$div_num requires exactly two operands"
+            ));
+        }
+        let op_2 = operands.pop().unwrap();
+        let op_1 = operands.pop().unwrap();
+        Ok(Box::new(DivNum::new(op_1, op_2)))
+    }
+}
+
+impl DivNum {
+    pub fn new(op_1: BoxedNode, op_2: BoxedNode) -> Self {
+        Self { op_1, op_2 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let sub = DivNum::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Int(2)),
+        );
+        assert_eq!(sub.apply(&Context::default()).unwrap(), Value::Int(0));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let sub = DivNum::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::String("foo".to_string())),
+        );
+        assert_eq!(
+            sub.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot divide by string"))
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let op = DivNum::new(
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(true)),
+        );
+        assert_eq!(op.print(), "DivNum(Bool(true), Bool(true))");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/arithmetic/mult.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/mult.rs
@@ -1,0 +1,89 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Mult as MultTrait;
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+
+/// A node representing an arithmetic multiplication operation.
+pub(crate) struct Mult {
+    operands: Vec<BoxedNode>,
+}
+
+impl Node for Mult {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let mut prod: Option<Value> = None;
+
+        for operand in self.operands.iter() {
+            let value = operand.apply(context)?;
+            match prod {
+                Some(s) => prod = Some(s.multiply(value)?),
+                None => prod = Some(value),
+            }
+        }
+
+        Ok(prod.unwrap_or(Value::Int(0)))
+    }
+
+    fn print(&self) -> String {
+        format!("Mult({:?})", self.operands)
+    }
+}
+
+impl Boxed for Mult {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        Ok(Box::new(Self::new(operands)))
+    }
+}
+
+impl Mult {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use reduct_base::unprocessable_entity;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let op = Mult::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Float(2.0));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let op = Mult::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::String("xxx".to_string())),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot multiply boolean by string"))
+        );
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let result = Mult::new(vec![]).apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Int(0));
+    }
+
+    #[rstest]
+    fn print() {
+        let and = Mult::new(vec![Constant::boxed(Value::Bool(true))]);
+        assert_eq!(and.print(), "Mult([Bool(true)])");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/arithmetic/rem.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/rem.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Rem as RemTrait;
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing a remainder operation.
+pub(crate) struct Rem {
+    op_1: BoxedNode,
+    op_2: BoxedNode,
+}
+
+impl Node for Rem {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let value_1 = self.op_1.apply(context)?;
+        let value_2 = self.op_2.apply(context)?;
+        value_1.remainder(value_2)
+    }
+
+    fn print(&self) -> String {
+        format!("Rem({:?}, {:?})", self.op_1, self.op_2)
+    }
+}
+
+impl Boxed for Rem {
+    fn boxed(mut operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 2 {
+            return Err(unprocessable_entity!("$rem requires exactly two operands"));
+        }
+        let op_2 = operands.pop().unwrap();
+        let op_1 = operands.pop().unwrap();
+        Ok(Box::new(Rem::new(op_1, op_2)))
+    }
+}
+
+impl Rem {
+    pub fn new(op_1: BoxedNode, op_2: BoxedNode) -> Self {
+        Self { op_1, op_2 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let op = Rem::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Int(2)),
+        );
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Int(1));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let op = Rem::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::String("foo".to_string())),
+        );
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot divide integer by string"))
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let op = Rem::new(
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(true)),
+        );
+        assert_eq!(op.print(), "Rem(Bool(true), Bool(true))");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/arithmetic/rem.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/rem.rs
@@ -71,6 +71,15 @@ mod tests {
     }
 
     #[rstest]
+    fn apply_empty() {
+        let op = Rem::boxed(vec![]);
+        assert_eq!(
+            op.err(),
+            Some(unprocessable_entity!("$rem requires exactly two operands"))
+        );
+    }
+
+    #[rstest]
     fn print() {
         let op = Rem::new(
             Constant::boxed(Value::Bool(true)),

--- a/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
@@ -17,7 +17,7 @@ impl Node for Sub {
     fn apply(&self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.op_1.apply(context)?;
         let value_2 = self.op_2.apply(context)?;
-        value_1.sub(value_2)
+        value_1.subtract(value_2)
     }
 
     fn print(&self) -> String {

--- a/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
@@ -71,6 +71,15 @@ mod tests {
     }
 
     #[rstest]
+    fn apply_empty() {
+        let op = Sub::boxed(vec![]);
+        assert_eq!(
+            op.err(),
+            Some(unprocessable_entity!("$sub requires exactly two operands"))
+        );
+    }
+
+    #[rstest]
     fn print() {
         let op = Sub::new(
             Constant::boxed(Value::Bool(true)),

--- a/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
@@ -1,0 +1,232 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an arithmetic subtraction operation.
+pub(crate) struct Sub {
+    operands: Vec<BoxedNode>,
+}
+
+impl Node for Sub {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let mut first = None;
+
+        for operand in self.operands.iter() {
+            let value = operand.apply(context)?;
+            match first {
+                Some(Value::Bool(s)) => match value {
+                    Value::Bool(v) => first = Some(Value::Int(s as i64 - v as i64)),
+                    Value::Int(v) => first = Some(Value::Int(s as i64 - v)),
+                    Value::Float(v) => first = Some(Value::Float(s as i8 as f64 - v)),
+                    Value::String(_) => {
+                        return Err(unprocessable_entity!("Cannot subtract string from boolean"));
+                    }
+                },
+
+                Some(Value::Int(s)) => match value {
+                    Value::Bool(v) => first = Some(Value::Int(s - v as i64)),
+                    Value::Int(v) => first = Some(Value::Int(s - v)),
+                    Value::Float(v) => {
+                        first = Some(Value::Float(s as f64 - v));
+                    }
+                    Value::String(_) => {
+                        return Err(unprocessable_entity!("Cannot subtract string from integer"));
+                    }
+                },
+
+                Some(Value::Float(s)) => match value {
+                    Value::Bool(v) => first = Some(Value::Float(s - v as i8 as f64)),
+                    Value::Int(v) => first = Some(Value::Float(s - v as f64)),
+                    Value::Float(v) => first = Some(Value::Float(s - v)),
+                    Value::String(_) => {
+                        return Err(unprocessable_entity!("Cannot subtract string from float"));
+                    }
+                },
+
+                Some(Value::String(_)) => {
+                    return Err(unprocessable_entity!("Cannot subtract string"))
+                }
+
+                None => first = Some(value),
+            }
+        }
+
+        Ok(first.unwrap_or(Value::Int(0)))
+    }
+
+    fn print(&self) -> String {
+        format!("Sub({:?})", self.operands)
+    }
+}
+
+impl Boxed for Sub {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        Ok(Box::new(Self::new(operands)))
+    }
+}
+
+impl Sub {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_bool() {
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Int(0));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Int(2)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Int(-1));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Float(-1.0));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::String("xxx".to_string())),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot subtract string from boolean"))
+        );
+    }
+
+    #[rstest]
+    fn apply_int() {
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Int(0));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Int(2)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Int(-1));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Float(-1.0));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::String("xxx".to_string())),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot subtract string from integer"))
+        );
+    }
+
+    #[rstest]
+    fn apply_float() {
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Float(0.0));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::Int(2)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Float(-1.0));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::Float(2.0)),
+        ]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Float(-1.0));
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::Float(1.0)),
+            Constant::boxed(Value::String("xxx".to_string())),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot subtract string from float"))
+        );
+    }
+
+    #[rstest]
+    fn apply_string() {
+        let op = Sub::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::Bool(true)),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot subtract string"))
+        );
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::Int(1)),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot subtract string"))
+        );
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::Float(1.0)),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot subtract string"))
+        );
+
+        let op = Sub::new(vec![
+            Constant::boxed(Value::String("a".to_string())),
+            Constant::boxed(Value::String("b".to_string())),
+        ]);
+
+        assert_eq!(
+            op.apply(&Context::default()),
+            Err(unprocessable_entity!("Cannot subtract string"))
+        );
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let result = Sub::new(vec![]).apply(&Context::default()).unwrap();
+        assert_eq!(result, Value::Int(0));
+    }
+
+    #[rstest]
+    fn print() {
+        let and = Sub::new(vec![Constant::boxed(Value::Bool(true))]);
+        assert_eq!(and.print(), "Sub([Bool(true)])");
+    }
+}

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
-use crate::storage::query::condition::operators::arithmetic::{Add, Sub};
+use crate::storage::query::condition::operators::arithmetic::{Add, Mult, Sub};
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
 use crate::storage::query::condition::reference::Reference;
@@ -94,6 +94,7 @@ impl Parser {
             // Arithmetic operators
             "$add" => Add::boxed(operands),
             "$sub" => Sub::boxed(operands),
+            "$mult" => Mult::boxed(operands),
 
             // Logical operators
             "$and" => AllOf::boxed(operands),
@@ -222,6 +223,7 @@ mod tests {
         // Arithmetic operators
         #[case("$add", vec![true, false], Value::Int(1))]
         #[case("$sub", vec![true, true], Value::Int(0))]
+        #[case("$mult", vec![true, false], Value::Int(0))]
         // Logical operators
         #[case("$and", vec![true, false], Value::Bool(false))]
         #[case("$all_of", vec![true, false], Value::Bool(false))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -93,6 +93,7 @@ impl Parser {
         match operator {
             // Arithmetic operators
             "$add" => Add::boxed(operands),
+            "$sub" => Add::boxed(operands),
 
             // Logical operators
             "$and" => AllOf::boxed(operands),
@@ -220,6 +221,7 @@ mod tests {
         #[rstest]
         // Arithmetic operators
         #[case("$add", vec![true, false], Value::Int(1))]
+        #[case("$sub", vec![true, true], Value::Int(0))]
         // Logical operators
         #[case("$and", vec![true, false], Value::Bool(false))]
         #[case("$all_of", vec![true, false], Value::Bool(false))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,7 +2,9 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
-use crate::storage::query::condition::operators::arithmetic::{Add, Div, DivNum, Mult, Rem, Sub};
+use crate::storage::query::condition::operators::arithmetic::{
+    Abs, Add, Div, DivNum, Mult, Rem, Sub,
+};
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
 use crate::storage::query::condition::reference::Reference;
@@ -98,6 +100,7 @@ impl Parser {
             "$div" => Div::boxed(operands),
             "$div_num" => DivNum::boxed(operands),
             "$rem" => Rem::boxed(operands),
+            "$abs" => Abs::boxed(operands),
 
             // Logical operators
             "$and" => AllOf::boxed(operands),
@@ -230,6 +233,7 @@ mod tests {
         #[case("$div", vec![true, true], Value::Float(1.0))]
         #[case("$div_num", vec![true, true], Value::Int(1))]
         #[case("$rem", vec![true, true], Value::Int(0))]
+        #[case("$abs", vec![true], Value::Int(1))]
         // Logical operators
         #[case("$and", vec![true, false], Value::Bool(false))]
         #[case("$all_of", vec![true, false], Value::Bool(false))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
-use crate::storage::query::condition::operators::arithmetic::{Add, Div, Mult, Sub};
+use crate::storage::query::condition::operators::arithmetic::{Add, Div, DivNum, Mult, Sub};
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
 use crate::storage::query::condition::reference::Reference;
@@ -96,6 +96,7 @@ impl Parser {
             "$sub" => Sub::boxed(operands),
             "$mult" => Mult::boxed(operands),
             "$div" => Div::boxed(operands),
+            "$div_num" => DivNum::boxed(operands),
 
             // Logical operators
             "$and" => AllOf::boxed(operands),
@@ -226,6 +227,7 @@ mod tests {
         #[case("$sub", vec![true, true], Value::Int(0))]
         #[case("$mult", vec![true, false], Value::Int(0))]
         #[case("$div", vec![true, true], Value::Float(1.0))]
+        #[case("$div_num", vec![true, true], Value::Int(1))]
         // Logical operators
         #[case("$and", vec![true, false], Value::Bool(false))]
         #[case("$all_of", vec![true, false], Value::Bool(false))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
-use crate::storage::query::condition::operators::arithmetic::Add;
+use crate::storage::query::condition::operators::arithmetic::{Add, Sub};
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
 use crate::storage::query::condition::reference::Reference;
@@ -93,7 +93,7 @@ impl Parser {
         match operator {
             // Arithmetic operators
             "$add" => Add::boxed(operands),
-            "$sub" => Add::boxed(operands),
+            "$sub" => Sub::boxed(operands),
 
             // Logical operators
             "$and" => AllOf::boxed(operands),

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
-use crate::storage::query::condition::operators::arithmetic::{Add, Div, DivNum, Mult, Sub};
+use crate::storage::query::condition::operators::arithmetic::{Add, Div, DivNum, Mult, Rem, Sub};
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
 use crate::storage::query::condition::reference::Reference;
@@ -97,6 +97,7 @@ impl Parser {
             "$mult" => Mult::boxed(operands),
             "$div" => Div::boxed(operands),
             "$div_num" => DivNum::boxed(operands),
+            "$rem" => Rem::boxed(operands),
 
             // Logical operators
             "$and" => AllOf::boxed(operands),
@@ -228,6 +229,7 @@ mod tests {
         #[case("$mult", vec![true, false], Value::Int(0))]
         #[case("$div", vec![true, true], Value::Float(1.0))]
         #[case("$div_num", vec![true, true], Value::Int(1))]
+        #[case("$rem", vec![true, true], Value::Int(0))]
         // Logical operators
         #[case("$and", vec![true, false], Value::Bool(false))]
         #[case("$all_of", vec![true, false], Value::Bool(false))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,6 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
+use crate::storage::query::condition::operators::arithmetic::Add;
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
 use crate::storage::query::condition::reference::Reference;
@@ -90,6 +91,9 @@ impl Parser {
 
     fn parse_operator(operator: &str, operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
         match operator {
+            // Arithmetic operators
+            "$add" => Add::boxed(operands),
+
             // Logical operators
             "$and" => AllOf::boxed(operands),
             "$all_of" => AllOf::boxed(operands),
@@ -107,6 +111,7 @@ impl Parser {
             "$lt" => Lt::boxed(operands),
             "$lte" => Lte::boxed(operands),
             "$ne" => Ne::boxed(operands),
+
             _ => Err(unprocessable_entity!(
                 "Operator '{}' not supported",
                 operator
@@ -213,6 +218,9 @@ mod tests {
     mod parse_operators {
         use super::*;
         #[rstest]
+        // Arithmetic operators
+        #[case("$add", vec![true, false], Value::Int(1))]
+        // Logical operators
         #[case("$and", vec![true, false], Value::Bool(false))]
         #[case("$all_of", vec![true, false], Value::Bool(false))]
         #[case("$or", vec![true, false], Value::Bool(true))]
@@ -221,6 +229,7 @@ mod tests {
         #[case("$none_of", vec![true, true], Value::Bool(false))]
         #[case("$xor", vec![true, true], Value::Bool(false))]
         #[case("$one_of", vec![true, true], Value::Bool(false))]
+        // Comparison operators
         #[case("$eq", vec![true, true], Value::Bool(true))]
         #[case("$gt", vec![true, false], Value::Bool(true))]
         #[case("$gte", vec![true, false], Value::Bool(true))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
-use crate::storage::query::condition::operators::arithmetic::{Add, Mult, Sub};
+use crate::storage::query::condition::operators::arithmetic::{Add, Div, Mult, Sub};
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
 use crate::storage::query::condition::reference::Reference;
@@ -95,6 +95,7 @@ impl Parser {
             "$add" => Add::boxed(operands),
             "$sub" => Sub::boxed(operands),
             "$mult" => Mult::boxed(operands),
+            "$div" => Div::boxed(operands),
 
             // Logical operators
             "$and" => AllOf::boxed(operands),
@@ -224,6 +225,7 @@ mod tests {
         #[case("$add", vec![true, false], Value::Int(1))]
         #[case("$sub", vec![true, true], Value::Int(0))]
         #[case("$mult", vec![true, false], Value::Int(0))]
+        #[case("$div", vec![true, true], Value::Float(1.0))]
         // Logical operators
         #[case("$and", vec![true, false], Value::Bool(false))]
         #[case("$all_of", vec![true, false], Value::Bool(false))]

--- a/reductstore/src/storage/query/condition/value.rs
+++ b/reductstore/src/storage/query/condition/value.rs
@@ -3,6 +3,7 @@
 
 mod add;
 mod cmp;
+mod div;
 mod mult;
 mod sub;
 
@@ -10,6 +11,7 @@ use reduct_base::error::ReductError;
 use reduct_base::unprocessable_entity;
 
 pub(crate) use add::Add;
+pub(crate) use div::Div;
 pub(crate) use mult::Mult;
 pub(crate) use sub::Sub;
 
@@ -77,7 +79,6 @@ impl Value {
     }
 
     /// Converts the value to a float.
-    #[allow(dead_code)]
     pub fn as_float(&self) -> Result<f64, ReductError> {
         match self {
             Value::Bool(value) => Ok(*value as i64 as f64),
@@ -104,6 +105,14 @@ impl Value {
             Value::Int(value) => Ok(value.to_string()),
             Value::Float(value) => Ok(value.to_string()),
             Value::String(value) => Ok(value.clone()),
+        }
+    }
+
+    /// Check if it is a string
+    pub fn is_string(&self) -> bool {
+        match self {
+            Value::String(_) => true,
+            _ => false,
         }
     }
 }

--- a/reductstore/src/storage/query/condition/value.rs
+++ b/reductstore/src/storage/query/condition/value.rs
@@ -4,6 +4,7 @@
 mod add;
 mod cmp;
 mod div;
+mod div_num;
 mod mult;
 mod sub;
 
@@ -12,6 +13,7 @@ use reduct_base::unprocessable_entity;
 
 pub(crate) use add::Add;
 pub(crate) use div::Div;
+pub(crate) use div_num::DivNum;
 pub(crate) use mult::Mult;
 pub(crate) use sub::Sub;
 

--- a/reductstore/src/storage/query/condition/value.rs
+++ b/reductstore/src/storage/query/condition/value.rs
@@ -3,12 +3,14 @@
 
 mod add;
 mod cmp;
+mod mult;
 mod sub;
 
 use reduct_base::error::ReductError;
 use reduct_base::unprocessable_entity;
 
 pub(crate) use add::Add;
+pub(crate) use mult::Mult;
 pub(crate) use sub::Sub;
 
 /// A value that can be used in a condition.

--- a/reductstore/src/storage/query/condition/value.rs
+++ b/reductstore/src/storage/query/condition/value.rs
@@ -6,6 +6,7 @@ mod cmp;
 mod div;
 mod div_num;
 mod mult;
+mod rem;
 mod sub;
 
 use reduct_base::error::ReductError;
@@ -15,6 +16,7 @@ pub(crate) use add::Add;
 pub(crate) use div::Div;
 pub(crate) use div_num::DivNum;
 pub(crate) use mult::Mult;
+pub(crate) use rem::Rem;
 pub(crate) use sub::Sub;
 
 /// A value that can be used in a condition.

--- a/reductstore/src/storage/query/condition/value.rs
+++ b/reductstore/src/storage/query/condition/value.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+mod abs;
 mod add;
 mod cmp;
 mod div;
@@ -12,6 +13,7 @@ mod sub;
 use reduct_base::error::ReductError;
 use reduct_base::unprocessable_entity;
 
+pub(crate) use abs::Abs;
 pub(crate) use add::Add;
 pub(crate) use div::Div;
 pub(crate) use div_num::DivNum;

--- a/reductstore/src/storage/query/condition/value.rs
+++ b/reductstore/src/storage/query/condition/value.rs
@@ -1,8 +1,15 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+mod add;
+mod cmp;
+mod sub;
+
 use reduct_base::error::ReductError;
 use reduct_base::unprocessable_entity;
+
+pub(crate) use add::Add;
+pub(crate) use sub::Sub;
 
 /// A value that can be used in a condition.
 #[derive(Debug, Clone)]
@@ -32,50 +39,6 @@ impl Value {
             Value::Float(value)
         } else {
             Value::String(value.to_string())
-        }
-    }
-}
-
-impl PartialEq<Self> for Value {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Value::Bool(left), Value::Bool(right)) => left == right,
-            (Value::Bool(left), Value::Int(right)) => *left as i64 == *right,
-            (Value::Bool(left), Value::Float(right)) => *left as i64 as f64 == *right,
-
-            (Value::Int(left), Value::Int(right)) => left == right,
-            (Value::Int(left), Value::Bool(right)) => *left == *right as i64,
-            (Value::Int(left), Value::Float(right)) => *left as f64 == *right,
-
-            (Value::Float(left), Value::Float(right)) => left == right,
-            (Value::Float(left), Value::Int(right)) => *left == *right as f64,
-            (Value::Float(left), Value::Bool(right)) => *left == *right as i64 as f64,
-
-            (Value::String(left), Value::String(right)) => left == right,
-            (Value::String(_), _) => false,
-            (_, Value::String(_)) => false,
-        }
-    }
-}
-
-impl PartialOrd for Value {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match (self, other) {
-            (Value::Bool(left), Value::Bool(right)) => left.partial_cmp(right),
-            (Value::Bool(left), Value::Int(right)) => (*left as i64).partial_cmp(right),
-            (Value::Bool(left), Value::Float(right)) => (*left as i64 as f64).partial_cmp(right),
-
-            (Value::Int(left), Value::Int(right)) => left.partial_cmp(right),
-            (Value::Int(left), Value::Bool(right)) => left.partial_cmp(&(*right as i64)),
-            (Value::Int(left), Value::Float(right)) => (*left as f64).partial_cmp(right),
-
-            (Value::Float(left), Value::Float(right)) => left.partial_cmp(right),
-            (Value::Float(left), Value::Int(right)) => left.partial_cmp(&(*right as f64)),
-            (Value::Float(left), Value::Bool(right)) => left.partial_cmp(&(*right as i64 as f64)),
-
-            (Value::String(left), Value::String(right)) => left.partial_cmp(right),
-            (Value::String(_), _) => None,
-            (_, Value::String(_)) => None,
         }
     }
 }
@@ -179,188 +142,6 @@ mod tests {
         fn parse_string() {
             let result = Value::parse("some string");
             assert_eq!(result, Value::String("some string".to_string()));
-        }
-    }
-
-    mod partial_eq {
-        use super::*;
-
-        #[rstest]
-        #[case(Value::Bool(true), Value::Bool(true), true)]
-        #[case(Value::Bool(true), Value::Bool(false), false)]
-        #[case(Value::Bool(false), Value::Bool(true), false)]
-        #[case(Value::Bool(true), Value::Int(1), true)]
-        #[case(Value::Bool(true), Value::Int(0), false)]
-        #[case(Value::Bool(true), Value::Int(-1), false)]
-        #[case(Value::Bool(true), Value::Float(1.0), true)]
-        #[case(Value::Bool(true), Value::Float(0.0), false)]
-        #[case(Value::Bool(true), Value::Float(-1.0), false)]
-        #[case(Value::Bool(true), Value::String("string".to_string()), false)]
-        #[case(Value::Bool(false), Value::String("string".to_string()), false)]
-        #[case(Value::Bool(true), Value::String("true".to_string()), false)]
-        fn partial_eq_bool(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
-            let result = left == right;
-            assert_eq!(result, expected);
-        }
-
-        #[rstest]
-        #[case(Value::Int(1), Value::Int(1), true)]
-        #[case(Value::Int(1), Value::Int(-1), false)]
-        #[case(Value::Int(-1), Value::Int(-1), true)]
-        #[case(Value::Int(-1), Value::Int(1), false)]
-        #[case(Value::Int(1), Value::Bool(true), true)]
-        #[case(Value::Int(1), Value::Bool(false), false)]
-        #[case(Value::Int(0), Value::Bool(true), false)]
-        #[case(Value::Int(0), Value::Bool(false), true)]
-        #[case(Value::Int(-1), Value::Bool(true), false)]
-        #[case(Value::Int(-1), Value::Bool(false), false)]
-        #[case(Value::Int(1), Value::Float(1.0), true)]
-        #[case(Value::Int(1), Value::Float(0.0), false)]
-        #[case(Value::Int(1), Value::Float(-1.0), false)]
-        #[case(Value::Int(1), Value::String("string".to_string()), false)]
-        #[case(Value::Int(-1), Value::String("string".to_string()), false)]
-        fn partial_eq_int(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
-            let result = left == right;
-            assert_eq!(result, expected);
-        }
-
-        #[rstest]
-        #[case(Value::Float(1.0), Value::Float(1.0), true)]
-        #[case(Value::Float(1.0), Value::Float(-1.0), false)]
-        #[case(Value::Float(-1.0), Value::Float(-1.0), true)]
-        #[case(Value::Float(-1.0), Value::Float(1.0), false)]
-        #[case(Value::Float(1.0), Value::Bool(true), true)]
-        #[case(Value::Float(1.0), Value::Bool(false), false)]
-        #[case(Value::Float(0.0), Value::Bool(true), false)]
-        #[case(Value::Float(0.0), Value::Bool(false), true)]
-        #[case(Value::Float(-1.0), Value::Bool(true), false)]
-        #[case(Value::Float(-1.0), Value::Bool(false), false)]
-        #[case(Value::Float(1.0), Value::Int(1), true)]
-        #[case(Value::Float(1.0), Value::Int(0), false)]
-        #[case(Value::Float(1.0), Value::Int(-1), false)]
-        #[case(Value::Float(1.0), Value::String("string".to_string()), false)]
-        #[case(Value::Float(-1.0), Value::String("string".to_string()), false)]
-        fn partial_eq_float(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
-            let result = left == right;
-            assert_eq!(result, expected);
-        }
-
-        #[rstest]
-        #[case(Value::String("a".to_string()), Value::String("a".to_string()), true)]
-        #[case(Value::String("a".to_string()), Value::String("b".to_string()), false)]
-        #[case(Value::String("b".to_string()), Value::String("a".to_string()), false)]
-        #[case(Value::String("a".to_string()), Value::Bool(true), false)]
-        #[case(Value::String("a".to_string()), Value::Bool(false), false)]
-        #[case(Value::String("a".to_string()), Value::Int(1), false)]
-        #[case(Value::String("a".to_string()), Value::Float(1.0), false)]
-        fn partial_eq_string(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
-            let result = left == right;
-            assert_eq!(result, expected);
-        }
-    }
-
-    mod partial_cmp {
-        use super::*;
-        use std::cmp::Ordering;
-
-        #[rstest]
-        #[case(Value::Bool(true), Value::Bool(true), Some(Ordering::Equal))]
-        #[case(Value::Bool(true), Value::Bool(false), Some(Ordering::Greater))]
-        #[case(Value::Bool(false), Value::Bool(true), Some(Ordering::Less))]
-        #[case(Value::Bool(true), Value::Int(2), Some(Ordering::Less))]
-        #[case(Value::Bool(true), Value::Int(1), Some(Ordering::Equal))]
-        #[case(Value::Bool(true), Value::Int(0), Some(Ordering::Greater))]
-        #[case(Value::Bool(true), Value::Int(-1), Some(Ordering::Greater))]
-        #[case(Value::Bool(false), Value::Int(1), Some(Ordering::Less))]
-        #[case(Value::Bool(false), Value::Int(0), Some(Ordering::Equal))]
-        #[case(Value::Bool(false), Value::Int(-1), Some(Ordering::Greater))]
-        #[case(Value::Bool(true), Value::Float(2.0), Some(Ordering::Less))]
-        #[case(Value::Bool(true), Value::Float(1.0), Some(Ordering::Equal))]
-        #[case(Value::Bool(true), Value::Float(0.0), Some(Ordering::Greater))]
-        #[case(Value::Bool(true), Value::Float(-1.0), Some(Ordering::Greater))]
-        #[case(Value::Bool(false), Value::Float(1.0), Some(Ordering::Less))]
-        #[case(Value::Bool(false), Value::Float(0.0), Some(Ordering::Equal))]
-        #[case(Value::Bool(false), Value::Float(-1.0), Some(Ordering::Greater))]
-        #[case(Value::Bool(true), Value::String("string".to_string()), None)]
-        #[case(Value::Bool(false), Value::String("string".to_string()), None)]
-        #[case(Value::Bool(true), Value::String("true".to_string()), None)]
-        #[case(Value::Bool(false), Value::String("true".to_string()), None)]
-        fn partial_cmp_bool(
-            #[case] left: Value,
-            #[case] right: Value,
-            #[case] expected: Option<Ordering>,
-        ) {
-            let result = left.partial_cmp(&right);
-            assert_eq!(result, expected);
-        }
-
-        #[rstest]
-        #[case(Value::Int(1), Value::Int(1), Some(Ordering::Equal))]
-        #[case(Value::Int(1), Value::Int(-1), Some(Ordering::Greater))]
-        #[case(Value::Int(-1), Value::Int(-1), Some(Ordering::Equal))]
-        #[case(Value::Int(-1), Value::Int(1), Some(Ordering::Less))]
-        #[case(Value::Int(1), Value::Bool(true), Some(Ordering::Equal))]
-        #[case(Value::Int(1), Value::Bool(false), Some(Ordering::Greater))]
-        #[case(Value::Int(0), Value::Bool(true), Some(Ordering::Less))]
-        #[case(Value::Int(0), Value::Bool(false), Some(Ordering::Equal))]
-        #[case(Value::Int(-1), Value::Bool(true), Some(Ordering::Less))]
-        #[case(Value::Int(-1), Value::Bool(false), Some(Ordering::Less))]
-        #[case(Value::Int(1), Value::Float(2.0), Some(Ordering::Less))]
-        #[case(Value::Int(1), Value::Float(1.0), Some(Ordering::Equal))]
-        #[case(Value::Int(1), Value::Float(0.0), Some(Ordering::Greater))]
-        #[case(Value::Int(1), Value::Float(-1.0), Some(Ordering::Greater))]
-        #[case(Value::Int(1), Value::String("string".to_string()), None)]
-        #[case(Value::Int(-1), Value::String("string".to_string()), None)]
-        fn partial_cmp_int(
-            #[case] left: Value,
-            #[case] right: Value,
-            #[case] expected: Option<Ordering>,
-        ) {
-            let result = left.partial_cmp(&right);
-            assert_eq!(result, expected);
-        }
-
-        #[rstest]
-        #[case(Value::Float(1.0), Value::Float(1.0), Some(Ordering::Equal))]
-        #[case(Value::Float(1.0), Value::Float(-1.0), Some(Ordering::Greater))]
-        #[case(Value::Float(-1.0), Value::Float(-1.0), Some(Ordering::Equal))]
-        #[case(Value::Float(-1.0), Value::Float(1.0), Some(Ordering::Less))]
-        #[case(Value::Float(1.0), Value::Bool(true), Some(Ordering::Equal))]
-        #[case(Value::Float(1.0), Value::Bool(false), Some(Ordering::Greater))]
-        #[case(Value::Float(0.0), Value::Bool(true), Some(Ordering::Less))]
-        #[case(Value::Float(0.0), Value::Bool(false), Some(Ordering::Equal))]
-        #[case(Value::Float(-1.0), Value::Bool(true), Some(Ordering::Less))]
-        #[case(Value::Float(-1.0), Value::Bool(false), Some(Ordering::Less))]
-        #[case(Value::Float(1.0), Value::Int(2), Some(Ordering::Less))]
-        #[case(Value::Float(1.0), Value::Int(1), Some(Ordering::Equal))]
-        #[case(Value::Float(1.0), Value::Int(0), Some(Ordering::Greater))]
-        #[case(Value::Float(1.0), Value::Int(-1), Some(Ordering::Greater))]
-        #[case(Value::Float(1.0), Value::String("string".to_string()), None)]
-        #[case(Value::Float(-1.0), Value::String("string".to_string()), None)]
-        fn partial_cmp_float(
-            #[case] left: Value,
-            #[case] right: Value,
-            #[case] expected: Option<Ordering>,
-        ) {
-            let result = left.partial_cmp(&right);
-            assert_eq!(result, expected);
-        }
-
-        #[rstest]
-        #[case(Value::String("a".to_string()), Value::String("a".to_string()), Some(Ordering::Equal))]
-        #[case(Value::String("a".to_string()), Value::String("b".to_string()), Some(Ordering::Less))]
-        #[case(Value::String("b".to_string()), Value::String("a".to_string()), Some(Ordering::Greater))]
-        #[case(Value::String("a".to_string()), Value::Bool(true), None)]
-        #[case(Value::String("a".to_string()), Value::Bool(false), None)]
-        #[case(Value::String("a".to_string()), Value::Int(1), None)]
-        #[case(Value::String("a".to_string()), Value::Float(1.0), None)]
-        fn partial_cmp_string(
-            #[case] left: Value,
-            #[case] right: Value,
-            #[case] expected: Option<Ordering>,
-        ) {
-            let result = left.partial_cmp(&right);
-            assert_eq!(result, expected);
         }
     }
 

--- a/reductstore/src/storage/query/condition/value/abs.rs
+++ b/reductstore/src/storage/query/condition/value/abs.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for calculating an absolute value.
+pub(crate) trait Abs {
+    /// Calculates the absolute value of a value.
+    fn abs(self) -> Result<Self, ReductError>
+    where
+        Self: Sized;
+}
+
+impl Abs for Value {
+    fn abs(self) -> Result<Self, ReductError> {
+        let mut result = self;
+        match result {
+            Value::Bool(s) => result = Value::Int(s as i64),
+            Value::Int(s) => result = Value::Int(s.abs()),
+            Value::Float(s) => result = Value::Float(s.abs()),
+            Value::String(_) => {
+                return Err(unprocessable_entity!(
+                    "Cannot calculate absolute value of a string"
+                ));
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    #[rstest]
+    #[case(Value::Bool(true), Value::Int(1))]
+    #[case(Value::Bool(false), Value::Int(0))]
+    #[case(Value::Int(-1), Value::Int(1))]
+    #[case(Value::Int(0), Value::Int(0))]
+    #[case(Value::Int(1), Value::Int(1))]
+    #[case(Value::Float(-1.0), Value::Float(1.0))]
+    #[case(Value::Float(0.0), Value::Float(0.0))]
+    #[case(Value::Float(1.0), Value::Float(1.0))]
+    fn test_abs(#[case] value: Value, #[case] expected: Value) {
+        let result = value.abs().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_abs_string() {
+        let value = Value::String("test".to_string());
+        assert_eq!(
+            value.abs(),
+            Err(unprocessable_entity!(
+                "Cannot calculate absolute value of a string"
+            ))
+        );
+    }
+}

--- a/reductstore/src/storage/query/condition/value/add.rs
+++ b/reductstore/src/storage/query/condition/value/add.rs
@@ -1,0 +1,101 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for adding two values.
+pub(crate) trait Add {
+    /// Adds two values.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The first value.
+    /// * `other` - The second value.
+    ///
+    /// # Returns
+    ///
+    /// The sum of the two values or an error if the values cannot be added.
+    fn add(self, other: Self) -> Result<Self, ReductError>
+    where
+        Self: Sized;
+}
+
+impl Add for Value {
+    fn add(self, other: Self) -> Result<Self, ReductError> {
+        let mut result = self;
+        match result {
+            Value::Bool(s) => match other {
+                Value::Bool(v) => result = Value::Int(s as i64 + v as i64),
+                Value::Int(v) => result = Value::Int(s as i64 + v),
+                Value::Float(v) => result = Value::Float(s as i8 as f64 + v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot add boolean to string"));
+                }
+            },
+
+            Value::Int(s) => match other {
+                Value::Bool(v) => result = Value::Int(s + v as i64),
+                Value::Int(v) => result = Value::Int(s + v),
+                Value::Float(v) => result = Value::Float(s as f64 + v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot add integer to string"));
+                }
+            },
+
+            Value::Float(s) => match other {
+                Value::Bool(v) => result = Value::Float(s + v as i8 as f64),
+                Value::Int(v) => result = Value::Float(s + v as f64),
+                Value::Float(v) => result = Value::Float(s + v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot add float to string"));
+                }
+            },
+
+            Value::String(s) => match other {
+                Value::Bool(_) => {
+                    return Err(unprocessable_entity!("Cannot add string to boolean"));
+                }
+                Value::Int(_) => {
+                    return Err(unprocessable_entity!("Cannot add string to integer"));
+                }
+
+                Value::Float(_) => {
+                    return Err(unprocessable_entity!("Cannot add string to float"));
+                }
+                Value::String(v) => result = Value::String(format!("{}{}", s, v)),
+            },
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    #[rstest]
+    #[case(Value::Bool(true), Value::Bool(false), Value::Int(1))]
+    #[case(Value::Bool(true), Value::Int(2), Value::Int(3))]
+    #[case(Value::Bool(true), Value::Float(2.0), Value::Float(3.0))]
+    #[case(Value::Int(2), Value::Int(3), Value::Int(5))]
+    #[case(Value::Int(2), Value::Float(3.0), Value::Float(5.0))]
+    #[case(Value::Float(2.0), Value::Float(3.0), Value::Float(5.0))]
+    #[case(Value::String("hello".to_string()), Value::String("world".to_string()), Value::String("helloworld".to_string()))]
+    fn test_add_ok(#[case] a: Value, #[case] b: Value, #[case] expected: Value) {
+        assert_eq!(a.add(b).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case(Value::Bool(true), Value::String("world".to_string()), unprocessable_entity!("Cannot add boolean to string"))]
+    #[case(Value::Int(2), Value::String("world".to_string()), unprocessable_entity!("Cannot add integer to string"))]
+    #[case(Value::Float(2.0), Value::String("world".to_string()), unprocessable_entity!("Cannot add float to string"))]
+    #[case(Value::String("hello".to_string()), Value::Bool(true), unprocessable_entity!("Cannot add string to boolean"))]
+    #[case(Value::String("hello".to_string()), Value::Int(2), unprocessable_entity!("Cannot add string to integer"))]
+    #[case(Value::String("hello".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot add string to float"))]
+    fn test_add_err(#[case] a: Value, #[case] b: Value, #[case] expected: ReductError) {
+        assert_eq!(a.add(b), Err(expected));
+    }
+}

--- a/reductstore/src/storage/query/condition/value/add.rs
+++ b/reductstore/src/storage/query/condition/value/add.rs
@@ -80,8 +80,11 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(false), Value::Int(1))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(3))]
     #[case(Value::Bool(true), Value::Float(2.0), Value::Float(3.0))]
+    #[case(Value::Int(2), Value::Bool(true), Value::Int(3))]
     #[case(Value::Int(2), Value::Int(3), Value::Int(5))]
     #[case(Value::Int(2), Value::Float(3.0), Value::Float(5.0))]
+    #[case(Value::Float(2.0), Value::Bool(true), Value::Float(3.0))]
+    #[case(Value::Float(2.0), Value::Int(3), Value::Float(5.0))]
     #[case(Value::Float(2.0), Value::Float(3.0), Value::Float(5.0))]
     #[case(Value::String("hello".to_string()), Value::String("world".to_string()), Value::String("helloworld".to_string()))]
     fn test_add_ok(#[case] a: Value, #[case] b: Value, #[case] expected: Value) {

--- a/reductstore/src/storage/query/condition/value/cmp.rs
+++ b/reductstore/src/storage/query/condition/value/cmp.rs
@@ -1,0 +1,235 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+
+impl PartialEq<Self> for Value {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Value::Bool(left), Value::Bool(right)) => left == right,
+            (Value::Bool(left), Value::Int(right)) => *left as i64 == *right,
+            (Value::Bool(left), Value::Float(right)) => *left as i64 as f64 == *right,
+
+            (Value::Int(left), Value::Int(right)) => left == right,
+            (Value::Int(left), Value::Bool(right)) => *left == *right as i64,
+            (Value::Int(left), Value::Float(right)) => *left as f64 == *right,
+
+            (Value::Float(left), Value::Float(right)) => left == right,
+            (Value::Float(left), Value::Int(right)) => *left == *right as f64,
+            (Value::Float(left), Value::Bool(right)) => *left == *right as i64 as f64,
+
+            (Value::String(left), Value::String(right)) => left == right,
+            (Value::String(_), _) => false,
+            (_, Value::String(_)) => false,
+        }
+    }
+}
+
+impl PartialOrd for Value {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (Value::Bool(left), Value::Bool(right)) => left.partial_cmp(right),
+            (Value::Bool(left), Value::Int(right)) => (*left as i64).partial_cmp(right),
+            (Value::Bool(left), Value::Float(right)) => (*left as i64 as f64).partial_cmp(right),
+
+            (Value::Int(left), Value::Int(right)) => left.partial_cmp(right),
+            (Value::Int(left), Value::Bool(right)) => left.partial_cmp(&(*right as i64)),
+            (Value::Int(left), Value::Float(right)) => (*left as f64).partial_cmp(right),
+
+            (Value::Float(left), Value::Float(right)) => left.partial_cmp(right),
+            (Value::Float(left), Value::Int(right)) => left.partial_cmp(&(*right as f64)),
+            (Value::Float(left), Value::Bool(right)) => left.partial_cmp(&(*right as i64 as f64)),
+
+            (Value::String(left), Value::String(right)) => left.partial_cmp(right),
+            (Value::String(_), _) => None,
+            (_, Value::String(_)) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Value;
+    use rstest::rstest;
+    mod partial_eq {
+        use super::*;
+
+        #[rstest]
+        #[case(Value::Bool(true), Value::Bool(true), true)]
+        #[case(Value::Bool(true), Value::Bool(false), false)]
+        #[case(Value::Bool(false), Value::Bool(true), false)]
+        #[case(Value::Bool(true), Value::Int(1), true)]
+        #[case(Value::Bool(true), Value::Int(0), false)]
+        #[case(Value::Bool(true), Value::Int(-1), false)]
+        #[case(Value::Bool(true), Value::Float(1.0), true)]
+        #[case(Value::Bool(true), Value::Float(0.0), false)]
+        #[case(Value::Bool(true), Value::Float(-1.0), false)]
+        #[case(Value::Bool(true), Value::String("string".to_string()), false)]
+        #[case(Value::Bool(false), Value::String("string".to_string()), false)]
+        #[case(Value::Bool(true), Value::String("true".to_string()), false)]
+        fn partial_eq_bool(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
+            let result = left == right;
+            assert_eq!(result, expected);
+        }
+
+        #[rstest]
+        #[case(Value::Int(1), Value::Int(1), true)]
+        #[case(Value::Int(1), Value::Int(-1), false)]
+        #[case(Value::Int(-1), Value::Int(-1), true)]
+        #[case(Value::Int(-1), Value::Int(1), false)]
+        #[case(Value::Int(1), Value::Bool(true), true)]
+        #[case(Value::Int(1), Value::Bool(false), false)]
+        #[case(Value::Int(0), Value::Bool(true), false)]
+        #[case(Value::Int(0), Value::Bool(false), true)]
+        #[case(Value::Int(-1), Value::Bool(true), false)]
+        #[case(Value::Int(-1), Value::Bool(false), false)]
+        #[case(Value::Int(1), Value::Float(1.0), true)]
+        #[case(Value::Int(1), Value::Float(0.0), false)]
+        #[case(Value::Int(1), Value::Float(-1.0), false)]
+        #[case(Value::Int(1), Value::String("string".to_string()), false)]
+        #[case(Value::Int(-1), Value::String("string".to_string()), false)]
+        fn partial_eq_int(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
+            let result = left == right;
+            assert_eq!(result, expected);
+        }
+
+        #[rstest]
+        #[case(Value::Float(1.0), Value::Float(1.0), true)]
+        #[case(Value::Float(1.0), Value::Float(-1.0), false)]
+        #[case(Value::Float(-1.0), Value::Float(-1.0), true)]
+        #[case(Value::Float(-1.0), Value::Float(1.0), false)]
+        #[case(Value::Float(1.0), Value::Bool(true), true)]
+        #[case(Value::Float(1.0), Value::Bool(false), false)]
+        #[case(Value::Float(0.0), Value::Bool(true), false)]
+        #[case(Value::Float(0.0), Value::Bool(false), true)]
+        #[case(Value::Float(-1.0), Value::Bool(true), false)]
+        #[case(Value::Float(-1.0), Value::Bool(false), false)]
+        #[case(Value::Float(1.0), Value::Int(1), true)]
+        #[case(Value::Float(1.0), Value::Int(0), false)]
+        #[case(Value::Float(1.0), Value::Int(-1), false)]
+        #[case(Value::Float(1.0), Value::String("string".to_string()), false)]
+        #[case(Value::Float(-1.0), Value::String("string".to_string()), false)]
+        fn partial_eq_float(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
+            let result = left == right;
+            assert_eq!(result, expected);
+        }
+
+        #[rstest]
+        #[case(Value::String("a".to_string()), Value::String("a".to_string()), true)]
+        #[case(Value::String("a".to_string()), Value::String("b".to_string()), false)]
+        #[case(Value::String("b".to_string()), Value::String("a".to_string()), false)]
+        #[case(Value::String("a".to_string()), Value::Bool(true), false)]
+        #[case(Value::String("a".to_string()), Value::Bool(false), false)]
+        #[case(Value::String("a".to_string()), Value::Int(1), false)]
+        #[case(Value::String("a".to_string()), Value::Float(1.0), false)]
+        fn partial_eq_string(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
+            let result = left == right;
+            assert_eq!(result, expected);
+        }
+    }
+
+    mod partial_cmp {
+        use super::*;
+        use std::cmp::Ordering;
+
+        #[rstest]
+        #[case(Value::Bool(true), Value::Bool(true), Some(Ordering::Equal))]
+        #[case(Value::Bool(true), Value::Bool(false), Some(Ordering::Greater))]
+        #[case(Value::Bool(false), Value::Bool(true), Some(Ordering::Less))]
+        #[case(Value::Bool(true), Value::Int(2), Some(Ordering::Less))]
+        #[case(Value::Bool(true), Value::Int(1), Some(Ordering::Equal))]
+        #[case(Value::Bool(true), Value::Int(0), Some(Ordering::Greater))]
+        #[case(Value::Bool(true), Value::Int(-1), Some(Ordering::Greater))]
+        #[case(Value::Bool(false), Value::Int(1), Some(Ordering::Less))]
+        #[case(Value::Bool(false), Value::Int(0), Some(Ordering::Equal))]
+        #[case(Value::Bool(false), Value::Int(-1), Some(Ordering::Greater))]
+        #[case(Value::Bool(true), Value::Float(2.0), Some(Ordering::Less))]
+        #[case(Value::Bool(true), Value::Float(1.0), Some(Ordering::Equal))]
+        #[case(Value::Bool(true), Value::Float(0.0), Some(Ordering::Greater))]
+        #[case(Value::Bool(true), Value::Float(-1.0), Some(Ordering::Greater))]
+        #[case(Value::Bool(false), Value::Float(1.0), Some(Ordering::Less))]
+        #[case(Value::Bool(false), Value::Float(0.0), Some(Ordering::Equal))]
+        #[case(Value::Bool(false), Value::Float(-1.0), Some(Ordering::Greater))]
+        #[case(Value::Bool(true), Value::String("string".to_string()), None)]
+        #[case(Value::Bool(false), Value::String("string".to_string()), None)]
+        #[case(Value::Bool(true), Value::String("true".to_string()), None)]
+        #[case(Value::Bool(false), Value::String("true".to_string()), None)]
+        fn partial_cmp_bool(
+            #[case] left: Value,
+            #[case] right: Value,
+            #[case] expected: Option<Ordering>,
+        ) {
+            let result = left.partial_cmp(&right);
+            assert_eq!(result, expected);
+        }
+
+        #[rstest]
+        #[case(Value::Int(1), Value::Int(1), Some(Ordering::Equal))]
+        #[case(Value::Int(1), Value::Int(-1), Some(Ordering::Greater))]
+        #[case(Value::Int(-1), Value::Int(-1), Some(Ordering::Equal))]
+        #[case(Value::Int(-1), Value::Int(1), Some(Ordering::Less))]
+        #[case(Value::Int(1), Value::Bool(true), Some(Ordering::Equal))]
+        #[case(Value::Int(1), Value::Bool(false), Some(Ordering::Greater))]
+        #[case(Value::Int(0), Value::Bool(true), Some(Ordering::Less))]
+        #[case(Value::Int(0), Value::Bool(false), Some(Ordering::Equal))]
+        #[case(Value::Int(-1), Value::Bool(true), Some(Ordering::Less))]
+        #[case(Value::Int(-1), Value::Bool(false), Some(Ordering::Less))]
+        #[case(Value::Int(1), Value::Float(2.0), Some(Ordering::Less))]
+        #[case(Value::Int(1), Value::Float(1.0), Some(Ordering::Equal))]
+        #[case(Value::Int(1), Value::Float(0.0), Some(Ordering::Greater))]
+        #[case(Value::Int(1), Value::Float(-1.0), Some(Ordering::Greater))]
+        #[case(Value::Int(1), Value::String("string".to_string()), None)]
+        #[case(Value::Int(-1), Value::String("string".to_string()), None)]
+        fn partial_cmp_int(
+            #[case] left: Value,
+            #[case] right: Value,
+            #[case] expected: Option<Ordering>,
+        ) {
+            let result = left.partial_cmp(&right);
+            assert_eq!(result, expected);
+        }
+
+        #[rstest]
+        #[case(Value::Float(1.0), Value::Float(1.0), Some(Ordering::Equal))]
+        #[case(Value::Float(1.0), Value::Float(-1.0), Some(Ordering::Greater))]
+        #[case(Value::Float(-1.0), Value::Float(-1.0), Some(Ordering::Equal))]
+        #[case(Value::Float(-1.0), Value::Float(1.0), Some(Ordering::Less))]
+        #[case(Value::Float(1.0), Value::Bool(true), Some(Ordering::Equal))]
+        #[case(Value::Float(1.0), Value::Bool(false), Some(Ordering::Greater))]
+        #[case(Value::Float(0.0), Value::Bool(true), Some(Ordering::Less))]
+        #[case(Value::Float(0.0), Value::Bool(false), Some(Ordering::Equal))]
+        #[case(Value::Float(-1.0), Value::Bool(true), Some(Ordering::Less))]
+        #[case(Value::Float(-1.0), Value::Bool(false), Some(Ordering::Less))]
+        #[case(Value::Float(1.0), Value::Int(2), Some(Ordering::Less))]
+        #[case(Value::Float(1.0), Value::Int(1), Some(Ordering::Equal))]
+        #[case(Value::Float(1.0), Value::Int(0), Some(Ordering::Greater))]
+        #[case(Value::Float(1.0), Value::Int(-1), Some(Ordering::Greater))]
+        #[case(Value::Float(1.0), Value::String("string".to_string()), None)]
+        #[case(Value::Float(-1.0), Value::String("string".to_string()), None)]
+        fn partial_cmp_float(
+            #[case] left: Value,
+            #[case] right: Value,
+            #[case] expected: Option<Ordering>,
+        ) {
+            let result = left.partial_cmp(&right);
+            assert_eq!(result, expected);
+        }
+
+        #[rstest]
+        #[case(Value::String("a".to_string()), Value::String("a".to_string()), Some(Ordering::Equal))]
+        #[case(Value::String("a".to_string()), Value::String("b".to_string()), Some(Ordering::Less))]
+        #[case(Value::String("b".to_string()), Value::String("a".to_string()), Some(Ordering::Greater))]
+        #[case(Value::String("a".to_string()), Value::Bool(true), None)]
+        #[case(Value::String("a".to_string()), Value::Bool(false), None)]
+        #[case(Value::String("a".to_string()), Value::Int(1), None)]
+        #[case(Value::String("a".to_string()), Value::Float(1.0), None)]
+        fn partial_cmp_string(
+            #[case] left: Value,
+            #[case] right: Value,
+            #[case] expected: Option<Ordering>,
+        ) {
+            let result = left.partial_cmp(&right);
+            assert_eq!(result, expected);
+        }
+    }
+}

--- a/reductstore/src/storage/query/condition/value/div.rs
+++ b/reductstore/src/storage/query/condition/value/div.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for dividing two values.
+pub(crate) trait Div {
+    /// Divides two values as floating point numbers.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The first value.
+    /// * `other` - The second value.
+    ///
+    /// # Returns
+    ///
+    /// The quotient of the two values or an error if the values cannot be divided.
+    fn divide(self, other: Value) -> Result<Value, ReductError>
+    where
+        Self: Sized;
+}
+
+impl Div for Value {
+    fn divide(self, divisor: Self) -> Result<Self, ReductError> {
+        let dividend = self;
+
+        if dividend.is_string() {
+            return Err(unprocessable_entity!("Cannot divide string"));
+        }
+
+        if divisor.is_string() {
+            return Err(unprocessable_entity!("Cannot divide by string"));
+        }
+
+        let divisor = divisor.as_float()?;
+        if divisor == 0.0 {
+            return Err(unprocessable_entity!("Cannot divide by zero"));
+        }
+
+        let result = Value::Float(dividend.as_float()? / divisor);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    #[rstest]
+    #[case(Value::Bool(true), Value::Bool(true), Value::Float(1.0))]
+    #[case(Value::Bool(true), Value::Int(2), Value::Float(0.5))]
+    #[case(Value::Bool(true), Value::Float(3.0), Value::Float(1.0 / 3.0))]
+    #[case(Value::Int(4), Value::Bool(true), Value::Float(4.0))]
+    #[case(Value::Int(5), Value::Int(2), Value::Float(2.5))]
+    #[case(Value::Int(6), Value::Float(3.0), Value::Float(2.0))]
+    #[case(Value::Float(7.0), Value::Bool(true), Value::Float(7.0))]
+    #[case(Value::Float(8.0), Value::Int(2), Value::Float(4.0))]
+    #[case(Value::Float(9.0), Value::Float(3.0), Value::Float(3.0))]
+    fn divide_ok(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
+        let result = value.divide(other).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(Value::Bool(true), Value::String("xxx".to_string()))]
+    #[case(Value::Int(1), Value::String("xxx".to_string()))]
+    #[case(Value::Float(2.0), Value::String("xxx".to_string()))]
+    fn divide_by_string(#[case] value: Value, #[case] other: Value) {
+        let result = value.divide(other);
+        assert_eq!(
+            result,
+            Err(unprocessable_entity!("Cannot divide by string"))
+        );
+    }
+
+    #[rstest]
+    #[case(Value::String("xxx".to_string()), Value::Bool(true))]
+    #[case(Value::String("xxx".to_string()), Value::Int(1))]
+    #[case(Value::String("xxx".to_string()), Value::Float(2.0))]
+    #[case(Value::String("xxx".to_string()), Value::String("xxx".to_string()))]
+    fn divide_string(#[case] value: Value, #[case] other: Value) {
+        let result = value.divide(other);
+        assert_eq!(result, Err(unprocessable_entity!("Cannot divide string")));
+    }
+
+    #[rstest]
+    #[case(Value::Int(1), Value::Int(0))]
+    #[case(Value::Float(1.0), Value::Float(0.0))]
+    fn divide_by_zero(#[case] value: Value, #[case] other: Value) {
+        let result = value.divide(other);
+        assert_eq!(result, Err(unprocessable_entity!("Cannot divide by zero")));
+    }
+}

--- a/reductstore/src/storage/query/condition/value/div_num.rs
+++ b/reductstore/src/storage/query/condition/value/div_num.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for numeric division.
+pub(crate) trait DivNum {
+    /// Divides two values as integers
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The first value.
+    /// * `other` - The second value.
+    ///
+    /// # Returns
+    ///
+    /// The quotient of the two values or an error if the values cannot be divided.
+    fn divide_num(self, other: Value) -> Result<Value, ReductError>
+    where
+        Self: Sized;
+}
+
+impl DivNum for Value {
+    fn divide_num(self, divisor: Self) -> Result<Self, ReductError> {
+        let dividend = self;
+
+        if dividend.is_string() {
+            return Err(unprocessable_entity!("Cannot divide string"));
+        }
+
+        if divisor.is_string() {
+            return Err(unprocessable_entity!("Cannot divide by string"));
+        }
+
+        let divisor = divisor.as_int()?;
+        if divisor == 0 {
+            return Err(unprocessable_entity!("Cannot divide by zero"));
+        }
+
+        let result = Value::Int(dividend.as_int()? / divisor);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    #[rstest]
+    #[case(Value::Bool(true), Value::Bool(true), Value::Int(1))]
+    #[case(Value::Bool(true), Value::Int(2), Value::Int(0))]
+    #[case(Value::Bool(true), Value::Float(3.0), Value::Int(0))]
+    #[case(Value::Int(4), Value::Bool(true), Value::Int(4))]
+    #[case(Value::Int(5), Value::Int(2), Value::Int(2))]
+    #[case(Value::Int(6), Value::Float(3.0), Value::Int(2))]
+    #[case(Value::Float(7.0), Value::Bool(true), Value::Int(7))]
+    #[case(Value::Float(8.0), Value::Int(2), Value::Int(4))]
+    #[case(Value::Float(9.0), Value::Float(3.0), Value::Int(3))]
+    fn divide_ok(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
+        let result = value.divide_num(other).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(Value::Bool(true), Value::String("xxx".to_string()))]
+    #[case(Value::Int(1), Value::String("xxx".to_string()))]
+    #[case(Value::Float(2.0), Value::String("xxx".to_string()))]
+    fn divide_by_string(#[case] value: Value, #[case] other: Value) {
+        let result = value.divide_num(other);
+        assert_eq!(
+            result,
+            Err(unprocessable_entity!("Cannot divide by string"))
+        );
+    }
+
+    #[rstest]
+    #[case(Value::String("xxx".to_string()), Value::Bool(true))]
+    #[case(Value::String("xxx".to_string()), Value::Int(1))]
+    #[case(Value::String("xxx".to_string()), Value::Float(2.0))]
+    #[case(Value::String("xxx".to_string()), Value::String("xxx".to_string()))]
+    fn divide_string(#[case] value: Value, #[case] other: Value) {
+        let result = value.divide_num(other);
+        assert_eq!(result, Err(unprocessable_entity!("Cannot divide string")));
+    }
+
+    #[rstest]
+    #[case(Value::Int(1), Value::Int(0))]
+    #[case(Value::Float(1.0), Value::Float(0.0))]
+    fn divide_by_zero(#[case] value: Value, #[case] other: Value) {
+        let result = value.divide_num(other);
+        assert_eq!(result, Err(unprocessable_entity!("Cannot divide by zero")));
+    }
+}

--- a/reductstore/src/storage/query/condition/value/mult.rs
+++ b/reductstore/src/storage/query/condition/value/mult.rs
@@ -1,0 +1,107 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for multiplying two values.
+pub(crate) trait Mult {
+    /// Multiplies two values.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The first value.
+    /// * `other` - The second value.
+    ///
+    /// # Returns
+    ///
+    /// The product of the two values or an error if the values cannot be multiplied.
+    fn multiply(self, other: Self) -> Result<Self, ReductError>
+    where
+        Self: Sized;
+}
+
+impl Mult for Value {
+    fn multiply(self, other: Self) -> Result<Self, ReductError> {
+        let mut result = self;
+        match result {
+            Value::Bool(s) => match other {
+                Value::Bool(v) => result = Value::Int(s as i64 * v as i64),
+                Value::Int(v) => result = Value::Int(s as i64 * v),
+                Value::Float(v) => result = Value::Float(s as i8 as f64 * v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot multiply boolean by string"));
+                }
+            },
+
+            Value::Int(s) => match other {
+                Value::Bool(v) => result = Value::Int(s * v as i64),
+                Value::Int(v) => result = Value::Int(s * v),
+                Value::Float(v) => result = Value::Float(s as f64 * v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot multiply integer by string"));
+                }
+            },
+
+            Value::Float(s) => match other {
+                Value::Bool(v) => result = Value::Float(s * v as i8 as f64),
+                Value::Int(v) => result = Value::Float(s * v as f64),
+                Value::Float(v) => result = Value::Float(s * v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot multiply float by string"));
+                }
+            },
+
+            Value::String(_) => {
+                return match other {
+                    Value::Bool(_) => {
+                        Err(unprocessable_entity!("Cannot multiply string by boolean"))
+                    }
+                    Value::Int(_) => {
+                        Err(unprocessable_entity!("Cannot multiply string by integer"))
+                    }
+
+                    Value::Float(_) => {
+                        Err(unprocessable_entity!("Cannot multiply string by float"))
+                    }
+                    Value::String(_) => {
+                        Err(unprocessable_entity!("Cannot multiply string by string"))
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    #[rstest]
+    #[case(Value::Bool(true), Value::Bool(false), Value::Int(0))]
+    #[case(Value::Bool(true), Value::Int(2), Value::Int(2))]
+    #[case(Value::Bool(true), Value::Float(2.0), Value::Float(2.0))]
+    #[case(Value::Int(2), Value::Int(2), Value::Int(4))]
+    #[case(Value::Int(2), Value::Float(2.0), Value::Float(4.0))]
+    #[case(Value::Float(2.0), Value::Float(2.0), Value::Float(4.0))]
+    fn multiply(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
+        let result = value.multiply(other).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(Value::Bool(true), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply boolean by string"))]
+    #[case(Value::Int(2), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply integer by string"))]
+    #[case(Value::Float(2.0), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply float by string"))]
+    #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot multiply string by boolean"))]
+    #[case(Value::String("string".to_string()), Value::Int(2), unprocessable_entity!("Cannot multiply string by integer"))]
+    #[case(Value::String("string".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot multiply string by float"))]
+    #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply string by string"))]
+    fn multiply_error(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
+        let result = value.multiply(other);
+        assert_eq!(result, Err(expected));
+    }
+}

--- a/reductstore/src/storage/query/condition/value/mult.rs
+++ b/reductstore/src/storage/query/condition/value/mult.rs
@@ -84,8 +84,11 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(false), Value::Int(0))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(2))]
     #[case(Value::Bool(true), Value::Float(2.0), Value::Float(2.0))]
+    #[case(Value::Int(2), Value::Bool(true), Value::Int(2))]
     #[case(Value::Int(2), Value::Int(2), Value::Int(4))]
     #[case(Value::Int(2), Value::Float(2.0), Value::Float(4.0))]
+    #[case(Value::Float(2.0), Value::Bool(true), Value::Float(2.0))]
+    #[case(Value::Float(2.0), Value::Int(2), Value::Float(4.0))]
     #[case(Value::Float(2.0), Value::Float(2.0), Value::Float(4.0))]
     fn multiply(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.multiply(other).unwrap();

--- a/reductstore/src/storage/query/condition/value/rem.rs
+++ b/reductstore/src/storage/query/condition/value/rem.rs
@@ -1,0 +1,101 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for calculating a remainder of division.
+pub(crate) trait Rem {
+    /// Calculates the remainder of division of two values.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The devidend.
+    /// * `other` - The divisor.
+    ///
+    /// # Returns
+    ///
+    /// The remainder of the division of the two values or an error if the values cannot be divided.
+    fn remainder(self, other: Self) -> Result<Self, ReductError>
+    where
+        Self: Sized;
+}
+
+impl Rem for Value {
+    fn remainder(self, other: Self) -> Result<Self, ReductError> {
+        let mut result = self;
+        match result {
+            Value::Bool(s) => match other {
+                Value::Bool(v) => result = Value::Int(s as i64 % v as i64),
+                Value::Int(v) => result = Value::Int(s as i64 % v),
+                Value::Float(v) => result = Value::Float(s as i8 as f64 % v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot divide boolean by string"));
+                }
+            },
+
+            Value::Int(s) => match other {
+                Value::Bool(v) => result = Value::Int(s % v as i64),
+                Value::Int(v) => result = Value::Int(s % v),
+                Value::Float(v) => result = Value::Float(s as f64 % v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot divide integer by string"));
+                }
+            },
+
+            Value::Float(s) => match other {
+                Value::Bool(v) => result = Value::Float(s % v as i8 as f64),
+                Value::Int(v) => result = Value::Float(s % v as f64),
+                Value::Float(v) => result = Value::Float(s % v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot divide float by string"));
+                }
+            },
+
+            Value::String(_) => {
+                return match other {
+                    Value::Bool(_) => Err(unprocessable_entity!("Cannot divide string by boolean")),
+                    Value::Int(_) => Err(unprocessable_entity!("Cannot divide string by integer")),
+
+                    Value::Float(_) => Err(unprocessable_entity!("Cannot divide string by float")),
+                    Value::String(_) => Err(unprocessable_entity!("Cannot divide string")),
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    #[rstest]
+    #[case(Value::Bool(true), Value::Bool(true), Value::Int(0))]
+    #[case(Value::Bool(true), Value::Int(2), Value::Int(1))]
+    #[case(Value::Bool(true), Value::Float(3.0), Value::Float(1.0))]
+    #[case(Value::Int(4), Value::Bool(true), Value::Int(0))]
+    #[case(Value::Int(5), Value::Int(2), Value::Int(1))]
+    #[case(Value::Int(6), Value::Float(3.5), Value::Float(2.5))]
+    #[case(Value::Float(7.0), Value::Bool(true), Value::Float(0.0))]
+    #[case(Value::Float(8.0), Value::Int(3), Value::Float(2.0))]
+    #[case(Value::Float(-9.0), Value::Float(3.5), Value::Float(-2.0))]
+    fn rem_ok(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
+        let result = value.remainder(other).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(Value::Bool(true), Value::String("string".to_string()), unprocessable_entity!("Cannot divide boolean by string"))]
+    #[case(Value::Int(1), Value::String("string".to_string()), unprocessable_entity!("Cannot divide integer by string"))]
+    #[case(Value::Float(2.0), Value::String("string".to_string()), unprocessable_entity!("Cannot divide float by string"))]
+    #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot divide string by boolean"))]
+    #[case(Value::String("string".to_string()), Value::Int(1), unprocessable_entity!("Cannot divide string by integer"))]
+    #[case(Value::String("string".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot divide string by float"))]
+    fn rem_err(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
+        let result = value.remainder(other);
+        assert_eq!(result, Err(expected));
+    }
+}

--- a/reductstore/src/storage/query/condition/value/rem.rs
+++ b/reductstore/src/storage/query/condition/value/rem.rs
@@ -94,6 +94,7 @@ mod tests {
     #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot divide string by boolean"))]
     #[case(Value::String("string".to_string()), Value::Int(1), unprocessable_entity!("Cannot divide string by integer"))]
     #[case(Value::String("string".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot divide string by float"))]
+    #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot divide string"))]
     fn rem_err(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
         let result = value.remainder(other);
         assert_eq!(result, Err(expected));

--- a/reductstore/src/storage/query/condition/value/sub.rs
+++ b/reductstore/src/storage/query/condition/value/sub.rs
@@ -17,13 +17,13 @@ pub(crate) trait Sub {
     /// # Returns
     ///
     /// The difference of the two values or an error if the values cannot be subtracted.
-    fn sub(self, other: Self) -> Result<Self, ReductError>
+    fn subtract(self, other: Self) -> Result<Self, ReductError>
     where
         Self: Sized;
 }
 
 impl Sub for Value {
-    fn sub(self, other: Self) -> Result<Self, ReductError> {
+    fn subtract(self, other: Self) -> Result<Self, ReductError> {
         let mut result = self;
         match result {
             Value::Bool(s) => match other {
@@ -53,21 +53,21 @@ impl Sub for Value {
                 }
             },
 
-            Value::String(_) => match other {
-                Value::Bool(_) => {
-                    return Err(unprocessable_entity!("Cannot subtract string from boolean"));
-                }
-                Value::Int(_) => {
-                    return Err(unprocessable_entity!("Cannot subtract string from integer"));
-                }
+            Value::String(_) => {
+                return match other {
+                    Value::Bool(_) => {
+                        Err(unprocessable_entity!("Cannot subtract string from boolean"))
+                    }
+                    Value::Int(_) => {
+                        Err(unprocessable_entity!("Cannot subtract string from integer"))
+                    }
 
-                Value::Float(_) => {
-                    return Err(unprocessable_entity!("Cannot subtract string from float"));
+                    Value::Float(_) => {
+                        Err(unprocessable_entity!("Cannot subtract string from float"))
+                    }
+                    Value::String(_) => Err(unprocessable_entity!("Cannot subtract string")),
                 }
-                Value::String(_) => {
-                    return Err(unprocessable_entity!("Cannot subtract string"));
-                }
-            },
+            }
         }
 
         Ok(result)
@@ -86,7 +86,7 @@ mod tests {
     #[case(Value::Int(1), Value::Float(1.0), Value::Float(0.0))]
     #[case(Value::Float(1.0), Value::Float(1.0), Value::Float(0.0))]
     fn sub(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
-        let result = value.sub(other).unwrap();
+        let result = value.subtract(other).unwrap();
         assert_eq!(result, expected);
     }
 
@@ -100,7 +100,7 @@ mod tests {
     #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string"))]
 
     fn sub_err(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
-        let result = value.sub(other);
+        let result = value.subtract(other);
         assert_eq!(result, Err(expected));
     }
 }

--- a/reductstore/src/storage/query/condition/value/sub.rs
+++ b/reductstore/src/storage/query/condition/value/sub.rs
@@ -1,0 +1,106 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for subtracting two values.
+pub(crate) trait Sub {
+    /// Subtracts two values.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The first value.
+    /// * `other` - The second value.
+    ///
+    /// # Returns
+    ///
+    /// The difference of the two values or an error if the values cannot be subtracted.
+    fn sub(self, other: Self) -> Result<Self, ReductError>
+    where
+        Self: Sized;
+}
+
+impl Sub for Value {
+    fn sub(self, other: Self) -> Result<Self, ReductError> {
+        let mut result = self;
+        match result {
+            Value::Bool(s) => match other {
+                Value::Bool(v) => result = Value::Int(s as i64 - v as i64),
+                Value::Int(v) => result = Value::Int(s as i64 - v),
+                Value::Float(v) => result = Value::Float(s as i8 as f64 - v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot subtract string from boolean"));
+                }
+            },
+
+            Value::Int(s) => match other {
+                Value::Bool(v) => result = Value::Int(s - v as i64),
+                Value::Int(v) => result = Value::Int(s - v),
+                Value::Float(v) => result = Value::Float(s as f64 - v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot subtract string from integer"));
+                }
+            },
+
+            Value::Float(s) => match other {
+                Value::Bool(v) => result = Value::Float(s - v as i8 as f64),
+                Value::Int(v) => result = Value::Float(s - v as f64),
+                Value::Float(v) => result = Value::Float(s - v),
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot subtract string from float"));
+                }
+            },
+
+            Value::String(_) => match other {
+                Value::Bool(_) => {
+                    return Err(unprocessable_entity!("Cannot subtract string from boolean"));
+                }
+                Value::Int(_) => {
+                    return Err(unprocessable_entity!("Cannot subtract string from integer"));
+                }
+
+                Value::Float(_) => {
+                    return Err(unprocessable_entity!("Cannot subtract string from float"));
+                }
+                Value::String(_) => {
+                    return Err(unprocessable_entity!("Cannot subtract string"));
+                }
+            },
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    #[rstest]
+    #[case(Value::Bool(true), Value::Bool(false), Value::Int(1))]
+    #[case(Value::Bool(true), Value::Int(1), Value::Int(0))]
+    #[case(Value::Bool(true), Value::Float(1.0), Value::Float(0.0))]
+    #[case(Value::Int(1), Value::Int(1), Value::Int(0))]
+    #[case(Value::Int(1), Value::Float(1.0), Value::Float(0.0))]
+    #[case(Value::Float(1.0), Value::Float(1.0), Value::Float(0.0))]
+    fn sub(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
+        let result = value.sub(other).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    #[case(Value::Bool(true), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from boolean"))]
+    #[case(Value::Int(1), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from integer"))]
+    #[case(Value::Float(1.0), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from float"))]
+    #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot subtract string from boolean"))]
+    #[case(Value::String("string".to_string()), Value::Int(1), unprocessable_entity!("Cannot subtract string from integer"))]
+    #[case(Value::String("string".to_string()), Value::Float(1.0), unprocessable_entity!("Cannot subtract string from float"))]
+    #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string"))]
+
+    fn sub_err(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
+        let result = value.sub(other);
+        assert_eq!(result, Err(expected));
+    }
+}

--- a/reductstore/src/storage/query/condition/value/sub.rs
+++ b/reductstore/src/storage/query/condition/value/sub.rs
@@ -82,8 +82,11 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(false), Value::Int(1))]
     #[case(Value::Bool(true), Value::Int(1), Value::Int(0))]
     #[case(Value::Bool(true), Value::Float(1.0), Value::Float(0.0))]
+    #[case(Value::Int(1), Value::Bool(true), Value::Int(0))]
     #[case(Value::Int(1), Value::Int(1), Value::Int(0))]
     #[case(Value::Int(1), Value::Float(1.0), Value::Float(0.0))]
+    #[case(Value::Float(1.0), Value::Bool(true), Value::Float(0.0))]
+    #[case(Value::Float(1.0), Value::Int(1), Value::Float(0.0))]
     #[case(Value::Float(1.0), Value::Float(1.0), Value::Float(0.0))]
     fn sub(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.subtract(other).unwrap();


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

This pull request introduces arithmetic operators to the query condition parser in the ReductStore project. The changes include the implementation of various arithmetic operations and their integration into the existing parsing logic.  

Changes:

* Added support for the following arithmetic operators:
  * `$add`: Adds two values.
  * `$sub`: Subtracts the second value from the first.
  * `$mult`: Multiplies two values.
  * `$div`: Divides the first value by the second.
  * `$div_num`: Integer division of the first value by the second.
  * `$rem`: Computes the remainder of the division of the first value by the second.
  * `$abs`: Computes the absolute value of a number.

* Updated the `Parser` struct to handle the new arithmetic operators.
* Modified the `parse_operator` function to include cases for the new operators.
* Added unit tests to verify the correct parsing and application of the arithmetic operators.

### Related issues

https://github.com/reductstore/website/pull/142

### Does this PR introduce a breaking change?

No


### Other information:
