### PR TITLE
RS-549: Support $in/$nin logical operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- RS-550: Add support for when condition on replication task, [PR-687](https://github.com/reductstore/reductstore/pull/687)
-- RS-531: Support for arithmetical operators in conditional query, [PR-696](https://github.com/reductstore/reductstore/pull/696)
-- RS-530: Implement string operators in conditional query, [PR-705](https://github.com/reductstore/reductstore/pull/705)
+- RS-550: Support for when condition on replication task, [PR-687](https://github.com/reductstore/reductstore/pull/687)
+- RS-531: Arithmetical operators in conditional query, [PR-696](https://github.com/reductstore/reductstore/pull/696)
+- RS-530: String operators in conditional query, [PR-705](https://github.com/reductstore/reductstore/pull/705)
+- RS-549: `$in/$nin` logical operators in conditional query, [PR-722](https://github.com/reductstore/reductstore/pull/722)
 
 ## [1.13.5] - 2025-02-05
 

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -16,7 +16,7 @@ use futures_util::Stream;
 
 use crate::storage::entry::RecordReader;
 use crate::storage::query::QueryRx;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use reduct_base::error::ReductError;
 use reduct_base::unprocessable_entity;
 use std::collections::HashMap;

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -14,7 +14,7 @@ use futures_util::StreamExt;
 use crate::api::entry::common::err_to_batched_header;
 use crate::replication::{Transaction, TransactionNotification};
 use crate::storage::bucket::Bucket;
-use crate::storage::entry::{Entry, RecordDrainer, WriteRecordContent};
+use crate::storage::entry::{RecordDrainer, WriteRecordContent};
 use crate::storage::proto::record::Label;
 use crate::storage::storage::IO_OPERATION_TIMEOUT;
 use log::{debug, error};
@@ -22,7 +22,7 @@ use reduct_base::batch::{parse_batched_header, sort_headers_by_time, RecordHeade
 use reduct_base::error::ReductError;
 use reduct_base::{bad_request, internal_server_error, unprocessable_entity};
 use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;

--- a/reductstore/src/storage/query/condition/operators/logical.rs
+++ b/reductstore/src/storage/query/condition/operators/logical.rs
@@ -3,6 +3,7 @@
 
 mod all_of;
 mod any_of;
+mod r#in;
 mod none_of;
 mod one_of;
 
@@ -10,3 +11,4 @@ pub(crate) use all_of::AllOf;
 pub(crate) use any_of::AnyOf;
 pub(crate) use none_of::NoneOf;
 pub(crate) use one_of::OneOf;
+pub(crate) use r#in::In;

--- a/reductstore/src/storage/query/condition/operators/logical.rs
+++ b/reductstore/src/storage/query/condition/operators/logical.rs
@@ -4,11 +4,13 @@
 mod all_of;
 mod any_of;
 mod r#in;
+mod nin;
 mod none_of;
 mod one_of;
 
 pub(crate) use all_of::AllOf;
 pub(crate) use any_of::AnyOf;
+pub(crate) use nin::Nin;
 pub(crate) use none_of::NoneOf;
 pub(crate) use one_of::OneOf;
 pub(crate) use r#in::In;

--- a/reductstore/src/storage/query/condition/operators/logical/in.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/in.rs
@@ -1,0 +1,87 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an `in` operation.
+pub(crate) struct In {
+    op: BoxedNode,
+    list: Vec<BoxedNode>,
+}
+
+impl Node for In {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let op_value = self.op.apply(context)?;
+        for item in self.list.iter() {
+            if item.apply(context)? == op_value {
+                return Ok(Value::Bool(true));
+            }
+        }
+
+        Ok(Value::Bool(false))
+    }
+
+    fn print(&self) -> String {
+        format!("In({:?}, {:?})", self.op, self.list)
+    }
+}
+
+impl Boxed for In {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() < 2 {
+            return Err(unprocessable_entity!(
+                "$in operator requires at least two operands"
+            ));
+        }
+        Ok(Box::new(Self::new(operands)))
+    }
+}
+
+impl In {
+    pub fn new(mut operands: Vec<BoxedNode>) -> Self {
+        let op = operands.remove(0);
+        Self { op, list: operands }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(Value::Int(1), vec![Value::Int(0), Value::Int(1)], Value::Bool(true))]
+    #[case(Value::Int(1), vec![Value::Int(0), Value::Int(2)], Value::Bool(false))]
+    #[case(Value::Int(1), vec![Value::Int(0), Value::Int(2), Value::Float(1.0)], Value::Bool(true))]
+    fn apply_ok(#[case] op: Value, #[case] list: Vec<Value>, #[case] expected: Value) {
+        let mut operands: Vec<BoxedNode> = vec![Constant::boxed(op)];
+        operands.extend(list.iter().map(|v| Constant::boxed(v.clone()) as BoxedNode));
+
+        let op = In::new(operands);
+        assert_eq!(op.apply(&Context::default()).unwrap(), expected);
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let op = In::boxed(vec![]);
+        assert_eq!(
+            op.err().unwrap(),
+            unprocessable_entity!("$in operator requires at least two operands")
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let op = In::boxed(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(false)),
+        ])
+        .unwrap();
+        assert_eq!(op.print(), "In(Bool(true), [Bool(false)])");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/logical/nin.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/nin.rs
@@ -1,0 +1,87 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an `nin` operation.
+pub(crate) struct Nin {
+    op: BoxedNode,
+    list: Vec<BoxedNode>,
+}
+
+impl Node for Nin {
+    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+        let op_value = self.op.apply(context)?;
+        for item in self.list.iter() {
+            if item.apply(context)? == op_value {
+                return Ok(Value::Bool(false));
+            }
+        }
+
+        Ok(Value::Bool(true))
+    }
+
+    fn print(&self) -> String {
+        format!("Nin({:?}, {:?})", self.op, self.list)
+    }
+}
+
+impl Boxed for Nin {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() < 2 {
+            return Err(unprocessable_entity!(
+                "$nin operator requires at least two operands"
+            ));
+        }
+        Ok(Box::new(Self::new(operands)))
+    }
+}
+
+impl Nin {
+    pub fn new(mut operands: Vec<BoxedNode>) -> Self {
+        let op = operands.remove(0);
+        Self { op, list: operands }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(Value::Int(1), vec![Value::Int(0), Value::Int(1)], Value::Bool(false))]
+    #[case(Value::Int(1), vec![Value::Int(0), Value::Int(2)], Value::Bool(true))]
+    #[case(Value::Int(1), vec![Value::Int(0), Value::Int(2), Value::Float(1.0)], Value::Bool(false))]
+    fn apply_ok(#[case] op: Value, #[case] list: Vec<Value>, #[case] expected: Value) {
+        let mut operands: Vec<BoxedNode> = vec![Constant::boxed(op)];
+        operands.extend(list.iter().map(|v| Constant::boxed(v.clone()) as BoxedNode));
+
+        let op = Nin::new(operands);
+        assert_eq!(op.apply(&Context::default()).unwrap(), expected);
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let op = Nin::boxed(vec![]);
+        assert_eq!(
+            op.err().unwrap(),
+            unprocessable_entity!("$nin operator requires at least two operands")
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let op = Nin::boxed(vec![
+            Constant::boxed(Value::Bool(true)),
+            Constant::boxed(Value::Bool(false)),
+        ])
+        .unwrap();
+        assert_eq!(op.print(), "Nin(Bool(true), [Bool(false)])");
+    }
+}

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -6,7 +6,7 @@ use crate::storage::query::condition::operators::arithmetic::{
     Abs, Add, Div, DivNum, Mult, Rem, Sub,
 };
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
-use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, In, NoneOf, OneOf};
+use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, In, Nin, NoneOf, OneOf};
 use crate::storage::query::condition::operators::misc::{Cast, Exists, Ref};
 use crate::storage::query::condition::operators::string::{Contains, EndsWith, StartsWith};
 use crate::storage::query::condition::reference::Reference;
@@ -119,6 +119,7 @@ impl Parser {
             "$xor" => OneOf::boxed(operands),
             "$one_of" => OneOf::boxed(operands),
             "$in" => In::boxed(operands),
+            "$nin" => Nin::boxed(operands),
 
             // Comparison operators
             "$eq" => Eq::boxed(operands),
@@ -262,6 +263,7 @@ mod tests {
         #[case("$xor", "[true, true]", Value::Bool(false))]
         #[case("$one_of", "[true, true]", Value::Bool(false))]
         #[case("$in", "[\"a\", \"a\", \"b\"]", Value::Bool(true))]
+        #[case("$nin", "[\"a\", \"a\", \"b\"]", Value::Bool(false))]
         // Comparison operators
         #[case("$eq", "[10, 10]", Value::Bool(true))]
         #[case("$gt", "[20, 10]", Value::Bool(true))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -6,7 +6,7 @@ use crate::storage::query::condition::operators::arithmetic::{
     Abs, Add, Div, DivNum, Mult, Rem, Sub,
 };
 use crate::storage::query::condition::operators::comparison::{Eq, Gt, Gte, Lt, Lte, Ne};
-use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, NoneOf, OneOf};
+use crate::storage::query::condition::operators::logical::{AllOf, AnyOf, In, NoneOf, OneOf};
 use crate::storage::query::condition::operators::misc::{Cast, Exists, Ref};
 use crate::storage::query::condition::operators::string::{Contains, EndsWith, StartsWith};
 use crate::storage::query::condition::reference::Reference;
@@ -118,6 +118,7 @@ impl Parser {
             "$none_of" => NoneOf::boxed(operands),
             "$xor" => OneOf::boxed(operands),
             "$one_of" => OneOf::boxed(operands),
+            "$in" => In::boxed(operands),
 
             // Comparison operators
             "$eq" => Eq::boxed(operands),
@@ -260,6 +261,7 @@ mod tests {
         #[case("$none_of", "[true, true]", Value::Bool(false))]
         #[case("$xor", "[true, true]", Value::Bool(false))]
         #[case("$one_of", "[true, true]", Value::Bool(false))]
+        #[case("$in", "[\"a\", \"a\", \"b\"]", Value::Bool(true))]
         // Comparison operators
         #[case("$eq", "[10, 10]", Value::Bool(true))]
         #[case("$gt", "[20, 10]", Value::Bool(true))]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR adds new logical operators:

* `$in`  - checks if the first operand is  in a list
* `$nin` - checks if the first operand isn't in a list

```json
{
   "$in": [ "&severity", "info", "warn", "error"]
}
```
### Related issues

#640 https://github.com/reductstore/website/pull/152

### Does this PR introduce a breaking change?

No

### Other information:
