### PR TITLE
Remove broken transaction log through file cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-689: Fix WAL recovery when a block wasn't saved in block index, [PR-785](https://github.com/reductstore/reductstore/pull/785)
 - Fix replication recovery from broken record, [PR-795](https://github.com/reductstore/reductstore/pull/795)
 - Fix deadlock in replication task, [PR-796](https://github.com/reductstore/reductstore/pull/796)
+- Remove broken transaction log through file cache, [PR-799](https://github.com/reductstore/reductstore/pull/799)
 
 ### Internal
 

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use log::{error, info};
 
 use crate::cfg::replication::ReplicationConfig;
+use crate::core::file_cache::FILE_CACHE;
 use crate::replication::diagnostics::DiagnosticsCounter;
 use crate::replication::remote_bucket::{create_remote_bucket, RemoteBucket};
 use crate::replication::replication_sender::{ReplicationSender, SyncState};
@@ -177,7 +178,7 @@ impl ReplicationTask {
                             &entry_name,
                             &replication_name,
                         );
-                        if let Err(err) = fs::remove_file(&path) {
+                        if let Err(err) = FILE_CACHE.remove(&path) {
                             error!("Failed to remove transaction log: {:?}", err);
                         }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR fixes the removal of the broken log. It wasn't being removed with the file cache and was causing the infinite loop of create/remove errors because the invalid file descriptor was stuck in the cache.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
