### PR TITLE
RS-578: Bump axum up to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-583: Close file descriptors before removing a folder, [PR-714](https://github.com/reductstore/reductstore/pull/714)
->>>>>>> stable
 
 ## [1.13.3] - 2025-01-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,14 +151,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "axum-macros",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -166,7 +166,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -179,54 +179,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
-dependencies = [
- "axum-core 0.5.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -258,8 +210,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
 dependencies = [
- "axum 0.8.1",
- "axum-core 0.5.0",
+ "axum",
+ "axum-core",
  "bytes",
  "futures-util",
  "headers",
@@ -276,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1375,12 +1327,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1931,7 +1877,7 @@ version = "1.14.0"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "axum-extra",
  "axum-server",
  "base64 0.22.1",
@@ -1966,7 +1912,6 @@ dependencies = [
  "tempfile",
  "thread-id",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "tower 0.5.2",
  "tower-http",
@@ -2595,17 +2540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -43,11 +43,10 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"
 regex = "1.11.1"
 bytes = "1.9.0"
-axum = { version = "0.7.9", features = ["default", "macros"] }
+axum = { version = "0.8.1", features = ["default", "macros"] }
 axum-extra = { version = "0.10.0", features = ["default", "typed-header"] }
 tokio = { version = "1.43.0", features = ["full"] }
 tokio-util = "0.7.13"
-tokio-stream = "0.1.17"
 hyper = { version = "1.5.1", features = ["full"] }
 tower = "0.5.2"
 futures-util = "0.3.31"

--- a/reductstore/src/api/bucket.rs
+++ b/reductstore/src/api/bucket.rs
@@ -15,7 +15,6 @@ use crate::api::bucket::remove::remove_bucket;
 use crate::api::bucket::rename::rename_bucket;
 use crate::api::bucket::update::update_bucket;
 use crate::api::{Components, HttpError};
-use axum::async_trait;
 use axum::body::Body;
 use axum::extract::FromRequest;
 use axum::http::Request;
@@ -42,7 +41,6 @@ impl Default for BucketSettingsAxum {
 #[derive(IntoResponse, Twin)]
 pub struct FullBucketInfoAxum(FullBucketInfo);
 
-#[async_trait]
 impl<S> FromRequest<S> for BucketSettingsAxum
 where
     Bytes: FromRequest<S>,
@@ -67,12 +65,12 @@ where
 
 pub(crate) fn create_bucket_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
-        .route("/:bucket_name", get(get_bucket))
-        .route("/:bucket_name", head(head_bucket))
-        .route("/:bucket_name", post(create_bucket))
-        .route("/:bucket_name", put(update_bucket))
-        .route("/:bucket_name", delete(remove_bucket))
-        .route("/:bucket_name/rename", put(rename_bucket))
+        .route("/{bucket_name}", get(get_bucket))
+        .route("/{bucket_name}", head(head_bucket))
+        .route("/{bucket_name}", post(create_bucket))
+        .route("/{bucket_name}", put(update_bucket))
+        .route("/{bucket_name}", delete(remove_bucket))
+        .route("/{bucket_name}/rename", put(rename_bucket))
 }
 
 #[cfg(test)]

--- a/reductstore/src/api/entry.rs
+++ b/reductstore/src/api/entry.rs
@@ -25,7 +25,6 @@ use crate::api::entry::write_batched::write_batched_records;
 use crate::api::entry::write_single::write_record;
 use crate::api::Components;
 use crate::api::HttpError;
-use axum::async_trait;
 use axum::extract::{FromRequest, Path, Query, State};
 
 use axum_extra::headers::HeaderMapExt;
@@ -67,7 +66,6 @@ impl MethodExtractor {
     }
 }
 
-#[async_trait]
 impl<S> FromRequest<S> for MethodExtractor
 where
     S: Send + Sync + 'static,
@@ -89,7 +87,6 @@ pub struct RemoveQueryInfoAxum(RemoveQueryInfo);
 #[derive(IntoResponse, Twin)]
 pub struct QueryEntryAxum(QueryEntry);
 
-#[async_trait]
 impl<S> FromRequest<S> for QueryEntryAxum
 where
     Bytes: FromRequest<S>,
@@ -141,32 +138,35 @@ async fn query_entry_router(
 
 pub(crate) fn create_entry_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
-        .route("/:bucket_name/:entry_name", post(write_record))
+        .route("/{bucket_name}/{entry_name}", post(write_record))
         .route(
-            "/:bucket_name/:entry_name/batch",
+            "/{bucket_name}/{entry_name}/batch",
             post(write_batched_records),
         )
-        .route("/:bucket_name/:entry_name", patch(update_record))
+        .route("/{bucket_name}/{entry_name}", patch(update_record))
         .route(
-            "/:bucket_name/:entry_name/batch",
+            "/{bucket_name}/{entry_name}/batch",
             patch(update_batched_records),
         )
-        .route("/:bucket_name/:entry_name", get(read_record))
-        .route("/:bucket_name/:entry_name", head(read_record))
-        .route("/:bucket_name/:entry_name/batch", get(read_batched_records))
+        .route("/{bucket_name}/{entry_name}", get(read_record))
+        .route("/{bucket_name}/{entry_name}", head(read_record))
         .route(
-            "/:bucket_name/:entry_name/batch",
+            "/{bucket_name}/{entry_name}/batch",
+            get(read_batched_records),
+        )
+        .route(
+            "/{bucket_name}/{entry_name}/batch",
             head(read_batched_records),
         )
-        .route("/:bucket_name/:entry_name/q", get(read_query::read_query)) // deprecated
-        .route("/:bucket_name/:entry_name", delete(remove_entry_router))
+        .route("/{bucket_name}/{entry_name}/q", get(read_query::read_query)) // deprecated
+        .route("/{bucket_name}/{entry_name}", delete(remove_entry_router))
         .route(
-            "/:bucket_name/:entry_name/batch",
+            "/{bucket_name}/{entry_name}/batch",
             delete(remove_batched_records),
         )
-        .route("/:bucket_name/:entry_name/q", delete(remove_query)) // deprecated
-        .route("/:bucket_name/:entry_name/rename", put(rename_entry))
-        .route("/:bucket_name/:entry_name/q", post(query_entry_router))
+        .route("/{bucket_name}/{entry_name}/q", delete(remove_query)) // deprecated
+        .route("/{bucket_name}/{entry_name}/rename", put(rename_entry))
+        .route("/{bucket_name}/{entry_name}/q", post(query_entry_router))
 }
 
 #[cfg(test)]

--- a/reductstore/src/api/replication.rs
+++ b/reductstore/src/api/replication.rs
@@ -14,7 +14,6 @@ use crate::api::replication::get::get_replication;
 use crate::api::replication::list::list_replications;
 use crate::api::replication::remove::remove_replication;
 use crate::api::replication::update::update_replication;
-use async_trait::async_trait;
 use axum::body::Body;
 use axum::extract::FromRequest;
 use axum::http::Request;
@@ -29,7 +28,6 @@ use std::sync::Arc;
 #[derive(IntoResponse, Twin)]
 pub struct ReplicationSettingsAxum(ReplicationSettings);
 
-#[async_trait]
 impl<S> FromRequest<S> for ReplicationSettingsAxum
 where
     Bytes: FromRequest<S>,
@@ -61,10 +59,10 @@ pub struct ReplicationFullInfoAxum(FullReplicationInfo);
 pub(crate) fn create_replication_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
         .route("/", get(list_replications))
-        .route("/:replication_name", get(get_replication))
-        .route("/:replication_name", post(create_replication))
-        .route("/:replication_name", put(update_replication))
-        .route("/:replication_name", delete(remove_replication))
+        .route("/{replication_name}", get(get_replication))
+        .route("/{replication_name}", post(create_replication))
+        .route("/{replication_name}", put(update_replication))
+        .route("/{replication_name}", delete(remove_replication))
 }
 
 #[cfg(test)]

--- a/reductstore/src/api/token.rs
+++ b/reductstore/src/api/token.rs
@@ -7,7 +7,6 @@ mod list;
 pub mod me;
 mod remove;
 
-use axum::async_trait;
 use axum::extract::FromRequest;
 use axum::http::Request;
 use bytes::Bytes;
@@ -40,7 +39,6 @@ pub struct TokenListAxum(TokenList);
 #[derive(IntoResponse, Twin)]
 pub struct PermissionsAxum(Permissions);
 
-#[async_trait]
 impl<S> FromRequest<S> for PermissionsAxum
 where
     Bytes: FromRequest<S>,
@@ -64,7 +62,7 @@ where
 pub(crate) fn create_token_api_routes() -> axum::Router<Arc<Components>> {
     axum::Router::new()
         .route("/", get(list_tokens))
-        .route("/:token_name", post(create_token))
-        .route("/:token_name", get(get_token))
-        .route("/:token_name", delete(remove_token))
+        .route("/{token_name}", post(create_token))
+        .route("/{token_name}", get(get_token))
+        .route("/{token_name}", delete(remove_token))
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Dependency update

### What was changed?

`axum` 0.8 has been released with major changes. This PR fixes compilation errors and applies the new syntax in paths.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
