### PR TITLE
RS-652: $exists operator checks multiple labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python client benchmarks in CI, [PR-764](https://github.com/reductstore/reductstore/pull/764)
 - RS-629: Extension API v0.1 and core implementation, [PR-762](https://github.com/reductstore/reductstore/pull/762)
 - RS-622: Improve Extension API, [PR-779](https://github.com/reductstore/reductstore/pull/779)
+- RS-652: $exists operator checks multiple labels, [PR-786](https://github.com/reductstore/reductstore/pull/786)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python client benchmarks in CI, [PR-764](https://github.com/reductstore/reductstore/pull/764)
 - RS-629: Extension API v0.1 and core implementation, [PR-762](https://github.com/reductstore/reductstore/pull/762)
 - RS-622: Improve Extension API, [PR-779](https://github.com/reductstore/reductstore/pull/779)
-- RS-652: $exists operator checks multiple labels, [PR-786](https://github.com/reductstore/reductstore/pull/786)
+- RS-652: `$exists\$has` operator checks multiple labels, [PR-786](https://github.com/reductstore/reductstore/pull/786)
 
 ### Changed
 

--- a/reductstore/src/storage/query/condition/constant.rs
+++ b/reductstore/src/storage/query/condition/constant.rs
@@ -37,7 +37,7 @@ impl Constant {
         }
     }
 
-    pub fn boxed(value: Value) -> Box<Self> {
+    pub fn boxed(value: Value) -> BoxedNode {
         Box::new(Constant::new(value))
     }
 }

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -189,6 +189,7 @@ impl Parser {
 
             // Misc
             "$exists" => Exists::boxed(operands),
+            "$has" => Exists::boxed(operands),
             "$cast" => Cast::boxed(operands),
             "$ref" => Ref::boxed(operands),
 
@@ -346,6 +347,7 @@ mod tests {
         #[case("$ends_with", "[\"abc\", \"bc\"]", Value::Bool(true))]
         // Misc
         #[case("$exists", "[\"label\"]", Value::Bool(true))]
+        #[case("$has", "[\"label\"]", Value::Bool(true))]
         #[case("$cast", "[10.0, \"int\"]", Value::Int(10))]
         #[case("$ref", "[\"label\"]", Value::Int(10))]
         fn test_parse_operator(


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR allows to check multiple labels in the `$exists` operator:

```json
{
  "$exists": [ "label-1", "label-2"]
}
```

Also the `$has` operator was added as an alias.

### Related issues

#719 

### Does this PR introduce a breaking change?

No

### Other information:
