### PR TITLE
RS-644: Implement $each_t operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-647: Build binaries for Linux and Macos ARM64, [PR-647](https://github.com/reductstore/reductstore/pull/782)
 
-## [1.4.6] - 2025-04-17
+## [1.14.6] - 2025-04-17
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-622: Improve Extension API, [PR-779](https://github.com/reductstore/reductstore/pull/779)
 - RS-652: `$exists\$has` operator checks multiple labels, [PR-786](https://github.com/reductstore/reductstore/pull/786)
 - RS-643: Implement `$each_n` operator, [PR-788](https://github.com/reductstore/reductstore/pull/788)
+- RS-644: Implement $each_t operator, [PR-792](https://github.com/reductstore/reductstore/pull/792)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-622: Improve Extension API, [PR-779](https://github.com/reductstore/reductstore/pull/779)
 - RS-652: `$exists\$has` operator checks multiple labels, [PR-786](https://github.com/reductstore/reductstore/pull/786)
 - RS-643: Implement `$each_n` operator, [PR-788](https://github.com/reductstore/reductstore/pull/788)
-- RS-644: Implement $each_t operator, [PR-792](https://github.com/reductstore/reductstore/pull/792)
+- RS-644: Implement `$each_t` operator, [PR-792](https://github.com/reductstore/reductstore/pull/792)
 
 ### Changed
 

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -865,7 +865,7 @@ pub(super) mod tests {
 
     impl RecordMeta for MockRecord {
         fn timestamp(&self) -> u64 {
-            todo!()
+            0
         }
 
         fn labels(&self) -> &Labels {

--- a/reductstore/src/ext/filter.rs
+++ b/reductstore/src/ext/filter.rs
@@ -56,7 +56,7 @@ impl ExtWhenFilter {
             }
         }
 
-        let context = Context::new(labels, EvaluationStage::Compute);
+        let context = Context::new(reader.timestamp(), labels, EvaluationStage::Compute);
         Ok(self
             .condition
             .as_mut()

--- a/reductstore/src/storage/query/condition.rs
+++ b/reductstore/src/storage/query/condition.rs
@@ -17,6 +17,7 @@ mod value;
 /// The context contains a set of labels that can be referenced by conditions.
 #[derive(Debug, Default)]
 pub(crate) struct Context<'a> {
+    timestamp: u64,
     labels: HashMap<&'a str, &'a str>,
     stage: EvaluationStage,
 }
@@ -29,8 +30,12 @@ pub(crate) enum EvaluationStage {
 }
 
 impl<'a> Context<'a> {
-    pub fn new(labels: HashMap<&'a str, &'a str>, stage: EvaluationStage) -> Self {
-        Context { labels, stage }
+    pub fn new(timestamp: u64, labels: HashMap<&'a str, &'a str>, stage: EvaluationStage) -> Self {
+        Context {
+            timestamp,
+            labels,
+            stage,
+        }
     }
 }
 

--- a/reductstore/src/storage/query/condition/operators/aggregation.rs
+++ b/reductstore/src/storage/query/condition/operators/aggregation.rs
@@ -2,5 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 mod each_n;
+mod each_t;
 
 pub(crate) use each_n::EachN;
+pub(crate) use each_t::EachT;

--- a/reductstore/src/storage/query/condition/operators/aggregation/each_n.rs
+++ b/reductstore/src/storage/query/condition/operators/aggregation/each_n.rs
@@ -48,12 +48,12 @@ impl Node for EachN {
         }
     }
 
-    fn print(&self) -> String {
-        format!("EachN({:?})", self.operands[0])
-    }
-
     fn operands(&self) -> &Vec<BoxedNode> {
         &self.operands
+    }
+
+    fn print(&self) -> String {
+        format!("EachN({:?})", self.operands[0])
     }
 }
 

--- a/reductstore/src/storage/query/condition/operators/aggregation/each_t.rs
+++ b/reductstore/src/storage/query/condition/operators/aggregation/each_t.rs
@@ -1,0 +1,112 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing an aggregation operation that keeps a record for the given duration.
+pub(crate) struct EachT {
+    operands: Vec<BoxedNode>,
+    last_timestamp: Option<u64>,
+}
+
+impl EachT {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self {
+            operands,
+            last_timestamp: None,
+        }
+    }
+}
+
+impl Boxed for EachT {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if operands.len() != 1 {
+            return Err(unprocessable_entity!(
+                "$each_t requires exactly one operand"
+            ));
+        }
+        Ok(Box::new(Self::new(operands)))
+    }
+}
+
+impl Node for EachT {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
+        if self.last_timestamp.is_none() {
+            self.last_timestamp = Some(context.timestamp);
+        }
+
+        let last_time = self.last_timestamp.unwrap();
+        let s = self.operands[0].apply(context)?.as_float()?;
+
+        let ret = context.timestamp - last_time >= (s * 1_000_000.0) as u64;
+        if ret {
+            self.last_timestamp = Some(context.timestamp);
+        }
+
+        Ok(Value::Bool(ret))
+    }
+
+    fn operands(&self) -> &Vec<BoxedNode> {
+        &self.operands
+    }
+
+    fn print(&self) -> String {
+        format!("EachT({:?})", self.operands[0])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use reduct_base::unprocessable_entity;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let mut op = EachT::new(vec![Constant::boxed(Value::Float(0.1))]);
+
+        let mut context = Context::default();
+        assert_eq!(op.apply(&context).unwrap(), Value::Bool(false));
+        context.timestamp += 1;
+        assert_eq!(op.apply(&context).unwrap(), Value::Bool(false));
+        context.timestamp += 100_000;
+        assert_eq!(op.apply(&context).unwrap(), Value::Bool(true));
+        context.timestamp += 1;
+        assert_eq!(op.apply(&context).unwrap(), Value::Bool(false));
+    }
+
+    #[rstest]
+    fn apply_bad() {
+        let mut op = EachT::new(vec![Constant::boxed(Value::String("foo".to_string()))]);
+        assert_eq!(
+            op.apply(&Context::default()).unwrap_err(),
+            unprocessable_entity!("Value 'foo' could not be parsed as float")
+        );
+    }
+
+    #[rstest]
+    fn apply_zero() {
+        let mut op = EachT::new(vec![Constant::boxed(Value::Int(0))]);
+        assert_eq!(op.apply(&Context::default()).unwrap(), Value::Bool(true));
+    }
+
+    #[rstest]
+    fn apply_empty() {
+        let result = EachT::boxed(vec![]);
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("$each_t requires exactly one operand")
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let and = EachT::new(vec![Constant::boxed(Value::Int(5))]);
+        assert_eq!(and.print(), "EachT(Int(5))");
+    }
+}

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -2,7 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use crate::storage::query::condition::constant::Constant;
-use crate::storage::query::condition::operators::aggregation::EachN;
+use crate::storage::query::condition::operators::aggregation::{EachN, EachT};
 use crate::storage::query::condition::operators::arithmetic::{
     Abs, Add, Div, DivNum, Mult, Rem, Sub,
 };
@@ -156,6 +156,7 @@ impl Parser {
         match operator {
             // Aggregation operators
             "$each_n" => EachN::boxed(operands),
+            "$each_t" => EachT::boxed(operands),
             // Arithmetic operators
             "$add" => Add::boxed(operands),
             "$sub" => Sub::boxed(operands),
@@ -322,6 +323,7 @@ mod tests {
         #[rstest]
         // Aggregation operators
         #[case("$each_n", "[1]", Value::Bool(true))]
+        #[case("$each_t", "[1]", Value::Bool(false))]
         // Arithmetic operators
         #[case("$add", "[1, 2.0]", Value::Float(3.0))]
         #[case("$sub", "[1, 2]", Value::Int(-1))]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -229,6 +229,7 @@ mod tests {
         let json = serde_json::from_str(r#"{"&label": {"$gt": 10}}"#).unwrap();
         let mut node = parser.parse(&json).unwrap();
         let context = Context::new(
+            0,
             HashMap::from_iter(vec![("label", "20")]),
             EvaluationStage::Retrieve,
         );
@@ -262,6 +263,7 @@ mod tests {
             serde_json::from_str(r#"{"&label": {"$and": true}, "$and": [true, true]}"#).unwrap();
         let mut node = parser.parse(&json).unwrap();
         let context = Context::new(
+            0,
             HashMap::from_iter(vec![("label", "true")]),
             EvaluationStage::Retrieve,
         );
@@ -402,7 +404,7 @@ mod tests {
             ];
 
             let mut staged_all_of = StagedAllOff::boxed(operands).unwrap();
-            let context = Context::new(HashMap::new(), EvaluationStage::Compute);
+            let context = Context::new(0, HashMap::new(), EvaluationStage::Compute);
             assert_eq!(staged_all_of.apply(&context).unwrap(), Value::Bool(true));
         }
     }

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -19,6 +19,7 @@ impl WhenFilter {
 impl RecordFilter for WhenFilter {
     fn filter(&mut self, record: &dyn RecordMeta) -> Result<bool, ReductError> {
         let context = Context::new(
+            record.timestamp(),
             record
                 .labels()
                 .iter()


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR implements the `$each_t` aggregation operator to retrieve records once for a given time interval in second.
 
### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
