### PR TITLE
RS-555: Close WAL file before removal it from disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-555: Close WAL file before removal it from disk, [PR-706](https://github.com/reductstore/reductstore/pull/706)
+
 ## [1.13.2] - 2025-01-15
 
 ### Fixed

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -1,15 +1,14 @@
 // Copyright 2023-2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+use crate::core::cache::Cache;
+use reduct_base::error::ReductError;
+use reduct_base::internal_server_error;
 use std::fs::{remove_dir_all, remove_file, rename, File};
 use std::io::{Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, RwLock, Weak};
 use std::time::Duration;
-
-use crate::core::cache::Cache;
-use reduct_base::error::ReductError;
-use reduct_base::internal_server_error;
 
 const FILE_CACHE_MAX_SIZE: usize = 1024;
 const FILE_CACHE_TIME_TO_LIVE: Duration = Duration::from_secs(60);
@@ -177,12 +176,13 @@ impl FileCache {
     /// This function will return an error if the file does not exist or if there is an issue
     /// removing the file from the file system.
     pub fn remove(&self, path: &PathBuf) -> Result<(), ReductError> {
+        let mut cache = self.cache.write()?;
+        cache.remove(path);
+
         if path.try_exists()? {
             remove_file(path)?;
         }
-        let mut cache = self.cache.write()?;
 
-        cache.remove(path);
         Ok(())
     }
 

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -49,7 +49,7 @@ impl Storage {
     /// If the data_path doesn't exist and can't be created, or if a bucket can't be restored.
     pub fn load(data_path: PathBuf, license: Option<License>) -> Storage {
         if !data_path.try_exists().unwrap_or(false) {
-            info!("Folder '{:?}' doesn't exist. Create it.", data_path);
+            info!("Folder {:?} doesn't exist. Create it.", data_path);
             std::fs::create_dir_all(&data_path).unwrap();
         }
 

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -297,6 +297,14 @@ mod tests {
     use tempfile::tempdir;
 
     #[rstest]
+    fn test_create_folder(path: PathBuf) {
+        let path = path.join("test");
+        assert!(!path.exists());
+        let _ = Storage::load(path.clone(), None);
+        assert!(path.exists(), "Engine creates a folder if it doesn't exist");
+    }
+
+    #[rstest]
     fn test_info(storage: Storage) {
         sleep(Duration::from_secs(1)); // uptime is 1 second
 


### PR DESCRIPTION
Closes #676 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR changed the order of removing a file:
1. Discard a file descriptor from the file cache so that the file is closed
2. Remove the file from the disk

The previous order was incorrect and caused an error with the Azure FUSE driver when the storage engine tried to remove a WAL file after the compaction process. 

### Related issues

#676 

### Does this PR introduce a breaking change?

No

### Other information:
