### PR TITLE
Fix deadlock in write operation for small records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-598: Optimize write operation for small records, [PR-723](https://github.com/reductstore/reductstore/pull/723)
 
+### Fixed
+
+- Fix deadlock in write operation for small records, [PR-724](https://github.com/reductstore/reductstore/pull/724)
+
 ## [1.13.5] - 2025-02-05
 
 ### Fixed

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -217,9 +217,7 @@ async fn write_chunk(
 
     writer
         .send_timeout(Ok(Some(chunk)), IO_OPERATION_TIMEOUT)
-        .await
-        .map_err(|err| internal_server_error!("Timeout while sending data: {:?}", err))?
-        .map_err(|err| internal_server_error!("Failed to write the record: {:?}", err))?;
+        .await?;
     Ok(rest)
 }
 

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -85,15 +85,7 @@ pub(crate) async fn write_record(
         Ok((ts, labels, mut writer)) => {
             macro_rules! send_chunk {
                 ($chunk:expr) => {
-                    writer
-                        .send_timeout($chunk, IO_OPERATION_TIMEOUT)
-                        .await
-                        .map_err(|err| {
-                            internal_server_error!("Timeout while sending data: {:?}", err)
-                        })?
-                        .map_err(|err| {
-                            internal_server_error!("Failed to write the record: {:?}", err)
-                        })?;
+                    writer.send_timeout($chunk, IO_OPERATION_TIMEOUT).await?;
                 };
             }
 

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -16,7 +16,7 @@ use crate::storage::storage::IO_OPERATION_TIMEOUT;
 use futures_util::StreamExt;
 use log::{debug, error};
 use reduct_base::error::ReductError;
-use reduct_base::{bad_request, internal_server_error, Labels};
+use reduct_base::{bad_request, Labels};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::timeout;

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -17,9 +17,7 @@ use std::io::SeekFrom;
 use std::io::Write;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{channel, Receiver};
-use tokio::time::error::Elapsed;
 
 type Chunk = Result<Option<Bytes>, ReductError>;
 type Rx = Receiver<Chunk>;

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -10,8 +10,8 @@ use crate::storage::storage::{CHANNEL_BUFFER_SIZE, MAX_IO_BUFFER_SIZE};
 use async_trait::async_trait;
 use bytes::Bytes;
 use log::error;
-use reduct_base::bad_request;
 use reduct_base::error::ReductError;
+use reduct_base::{bad_request, internal_server_error};
 use std::io::Seek;
 use std::io::SeekFrom;
 use std::io::Write;
@@ -29,16 +29,12 @@ pub(crate) trait WriteRecordContent {
     /// Sends a chunk of the record content.
     ///
     /// Stops the writer if the chunk is an error or None.
-    async fn send(&mut self, chunk: Chunk) -> Result<(), SendError<Chunk>>;
+    async fn send(&mut self, chunk: Chunk) -> Result<(), ReductError>;
 
     #[cfg(test)]
-    fn blocking_send(&mut self, chunk: Chunk) -> Result<(), SendError<Chunk>>;
+    fn blocking_send(&mut self, chunk: Chunk) -> Result<(), ReductError>;
 
-    async fn send_timeout(
-        &mut self,
-        chunk: Chunk,
-        timeout: Duration,
-    ) -> Result<Result<(), SendError<Chunk>>, Elapsed>;
+    async fn send_timeout(&mut self, chunk: Chunk, timeout: Duration) -> Result<(), ReductError>;
 }
 
 /// RecordWriter is responsible for writing the content of a record to the storage.
@@ -214,32 +210,27 @@ impl WriteRecordContent for RecordDrainer {
     async fn send(
         &mut self,
         _chunk: Result<Option<Bytes>, ReductError>,
-    ) -> Result<(), SendError<Chunk>> {
+    ) -> Result<(), ReductError> {
         Ok(())
     }
 
     #[cfg(test)]
-    fn blocking_send(&mut self, _chunk: Chunk) -> Result<(), SendError<Chunk>> {
+    fn blocking_send(&mut self, _chunk: Chunk) -> Result<(), ReductError> {
         Ok(())
     }
 
-    async fn send_timeout(
-        &mut self,
-        _chunk: Chunk,
-        _timeout: Duration,
-    ) -> Result<Result<(), SendError<Chunk>>, Elapsed> {
-        Ok(Ok(()))
+    async fn send_timeout(&mut self, _chunk: Chunk, _timeout: Duration) -> Result<(), ReductError> {
+        Ok(())
     }
 }
 
 #[async_trait]
 impl WriteRecordContent for RecordWriter {
-    async fn send(
-        &mut self,
-        chunk: Result<Option<Bytes>, ReductError>,
-    ) -> Result<(), SendError<Chunk>> {
+    async fn send(&mut self, chunk: Result<Option<Bytes>, ReductError>) -> Result<(), ReductError> {
         let stop = chunk.is_err() || chunk.as_ref().unwrap().is_none();
-        self.tx.send(chunk).await?;
+        self.tx.send(chunk).await.map_err(|err| {
+            internal_server_error!("Failed to write the record to internal buffer: {:?}", err)
+        })?;
 
         if stop {
             if let Some((rx, ctx)) = self.lazy_write.take() {
@@ -252,9 +243,11 @@ impl WriteRecordContent for RecordWriter {
     }
 
     #[cfg(test)]
-    fn blocking_send(&mut self, chunk: Chunk) -> Result<(), SendError<Chunk>> {
+    fn blocking_send(&mut self, chunk: Chunk) -> Result<(), ReductError> {
         let stop = chunk.is_err() || chunk.as_ref().unwrap().is_none();
-        self.tx.blocking_send(chunk)?;
+        self.tx.blocking_send(chunk).map_err(|err| {
+            internal_server_error!("Failed to write the record to internal buffer: {:?}", err)
+        })?;
 
         if stop {
             if let Some((rx, ctx)) = self.lazy_write.take() {
@@ -265,12 +258,12 @@ impl WriteRecordContent for RecordWriter {
         Ok(())
     }
 
-    async fn send_timeout(
-        &mut self,
-        chunk: Chunk,
-        timeout: Duration,
-    ) -> Result<Result<(), SendError<Chunk>>, Elapsed> {
-        tokio::time::timeout(timeout, self.send(chunk)).await
+    async fn send_timeout(&mut self, chunk: Chunk, timeout: Duration) -> Result<(), ReductError> {
+        tokio::time::timeout(timeout, self.send(chunk))
+            .await
+            .map_err(|_| {
+                internal_server_error!("Timeout while writing the record to internal buffer")
+            })?
     }
 }
 
@@ -409,6 +402,28 @@ mod tests {
             assert_eq!(
                 block_ref.read().unwrap().get_record(1).unwrap().state,
                 record::State::Errored as i32
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_timeout(block_manager: Arc<RwLock<BlockManager>>, block_ref: BlockRef) {
+            let mut writer =
+                RecordWriter::try_new(block_manager.clone(), block_ref, SMALL_RECORD_TIME).unwrap();
+
+            let result = async {
+                // we overload the channel buffer
+                for _ in 0..100 {
+                    writer
+                        .send_timeout(Ok(Some(Bytes::from("x"))), Duration::from_millis(10))
+                        .await?;
+                }
+                Ok::<(), ReductError>(())
+            };
+
+            assert_eq!(
+                result.await.err().unwrap(),
+                internal_server_error!("Timeout while writing the record to internal buffer")
             );
         }
 

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -416,6 +416,7 @@ mod tests {
                         .send_timeout(Ok(Some(Bytes::from("x"))), Duration::from_millis(10))
                         .await?;
                 }
+
                 Ok::<(), ReductError>(())
             };
 
@@ -471,10 +472,20 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_does_nothing() {
+        async fn test_send() {
             let mut drainer = RecordDrainer::new();
             drainer.send(Ok(Some(Bytes::from("test")))).await.unwrap();
             drainer.send(Ok(None)).await.unwrap();
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_send_timeout() {
+            let mut drainer = RecordDrainer::new();
+            drainer
+                .send_timeout(Ok(Some(Bytes::from("test"))), Duration::from_millis(10))
+                .await
+                .unwrap();
         }
     }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The channel size for large and small records was 16. It was too small for small records because if it's sent in small chunks, we have a deadlock. The PR increases the channel size for small records to MAX_SIZE_OF_SMALL_RECORD/8KB.

### Related issues

#723 

### Does this PR introduce a breaking change?

No

### Other information:
