### PR TITLE
RS-692: Fix removal of replication task after update with invalid configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RS-692: Fix removal of replication task after update with invalid configuration, [PR-790](https://github.com/reductstore/reductstore/pull/790)
+
 ## [1.14.5] - 2025-04-03
 
 ### Fixed


### PR DESCRIPTION
Closes #789 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

bug fix

### What was changed?

This PR fixes a regression in issue #737. The replication engine now removes old replications after passing all checks.

### Related issues

#789 #737

### Does this PR introduce a breaking change?

No

### Other information:
