### PR TITLE
RS-583: Remove contents of folder before remove it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-555: Close WAL file before removal it from disk, [PR-706](https://github.com/reductstore/reductstore/pull/706)
+- RS-583: Remove contents of folder before remove it, [PR-711](https://github.com/reductstore/reductstore/pull/711)
 
 ## [1.13.2] - 2025-01-15
 

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -4,9 +4,9 @@
 use crate::core::cache::Cache;
 use reduct_base::error::ReductError;
 use reduct_base::internal_server_error;
-use std::fs::{remove_dir_all, remove_file, rename, File};
+use std::fs::{read_dir, remove_dir, remove_dir_all, remove_file, rename, File};
 use std::io::{Seek, SeekFrom};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, RwLock, Weak};
 use std::time::Duration;
 
@@ -188,7 +188,10 @@ impl FileCache {
 
     pub fn remove_dir(&self, path: &PathBuf) -> Result<(), ReductError> {
         if path.try_exists()? {
-            remove_dir_all(path)?;
+            // Remove all files in the directory recursively
+            // due to some file systems not supporting removing non-empty directories
+            Self::remove_dir_contents(path)?;
+            remove_dir(path)?;
         }
         self.discard_recursive(path)
     }
@@ -221,9 +224,24 @@ impl FileCache {
     ///
     /// A `Result` which is `Ok` if the file was successfully renamed, or an `Err` containing
     pub fn rename(&self, old_path: &PathBuf, new_path: &PathBuf) -> Result<(), ReductError> {
-        rename(old_path, new_path)?;
         let mut cache = self.cache.write()?;
         cache.remove(old_path);
+        rename(old_path, new_path)?;
+        Ok(())
+    }
+
+    fn remove_dir_contents<P: AsRef<Path>>(path: P) -> Result<(), ReductError> {
+        for entry in read_dir(path)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if entry.file_type()?.is_dir() {
+                Self::remove_dir_contents(&path)?;
+                remove_dir(path)?;
+            } else {
+                remove_file(path)?;
+            }
+        }
         Ok(())
     }
 }

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -4,7 +4,7 @@
 use crate::core::cache::Cache;
 use reduct_base::error::ReductError;
 use reduct_base::internal_server_error;
-use std::fs::{read_dir, remove_dir, remove_dir_all, remove_file, rename, File};
+use std::fs::{read_dir, remove_dir, remove_file, rename, File};
 use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, RwLock, Weak};


### PR DESCRIPTION
Closes #707 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR works around the issue with the Azure Blob FUSE driver, which doesn't allow removing a non-empty folder. Now the storage engine removes all files and directories recursively.  

### Related issues

#707

### Does this PR introduce a breaking change?

No

### Other information:
