### PR TITLE
RS-583: Close file descriptors before removing a folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-583: Close file descriptors before removing a folder, [PR-714](https://github.com/reductstore/reductstore/pull/714)
+
 ## [1.13.3] - 2025-01-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "chrono",
  "http",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "quote",
  "syn 2.0.90",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.13.3"
+version = "1.13.4"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.80.0"

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -4,9 +4,9 @@
 use crate::core::cache::Cache;
 use reduct_base::error::ReductError;
 use reduct_base::internal_server_error;
-use std::fs::{read_dir, remove_dir, remove_dir_all, remove_file, rename, File};
+use std::fs::{remove_dir_all, remove_file, rename, File};
 use std::io::{Seek, SeekFrom};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, RwLock, Weak};
 use std::time::Duration;
 

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -187,13 +187,15 @@ impl FileCache {
     }
 
     pub fn remove_dir(&self, path: &PathBuf) -> Result<(), ReductError> {
+        self.discard_recursive(path)?;
         if path.try_exists()? {
             // Remove all files in the directory recursively
             // due to some file systems not supporting removing non-empty directories
             Self::remove_dir_contents(path)?;
             remove_dir(path)?;
         }
-        self.discard_recursive(path)
+
+        Ok(())
     }
 
     pub fn discard_recursive(&self, path: &PathBuf) -> Result<(), ReductError> {

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 mod quotas;
-mod settings;
+pub(super) mod settings;
 
 use crate::core::file_cache::FILE_CACHE;
 use crate::core::thread_pool::{group_from_path, shared, unique, GroupDepth, TaskHandle};

--- a/reductstore/src/storage/bucket/settings.rs
+++ b/reductstore/src/storage/bucket/settings.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 
 pub(super) const DEFAULT_MAX_RECORDS: u64 = 1024;
 pub(super) const DEFAULT_MAX_BLOCK_SIZE: u64 = 64000000;
-pub(super) const SETTINGS_NAME: &str = "bucket.settings";
+pub(crate) const SETTINGS_NAME: &str = "bucket.settings";
 
 impl From<BucketSettings> for crate::storage::proto::BucketSettings {
     fn from(settings: BucketSettings) -> Self {

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -333,66 +333,6 @@ mod tests {
     }
 
     #[rstest]
-    fn test_recover_from_fs(storage: Storage) {
-        let bucket_settings = BucketSettings {
-            quota_size: Some(100),
-            quota_type: Some(QuotaType::FIFO),
-            ..Bucket::defaults()
-        };
-        let bucket = storage
-            .create_bucket("test", bucket_settings.clone())
-            .unwrap()
-            .upgrade_and_unwrap();
-        assert_eq!(bucket.name(), "test");
-
-        macro_rules! write_entry {
-            ($bucket:expr, $entry_name:expr, $record_ts:expr) => {
-                let entry = $bucket
-                    .get_or_create_entry($entry_name)
-                    .unwrap()
-                    .upgrade_and_unwrap();
-                let sender = entry
-                    .begin_write($record_ts, 10, "text/plain".to_string(), Labels::new())
-                    .wait()
-                    .unwrap();
-                sender
-                    .tx()
-                    .blocking_send(Ok(Some(Bytes::from("0123456789"))))
-                    .unwrap();
-
-                sender.tx().blocking_send(Ok(None)).unwrap();
-            };
-        }
-
-        write_entry!(bucket, "entry-1", 1000);
-        write_entry!(bucket, "entry-2", 2000);
-        write_entry!(bucket, "entry-2", 5000);
-
-        sleep(Duration::from_millis(10)); // to make sure that write tasks are completed
-        storage.sync_fs().unwrap();
-        let storage = Storage::load(storage.data_path.clone(), None);
-        assert_eq!(
-            storage.info().unwrap(),
-            ServerInfo {
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                bucket_count: 1,
-                usage: 142,
-                uptime: 0,
-                oldest_record: 1000,
-                latest_record: 5000,
-                defaults: Defaults {
-                    bucket: Bucket::defaults(),
-                },
-                license: None,
-            }
-        );
-
-        let bucket = storage.get_bucket("test").unwrap().upgrade_and_unwrap();
-        assert_eq!(bucket.name(), "test");
-        assert_eq!(bucket.settings(), bucket_settings);
-    }
-
-    #[rstest]
     fn test_license_info(storage: Storage) {
         let license = License {
             licensee: "ReductSoftware UG".to_string(),
@@ -406,6 +346,103 @@ mod tests {
 
         let storage = Storage::load(storage.data_path, Some(license.clone()));
         assert_eq!(storage.info().unwrap().license, Some(license));
+    }
+
+    mod recovery {
+        use super::*;
+        use crate::storage::bucket::settings::SETTINGS_NAME;
+        #[rstest]
+        fn test_recover_from_fs(storage: Storage) {
+            let bucket_settings = BucketSettings {
+                quota_size: Some(100),
+                quota_type: Some(QuotaType::FIFO),
+                ..Bucket::defaults()
+            };
+            let bucket = storage
+                .create_bucket("test", bucket_settings.clone())
+                .unwrap()
+                .upgrade_and_unwrap();
+            assert_eq!(bucket.name(), "test");
+
+            macro_rules! write_entry {
+                ($bucket:expr, $entry_name:expr, $record_ts:expr) => {
+                    let entry = $bucket
+                        .get_or_create_entry($entry_name)
+                        .unwrap()
+                        .upgrade_and_unwrap();
+                    let sender = entry
+                        .begin_write($record_ts, 10, "text/plain".to_string(), Labels::new())
+                        .wait()
+                        .unwrap();
+                    sender
+                        .tx()
+                        .blocking_send(Ok(Some(Bytes::from("0123456789"))))
+                        .unwrap();
+
+                    sender.tx().blocking_send(Ok(None)).unwrap();
+                };
+            }
+
+            write_entry!(bucket, "entry-1", 1000);
+            write_entry!(bucket, "entry-2", 2000);
+            write_entry!(bucket, "entry-2", 5000);
+
+            sleep(Duration::from_millis(10)); // to make sure that write tasks are completed
+            storage.sync_fs().unwrap();
+            let storage = Storage::load(storage.data_path.clone(), None);
+            assert_eq!(
+                storage.info().unwrap(),
+                ServerInfo {
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    bucket_count: 1,
+                    usage: 142,
+                    uptime: 0,
+                    oldest_record: 1000,
+                    latest_record: 5000,
+                    defaults: Defaults {
+                        bucket: Bucket::defaults(),
+                    },
+                    license: None,
+                }
+            );
+
+            let bucket = storage.get_bucket("test").unwrap().upgrade_and_unwrap();
+            assert_eq!(bucket.name(), "test");
+            assert_eq!(bucket.settings(), bucket_settings);
+        }
+
+        #[rstest]
+        fn test_ignore_broken_buket(storage: Storage) {
+            let bucket_settings = BucketSettings {
+                quota_size: Some(100),
+                quota_type: Some(QuotaType::FIFO),
+                ..Bucket::defaults()
+            };
+            let bucket = storage
+                .create_bucket("test", bucket_settings.clone())
+                .unwrap()
+                .upgrade_and_unwrap();
+            assert_eq!(bucket.name(), "test");
+
+            let path = storage.data_path.join("test");
+            std::fs::remove_file(path.join(SETTINGS_NAME)).unwrap();
+            let storage = Storage::load(storage.data_path.clone(), None);
+            assert_eq!(
+                storage.info().unwrap(),
+                ServerInfo {
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    bucket_count: 0,
+                    usage: 0,
+                    uptime: 0,
+                    oldest_record: u64::MAX,
+                    latest_record: 0,
+                    defaults: Defaults {
+                        bucket: Bucket::defaults(),
+                    },
+                    license: None,
+                }
+            );
+        }
     }
 
     #[rstest]

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -58,9 +58,15 @@ impl Storage {
         for entry in std::fs::read_dir(&data_path).unwrap() {
             let path = entry.unwrap().path();
             if path.is_dir() {
-                let bucket = Bucket::restore(path.clone())
-                    .expect(format!("Failed to restore bucket '{:?}'", path).as_str());
-                buckets.insert(bucket.name().to_string(), Arc::new(bucket));
+                match Bucket::restore(path.clone()) {
+                    Ok(bucket) => {
+                        let bucket = Arc::new(bucket);
+                        buckets.insert(bucket.name().to_string(), bucket);
+                    }
+                    Err(e) => {
+                        error!("Failed to restore bucket from {:?}: {}", path, e);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The storage engine kept files open in the removed folder, preventing removal with Azure FUSE Receive. The PR cleans the cache before removing a bucket or entry.

The PR also revert changes from #711 

### Related issues

#711 #707

### Does this PR introduce a breaking change?

No

### Other information:
