### PR TITLE
RS-609: Restart replication thread when task settings are updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix deadlock in write operation for small records, [PR-724](https://github.com/reductstore/reductstore/pull/724)
+- RS-609: Restart replication thread when task settings are updated, [PR-737](https://github.com/reductstore/reductstore/pull/737)
 
 ## [1.13.5] - 2025-02-05
 

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::thread::{sleep, spawn};
 use std::time::Duration;
 


### PR DESCRIPTION
Closes #734

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

When replication task settings were updated, the replication engine recreated the task with new settings, but didn't stop the replication thread that continued to replicate data in parallel. The PR fixes the issue of stopping the thread when a task is removed.

The PR also fixes the replication log change made in #735. 

### Related issues

#735, #734

### Does this PR introduce a breaking change?

No

### Other information:
