### PR TITLE
RS-633: Link runtime libraries statically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
         run: cargo install cargo-export
 
       - name: Build binary
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
         run: cargo build --release -p reductstore --target ${{ matrix.target }}
 
       - name: Upload binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minimum Rust version to 1.85
-
+- RS-633: Link runtime libraries statically, [PR-761](https://github.com/reductstore/reductstore/pull/761)
 
 ## [1.14.3] - 2025-03-10
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR changes the CI/CD build to link the runtime libraries with the binaries. This makes installation easier for older distributions and operating systems.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
