### PR TITLE
RS-669: Fix JSON format in error messages with quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-692: Fix removal of replication task after update with invalid configuration, [PR-790](https://github.com/reductstore/reductstore/pull/790)
+- RS-669: Fix JSON format in error messages with quotes, [PR-791](https://github.com/reductstore/reductstore/pull/791)
 
 ## [1.14.5] - 2025-04-03
 

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -78,7 +78,8 @@ impl StdError for HttpError {
 impl IntoResponse for HttpError {
     fn into_response(self) -> Response {
         let err: BaseHttpError = self.into();
-        let body = format!("{{\"detail\": \"{}\"}}", err.message.to_string());
+        let converted_quotes = err.message.to_string().replace("\"", "'");
+        let body = format!("{{\"detail\": \"{}\"}}", converted_quotes);
 
         // its often easiest to implement `IntoResponse` by calling other implementations
         let mut resp = (StatusCode::from_u16(err.status as u16).unwrap(), body).into_response();
@@ -174,6 +175,46 @@ mod tests {
     use crate::replication::create_replication_repo;
 
     use super::*;
+
+    mod http_error {
+        use super::*;
+        use axum::body::to_bytes;
+        use rstest::rstest;
+        use tokio;
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_http_error() {
+            let error = HttpError::new(ErrorCode::BadRequest, "Test error");
+            let resp = error.into_response();
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                resp.headers().get("content-type").unwrap(),
+                HeaderValue::from_static("application/json")
+            );
+            assert_eq!(
+                resp.headers().get("x-reduct-error").unwrap(),
+                HeaderValue::from_static("Test error")
+            );
+
+            let body: Bytes = to_bytes(resp.into_body(), 1000).await.unwrap();
+            assert_eq!(body, Bytes::from(r#"{"detail": "Test error"}"#))
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_http_json_format() {
+            let error = HttpError::new(ErrorCode::BadRequest, "Test \"error\"");
+            let resp = error.into_response();
+            assert_eq!(
+                resp.headers().get("x-reduct-error").unwrap(),
+                HeaderValue::from_static("Test \"error\"")
+            );
+
+            let body: Bytes = to_bytes(resp.into_body(), 1000).await.unwrap();
+            assert_eq!(body, Bytes::from(r#"{"detail": "Test 'error'"}"#))
+        }
+    }
 
     #[fixture]
     pub(crate) async fn components() -> Arc<Components> {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The RPs add the replacement of double quotes with single quotes in the error message before sending it in JSON format.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
