### PR TITLE
Fix dead lock in replication task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-660: Fix deadlocks using `current_thread` runtime, [PR-781](https://github.com/reductstore/reductstore/pull/781)
 - RS-689: Fix WAL recovery when a block wasn't saved in block index, [PR-785](https://github.com/reductstore/reductstore/pull/785)
 - Fix replication recovery from broken record, [PR-795](https://github.com/reductstore/reductstore/pull/795)
+- Fix deadlock in replication task, [PR-796](https://github.com/reductstore/reductstore/pull/796)
 
 ### Internal
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The replication may have a deadlock when it replicates to a local bucket and adds a transaction log for a new entry.
The PR removes the read lock of the transaction log map while sending data.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
