### PR TITLE
 Recover database if a block descriptor missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove non-existing block from block index, [PR-744](https://github.com/reductstore/reductstore/pull/744)
+
 ## [1.14.0] - 2025-02-25
 
 ### Added

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -1030,7 +1030,7 @@ mod tests {
     }
 
     #[fixture]
-    fn block(block_manager: BlockManager, block_id: u64) -> BlockRef {
+    fn block(mut block_manager: BlockManager, block_id: u64) -> BlockRef {
         block_manager.load_block(block_id).unwrap()
     }
 

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -419,7 +419,7 @@ mod tests {
         assert_eq!(info.latest_record, 2000010);
 
         let block_index = BlockIndex::try_load(path.join(BLOCK_INDEX_FILE)).unwrap();
-        let block_manager = BlockManager::new(path.clone(), block_index); // reload the block manager
+        let mut block_manager = BlockManager::new(path.clone(), block_index); // reload the block manager
         let block_v1_9 = block_manager.load_block(1).unwrap().read().unwrap().clone();
         assert_eq!(block_v1_9.record_count(), 2);
         assert_eq!(block_v1_9.size(), 20);
@@ -586,7 +586,7 @@ mod tests {
 
             let entry = EntryLoader::restore_entry(path, entry.settings()).unwrap();
 
-            let block = entry.block_manager.read().unwrap().load_block(1).unwrap();
+            let block = entry.block_manager.write().unwrap().load_block(1).unwrap();
             let block = block.read().unwrap();
             assert_eq!(block.record_count(), 1);
             assert!(block.get_record(0).is_none());
@@ -602,7 +602,7 @@ mod tests {
             wal.append(1, WalEntry::RemoveBlock).unwrap();
             let entry = EntryLoader::restore_entry(path, entry.settings()).unwrap();
 
-            let block = entry.block_manager.read().unwrap().load_block(1).clone();
+            let block = entry.block_manager.write().unwrap().load_block(1).clone();
             assert_eq!(block.err().unwrap().status, InternalServerError,);
         }
 

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -298,7 +298,7 @@ mod tests {
             writer.send(Ok(None)).await.unwrap();
 
             let block_ref = block_manager
-                .read()
+                .write()
                 .unwrap()
                 .load_block(SMALL_RECORD_TIME)
                 .unwrap();
@@ -347,7 +347,7 @@ mod tests {
                 "task is finished"
             );
 
-            let block_ref = block_manager.read().unwrap().load_block(1).unwrap();
+            let block_ref = block_manager.write().unwrap().load_block(1).unwrap();
             assert_eq!(
                 block_ref
                     .read()
@@ -380,7 +380,7 @@ mod tests {
 
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            let block_ref = block_manager.read().unwrap().load_block(1).unwrap();
+            let block_ref = block_manager.write().unwrap().load_block(1).unwrap();
             assert_eq!(
                 block_ref.read().unwrap().get_record(1).unwrap().state,
                 record::State::Errored as i32
@@ -396,7 +396,7 @@ mod tests {
             writer.send(Ok(None)).await.unwrap();
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            let block_ref = block_manager.read().unwrap().load_block(1).unwrap();
+            let block_ref = block_manager.write().unwrap().load_block(1).unwrap();
             assert_eq!(
                 block_ref.read().unwrap().get_record(1).unwrap().state,
                 record::State::Errored as i32

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -25,7 +25,7 @@ impl Entry {
             debug!("Reading record for ts={}", time);
 
             let (block_ref, record) = {
-                let bm = block_manager.read()?;
+                let mut bm = block_manager.write()?;
                 let block_ref = bm.find_block(time)?;
                 let block = block_ref.read()?;
                 let record = block

--- a/reductstore/src/storage/entry/remove_records.rs
+++ b/reductstore/src/storage/entry/remove_records.rs
@@ -137,7 +137,7 @@ impl Entry {
         let mut records_per_block = BTreeMap::new();
 
         {
-            let bm = block_manager.read()?;
+            let mut bm = block_manager.write()?;
             for time in timestamps {
                 // Find the block that contains the record
                 // TODO: Try to avoid the lookup for each record

--- a/reductstore/src/storage/entry/update_labels.rs
+++ b/reductstore/src/storage/entry/update_labels.rs
@@ -43,7 +43,7 @@ impl Entry {
             let mut records_per_block = BTreeMap::new();
 
             {
-                let bm = block_manager.read()?;
+                let mut bm = block_manager.write()?;
                 for UpdateLabels {
                     time,
                     update,

--- a/reductstore/src/storage/entry/write_record.rs
+++ b/reductstore/src/storage/entry/write_record.rs
@@ -188,12 +188,12 @@ mod tests {
 
         write_stub_record(&mut entry, 1);
         write_stub_record(&mut entry, 2000010);
-        let bm = entry.block_manager.read().unwrap();
+        let mut bm = entry.block_manager.write().unwrap();
 
         assert_eq!(
             bm.load_block(1)
                 .unwrap()
-                .read()
+                .write()
                 .unwrap()
                 .get_record(1)
                 .unwrap()
@@ -211,7 +211,7 @@ mod tests {
         assert_eq!(
             bm.load_block(2000010)
                 .unwrap()
-                .read()
+                .write()
                 .unwrap()
                 .get_record(2000010)
                 .unwrap()
@@ -241,11 +241,11 @@ mod tests {
         write_stub_record(&mut entry, 2);
         write_stub_record(&mut entry, 2000010);
 
-        let bm = entry.block_manager.read().unwrap();
+        let mut bm = entry.block_manager.write().unwrap();
         let records = bm
             .load_block(1)
             .unwrap()
-            .read()
+            .write()
             .unwrap()
             .record_index()
             .clone();
@@ -264,7 +264,7 @@ mod tests {
         let records = bm
             .load_block(2000010)
             .unwrap()
-            .read()
+            .write()
             .unwrap()
             .record_index()
             .clone();
@@ -287,7 +287,7 @@ mod tests {
         write_stub_record(&mut entry, 3000000);
         write_stub_record(&mut entry, 2000000);
 
-        let bm = entry.block_manager.read().unwrap();
+        let mut bm = entry.block_manager.write().unwrap();
         let records = bm
             .load_block(1000000)
             .unwrap()
@@ -315,7 +315,7 @@ mod tests {
         write_stub_record(&mut entry, 3000000);
         write_stub_record(&mut entry, 1000000);
 
-        let bm = entry.block_manager.read().unwrap();
+        let mut bm = entry.block_manager.write().unwrap();
         let records = bm
             .load_block(1000000)
             .unwrap()

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -107,7 +107,7 @@ impl Query for HistoricalQuery {
             };
 
             let block_range = {
-                let bm = block_manager.read()?;
+                let mut bm = block_manager.write()?;
                 let first_block = {
                     if let Ok(block) = bm.find_block(start) {
                         block.read()?.block_id()
@@ -123,7 +123,7 @@ impl Query for HistoricalQuery {
             };
 
             for block_id in block_range {
-                let bm = block_manager.read()?;
+                let mut bm = block_manager.write()?;
                 let block_ref = bm.load_block(block_id)?;
 
                 self.current_block = Some(block_ref);


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

This PR fixes an error that could occur when a block descriptor was removed from disk. Now, the storage engine removes the descriptor from the block index if it can't be read from disk.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
