### PR TITLE
Ignore content-length when update labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore the `Content-Length` header when updating labels, [PR-800](https://github.com/reductstore/reductstore/pull/800)
+
 ## [1.4.6] - 2025-04-17
 
 ### Fixed

--- a/reductstore/src/api/entry/update_single.rs
+++ b/reductstore/src/api/entry/update_single.rs
@@ -10,7 +10,7 @@ use axum_extra::headers::HeaderMap;
 
 use reduct_base::Labels;
 
-use crate::api::entry::common::{parse_content_length_from_header, parse_timestamp_from_query};
+use crate::api::entry::common::parse_timestamp_from_query;
 use crate::api::middleware::check_permissions;
 use crate::api::{Components, ErrorCode, HttpError};
 use crate::auth::policy::WriteAccessPolicy;
@@ -34,16 +34,6 @@ pub(crate) async fn update_record(
         },
     )
     .await?;
-
-    let content_size = parse_content_length_from_header(&headers)?;
-
-    // we update only labels, so content-length must be 0
-    if content_size > 0 {
-        return Err(HttpError::new(
-            ErrorCode::UnprocessableEntity,
-            "content-length header must be 0",
-        ));
-    }
 
     let ts = parse_timestamp_from_query(&params)?;
 
@@ -262,7 +252,6 @@ mod tests {
     #[fixture]
     pub fn headers() -> HeaderMap {
         let mut headers = HeaderMap::new();
-        headers.insert("content-length", "0".parse().unwrap());
         headers.insert("x-reduct-label-x", "z".parse().unwrap()); // update
         headers.insert("x-reduct-label-b", "".parse().unwrap()); // remove
         headers.insert("x-reduct-label-1", "2".parse().unwrap()); // add


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The Fetch API doesn't allow to send the "content-length" header for an HTTP request without a body. However, the server requests it. The PR removes the restriction so that the HTTP API ignores the header. 

### Related issues

https://github.com/reductstore/reduct-js/pull/102

### Does this PR introduce a breaking change?

We change behavior, but only in extreme cases.

### Other information:
