### PR TITLE
RS-659: Fix replication timeout for large records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-659: Fix replication timeout for large records, [PR-774](https://github.com/reductstore/reductstore/pull/774)
+
 ## [1.14.4] - 2025-03-28
 
 ### Fixed

--- a/reductstore/src/api/entry/read_query_post.rs
+++ b/reductstore/src/api/entry/read_query_post.rs
@@ -19,12 +19,6 @@ pub(crate) async fn read_query_json(
     request: QueryEntry,
     headers: HeaderMap,
 ) -> Result<QueryInfoAxum, HttpError> {
-    assert_eq!(
-        request.query_type,
-        QueryType::Query,
-        "Query type must be Query"
-    );
-
     let bucket_name = path.get("bucket_name").unwrap();
     let entry_name = path.get("entry_name").unwrap();
 

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -66,7 +66,7 @@ impl ReductClient {
 
         let client = Client::builder()
             .default_headers(headers)
-            .timeout(std::time::Duration::from_secs(10))
+            .connect_timeout(std::time::Duration::from_secs(10))
             .danger_accept_invalid_certs(true)
             .http1_only()
             .build()


### PR DESCRIPTION
Closes #773 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The replication engine was using an incorrect timeout for its http client. It limited the entire request to 10 seconds, which is too little for large files. The PR fixes this by using the timeout for the TCP connection instead.

### Related issues

#773 

### Does this PR introduce a breaking change?

No

### Other information:
