### PR TITLE
RS-598: Optimize write operation for small records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-530: String operators in conditional query, [PR-705](https://github.com/reductstore/reductstore/pull/705)
 - RS-549: `$in/$nin` logical operators in conditional query, [PR-722](https://github.com/reductstore/reductstore/pull/722)
 
+
+### Changed
+
+- RS-598: Optimize write operation for small records, [PR-723](https://github.com/reductstore/reductstore/pull/723)
+
 ## [1.13.5] - 2025-02-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,6 @@ dependencies = [
  "tempfile",
  "thread-id",
  "tokio",
- "tokio-util",
  "tower 0.5.2",
  "tower-http",
  "url",

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -46,7 +46,6 @@ bytes = "1.9.0"
 axum = { version = "0.8.1", features = ["default", "macros"] }
 axum-extra = { version = "0.10.0", features = ["default", "typed-header"] }
 tokio = { version = "1.43.0", features = ["full"] }
-tokio-util = "0.7.13"
 hyper = { version = "1.6.0", features = ["full"] }
 tower = "0.5.2"
 futures-util = "0.3.31"

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -194,20 +194,15 @@ mod tests {
             ("b".to_string(), "[a,b]".to_string()),
         ]);
 
-        let sender = storage
+        let mut sender = storage
             .get_bucket("bucket-1")
             .unwrap()
             .upgrade_and_unwrap()
             .begin_write("entry-1", 0, 6, "text/plain".to_string(), labels)
             .await
             .unwrap();
-        sender
-            .tx()
-            .send(Ok(Some(Bytes::from("Hey!!!"))))
-            .await
-            .unwrap();
-        sender.tx().send(Ok(None)).await.unwrap();
-        sender.tx().closed().await;
+        sender.send(Ok(Some(Bytes::from("Hey!!!")))).await.unwrap();
+        sender.send(Ok(None)).await.unwrap();
 
         let permissions = Permissions {
             read: vec!["bucket-1".to_string(), "bucket-2".to_string()],

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -297,16 +297,12 @@ mod tests {
             .unwrap()
             .upgrade_and_unwrap();
         for time in 10..100 {
-            let writer = entry
+            let mut writer = entry
                 .begin_write(time, 6, "text/plain".to_string(), HashMap::new())
                 .await
                 .unwrap();
-            writer
-                .tx()
-                .send(Ok(Some(Bytes::from("Hey!!!"))))
-                .await
-                .unwrap();
-            writer.tx().send(Ok(None)).await.unwrap();
+            writer.send(Ok(Some(Bytes::from("Hey!!!")))).await.unwrap();
+            writer.send(Ok(None)).await.unwrap();
         }
 
         // let threads finish writing

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -241,7 +241,7 @@ mod tests {
     ) {
         let components = components.await;
         {
-            let writer = components
+            let mut writer = components
                 .storage
                 .get_bucket("bucket-1")
                 .unwrap()
@@ -250,12 +250,10 @@ mod tests {
                 .await
                 .unwrap();
             writer
-                .tx()
                 .send(Ok(Some(Bytes::from(vec![0; 20]))))
                 .await
                 .unwrap();
-            writer.tx().send(Ok(None)).await.unwrap();
-            writer.tx().closed().await;
+            writer.send(Ok(None)).await.unwrap();
         }
 
         headers.insert("content-length", "0".parse().unwrap());

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -103,7 +103,6 @@ pub(crate) async fn write_batched_records(
                         {
                             debug!("Timeout while sending EOF: {}", err);
                         }
-                        ctx.writer.tx().closed().await;
 
                         components.replication_repo.write().await.notify(
                             TransactionNotification {

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -388,7 +388,7 @@ mod tests {
             .push_back(Transaction::WriteRecord(20))
             .unwrap();
 
-        let writer = sender
+        let mut writer = sender
             .storage
             .create_bucket("src", BucketSettings::default())
             .unwrap()
@@ -404,11 +404,8 @@ mod tests {
             sender.run()
         });
 
-        writer
-            .tx()
-            .blocking_send(Ok(Some(Bytes::from("xxxx"))))
-            .unwrap();
-        writer.tx().blocking_send(Ok(None)).unwrap_or(());
+        writer.blocking_send(Ok(Some(Bytes::from("xxxx")))).unwrap();
+        writer.blocking_send(Ok(None)).unwrap_or(());
         sleep(Duration::from_millis(100));
 
         let diagnostics = hourly_diagnostics.read().unwrap().diagnostics();
@@ -582,7 +579,7 @@ mod tests {
             Err(_err) => sender.storage.get_bucket("src").unwrap(),
         };
 
-        let writer = bucket
+        let mut writer = bucket
             .upgrade_and_unwrap()
             .begin_write(
                 "test",
@@ -594,12 +591,11 @@ mod tests {
             .wait()
             .unwrap();
         writer
-            .tx()
             .blocking_send(Ok(Some(Bytes::from(
                 (0..size).map(|_| 'x').collect::<String>(),
             ))))
             .unwrap();
-        writer.tx().blocking_send(Ok(None)).unwrap_or(());
+        writer.blocking_send(Ok(None)).unwrap_or(());
     }
 
     fn build_sender(

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -500,15 +500,12 @@ mod tests {
         let mut time = 10;
         for entry in ["test1", "test2"] {
             for _ in 0..3 {
-                let writer = bucket
+                let mut writer = bucket
                     .begin_write(entry, time, 4, "text/plain".to_string(), Labels::new())
                     .wait()
                     .unwrap();
-                writer
-                    .tx()
-                    .blocking_send(Ok(Some(Bytes::from("test"))))
-                    .unwrap();
-                writer.tx().blocking_send(Ok(None)).unwrap_or(());
+                writer.blocking_send(Ok(Some(Bytes::from("test")))).unwrap();
+                writer.blocking_send(Ok(None)).unwrap_or(());
                 time += 10;
             }
 

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -577,7 +577,6 @@ mod tests {
     use prost_wkt_types::Timestamp;
     use reduct_base::error::ErrorCode;
     use rstest::{fixture, rstest};
-    use std::thread::spawn;
 
     use crate::storage::entry::{RecordWriter, WriteRecordContent};
     use crate::storage::storage::MAX_IO_BUFFER_SIZE;

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -540,7 +540,7 @@ mod tests {
         time: u64,
         content: &'static [u8],
     ) -> Result<(), ReductError> {
-        let sender = bucket
+        let mut sender = bucket
             .begin_write(
                 entry_name,
                 time,
@@ -550,16 +550,13 @@ mod tests {
             )
             .await?;
         sender
-            .tx()
             .send(Ok(Some(Bytes::from(content))))
             .await
             .map_err(|e| internal_server_error!("Failed to send data: {}", e))?;
         sender
-            .tx()
             .send(Ok(None))
             .await
             .map_err(|e| internal_server_error!("Failed to sync channel: {}", e))?;
-        sender.tx().closed().await;
         Ok(())
     }
 

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -7,6 +7,7 @@ use crate::core::thread_pool::{group_from_path, shared_child_isolated};
 use crate::storage::block_manager::{BlockManager, BlockRef, RecordTx};
 use crate::storage::proto::record;
 use crate::storage::storage::{CHANNEL_BUFFER_SIZE, MAX_IO_BUFFER_SIZE};
+use async_trait::async_trait;
 use bytes::Bytes;
 use log::error;
 use reduct_base::bad_request;
@@ -16,13 +17,31 @@ use std::io::SeekFrom;
 use std::io::Write;
 use std::sync::{Arc, RwLock};
 use std::thread::{spawn, JoinHandle};
+use std::time::Duration;
+use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{channel, Receiver};
+use tokio::task::block_in_place;
+use tokio::time::error::Elapsed;
+use tokio::time::Timeout;
 
+type Chunk = Result<Option<Bytes>, ReductError>;
+type Rx = Receiver<Chunk>;
+
+#[async_trait]
 pub(crate) trait WriteRecordContent {
-    fn tx(&self) -> &RecordTx;
-}
+    /// Sends a chunk of the record content.
+    ///
+    /// Stops the writer if the chunk is an error or None.
+    async fn send(&mut self, chunk: Chunk) -> Result<(), SendError<Chunk>>;
 
-type Rx = Receiver<Result<Option<Bytes>, ReductError>>;
+    fn blocking_send(&mut self, chunk: Chunk) -> Result<(), SendError<Chunk>>;
+
+    async fn send_timeout(
+        &mut self,
+        chunk: Chunk,
+        timeout: Duration,
+    ) -> Result<Result<(), SendError<Chunk>>, Elapsed>;
+}
 
 /// RecordWriter is responsible for writing the content of a record to the storage.
 pub(crate) struct RecordWriter {
@@ -178,16 +197,6 @@ impl RecordWriter {
     }
 }
 
-impl Drop for RecordWriter {
-    fn drop(&mut self) {
-        if let Some((rx, ctx)) = self.lazy_write.take() {
-            spawn(move || {
-                Self::receive(rx, ctx);
-            });
-        }
-    }
-}
-
 /// Drains the record content and discards it.
 pub(crate) struct RecordDrainer {
     tx: RecordTx,
@@ -215,15 +224,68 @@ impl RecordDrainer {
     }
 }
 
+#[async_trait]
 impl WriteRecordContent for RecordDrainer {
-    fn tx(&self) -> &RecordTx {
-        &self.tx
+    async fn send(
+        &mut self,
+        chunk: Result<Option<Bytes>, ReductError>,
+    ) -> Result<(), SendError<Chunk>> {
+        Ok(())
+    }
+
+    fn blocking_send(&mut self, chunk: Chunk) -> Result<(), SendError<Chunk>> {
+        Ok(())
+    }
+
+    async fn send_timeout(
+        &mut self,
+        chunk: Chunk,
+        timeout: Duration,
+    ) -> Result<Result<(), SendError<Chunk>>, Elapsed> {
+        Ok(Ok(()))
     }
 }
 
+#[async_trait]
 impl WriteRecordContent for RecordWriter {
-    fn tx(&self) -> &RecordTx {
-        &self.tx
+    async fn send(
+        &mut self,
+        chunk: Result<Option<Bytes>, ReductError>,
+    ) -> Result<(), SendError<Chunk>> {
+        let stop = chunk.is_err() || chunk.as_ref().unwrap().is_none();
+        self.tx.send(chunk).await?;
+
+        if stop {
+            if let Some((rx, ctx)) = self.lazy_write.take() {
+                // tokio::spawn(async move {  Self::receive(rx, ctx); });
+                tokio::task::spawn_blocking(|| Self::receive(rx, ctx));
+                // Self::receive(rx, ctx);
+            }
+            self.tx.closed().await;
+        }
+
+        Ok(())
+    }
+
+    fn blocking_send(&mut self, chunk: Chunk) -> Result<(), SendError<Chunk>> {
+        let stop = chunk.is_err() || chunk.as_ref().unwrap().is_none();
+        self.tx.blocking_send(chunk)?;
+
+        if stop {
+            if let Some((rx, ctx)) = self.lazy_write.take() {
+                Self::receive(rx, ctx);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn send_timeout(
+        &mut self,
+        chunk: Chunk,
+        timeout: Duration,
+    ) -> Result<Result<(), SendError<Chunk>>, Elapsed> {
+        tokio::time::timeout(timeout, self.send(chunk)).await
     }
 }
 
@@ -246,31 +308,31 @@ mod tests {
         use tempfile::tempdir;
         use tokio::time::sleep;
 
+        const SMALL_RECORD_TIME: u64 = 1;
+        const BIG_RECORD_TIME: u64 = 2;
+
         #[rstest]
         #[tokio::test]
-        async fn test_ok(block_manager: Arc<RwLock<BlockManager>>, block_ref: BlockRef) {
-            let writer = RecordWriter::try_new(block_manager.clone(), block_ref, 1).unwrap();
+        async fn test_small_ok(block_manager: Arc<RwLock<BlockManager>>, block_ref: BlockRef) {
+            let mut writer =
+                RecordWriter::try_new(block_manager.clone(), block_ref, SMALL_RECORD_TIME).unwrap();
 
-            sleep(Duration::from_millis(100)).await;
-            let path = block_manager.read().unwrap().path().clone();
-            assert!(
-                find_task_group(&get_task_group(&path, 1)).is_some(),
-                "task is running"
-            );
+            writer.send(Ok(Some(Bytes::from("te")))).await.unwrap();
+            writer.send(Ok(Some(Bytes::from("st")))).await.unwrap();
+            writer.send(Ok(None)).await.unwrap();
 
-            writer.tx().send(Ok(Some(Bytes::from("te")))).await.unwrap();
-            writer.tx().send(Ok(Some(Bytes::from("st")))).await.unwrap();
-            writer.tx().send(Ok(None)).await.unwrap();
-
-            sleep(Duration::from_millis(100)).await;
-            assert!(
-                find_task_group(&get_task_group(&path, 1)).is_none(),
-                "task is finished"
-            );
-
-            let block_ref = block_manager.read().unwrap().load_block(1).unwrap();
+            let block_ref = block_manager
+                .read()
+                .unwrap()
+                .load_block(SMALL_RECORD_TIME)
+                .unwrap();
             assert_eq!(
-                block_ref.read().unwrap().get_record(1).unwrap().state,
+                block_ref
+                    .read()
+                    .unwrap()
+                    .get_record(SMALL_RECORD_TIME)
+                    .unwrap()
+                    .state,
                 record::State::Finished as i32
             );
 
@@ -285,14 +347,60 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_too_long(block_manager: Arc<RwLock<BlockManager>>, block_ref: BlockRef) {
-            let writer = RecordWriter::try_new(block_manager.clone(), block_ref, 1).unwrap();
+        async fn test_big_ok(block_manager: Arc<RwLock<BlockManager>>, block_ref: BlockRef) {
+            let mut writer =
+                RecordWriter::try_new(block_manager.clone(), block_ref, BIG_RECORD_TIME).unwrap();
+
+            sleep(Duration::from_millis(100)).await;
+            let path = block_manager.read().unwrap().path().clone();
+            assert!(
+                find_task_group(&get_task_group(&path, 1)).is_some(),
+                "task is running"
+            );
+
+            let content = vec![0xaau8; MAX_IO_BUFFER_SIZE + 1];
             writer
-                .tx()
+                .send(Ok(Some(Bytes::from(content.clone()))))
+                .await
+                .unwrap();
+            writer.send(Ok(None)).await.unwrap();
+
+            sleep(Duration::from_millis(100)).await;
+            assert!(
+                find_task_group(&get_task_group(&path, 1)).is_none(),
+                "task is finished"
+            );
+
+            let block_ref = block_manager.read().unwrap().load_block(1).unwrap();
+            assert_eq!(
+                block_ref
+                    .read()
+                    .unwrap()
+                    .get_record(BIG_RECORD_TIME)
+                    .unwrap()
+                    .state,
+                record::State::Finished as i32
+            );
+
+            let mut block_content = vec![0u8; content.len() + 4];
+            fs::File::open(block_manager.read().unwrap().path().join("1.blk"))
+                .unwrap()
+                .read(&mut block_content)
+                .unwrap();
+
+            assert_eq!(content, block_content[4..]);
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_too_long(block_manager: Arc<RwLock<BlockManager>>, block_ref: BlockRef) {
+            let mut writer =
+                RecordWriter::try_new(block_manager.clone(), block_ref, SMALL_RECORD_TIME).unwrap();
+            writer
                 .send(Ok(Some(Bytes::from("xxxxxxxxx"))))
                 .await
                 .unwrap();
-            writer.tx().send(Ok(None)).await.unwrap();
+            writer.send(Ok(None)).await.unwrap();
 
             tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -306,10 +414,10 @@ mod tests {
         #[rstest]
         #[tokio::test]
         async fn test_too_short(block_manager: Arc<RwLock<BlockManager>>, block_ref: BlockRef) {
-            let writer = RecordWriter::try_new(block_manager.clone(), block_ref, 1).unwrap();
-            writer.tx().send(Ok(Some(Bytes::from("xx")))).await.unwrap();
-            writer.tx().send(Ok(None)).await.unwrap();
-
+            let mut writer =
+                RecordWriter::try_new(block_manager.clone(), block_ref, SMALL_RECORD_TIME).unwrap();
+            writer.send(Ok(Some(Bytes::from("xx")))).await.unwrap();
+            writer.send(Ok(None)).await.unwrap();
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             let block_ref = block_manager.read().unwrap().load_block(1).unwrap();
@@ -340,9 +448,18 @@ mod tests {
                 .start_new_block(1, 1000)
                 .unwrap();
             block_ref.write().unwrap().insert_or_update_record(Record {
-                timestamp: Some(us_to_ts(&1)),
+                timestamp: Some(us_to_ts(&SMALL_RECORD_TIME)),
                 begin: 0,
                 end: 4,
+                state: record::State::Started as i32,
+                labels: vec![],
+                content_type: "".to_string(),
+            });
+
+            block_ref.write().unwrap().insert_or_update_record(Record {
+                timestamp: Some(us_to_ts(&BIG_RECORD_TIME)),
+                begin: 4,
+                end: MAX_IO_BUFFER_SIZE as u64 + 5,
                 state: record::State::Started as i32,
                 labels: vec![],
                 content_type: "".to_string(),
@@ -358,13 +475,10 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_drop() {
-            let drainer = RecordDrainer::new();
-            assert!(!drainer.io_task_handle.is_finished(), "wait for data");
-
-            drainer.tx().send(Ok(None)).await.unwrap();
-            sleep(Duration::from_millis(100)).await;
-            assert!(drainer.io_task_handle.is_finished(), "task is finished");
+        async fn test_does_nothing() {
+            let mut drainer = RecordDrainer::new();
+            drainer.send(Ok(Some(Bytes::from("test")))).await.unwrap();
+            drainer.send(Ok(None)).await.unwrap();
         }
     }
 }

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -65,8 +65,6 @@ mod tests {
     use reduct_base::Labels;
     use rstest::rstest;
     use std::path::PathBuf;
-    use std::thread::sleep;
-    use std::time::Duration;
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -100,16 +100,15 @@ mod tests {
 
     #[rstest]
     fn test_begin_read_broken(entry: Entry) {
-        let sender = entry
+        let mut sender = entry
             .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
             .wait()
             .unwrap();
         sender
-            .tx()
             .blocking_send(Ok(Some(Bytes::from(vec![0; 50]))))
             .unwrap();
+        sender.blocking_send(Ok(None)).unwrap();
 
-        sleep(Duration::from_millis(100));
         let reader = entry.begin_read(1000000).wait();
         assert_eq!(
             reader.err(),
@@ -121,12 +120,11 @@ mod tests {
 
     #[rstest]
     fn test_begin_read_still_written(entry: Entry) {
-        let sender = entry
+        let mut sender = entry
             .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
             .wait()
             .unwrap();
         sender
-            .tx()
             .blocking_send(Ok(Some(Bytes::from(vec![0; 5]))))
             .unwrap();
 

--- a/reductstore/src/storage/entry/write_record.rs
+++ b/reductstore/src/storage/entry/write_record.rs
@@ -363,15 +363,14 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_begin_override_errored(entry: Entry) {
-        let sender = entry
+        let mut sender = entry
             .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
             .await
             .unwrap();
 
-        sender.tx().send(Ok(None)).await.unwrap();
-        sender.tx().closed().await;
+        sender.send(Ok(None)).await.unwrap();
 
-        let sender = entry
+        let mut sender = entry
             .begin_write(
                 1000000,
                 10,
@@ -381,7 +380,6 @@ mod tests {
             .await
             .unwrap();
         sender
-            .tx()
             .send(Ok(Some(Bytes::from(vec![0; 10]))))
             .await
             .unwrap();
@@ -406,13 +404,11 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_begin_not_override_if_different_size(entry: Entry) {
-        let sender = entry
+        let mut sender = entry
             .begin_write(1000000, 10, "text/plain".to_string(), Labels::new())
             .await
             .unwrap();
-
-        sender.tx().send(Ok(None)).await.unwrap();
-        sender.tx().closed().await;
+        sender.send(Ok(None)).await.unwrap();
 
         let err = entry
             .begin_write(

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -370,16 +370,15 @@ mod tests {
                         .get_or_create_entry($entry_name)
                         .unwrap()
                         .upgrade_and_unwrap();
-                    let sender = entry
+                    let mut sender = entry
                         .begin_write($record_ts, 10, "text/plain".to_string(), Labels::new())
                         .wait()
                         .unwrap();
                     sender
-                        .tx()
                         .blocking_send(Ok(Some(Bytes::from("0123456789"))))
                         .unwrap();
 
-                    sender.tx().blocking_send(Ok(None)).unwrap();
+                    sender.blocking_send(Ok(None)).unwrap();
                 };
             }
 
@@ -553,17 +552,16 @@ mod tests {
                 .upgrade_and_unwrap();
             assert_eq!(bucket.name(), "test");
 
-            let writer = bucket
+            let mut writer = bucket
                 .begin_write("entry-1", 0, 10, "text/plain".to_string(), Labels::new())
                 .wait()
                 .unwrap();
             writer
-                .tx()
                 .send(Ok(Some(Bytes::from("0123456789"))))
                 .await
                 .unwrap();
-            writer.tx().send(Ok(None)).await.unwrap();
-            writer.tx().closed().await;
+            writer.send(Ok(None)).await.unwrap();
+
             let result = storage.rename_bucket("test", "new").wait();
             assert_eq!(result, Ok(()));
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Optimization

### What was changed?

The PR optimizes the RecordWriter for small records, less than 512KB. Instead of starting a thread with a queue message for each record, the writer caches the data and writes it when the transfer is complete.

### Related issues

#720 

### Does this PR introduce a breaking change?

No

### Other information:
