### PR TITLE
RS-656: Fix replication lock during API HTTP iteration and batching issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,11 @@ jobs:
     strategy:
       matrix:
         include:
-          # Many small blobs
+          # 10Kb blobs max records in a batch
+          - max_blob_size: 0.01
+            entries: 4
+            records: 1536
+          # 1MB blobs
           - max_blob_size: 1
             entries: 4
             records: 1536

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-656: Fix replication lock during API HTTP iteration and batching issues, [PR-771](https://github.com/reductstore/reductstore/pull/771)
+
 ## [1.14.3] - 2025-03-10
 
 ### Fixed

--- a/integration_tests/api/replication_api_test.py
+++ b/integration_tests/api/replication_api_test.py
@@ -36,7 +36,7 @@ def test__create_replication_ok(base_url, session, bucket_name, replication_name
     assert resp.json() == {
         "diagnostics": {"hourly": {"errored": 0, "errors": {}, "ok": 0}},
         "info": {
-            "is_active": False,
+            "is_active": True,
             "is_provisioned": False,
             "name": replication_name,
             "pending_records": 0,
@@ -105,7 +105,7 @@ def test__update_replication_ok(base_url, session, bucket_name, replication_name
     assert resp.json() == {
         "diagnostics": {"hourly": {"errored": 0, "errors": {}, "ok": 0}},
         "info": {
-            "is_active": False,
+            "is_active": True,
             "is_provisioned": False,
             "name": replication_name,
             "pending_records": 0,

--- a/integration_tests/data_check/uploader.py
+++ b/integration_tests/data_check/uploader.py
@@ -9,7 +9,7 @@ import random
 
 NUMBER_OF_ENTRIES = int(getenv("NUMBER_OF_ENTRIES", 18))
 NUMBER_OF_RECORDS = int(getenv("NUMBER_OF_RECORDS", 512))
-MAX_BLOB_SIZE = 1024 * 1024 * int(getenv("MAX_BLOB_SIZE", 1))
+MAX_BLOB_SIZE = int(1024 * 1024 * float(getenv("MAX_BLOB_SIZE", 1)))
 
 BLOB = random.randbytes(MAX_BLOB_SIZE)
 BUCKET_NAME = getenv("BUCKET_NAME", "data_check")

--- a/reductstore/src/api/replication/list.rs
+++ b/reductstore/src/api/replication/list.rs
@@ -48,7 +48,7 @@ mod tests {
 
         assert_eq!(list.replications.len(), 1);
         assert_eq!(list.replications[0].name, "api-test");
-        assert_eq!(list.replications[0].is_active, false);
+        assert_eq!(list.replications[0].is_active, true);
         assert_eq!(list.replications[0].is_provisioned, false);
     }
 }

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -10,7 +10,6 @@ use std::collections::BTreeMap;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::storage::entry::RecordReader;
 use crate::storage::proto::ts_to_us;
-use log::error;
 use reduct_base::error::{ErrorCode, IntEnum, ReductError};
 use reduct_base::unprocessable_entity;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::storage::entry::RecordReader;
 use crate::storage::proto::ts_to_us;
+use log::error;
 use reduct_base::error::{ErrorCode, IntEnum, ReductError};
 use reduct_base::unprocessable_entity;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -87,7 +87,7 @@ impl ReplicationSender {
                                 total_size += record_size;
                                 batch.push((record_to_sync, transaction));
 
-                                if total_size > 0 && total_size + record_size > MAX_PAYLOAD_SIZE {
+                                if total_size >= MAX_PAYLOAD_SIZE {
                                     break;
                                 }
                             }

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -40,8 +40,8 @@ pub(super) enum SyncState {
     BrokenLog(String),
 }
 
-const MAX_PAYLOAD_SIZE: u64 = 16_000_000;
-const MAX_BATCH_SIZE: usize = 100;
+const MAX_PAYLOAD_SIZE: u64 = 4_000_000;
+const MAX_BATCH_SIZE: usize = 80;
 
 impl ReplicationSender {
     pub fn new(

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -8,7 +8,7 @@ use crate::replication::transaction_log::TransactionLog;
 use crate::storage::storage::Storage;
 use std::cmp::PartialEq;
 
-use log::{debug, error, info};
+use log::{debug, error};
 use reduct_base::error::{ErrorCode, ReductError};
 
 use crate::replication::diagnostics::DiagnosticsCounter;

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -8,7 +8,7 @@ use crate::replication::transaction_log::TransactionLog;
 use crate::storage::storage::Storage;
 use std::cmp::PartialEq;
 
-use log::{debug, error};
+use log::{debug, error, info};
 use reduct_base::error::{ErrorCode, ReductError};
 
 use crate::replication::diagnostics::DiagnosticsCounter;
@@ -80,16 +80,16 @@ impl ReplicationSender {
                             );
 
                             let record_to_sync = self.read_record(entry_name, &transaction);
+                            processed_transactions += 1;
+
                             if let Some(record_to_sync) = record_to_sync {
                                 let record_size = record_to_sync.content_length();
+                                total_size += record_size;
+                                batch.push((record_to_sync, transaction));
+
                                 if total_size > 0 && total_size + record_size > MAX_PAYLOAD_SIZE {
                                     break;
                                 }
-                                total_size += record_size;
-                                batch.push((record_to_sync, transaction));
-                                processed_transactions += 1;
-                            } else {
-                                processed_transactions += 1; // we count to remove errored transactions from log
                             }
                         }
 

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -39,7 +39,6 @@ pub struct ReplicationTask {
     filter_map: Arc<RwLock<HashMap<String, TransactionFilter>>>,
     log_map: Arc<RwLock<HashMap<String, RwLock<TransactionLog>>>>,
     storage: Arc<Storage>,
-    remote_bucket: Arc<RwLock<dyn RemoteBucket + Send + Sync>>,
     hourly_diagnostics: Arc<RwLock<DiagnosticsCounter>>,
     stop_flag: Arc<AtomicBool>,
     is_active: Arc<AtomicBool>,
@@ -111,7 +110,6 @@ impl ReplicationTask {
         let config = settings.clone();
         let replication_name = name.clone();
         let thr_log_map = Arc::clone(&log_map);
-        let thr_bucket = Arc::clone(&remote_bucket);
         let thr_storage = Arc::clone(&storage);
         let thr_hourly_diagnostics = Arc::clone(&hourly_diagnostics);
         let thr_system_options = system_options.clone();
@@ -152,7 +150,7 @@ impl ReplicationTask {
                 thr_storage.clone(),
                 config.clone(),
                 thr_hourly_diagnostics,
-                thr_bucket,
+                remote_bucket,
             );
 
             while !thr_stop_flag.load(Ordering::Relaxed) {
@@ -213,7 +211,6 @@ impl ReplicationTask {
             storage,
             filter_map: filter,
             log_map,
-            remote_bucket,
             hourly_diagnostics,
             stop_flag,
             is_active,

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -42,6 +42,7 @@ pub struct ReplicationTask {
     remote_bucket: Arc<RwLock<dyn RemoteBucket + Send + Sync>>,
     hourly_diagnostics: Arc<RwLock<DiagnosticsCounter>>,
     stop_flag: Arc<AtomicBool>,
+    is_active: Arc<AtomicBool>,
 }
 
 impl Default for ReplicationSystemOptions {
@@ -105,6 +106,7 @@ impl ReplicationTask {
             Duration::from_secs(3600),
         )));
         let stop_flag = Arc::new(AtomicBool::new(false));
+        let is_active = Arc::new(AtomicBool::new(true));
 
         let config = settings.clone();
         let replication_name = name.clone();
@@ -114,6 +116,7 @@ impl ReplicationTask {
         let thr_hourly_diagnostics = Arc::clone(&hourly_diagnostics);
         let thr_system_options = system_options.clone();
         let thr_stop_flag = Arc::clone(&stop_flag);
+        let thr_is_active = Arc::clone(&is_active);
 
         spawn(move || {
             let init_transaction_logs = || {
@@ -154,15 +157,21 @@ impl ReplicationTask {
 
             while !thr_stop_flag.load(Ordering::Relaxed) {
                 match sender.run() {
-                    SyncState::SyncedOrRemoved => {}
+                    SyncState::SyncedOrRemoved => {
+                        thr_is_active.store(true, Ordering::Relaxed);
+                    }
                     SyncState::NotAvailable => {
+                        thr_is_active.store(false, Ordering::Relaxed);
                         sleep(thr_system_options.remote_bucket_unavailable_timeout);
                     }
                     SyncState::NoTransactions => {
                         // NOTE: we don't want to spin the CPU when there is nothing to do or the bucket is not available
+                        thr_is_active.store(true, Ordering::Relaxed);
                         sleep(thr_system_options.next_transaction_timeout);
                     }
                     SyncState::BrokenLog(entry_name) => {
+                        thr_is_active.store(false, Ordering::Relaxed);
+
                         info!("Transaction log is corrupted, dropping the whole log");
                         let path = ReplicationTask::build_path_to_transaction_log(
                             thr_storage.data_path(),
@@ -207,6 +216,7 @@ impl ReplicationTask {
             remote_bucket,
             hourly_diagnostics,
             stop_flag,
+            is_active,
         }
     }
 
@@ -284,9 +294,10 @@ impl ReplicationTask {
         for (_, log) in self.log_map.read().unwrap().iter() {
             pending_records += log.read().unwrap().len() as u64;
         }
+
         ReplicationInfo {
             name: self.name.clone(),
-            is_active: self.remote_bucket.read().unwrap().is_active(),
+            is_active: self.is_active.load(Ordering::Relaxed),
             is_provisioned: self.is_provisioned,
             pending_records,
         }

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -8,7 +8,7 @@ use crate::storage::proto::record::Label;
 use crate::storage::proto::{ts_to_us, Record};
 use crate::storage::storage::{CHANNEL_BUFFER_SIZE, MAX_IO_BUFFER_SIZE};
 use bytes::Bytes;
-use log::{debug, error};
+use log::error;
 use reduct_base::error::ReductError;
 use reduct_base::internal_server_error;
 use std::cmp::min;

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -8,7 +8,7 @@ use crate::storage::proto::record::Label;
 use crate::storage::proto::{ts_to_us, Record};
 use crate::storage::storage::{CHANNEL_BUFFER_SIZE, MAX_IO_BUFFER_SIZE};
 use bytes::Bytes;
-use log::debug;
+use log::{debug, error};
 use reduct_base::error::ReductError;
 use reduct_base::internal_server_error;
 use std::cmp::min;
@@ -204,9 +204,14 @@ impl RecordReader {
         };
 
         if let Err(e) = read_all() {
-            debug!(
-                "Failed to send record {}/{}/{}: {}",
-                ctx.bucket_name, ctx.entry_name, ctx.record_timestamp, e
+            error!(
+                "Failed to send record {}/{}/{}: {}, sent {}/{} bytes",
+                ctx.bucket_name,
+                ctx.entry_name,
+                ctx.record_timestamp,
+                e,
+                read_bytes,
+                ctx.content_size
             )
         }
     }

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -205,13 +205,8 @@ impl RecordReader {
 
         if let Err(e) = read_all() {
             error!(
-                "Failed to send record {}/{}/{}: {}, sent {}/{} bytes",
-                ctx.bucket_name,
-                ctx.entry_name,
-                ctx.record_timestamp,
-                e,
-                read_bytes,
-                ctx.content_size
+                "Failed to send record {}/{}/{}: {}",
+                ctx.bucket_name, ctx.entry_name, ctx.record_timestamp, e
             )
         }
     }


### PR DESCRIPTION
Closes #770 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR fixes the following issues:

1. Using an independent active/inactive flag for a replication task. Previously we were locking the remote bucket to get its status. This causes the HTTP API to hang and was the reason for #770
2. The batch size is 80 records for replication. Previously 100 didn't work with the defaults. This causes an unknown error when replicating small records
3. The last record in the batch is added to the batch even if it exceeds the limits. This is necessary to avoid double reading.
4. Replication is active after creation


### Related issues

#770 #735

### Does this PR introduce a breaking change?

No,

### Other information:
