### PR TITLE
RS-628: Return error if extension not found in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimum Rust version to 1.85
 - RS-633: Link runtime libraries statically, [PR-761](https://github.com/reductstore/reductstore/pull/761)
+- RS-628: Return error if extension not found in query, [PR-780](https://github.com/reductstore/reductstore/pull/780)
 
 ## [1.14.5] - 2025-04-03
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

If a request has a reference to an unknown extension, the server returns the HTTP error 422.

### Related issues

#762 

### Does this PR introduce a breaking change?

No

### Other information:
