### PR TITLE
Fix replication recovery from broken record,

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,6 @@ jobs:
 
       - name: Run tests
         shell: bash
-        env:
-          RUST_LOG: trace
         run: |
           set -e -x
           for f in ./tmp/tests/*; do
@@ -185,6 +183,7 @@ jobs:
       - rust_fmt
     env:
       CARGO_TERM_COLOR: always
+      RUST_LOG: trace # expand logging
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,8 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          RUST_LOG: trace
         run: |
           set -e -x
           for f in ./tmp/tests/*; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-660: Fix deadlocks using `current_thread` runtime, [PR-781](https://github.com/reductstore/reductstore/pull/781)
-- RS-689: Fix WAL recovery when a block wasn't saved in block index, [PR-785](https://github.com/reductstore/reductstore/pull/785)
+- RS-689: Fix WAL recovery when a block wasn't saved in block index, [PR-785](https://github.com/reductstore/reductstore/pull/785
+- Fix replication recovery from broken record, [PR-795](https://github.com/reductstore/reductstore/pull/795)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RS-660: Fix deadlocks using `current_thread` runtime, [PR-781](https://github.com/reductstore/reductstore/pull/781)
-- RS-689: Fix WAL recovery when a block wasn't saved in block index, [PR-785](https://github.com/reductstore/reductstore/pull/785
+- RS-689: Fix WAL recovery when a block wasn't saved in block index, [PR-785](https://github.com/reductstore/reductstore/pull/785)
 - Fix replication recovery from broken record, [PR-795](https://github.com/reductstore/reductstore/pull/795)
 
 ### Internal

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -14,7 +14,8 @@ use url::ParseError;
 #[repr(i16)]
 #[derive(Debug, PartialEq, PartialOrd, Copy, Clone, IntEnum)]
 pub enum ErrorCode {
-    Interrupt = -5, // used for interrupting a long-running task or query
+    InvalidRequest = -6, // used for invalid requests
+    Interrupt = -5,      // used for interrupting a long-running task or query
     UrlParseError = -4,
     ConnectionError = -3,
     Timeout = -2,

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -9,7 +9,6 @@ use std::collections::BTreeMap;
 
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::storage::entry::RecordReader;
-use futures_util::future::err;
 use reduct_base::error::{ErrorCode, IntEnum, ReductError};
 use reduct_base::io::{ReadRecord, RecordMeta};
 use reduct_base::unprocessable_entity;

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::storage::entry::RecordReader;
+use futures_util::future::err;
 use reduct_base::error::{ErrorCode, IntEnum, ReductError};
 use reduct_base::io::{ReadRecord, RecordMeta};
 use reduct_base::unprocessable_entity;
@@ -215,6 +216,8 @@ fn check_response(response: Result<Response, Error>) -> Result<(), ReductError> 
             ErrorCode::ConnectionError
         } else if error.is_timeout() {
             ErrorCode::Timeout
+        } else if error.is_request() {
+            ErrorCode::InvalidRequest
         } else {
             ErrorCode::Unknown
         };

--- a/reductstore/src/replication/remote_bucket/states/bucket_available.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_available.rs
@@ -7,7 +7,7 @@ use crate::replication::remote_bucket::states::RemoteBucketState;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::replication::Transaction;
 use crate::storage::entry::RecordReader;
-use log::{debug, error, warn};
+use log::{debug, warn};
 use reduct_base::error::ErrorCode::MethodNotAllowed;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::RecordMeta;

--- a/reductstore/src/replication/remote_bucket/states/bucket_available.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_available.rs
@@ -9,7 +9,7 @@ use crate::replication::Transaction;
 use crate::storage::entry::RecordReader;
 use log::{debug, error, warn};
 use reduct_base::error::ErrorCode::MethodNotAllowed;
-use reduct_base::error::{ErrorCode, IntEnum, ReductError};
+use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::RecordMeta;
 use std::collections::BTreeMap;
 
@@ -159,6 +159,7 @@ mod tests {
     use crate::storage::entry::RecordReader;
     use reduct_base::error::{ErrorCode, ReductError};
     use rstest::{fixture, rstest};
+    use test_log;
 
     #[rstest]
     #[tokio::test]
@@ -214,16 +215,19 @@ mod tests {
         assert!(state.is_available());
     }
 
-    #[rstest]
+    #[test_log::test(rstest)]
+    #[case(ErrorCode::Timeout)]
+    #[case(ErrorCode::ConnectionError)]
     #[tokio::test]
     async fn test_write_record_conn_err(
+        #[case] err: ErrorCode,
         client: MockReductClientApi,
         mut bucket: MockReductBucketApi,
         record_to_write: (RecordReader, Transaction),
     ) {
         bucket
             .expect_write_batch()
-            .returning(|_, _| Err(ReductError::new(ErrorCode::Timeout, "")));
+            .returning(move |_, _| Err(ReductError::new(err.clone(), "")));
         bucket.expect_update_batch().times(0);
 
         let state = Box::new(BucketAvailableState::new(
@@ -232,16 +236,16 @@ mod tests {
         ));
 
         let state = state.write_batch("test", vec![record_to_write]);
-        assert_eq!(
-            state.last_result(),
-            &Err(ReductError::new(ErrorCode::Timeout, ""))
-        );
+        assert_eq!(state.last_result(), &Err(ReductError::new(err, "")));
         assert!(!state.is_available());
     }
 
-    #[rstest]
+    #[test_log::test(rstest)]
+    #[case(ErrorCode::Timeout)]
+    #[case(ErrorCode::ConnectionError)]
     #[tokio::test]
     async fn test_update_record_conn_err(
+        #[case] err: ErrorCode,
         client: MockReductClientApi,
         mut bucket: MockReductBucketApi,
         record_to_update: (RecordReader, Transaction),
@@ -249,7 +253,7 @@ mod tests {
         bucket.expect_write_batch().times(0);
         bucket
             .expect_update_batch()
-            .returning(|_, _| Err(ReductError::new(ErrorCode::Timeout, "")));
+            .returning(move |_, _| Err(ReductError::new(err.clone(), "")));
 
         let state = Box::new(BucketAvailableState::new(
             Box::new(client),
@@ -257,23 +261,23 @@ mod tests {
         ));
 
         let state = state.write_batch("test", vec![record_to_update]);
-        assert_eq!(
-            state.last_result(),
-            &Err(ReductError::new(ErrorCode::Timeout, ""))
-        );
+        assert_eq!(state.last_result(), &Err(ReductError::new(err, "")));
         assert!(!state.is_available());
     }
 
-    #[rstest]
+    #[test_log::test(rstest)]
+    #[case(ErrorCode::InternalServerError)]
+    #[case(ErrorCode::InvalidRequest)]
     #[tokio::test]
-    async fn test_write_record_server_err(
+    async fn test_write_record_unrecoverable_err(
+        #[case] err: ErrorCode,
         client: MockReductClientApi,
         mut bucket: MockReductBucketApi,
         record_to_write: (RecordReader, Transaction),
     ) {
         bucket
             .expect_write_batch()
-            .returning(|_, _| Err(ReductError::new(ErrorCode::InternalServerError, "")));
+            .returning(move |_, _| Err(ReductError::new(err.clone(), "")));
 
         let state = Box::new(BucketAvailableState::new(
             Box::new(client),
@@ -281,10 +285,7 @@ mod tests {
         ));
 
         let state = state.write_batch("test", vec![record_to_write]);
-        assert_eq!(
-            state.last_result(),
-            &Err(ReductError::new(ErrorCode::InternalServerError, ""))
-        );
+        assert_eq!(state.last_result(), &Err(ReductError::new(err, "")));
         assert!(state.is_available());
     }
 

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -161,6 +161,10 @@ impl RecordReader {
                     match read_in_chunks(&ctx.file_ref, ctx.offset, ctx.content_size, read_bytes) {
                         Ok((buf, read)) => (buf, read),
                         Err(e) => {
+                            error!(
+                                "Failed to read record {}/{}/{}: {}",
+                                ctx.bucket_name, ctx.entry_name, ctx.record_timestamp, e
+                            );
                             tx.blocking_send(Err(e))?;
                             break;
                         }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR fixes an issue where a replication task would try to replicate a broken record, causing the invalid request error, but the task would try again and get stuck. Now the task will only retry to replicate records for connection and timeout errors.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
