### PR TITLE
RS-532: Support for misc operators in conditional query

### DIFF
--- a/reductstore/src/storage/query/condition/operators.rs
+++ b/reductstore/src/storage/query/condition/operators.rs
@@ -4,4 +4,5 @@
 pub(crate) mod arithmetic;
 pub(crate) mod comparison;
 pub(crate) mod logical;
+pub(crate) mod misc;
 pub(crate) mod string;

--- a/reductstore/src/storage/query/condition/operators/misc.rs
+++ b/reductstore/src/storage/query/condition/operators/misc.rs
@@ -3,6 +3,8 @@
 
 mod cast;
 mod exists;
+mod r#ref;
 
 pub(crate) use cast::Cast;
 pub(crate) use exists::Exists;
+pub(crate) use r#ref::Ref;

--- a/reductstore/src/storage/query/condition/operators/misc.rs
+++ b/reductstore/src/storage/query/condition/operators/misc.rs
@@ -1,0 +1,6 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+mod exists;
+
+pub(crate) use exists::Exists;

--- a/reductstore/src/storage/query/condition/operators/misc/cast.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/cast.rs
@@ -1,0 +1,89 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::{Cast as CastTrait, Value};
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing a cast operation.
+pub(crate) struct Cast {
+    op_1: BoxedNode,
+    op_2: BoxedNode,
+}
+
+impl Node for Cast {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let op = self.op_1.apply(context)?;
+        let type_name = self.op_2.apply(context)?.as_string()?;
+        op.cast(type_name.as_str())
+    }
+
+    fn print(&self) -> String {
+        format!("Cast({:?}, {:?})", self.op_1, self.op_2)
+    }
+}
+
+impl Boxed for Cast {
+    fn boxed(mut operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 2 {
+            return Err(unprocessable_entity!("$cast requires exactly two operands"));
+        }
+        let op_2 = operands.pop().unwrap();
+        let op_1 = operands.pop().unwrap();
+        Ok(Box::new(Cast::new(op_1, op_2)))
+    }
+}
+
+impl Cast {
+    pub fn new(op_1: BoxedNode, op_2: BoxedNode) -> Self {
+        Self { op_1, op_2 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let sub = Cast::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::String("float".to_string())),
+        );
+        assert_eq!(sub.apply(&Context::default()).unwrap(), Value::Float(1.0));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let sub = Cast::new(
+            Constant::boxed(Value::Int(1)),
+            Constant::boxed(Value::String("foo".to_string())),
+        );
+        assert_eq!(
+            sub.apply(&Context::default()),
+            Err(unprocessable_entity!("Unknown type 'foo'"))
+        );
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let op = Cast::boxed(vec![]);
+        assert_eq!(
+            op.err(),
+            Some(unprocessable_entity!("$cast requires exactly two operands"))
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let op = Cast::new(
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::String("bool".to_string())),
+        );
+        assert_eq!(op.print(), "Cast(Bool(true), String(\"bool\"))");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/misc/exists.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/exists.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an exists operation that checks if a label exists in the context.
+pub(crate) struct Exists {
+    op: BoxedNode,
+}
+
+impl Node for Exists {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let value = self.op.apply(context)?.as_string()?;
+        Ok(Value::Bool(context.labels.contains_key(value.as_str())))
+    }
+
+    fn print(&self) -> String {
+        format!("Exists({:?})", self.op)
+    }
+}
+
+impl Boxed for Exists {
+    fn boxed(mut operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 1 {
+            return Err(unprocessable_entity!("Exists requires exactly one operand"));
+        }
+
+        let op = operands.pop().unwrap();
+        Ok(Box::new(Exists::new(op)))
+    }
+}
+
+impl Exists {
+    pub fn new(op: BoxedNode) -> Self {
+        Self { op }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use reduct_base::unprocessable_entity;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let op = Exists::new(Constant::boxed(Value::String("foo".to_string())));
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Bool(false));
+
+        let mut context = Context::default();
+        context.labels.insert("foo", "bar");
+        assert_eq!(op.apply(&context).unwrap(), Value::Bool(true));
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let result = Exists::boxed(vec![]);
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("Exists requires exactly one operand")
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let and = Exists::new(Constant::boxed(Value::Bool(true)));
+        assert_eq!(and.print(), "Exists(Bool(true))");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/string.rs
+++ b/reductstore/src/storage/query/condition/operators/string.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ReductSoftware UG
+// Copyright 2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
 mod contains;

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -7,6 +7,7 @@ use crate::storage::query::condition::operators::arithmetic::{
 };
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
+use crate::storage::query::condition::operators::misc::Exists;
 use crate::storage::query::condition::operators::string::{Contains, EndsWith, StartsWith};
 use crate::storage::query::condition::reference::Reference;
 use crate::storage::query::condition::value::Value;
@@ -130,6 +131,9 @@ impl Parser {
             "$contains" => Contains::boxed(operands),
             "$starts_with" => StartsWith::boxed(operands),
             "$ends_with" => EndsWith::boxed(operands),
+
+            // Misc
+            "$exists" => Exists::boxed(operands),
 
             _ => Err(unprocessable_entity!(
                 "Operator '{}' not supported",
@@ -265,6 +269,8 @@ mod tests {
         #[case("$contains", "[\"abc\", \"b\"]", Value::Bool(true))]
         #[case("$starts_with", "[\"abc\", \"ab\"]", Value::Bool(true))]
         #[case("$ends_with", "[\"abc\", \"bc\"]", Value::Bool(true))]
+        // Misc
+        #[case("$exists", "[\"label\"]", Value::Bool(false))]
         fn test_parse_operator(
             parser: Parser,
             context: Context,

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -7,7 +7,7 @@ use crate::storage::query::condition::operators::arithmetic::{
 };
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
-use crate::storage::query::condition::operators::misc::{Cast, Exists};
+use crate::storage::query::condition::operators::misc::{Cast, Exists, Ref};
 use crate::storage::query::condition::operators::string::{Contains, EndsWith, StartsWith};
 use crate::storage::query::condition::reference::Reference;
 use crate::storage::query::condition::value::Value;
@@ -135,6 +135,7 @@ impl Parser {
             // Misc
             "$exists" => Exists::boxed(operands),
             "$cast" => Cast::boxed(operands),
+            "$ref" => Ref::boxed(operands),
 
             _ => Err(unprocessable_entity!(
                 "Operator '{}' not supported",
@@ -271,8 +272,9 @@ mod tests {
         #[case("$starts_with", "[\"abc\", \"ab\"]", Value::Bool(true))]
         #[case("$ends_with", "[\"abc\", \"bc\"]", Value::Bool(true))]
         // Misc
-        #[case("$exists", "[\"label\"]", Value::Bool(false))]
+        #[case("$exists", "[\"label\"]", Value::Bool(true))]
         #[case("$cast", "[10.0, \"int\"]", Value::Int(10))]
+        #[case("$ref", "[\"label\"]", Value::Int(10))]
         fn test_parse_operator(
             parser: Parser,
             context: Context,
@@ -303,6 +305,8 @@ mod tests {
 
     #[fixture]
     fn context() -> Context<'static> {
-        Context::default()
+        let mut context = Context::default();
+        context.labels.insert("label", "10");
+        context
     }
 }

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -7,7 +7,7 @@ use crate::storage::query::condition::operators::arithmetic::{
 };
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
 use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
-use crate::storage::query::condition::operators::misc::Exists;
+use crate::storage::query::condition::operators::misc::{Cast, Exists};
 use crate::storage::query::condition::operators::string::{Contains, EndsWith, StartsWith};
 use crate::storage::query::condition::reference::Reference;
 use crate::storage::query::condition::value::Value;
@@ -134,6 +134,7 @@ impl Parser {
 
             // Misc
             "$exists" => Exists::boxed(operands),
+            "$cast" => Cast::boxed(operands),
 
             _ => Err(unprocessable_entity!(
                 "Operator '{}' not supported",
@@ -271,6 +272,7 @@ mod tests {
         #[case("$ends_with", "[\"abc\", \"bc\"]", Value::Bool(true))]
         // Misc
         #[case("$exists", "[\"label\"]", Value::Bool(false))]
+        #[case("$cast", "[10.0, \"int\"]", Value::Int(10))]
         fn test_parse_operator(
             parser: Parser,
             context: Context,

--- a/reductstore/src/storage/query/condition/value.rs
+++ b/reductstore/src/storage/query/condition/value.rs
@@ -4,6 +4,7 @@
 mod cmp;
 
 mod arithmetic;
+mod misc;
 mod string;
 
 use reduct_base::error::ReductError;
@@ -20,6 +21,8 @@ pub(crate) use arithmetic::sub::Sub;
 pub(crate) use string::contains::Contains;
 pub(crate) use string::ends_with::EndsWith;
 pub(crate) use string::starts_with::StartsWith;
+
+pub(crate) use misc::cast::Cast;
 
 /// A value that can be used in a condition.
 #[derive(Debug, Clone)]

--- a/reductstore/src/storage/query/condition/value/misc.rs
+++ b/reductstore/src/storage/query/condition/value/misc.rs
@@ -1,8 +1,4 @@
 // Copyright 2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-mod cast;
-mod exists;
-
-pub(crate) use cast::Cast;
-pub(crate) use exists::Exists;
+pub(crate) mod cast;

--- a/reductstore/src/storage/query/condition/value/misc/cast.rs
+++ b/reductstore/src/storage/query/condition/value/misc/cast.rs
@@ -1,0 +1,70 @@
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A trait for adding two values.
+pub(crate) trait Cast {
+    /// Casts a value to a different type.
+    ///
+    /// # Arguments
+    ///
+    /// * `type_name` - The name of the type to cast to.
+    ///
+    /// # Returns
+    ///
+    /// The value cast to the specified type or an error if the value cannot be cast.
+    fn cast(self, type_name: &str) -> Result<Self, ReductError>
+    where
+        Self: Sized;
+}
+
+impl Cast for Value {
+    fn cast(self, type_name: &str) -> Result<Self, ReductError>
+    where
+        Self: Sized,
+    {
+        match type_name {
+            "bool" => self.as_bool().map(Value::Bool),
+            "int" => self.as_int().map(Value::Int),
+            "float" => self.as_float().map(Value::Float),
+            "string" => self.as_string().map(Value::String),
+            _ => Err(unprocessable_entity!("Unknown type '{}'", type_name)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("bool", Value::Bool(true), Ok(Value::Bool(true)))]
+    #[case("bool", Value::Int(1), Ok(Value::Bool(true)))]
+    #[case("bool", Value::Float(1.0), Ok(Value::Bool(true)))]
+    #[case("bool", Value::String("true".to_string()), Ok(Value::Bool(true)))]
+    #[case("int", Value::Bool(true), Ok(Value::Int(1)))]
+    #[case("int", Value::Int(1), Ok(Value::Int(1)))]
+    #[case("int", Value::Float(1.0), Ok(Value::Int(1)))]
+    #[case("int", Value::String("1".to_string()), Ok(Value::Int(1)))]
+    #[case("int", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as integer")))]
+    #[case("float", Value::Bool(true), Ok(Value::Float(1.0)))]
+    #[case("float", Value::Int(1), Ok(Value::Float(1.0)))]
+    #[case("float", Value::Float(1.0), Ok(Value::Float(1.0)))]
+    #[case("float", Value::String("1.0".to_string()), Ok(Value::Float(1.0)))]
+    #[case("float", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as float")))]
+    #[case("string", Value::Bool(true), Ok(Value::String("true".to_string())))]
+    #[case("string", Value::Int(1), Ok(Value::String("1".to_string())))]
+    #[case("string", Value::Float(1.0), Ok(Value::String("1".to_string())))]
+    #[case("string", Value::String("1".to_string()), Ok(Value::String("1".to_string())))]
+    #[case("unknown", Value::Bool(true), Err(unprocessable_entity!("Unknown type 'unknown'")))]
+    fn test_cast(
+        #[case] type_name: &str,
+        #[case] value: Value,
+        #[case] expected: Result<Value, ReductError>,
+    ) {
+        let result = value.cast(type_name);
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

This pull request introduces additional operators for working with reference and explicitly cast values:

* $ref - explicitly accesses the value of a label
* $exists - checks if a label exists
* $cast - cast value to another type

### Related issues

#640  https://github.com/reductstore/website/pull/151

### Does this PR introduce a breaking change?

No

### Other information:
