### PR TITLE
RS-645: Implement `$timestamp` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-643: Implement `$each_n` operator, [PR-788](https://github.com/reductstore/reductstore/pull/788)
 - RS-644: Implement `$each_t` operator, [PR-792](https://github.com/reductstore/reductstore/pull/792)
 - RS-672: Implement `$limit` operator, [PR-793](https://github.com/reductstore/reductstore/pull/793)
-- RS-646: enable logging in extensions, [PR-646](https://github.com/reductstore/reductstore/pull/794)
+- RS-645: Implement `$timestamp` operator, [PR-798](https://github.com/reductstore/reductstore/pull/798)
+- RS-646: Enable logging in extensions, [PR-646](https://github.com/reductstore/reductstore/pull/794)
+
 
 ### Changed
 

--- a/reductstore/src/storage/query/condition/operators/misc.rs
+++ b/reductstore/src/storage/query/condition/operators/misc.rs
@@ -4,7 +4,9 @@
 mod cast;
 mod exists;
 mod r#ref;
+mod timestamp;
 
 pub(crate) use cast::Cast;
 pub(crate) use exists::Exists;
 pub(crate) use r#ref::Ref;
+pub(crate) use timestamp::Timestamp;

--- a/reductstore/src/storage/query/condition/operators/misc/timestamp.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/timestamp.rs
@@ -1,0 +1,75 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::value::Value;
+use crate::storage::query::condition::{Boxed, BoxedNode, Context, Node};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// A node representing the timestamp of a current record in a query.
+pub(crate) struct Timestamp {
+    operands: Vec<BoxedNode>,
+}
+
+impl Node for Timestamp {
+    fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
+        Ok(Value::Int(context.timestamp as i64))
+    }
+
+    fn operands(&self) -> &Vec<BoxedNode> {
+        &self.operands
+    }
+
+    fn print(&self) -> String {
+        "Timestamp()".to_string()
+    }
+}
+
+impl Boxed for Timestamp {
+    fn boxed(operands: Vec<BoxedNode>) -> Result<BoxedNode, ReductError> {
+        if !operands.is_empty() {
+            return Err(unprocessable_entity!("$timestamp requires no operands"));
+        }
+
+        Ok(Box::new(Timestamp::new(operands)))
+    }
+}
+
+impl Timestamp {
+    pub fn new(operands: Vec<BoxedNode>) -> Self {
+        Self { operands }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::condition::constant::Constant;
+    use crate::storage::query::condition::value::Value;
+    use reduct_base::unprocessable_entity;
+    use rstest::rstest;
+
+    #[rstest]
+    fn apply_ok() {
+        let mut op = Timestamp::new(vec![]);
+
+        let mut context = Context::default();
+        context.timestamp = 1234567890;
+        assert_eq!(op.apply(&context).unwrap(), Value::Int(1234567890));
+    }
+
+    #[rstest]
+    fn apply_not_empty() {
+        let result = Timestamp::boxed(vec![Constant::boxed(Value::String("foo".to_string()))]);
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("$timestamp requires no operands")
+        );
+    }
+
+    #[rstest]
+    fn print() {
+        let and = Timestamp::new(vec![]);
+        assert_eq!(and.print(), "Timestamp()".to_string());
+    }
+}

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -216,18 +216,23 @@ mod tests {
     use super::*;
     use crate::storage::query::condition::Context;
     use rstest::{fixture, rstest};
+    use serde_json::json;
     use std::collections::HashMap;
 
     #[rstest]
     fn test_parser_array_syntax(parser: Parser, context: Context) {
-        let json = serde_json::from_str(r#"{"$and": [true, {"$gt": [20, 10]}]}"#).unwrap();
+        let json = json!({
+        "$and": [true, {"$gt": [20, 10]}]
+        });
         let mut node = parser.parse(&json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
     #[rstest]
     fn test_parser_object_syntax(parser: Parser) {
-        let json = serde_json::from_str(r#"{"&label": {"$gt": 10}}"#).unwrap();
+        let json = json!({
+            "&label": {"$gt": 10}
+        });
         let mut node = parser.parse(&json).unwrap();
         let context = Context::new(
             0,
@@ -239,29 +244,40 @@ mod tests {
 
     #[rstest]
     fn test_parse_int(parser: Parser, context: Context) {
-        let json = serde_json::from_str(r#"{"$and": [1, -2]}"#).unwrap();
+        let json = json!({
+            "$and": [1, -2]
+        });
         let mut node = parser.parse(&json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
     #[rstest]
     fn test_parse_float(parser: Parser, context: Context) {
-        let json = serde_json::from_str(r#"{"$and": [1.1, -2.2]}"#).unwrap();
+        let json = json!({
+            "$and": [1.1, -2.2]
+        });
         let mut node = parser.parse(&json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
     #[rstest]
     fn test_parse_string(parser: Parser, context: Context) {
-        let json = serde_json::from_str(r#"{"$and": ["a", "b"]}"#).unwrap();
+        let json = json!({
+            "$and": [                "a","b"]
+        });
         let mut node = parser.parse(&json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
     #[rstest]
     fn test_parser_multiline(parser: Parser) {
-        let json =
-            serde_json::from_str(r#"{"&label": {"$and": true}, "$and": [true, true]}"#).unwrap();
+        let json = json!({
+            "$and": [
+                {"&label": {"$and": true}},
+                true
+            ]
+        }        );
+
         let mut node = parser.parse(&json).unwrap();
         let context = Context::new(
             0,
@@ -269,6 +285,18 @@ mod tests {
             EvaluationStage::Retrieve,
         );
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
+    }
+
+    #[rstest]
+    fn test_parse_nullary_operator(parser: Parser, context: Context) {
+        let json = json!({
+            "$add": [
+                "$timestamp",
+                1
+            ]
+        });
+        let mut node = parser.parse(&json).unwrap();
+        assert_eq!(node.apply(&context).unwrap(), Value::Int(1));
     }
 
     #[rstest]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -77,15 +77,8 @@ impl Parser {
                     } else {
                         // For unary operators, we need to parse the value
                         let operands = self.parse_intern(value)?;
-                        if operands.len() == 1 {
-                            expressions.extend(operands);
-                        } else {
-                            return Err(unprocessable_entity!(
-                                "The '{}' filed must contain a single value, array or object: {}",
-                                key,
-                                json
-                            ));
-                        }
+                        let operator = Self::parse_operator(key, operands)?;
+                        expressions.push(operator);
                     }
                 }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR introduces the` $timestamp` nullary operator, which returns the current record timestamp as a UNIX time in mircorsecods. It can be used to filter specific records by timestamp:

```json
{
  "$in": [
    "$timestamp",
    1,2,3,4,5
  ]
}
```

Additionally, I've add an option specify operands for a unary operator a single value:

```json
{
 "$limit": 100
}
```
### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
