### PR TITLE
RS-585: Fix performance regression for querying records,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- RS-585: Fix performance regression for querying records, [PR-721](https://github.com/reductstore/reductstore/pull/721)
+
 ## [1.13.4] - 2025-01-27
 
 ### Fixed

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -241,7 +241,7 @@ impl Stream for ReadersWrapper {
         }
 
         let mut index = 0;
-        while !self.readers.is_empty() {
+        while index < self.readers.len() {
             if let Poll::Ready(data) = self.readers[index].rx().poll_recv(_cx) {
                 match data {
                     Some(Ok(chunk)) => {

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -73,7 +73,7 @@ pub(super) fn spawn_query_task(
 
                 if tx.capacity() == 0 {
                     trace!("Query '{}' task channel full", group);
-                    return Some(Duration::from_millis(10));
+                    return Some(Duration::from_micros(10));
                 }
 
                 let next_result = query.lock().unwrap().next(block_manager.clone());


### PR DESCRIPTION
Closes #720

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR addresses the performance regressions between v12.0 and 13.0: 

* reduce the wait time for a new record reader in the query task
*  add a queue for record writers in the batch write endpoint

The regression for the write operation wasn't completely fixed because it is related to the number of records in a block. It has been increased from 256 to 1024 and now it takes longer to serialize the block descriptors. 


### Related issues

#720 #621

### Does this PR introduce a breaking change?

No

### Other information:
