### PR TITLE
RS-668: Fix deadlocks using curent_thread runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
             --name reductstore \
             --env RS_DATA_PATH=/data \
             --env RS_API_TOKEN=token \
-            --env RS_LOG_LEVEL=INFO \
+            --env RS_LOG_LEVEL=DEBUG \
             -p 8383:8383 \
             -v ./data:/data \
             ${{ github.repository }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   rust_fmt:
+
     runs-on: ubuntu-latest
     name: Rust Linter
     steps:
@@ -143,6 +144,7 @@ jobs:
             target: x86_64-apple-darwin
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     env:
       RUST_BACKTRACE: 1
     steps:
@@ -168,6 +170,7 @@ jobs:
   coverage:
     name: Generate Code Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - rust_fmt
     env:
@@ -213,6 +216,7 @@ jobs:
             url: https://127.0.0.1:8383
           - cert_path: ""
             url: http://127.0.0.1:8383
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -278,6 +282,7 @@ jobs:
           ]
     env:
       RS_API_TOKEN: XXXX
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -417,6 +422,7 @@ jobs:
             records: 128
     env:
       RS_API_TOKEN: XXXX
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -500,6 +506,7 @@ jobs:
     strategy:
       matrix:
         branch: ["main", "latest"]
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-633: Link runtime libraries statically, [PR-761](https://github.com/reductstore/reductstore/pull/761)
 - RS-628: Return error if extension not found in query, [PR-780](https://github.com/reductstore/reductstore/pull/780)
 
+### Fixed
+
+- RS-660: Fix deadlocks using curent_thread runtime, [PR-781](https://github.com/reductstore/reductstore/pull/781)
+
 ## [1.14.5] - 2025-04-03
 
 ### Fixed

--- a/integration_tests/data_check/uploader.py
+++ b/integration_tests/data_check/uploader.py
@@ -7,8 +7,8 @@ from reduct import Client, Bucket, ServerInfo, BucketSettings
 from os import getenv
 import random
 
-NUMBER_OF_ENTRIES = int(getenv("NUMBER_OF_ENTRIES", 18))
-NUMBER_OF_RECORDS = int(getenv("NUMBER_OF_RECORDS", 512))
+NUMBER_OF_ENTRIES = int(getenv("NUMBER_OF_ENTRIES", 4))
+NUMBER_OF_RECORDS = int(getenv("NUMBER_OF_RECORDS", 1536))
 MAX_BLOB_SIZE = int(1024 * 1024 * float(getenv("MAX_BLOB_SIZE", 1)))
 
 BLOB = random.randbytes(MAX_BLOB_SIZE)

--- a/reductstore/src/api/entry/read_query_post.rs
+++ b/reductstore/src/api/entry/read_query_post.rs
@@ -37,7 +37,8 @@ pub(crate) async fn read_query_json(
 
     components
         .ext_repo
-        .register_query(id, bucket_name, entry_name, request)?;
+        .register_query(id, bucket_name, entry_name, request)
+        .await?;
 
     Ok(QueryInfoAxum::from(QueryInfo { id }))
 }

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -117,7 +117,8 @@ async fn launch_server() {
     };
 }
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+// IMPORTANT: Use only current_thread runtime for the main function, we have deadlocks with multi-threaded runtime
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     launch_server().await;
 }

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -78,7 +78,10 @@ impl ReductClient {
             url.to_string()
         };
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
         Self {
             client,
             server_url,

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -78,7 +78,14 @@ impl Entry {
         let path = path.join(name);
         Ok(Self {
             name: name.to_string(),
-            bucket_name: path.file_name().unwrap().to_str().unwrap().to_string(),
+            bucket_name: path
+                .parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
             settings: RwLock::new(settings),
             block_manager: Arc::new(RwLock::new(BlockManager::new(
                 path.clone(),


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

In #779, we switched to the `multi_thread` Tokio runtime. This caused deadlocks in the storage engine. This PR reverts that change.

### Related issues

#779

### Does this PR introduce a breaking change?

No

### Other information:
