### PR TITLE
RS-643: Implement $each_n operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-629: Extension API v0.1 and core implementation, [PR-762](https://github.com/reductstore/reductstore/pull/762)
 - RS-622: Improve Extension API, [PR-779](https://github.com/reductstore/reductstore/pull/779)
 - RS-652: `$exists\$has` operator checks multiple labels, [PR-786](https://github.com/reductstore/reductstore/pull/786)
+- RS-643: Implement `$each_n` operator, [PR-788](https://github.com/reductstore/reductstore/pull/788)
 
 ### Changed
 

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -261,8 +261,8 @@ impl ManageExtensions for ExtRepository {
 
                     let status = Self::send_record_to_ext_pipeline(query_id, record, pipline).await;
                     if let ProcessStatus::Ready(Ok(record)) = status {
-                        let lock = self.query_map.read().await;
-                        let query = lock.get(&query_id).unwrap();
+                        let mut lock = self.query_map.write().await;
+                        let query = lock.get_mut(&query_id).unwrap();
                         query
                             .condition_filter
                             .filter_record(ProcessStatus::Ready(Ok(record)), query.query.strict)

--- a/reductstore/src/storage/query/condition.rs
+++ b/reductstore/src/storage/query/condition.rs
@@ -39,7 +39,7 @@ impl<'a> Context<'a> {
 /// Nodes can be evaluated in a context to produce a value.
 pub(crate) trait Node {
     /// Evaluates the node in the given context.
-    fn apply(&self, context: &Context) -> Result<Value, ReductError>;
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError>;
 
     fn operands(&self) -> &Vec<BoxedNode>;
 

--- a/reductstore/src/storage/query/condition/constant.rs
+++ b/reductstore/src/storage/query/condition/constant.rs
@@ -12,7 +12,7 @@ pub(super) struct Constant {
 }
 
 impl Node for Constant {
-    fn apply(&self, _context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, _context: &Context) -> Result<Value, ReductError> {
         Ok(self.value.clone())
     }
 
@@ -61,7 +61,7 @@ mod tests {
 
         #[test]
         fn apply() {
-            let constant = Constant::new(Value::Bool(true));
+            let mut constant = Constant::new(Value::Bool(true));
             let context = Context::default();
             let result = constant.apply(&context).unwrap();
             assert_eq!(result, Value::Bool(true));
@@ -83,7 +83,7 @@ mod tests {
 
         #[test]
         fn from_bool() {
-            let constant = Constant::from(true);
+            let mut constant = Constant::from(true);
             let result = constant.apply(&Context::default()).unwrap();
             assert_eq!(result, Value::Bool(true));
         }

--- a/reductstore/src/storage/query/condition/operators.rs
+++ b/reductstore/src/storage/query/condition/operators.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+pub(crate) mod aggregation;
 pub(crate) mod arithmetic;
 pub(crate) mod comparison;
 pub(crate) mod logical;

--- a/reductstore/src/storage/query/condition/operators/aggregation.rs
+++ b/reductstore/src/storage/query/condition/operators/aggregation.rs
@@ -1,0 +1,6 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+mod each_n;
+
+pub(crate) use each_n::EachN;

--- a/reductstore/src/storage/query/condition/operators/aggregation/each_n.rs
+++ b/reductstore/src/storage/query/condition/operators/aggregation/each_n.rs
@@ -1,0 +1,108 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an aggregation operation that keeps every n-th element.
+pub(crate) struct EachN {
+    operands: Vec<BoxedNode>,
+    count: i64,
+}
+
+impl EachN {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands, count: 0 }
+    }
+}
+
+impl Boxed for EachN {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 1 {
+            return Err(unprocessable_entity!(
+                "$each_n requires exactly one operand"
+            ));
+        }
+        Ok(Box::new(Self::new(operands)))
+    }
+}
+
+impl Node for EachN {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
+        self.count += 1;
+
+        let value = self.operands[0].apply(context)?;
+        let n = value.as_int()?;
+        if n == 0 {
+            return Err(unprocessable_entity!(
+                "Value '0' is not a valid operand for $each_n"
+            ));
+        }
+
+        if self.count % n == 0 {
+            Ok(Value::Bool(true))
+        } else {
+            Ok(Value::Bool(false))
+        }
+    }
+
+    fn print(&self) -> String {
+        format!("EachN({:?})", self.operands[0])
+    }
+
+    fn operands(&self) -> &Vec<BoxedNode> {
+        &self.operands
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use reduct_base::unprocessable_entity;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let mut op = EachN::new(vec![Constant::boxed(Value::Int(2))]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Bool(false));
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Bool(true));
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Bool(false));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let mut op = EachN::new(vec![Constant::boxed(Value::String("foo".to_string()))]);
+        assert_eq!(
+            op.apply(&Context::default()).unwrap_err(),
+            unprocessable_entity!("Value 'foo' could not be parsed as integer")
+        );
+    }
+
+    #[rstest]
+    fn apply_zero() {
+        let mut op = EachN::new(vec![Constant::boxed(Value::Int(0))]);
+        assert_eq!(
+            op.apply(&Context::default()).unwrap_err(),
+            unprocessable_entity!("Value '0' is not a valid operand for $each_n")
+        );
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let result = EachN::boxed(vec![]);
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("$each_n requires exactly one operand")
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let and = EachN::new(vec![Constant::boxed(Value::Int(5))]);
+        assert_eq!(and.print(), "EachN(Int(5))");
+    }
+}

--- a/reductstore/src/storage/query/condition/operators/arithmetic/abs.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/abs.rs
@@ -13,7 +13,7 @@ pub(crate) struct Abs {
 }
 
 impl Node for Abs {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value = self.operands[0].apply(context)?;
         value.abs()
     }
@@ -30,7 +30,7 @@ impl Node for Abs {
 impl Boxed for Abs {
     fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
         if operands.len() != 1 {
-            return Err(unprocessable_entity!("Abs requires exactly one operand"));
+            return Err(unprocessable_entity!("$abs requires exactly one operand"));
         }
         Ok(Box::new(Self::new(operands)))
     }
@@ -52,13 +52,13 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let op = Abs::new(vec![Constant::boxed(Value::Int(-1))]);
+        let mut op = Abs::new(vec![Constant::boxed(Value::Int(-1))]);
         assert_eq!(op.apply(&Context::default()).unwrap(), Value::Int(1));
     }
 
     #[rstest]
     fn apply_bad() {
-        let op = Abs::new(vec![Constant::boxed(Value::String("foo".to_string()))]);
+        let mut op = Abs::new(vec![Constant::boxed(Value::String("foo".to_string()))]);
         assert_eq!(
             op.apply(&Context::default()).unwrap_err(),
             unprocessable_entity!("Cannot calculate absolute value of a string")
@@ -70,7 +70,7 @@ mod tests {
         let result = Abs::boxed(vec![]);
         assert_eq!(
             result.err().unwrap(),
-            unprocessable_entity!("Abs requires exactly one operand")
+            unprocessable_entity!("$abs requires exactly one operand")
         );
     }
 

--- a/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/add.rs
@@ -12,10 +12,10 @@ pub(crate) struct Add {
 }
 
 impl Node for Add {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let mut sum: Option<Value> = None;
 
-        for operand in self.operands.iter() {
+        for operand in self.operands.iter_mut() {
             let value = operand.apply(context)?;
             match sum {
                 Some(s) => sum = Some(s.add(value)?),
@@ -57,7 +57,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let add = Add::new(vec![
+        let mut add = Add::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Bool(false)),
         ]);
@@ -67,7 +67,7 @@ mod tests {
 
     #[rstest]
     fn apply_bad() {
-        let add = Add::new(vec![
+        let mut add = Add::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::String("xxx".to_string())),
         ]);

--- a/reductstore/src/storage/query/condition/operators/arithmetic/div.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/div.rs
@@ -13,7 +13,7 @@ pub(crate) struct Div {
 }
 
 impl Node for Div {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         value_1.divide(value_2)
@@ -53,7 +53,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let sub = Div::new(vec![
+        let mut sub = Div::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Int(2)),
         ]);
@@ -62,7 +62,7 @@ mod tests {
 
     #[rstest]
     fn apply_bad() {
-        let sub = Div::new(vec![
+        let mut sub = Div::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::String("foo".to_string())),
         ]);

--- a/reductstore/src/storage/query/condition/operators/arithmetic/div_num.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/div_num.rs
@@ -13,7 +13,7 @@ pub(crate) struct DivNum {
 }
 
 impl Node for DivNum {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         value_1.divide_num(value_2)
@@ -55,7 +55,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let sub = DivNum::new(vec![
+        let mut sub = DivNum::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Int(2)),
         ]);
@@ -64,7 +64,7 @@ mod tests {
 
     #[rstest]
     fn apply_bad() {
-        let sub = DivNum::new(vec![
+        let mut sub = DivNum::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::String("foo".to_string())),
         ]);

--- a/reductstore/src/storage/query/condition/operators/arithmetic/mult.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/mult.rs
@@ -12,10 +12,10 @@ pub(crate) struct Mult {
 }
 
 impl Node for Mult {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let mut prod: Option<Value> = None;
 
-        for operand in self.operands.iter() {
+        for operand in self.operands.iter_mut() {
             let value = operand.apply(context)?;
             match prod {
                 Some(s) => prod = Some(s.multiply(value)?),
@@ -57,7 +57,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let op = Mult::new(vec![
+        let mut op = Mult::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(2.0)),
@@ -68,7 +68,7 @@ mod tests {
 
     #[rstest]
     fn apply_bad() {
-        let op = Mult::new(vec![
+        let mut op = Mult::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::String("xxx".to_string())),
         ]);

--- a/reductstore/src/storage/query/condition/operators/arithmetic/rem.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/rem.rs
@@ -13,7 +13,7 @@ pub(crate) struct Rem {
 }
 
 impl Node for Rem {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         value_1.remainder(value_2)
@@ -53,7 +53,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let op = Rem::new(vec![
+        let mut op = Rem::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Int(2)),
         ]);
@@ -62,7 +62,7 @@ mod tests {
 
     #[rstest]
     fn apply_bad() {
-        let op = Rem::new(vec![
+        let mut op = Rem::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::String("foo".to_string())),
         ]);

--- a/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
+++ b/reductstore/src/storage/query/condition/operators/arithmetic/sub.rs
@@ -13,7 +13,7 @@ pub(crate) struct Sub {
 }
 
 impl Node for Sub {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         value_1.subtract(value_2)
@@ -53,7 +53,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let sub = Sub::new(vec![
+        let mut sub = Sub::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Int(2)),
         ]);
@@ -62,7 +62,7 @@ mod tests {
 
     #[rstest]
     fn apply_bad() {
-        let sub = Sub::new(vec![
+        let mut sub = Sub::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::String("foo".to_string())),
         ]);

--- a/reductstore/src/storage/query/condition/operators/comparison/eq.rs
+++ b/reductstore/src/storage/query/condition/operators/comparison/eq.rs
@@ -12,7 +12,7 @@ pub(crate) struct Eq {
 }
 
 impl Node for Eq {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1 == value_2))
@@ -54,7 +54,7 @@ mod tests {
     #[case(Value::Int(1), Value::Int(2), Value::Bool(false))]
     #[case(Value::Int(2), Value::Int(1), Value::Bool(false))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let eq = Eq::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut eq = Eq::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(eq.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/comparison/gt.rs
+++ b/reductstore/src/storage/query/condition/operators/comparison/gt.rs
@@ -12,7 +12,7 @@ pub(crate) struct Gt {
 }
 
 impl Node for Gt {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1 > value_2))
@@ -53,7 +53,7 @@ mod tests {
     #[case(Value::Int(1), Value::Int(2), Value::Bool(false))]
     #[case(Value::Int(2), Value::Int(1), Value::Bool(true))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let eq = Gt::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut eq = Gt::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(eq.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/comparison/gte.rs
+++ b/reductstore/src/storage/query/condition/operators/comparison/gte.rs
@@ -12,7 +12,7 @@ pub(crate) struct Gte {
 }
 
 impl Node for Gte {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1 >= value_2))
@@ -53,7 +53,7 @@ mod tests {
     #[case(Value::Int(1), Value::Int(2), Value::Bool(false))]
     #[case(Value::Int(2), Value::Int(1), Value::Bool(true))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let eq = Gte::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut eq = Gte::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(eq.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/comparison/lt.rs
+++ b/reductstore/src/storage/query/condition/operators/comparison/lt.rs
@@ -12,7 +12,7 @@ pub(crate) struct Lt {
 }
 
 impl Node for Lt {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1 < value_2))
@@ -53,7 +53,7 @@ mod tests {
     #[case(Value::Int(1), Value::Int(2), Value::Bool(true))]
     #[case(Value::Int(2), Value::Int(1), Value::Bool(false))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let eq = Lt::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut eq = Lt::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(eq.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/comparison/lte.rs
+++ b/reductstore/src/storage/query/condition/operators/comparison/lte.rs
@@ -12,7 +12,7 @@ pub(crate) struct Lte {
 }
 
 impl Node for Lte {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1 <= value_2))
@@ -53,7 +53,7 @@ mod tests {
     #[case(Value::Int(1), Value::Int(2), Value::Bool(true))]
     #[case(Value::Int(2), Value::Int(1), Value::Bool(false))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let eq = Lte::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut eq = Lte::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(eq.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/comparison/ne.rs
+++ b/reductstore/src/storage/query/condition/operators/comparison/ne.rs
@@ -12,7 +12,7 @@ pub(crate) struct Ne {
 }
 
 impl Node for Ne {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1 != value_2))
@@ -53,7 +53,7 @@ mod tests {
     #[case(Value::Int(1), Value::Int(2), Value::Bool(true))]
     #[case(Value::Int(2), Value::Int(1), Value::Bool(true))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let eq = Ne::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut eq = Ne::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(eq.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/logical/all_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/all_of.rs
@@ -11,8 +11,8 @@ pub(crate) struct AllOf {
 }
 
 impl Node for AllOf {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
-        for operand in self.operands.iter() {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
+        for operand in self.operands.iter_mut() {
             let value = operand.apply(context)?;
             if !value.as_bool()? {
                 return Ok(Value::Bool(false));
@@ -52,7 +52,7 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let and = AllOf::new(vec![
+        let mut and = AllOf::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
@@ -60,7 +60,7 @@ mod tests {
         ]);
         assert_eq!(and.apply(&Context::default()).unwrap(), Value::Bool(true));
 
-        let and = AllOf::new(vec![
+        let mut and = AllOf::new(vec![
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(true)),

--- a/reductstore/src/storage/query/condition/operators/logical/any_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/any_of.rs
@@ -11,8 +11,8 @@ pub(crate) struct AnyOf {
 }
 
 impl Node for AnyOf {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
-        for operand in self.operands.iter() {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
+        for operand in self.operands.iter_mut() {
             let value = operand.apply(context)?;
             if value.as_bool()? {
                 return Ok(Value::Bool(true));
@@ -52,7 +52,7 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let or = AnyOf::new(vec![
+        let mut or = AnyOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
@@ -60,7 +60,7 @@ mod tests {
         ]);
         assert_eq!(or.apply(&Context::default()).unwrap(), Value::Bool(true));
 
-        let or = AnyOf::new(vec![
+        let mut or = AnyOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
@@ -70,7 +70,7 @@ mod tests {
 
     #[rstest]
     fn apply_empty() {
-        let or = AnyOf::new(vec![]);
+        let mut or = AnyOf::new(vec![]);
         assert_eq!(or.apply(&Context::default()).unwrap(), Value::Bool(false));
     }
 

--- a/reductstore/src/storage/query/condition/operators/logical/in.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/in.rs
@@ -12,9 +12,9 @@ pub(crate) struct In {
 }
 
 impl Node for In {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let op_value = self.operands[0].apply(context)?;
-        for item in self.operands[1..].iter() {
+        for item in self.operands[1..].iter_mut() {
             if item.apply(context)? == op_value {
                 return Ok(Value::Bool(true));
             }
@@ -72,7 +72,7 @@ mod tests {
         let mut operands: Vec<BoxedNode> = vec![Constant::boxed(op)];
         operands.extend(list.iter().map(|v| Constant::boxed(v.clone()) as BoxedNode));
 
-        let op = In::new(operands);
+        let mut op = In::new(operands);
         assert_eq!(op.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/logical/nin.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/nin.rs
@@ -12,9 +12,9 @@ pub(crate) struct Nin {
 }
 
 impl Node for Nin {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let op_value = self.operands[0].apply(context)?;
-        for item in self.operands[1..].iter() {
+        for item in self.operands[1..].iter_mut() {
             if item.apply(context)? == op_value {
                 return Ok(Value::Bool(false));
             }
@@ -71,7 +71,7 @@ mod tests {
         let mut operands: Vec<BoxedNode> = vec![Constant::boxed(op)];
         operands.extend(list.iter().map(|v| Constant::boxed(v.clone()) as BoxedNode));
 
-        let op = Nin::new(operands);
+        let mut op = Nin::new(operands);
         assert_eq!(op.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/logical/none_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/none_of.rs
@@ -11,8 +11,8 @@ pub(crate) struct NoneOf {
 }
 
 impl Node for NoneOf {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
-        for operand in self.operands.iter() {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
+        for operand in self.operands.iter_mut() {
             let value = operand.apply(context)?;
             if value.as_bool()? {
                 return Ok(Value::Bool(false));
@@ -52,7 +52,7 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let not = NoneOf::new(vec![
+        let mut not = NoneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
@@ -60,7 +60,7 @@ mod tests {
         ]);
         assert_eq!(not.apply(&Context::default()).unwrap(), Value::Bool(false));
 
-        let not = NoneOf::new(vec![
+        let mut not = NoneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(false)),
@@ -70,7 +70,7 @@ mod tests {
 
     #[rstest]
     fn apply_empty() {
-        let not = NoneOf::new(vec![]);
+        let mut not = NoneOf::new(vec![]);
         assert_eq!(not.apply(&Context::default()).unwrap(), Value::Bool(true));
     }
 

--- a/reductstore/src/storage/query/condition/operators/logical/one_of.rs
+++ b/reductstore/src/storage/query/condition/operators/logical/one_of.rs
@@ -11,9 +11,9 @@ pub(crate) struct OneOf {
 }
 
 impl Node for OneOf {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let mut count = 0;
-        for operand in self.operands.iter() {
+        for operand in self.operands.iter_mut() {
             let value = operand.apply(context)?;
             if value.as_bool()? {
                 count += 1;
@@ -53,7 +53,7 @@ mod tests {
 
     #[rstest]
     fn apply() {
-        let xor = OneOf::new(vec![
+        let mut xor = OneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::Float(-2.0)),
@@ -62,7 +62,7 @@ mod tests {
 
         assert_eq!(xor.apply(&Context::default()).unwrap(), Value::Bool(false));
 
-        let xor = OneOf::new(vec![
+        let mut xor = OneOf::new(vec![
             Constant::boxed(Value::Bool(false)),
             Constant::boxed(Value::Bool(true)),
             Constant::boxed(Value::Bool(false)),
@@ -73,7 +73,7 @@ mod tests {
 
     #[rstest]
     fn apply_empty() {
-        let xor = OneOf::new(vec![]);
+        let mut xor = OneOf::new(vec![]);
         assert_eq!(xor.apply(&Context::default()).unwrap(), Value::Bool(false));
     }
 

--- a/reductstore/src/storage/query/condition/operators/misc/cast.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/cast.rs
@@ -12,7 +12,7 @@ pub(crate) struct Cast {
 }
 
 impl Node for Cast {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let op = self.operands[0].apply(context)?;
         let type_name = self.operands[1].apply(context)?.as_string()?;
         op.cast(type_name.as_str())
@@ -51,7 +51,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let sub = Cast::new(vec![
+        let mut sub = Cast::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::String("float".to_string())),
         ]);
@@ -60,7 +60,7 @@ mod tests {
 
     #[rstest]
     fn apply_bad() {
-        let sub = Cast::new(vec![
+        let mut sub = Cast::new(vec![
             Constant::boxed(Value::Int(1)),
             Constant::boxed(Value::String("foo".to_string())),
         ]);

--- a/reductstore/src/storage/query/condition/operators/misc/exists.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/exists.rs
@@ -12,8 +12,8 @@ pub(crate) struct Exists {
 }
 
 impl Node for Exists {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
-        for operand in &self.operands {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
+        for operand in &mut self.operands {
             let value = operand.apply(context)?;
             if !context.labels.contains_key(value.as_string()?.as_str()) {
                 return Ok(Value::Bool(false));
@@ -61,7 +61,7 @@ mod tests {
     #[case(vec!["foo".to_string()], true)]
     #[case(vec!["foo".to_string(), "bazz".to_string()], false)]
     fn apply_ok(#[case] labels: Vec<String>, #[case] expected: bool) {
-        let op = Exists::new(
+        let mut op = Exists::new(
             labels
                 .iter()
                 .map(|label| Constant::boxed(Value::String(label.clone())))

--- a/reductstore/src/storage/query/condition/operators/misc/ref.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/ref.rs
@@ -12,7 +12,7 @@ pub(crate) struct Ref {
 }
 
 impl Node for Ref {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let label = self.operands[0].apply(context)?.as_string()?;
         context.labels.get(label.as_str()).map_or_else(
             || Err(not_found!("Label '{:?}' not found", label)),
@@ -55,7 +55,7 @@ mod tests {
 
     #[rstest]
     fn apply_ok() {
-        let op = Ref::new(vec![Constant::boxed(Value::String("foo".to_string()))]);
+        let mut op = Ref::new(vec![Constant::boxed(Value::String("foo".to_string()))]);
 
         let mut context = Context::default();
         context.labels.insert("foo", "bar");

--- a/reductstore/src/storage/query/condition/operators/string/contains.rs
+++ b/reductstore/src/storage/query/condition/operators/string/contains.rs
@@ -12,7 +12,7 @@ pub(crate) struct Contains {
 }
 
 impl Node for Contains {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1.contains(value_2)?))
@@ -57,7 +57,7 @@ mod tests {
     #[case(Value::String("test".to_string()), Value::String("esx".to_string()), Value::Bool(false))]
     #[case(Value::String("test".to_string()), Value::String("test".to_string()), Value::Bool(true))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let contains = Contains::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut contains = Contains::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(contains.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/string/ends_with.rs
+++ b/reductstore/src/storage/query/condition/operators/string/ends_with.rs
@@ -12,7 +12,7 @@ pub(crate) struct EndsWith {
 }
 
 impl Node for EndsWith {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1.ends_with(value_2)?))
@@ -56,7 +56,7 @@ mod tests {
     #[case(Value::String("test".to_string()), Value::String("es".to_string()), Value::Bool(false))]
     #[case(Value::String("test".to_string()), Value::String("st".to_string()), Value::Bool(true))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let contains = EndsWith::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut contains = EndsWith::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(contains.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/operators/string/starts_with.rs
+++ b/reductstore/src/storage/query/condition/operators/string/starts_with.rs
@@ -12,7 +12,7 @@ pub(crate) struct StartsWith {
 }
 
 impl Node for StartsWith {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let value_1 = self.operands[0].apply(context)?;
         let value_2 = self.operands[1].apply(context)?;
         Ok(Value::Bool(value_1.starts_with(value_2)?))
@@ -55,7 +55,7 @@ mod tests {
     #[case(Value::String("test".to_string()), Value::String("es".to_string()), Value::Bool(false))]
     #[case(Value::String("test".to_string()), Value::String("te".to_string()), Value::Bool(true))]
     fn apply(#[case] op_1: Value, #[case] op_2: Value, #[case] expected: Value) {
-        let contains = StartsWith::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
+        let mut contains = StartsWith::new(vec![Constant::boxed(op_1), Constant::boxed(op_2)]);
         assert_eq!(contains.apply(&Context::default()).unwrap(), expected);
     }
 

--- a/reductstore/src/storage/query/condition/reference.rs
+++ b/reductstore/src/storage/query/condition/reference.rs
@@ -14,7 +14,7 @@ pub(super) struct Reference {
 }
 
 impl Node for Reference {
-    fn apply(&self, context: &Context) -> Result<Value, ReductError> {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let label_value = context
             .labels
             .get(self.name.as_str())
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn apply() {
-        let reference = Reference::new("label".to_string(), EvaluationStage::Retrieve);
+        let mut reference = Reference::new("label".to_string(), EvaluationStage::Retrieve);
         let mut context = Context::default();
         context.labels.insert("label", "true");
         let result = reference.apply(&context).unwrap();
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn apply_not_found() {
-        let reference = Reference::new("label".to_string(), EvaluationStage::Retrieve);
+        let mut reference = Reference::new("label".to_string(), EvaluationStage::Retrieve);
         let context = Context::default();
         let result = reference.apply(&context);
         assert!(result


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR introduce the `$each_n` aggregation operator to return each nth record:

```json
{
  "&score": { "$gt": 10 },
  "$each_n": [5]  
}
```
### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
