### PR TITLE
 Channel timeout for read operation to prevent hanging readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimum Rust version to 1.85
 - RS-633: Link runtime libraries statically, [PR-761](https://github.com/reductstore/reductstore/pull/761)
 - RS-628: Return error if extension not found in query, [PR-780](https://github.com/reductstore/reductstore/pull/780)
+- Timout for IO operation 5s, [PR-804](https://github.com/reductstore/reductstore/pull/804)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix replication recovery from broken record, [PR-795](https://github.com/reductstore/reductstore/pull/795)
 - Fix deadlock in replication task, [PR-796](https://github.com/reductstore/reductstore/pull/796)
 - Remove broken transaction log through file cache, [PR-799](https://github.com/reductstore/reductstore/pull/799)
+- Channel timeout for read operation to prevent hanging readers, [PR-804](https://github.com/reductstore/reductstore/pull/804)
 
 ### Internal
 

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -402,7 +402,7 @@ mod tests {
         let send_error: SendError<()> = SendError(());
         let error: ReductError = send_error.into();
         assert_eq!(error.status, ErrorCode::InternalServerError);
-        assert_eq!(error.message, "SendError");
+        assert_eq!(error.message, "channel closed");
     }
 
     mod macros {

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -8,8 +8,10 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Error as FmtError, Formatter};
 use std::sync::PoisonError;
 use std::time::SystemTimeError;
-use tokio::sync::mpsc::error::SendError;
 use url::ParseError;
+
+#[cfg(feature = "io")]
+use tokio::sync::mpsc::error::SendError;
 
 /// HTTP status codes + client errors (negative).
 #[repr(i16)]
@@ -139,6 +141,7 @@ impl From<Box<dyn std::any::Any + Send>> for ReductError {
     }
 }
 
+#[cfg(feature = "io")]
 impl<T> From<SendError<T>> for ReductError {
     fn from(err: SendError<T>) -> Self {
         // A send error is an internal reductstore error
@@ -347,4 +350,118 @@ macro_rules! unauthorized {
     ($msg:expr) => {
         ReductError::unauthorized($msg)
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn creates_internal_server_error() {
+        let error = ReductError::internal_server_error("Unexpected server error");
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "Unexpected server error");
+    }
+
+    #[test]
+    fn converts_io_error_to_reduct_error() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::Other, "IO failure");
+        let error: ReductError = io_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "IO failure");
+    }
+
+    #[test]
+    fn converts_system_time_error_to_reduct_error() {
+        let system_time_error = UNIX_EPOCH.duration_since(SystemTime::now()).unwrap_err();
+        let error: ReductError = system_time_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "second time provided was later than self");
+    }
+
+    #[test]
+    fn converts_url_parse_error_to_reduct_error() {
+        let parse_error = ParseError::EmptyHost;
+        let error: ReductError = parse_error.into();
+        assert_eq!(error.status, ErrorCode::UrlParseError);
+        assert_eq!(error.message, "empty host");
+    }
+
+    #[test]
+    fn converts_poison_error_to_reduct_error() {
+        let poison_error: PoisonError<()> = PoisonError::new(());
+        let error: ReductError = poison_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "Poison error");
+    }
+
+    #[cfg(feature = "io")]
+    #[test]
+    fn converts_send_error_to_reduct_error() {
+        let send_error: SendError<()> = SendError(());
+        let error: ReductError = send_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "SendError");
+    }
+
+    mod macros {
+        use super::*;
+
+        #[test]
+        fn test_timeout_macro() {
+            let error = timeout!("Timeout error: {}", 42);
+            assert_eq!(error.status, ErrorCode::Timeout);
+            assert_eq!(error.message, "Timeout error: 42");
+        }
+
+        #[test]
+        fn test_no_content_macro() {
+            let error = no_content!("No content error: {}", 42);
+            assert_eq!(error.status, ErrorCode::NoContent);
+            assert_eq!(error.message, "No content error: 42");
+        }
+
+        #[test]
+        fn test_bad_request_macro() {
+            let error = bad_request!("Bad request error: {}", 42);
+            assert_eq!(error.status, ErrorCode::BadRequest);
+            assert_eq!(error.message, "Bad request error: 42");
+        }
+
+        #[test]
+        fn test_unprocessable_entity_macro() {
+            let error = unprocessable_entity!("Unprocessable entity error: {}", 42);
+            assert_eq!(error.status, ErrorCode::UnprocessableEntity);
+            assert_eq!(error.message, "Unprocessable entity error: 42");
+        }
+
+        #[test]
+        fn test_not_found_macro() {
+            let error = not_found!("Not found error: {}", 42);
+            assert_eq!(error.status, ErrorCode::NotFound);
+            assert_eq!(error.message, "Not found error: 42");
+        }
+
+        #[test]
+        fn test_conflict_macro() {
+            let error = conflict!("Conflict error: {}", 42);
+            assert_eq!(error.status, ErrorCode::Conflict);
+            assert_eq!(error.message, "Conflict error: 42");
+        }
+
+        #[test]
+        fn test_too_early_macro() {
+            let error = too_early!("Too early error: {}", 42);
+            assert_eq!(error.status, ErrorCode::TooEarly);
+            assert_eq!(error.message, "Too early error: 42");
+        }
+
+        #[test]
+        fn test_internal_server_error_macro() {
+            let error = internal_server_error!("Internal server error: {}", 42);
+            assert_eq!(error.status, ErrorCode::InternalServerError);
+            assert_eq!(error.message, "Internal server error: 42");
+        }
+    }
 }

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 ReductSoftware UG
+// Copyright 2023-2025 ReductSoftware UG
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -21,8 +21,6 @@ use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::mpsc::error::{SendError, TrySendError};
 use tokio::sync::mpsc::{channel, Sender};
-use tokio::time::error::Elapsed;
-use tokio::time::{timeout, Timeout};
 
 /// RecordReader is responsible for reading the content of a record from the storage.
 pub(crate) struct RecordReader {
@@ -481,7 +479,7 @@ mod tests {
         #[rstest]
         fn test_channel_timeout() {
             let msg = Ok(Bytes::from("test"));
-            let (tx, mut rx) = channel(1);
+            let (tx, _rx) = channel(1);
 
             tx.blocking_send(msg.clone()).unwrap(); // full
             let result =

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -5,19 +5,23 @@ use crate::core::file_cache::FileWeak;
 use crate::core::thread_pool::shared_child_isolated;
 use crate::storage::block_manager::{BlockManager, BlockRef, RecordRx};
 use crate::storage::proto::{ts_to_us, Record};
-use crate::storage::storage::{CHANNEL_BUFFER_SIZE, MAX_IO_BUFFER_SIZE};
+use crate::storage::storage::{CHANNEL_BUFFER_SIZE, IO_OPERATION_TIMEOUT, MAX_IO_BUFFER_SIZE};
 use async_trait::async_trait;
 use bytes::Bytes;
 use log::error;
 use reduct_base::error::ReductError;
 use reduct_base::io::{ReadChunk, ReadRecord, RecordMeta};
-use reduct_base::{internal_server_error, Labels};
+use reduct_base::{internal_server_error, timeout, Labels};
 use std::cmp::min;
 use std::io::Read;
 use std::io::{Seek, SeekFrom};
 use std::sync::{Arc, RwLock};
-use tokio::sync::mpsc::error::SendError;
+use std::thread::sleep;
+use std::time::Instant;
+use tokio::sync::mpsc::error::{SendError, TrySendError};
 use tokio::sync::mpsc::{channel, Sender};
+use tokio::time::error::Elapsed;
+use tokio::time::{timeout, Timeout};
 
 /// RecordReader is responsible for reading the content of a record from the storage.
 pub(crate) struct RecordReader {
@@ -154,28 +158,30 @@ impl RecordReader {
 
     fn read(tx: Sender<Result<Bytes, ReductError>>, ctx: ReadContext) {
         let mut read_bytes = 0;
-
+        let path = format!(
+            "{}/{}/{}",
+            ctx.bucket_name, ctx.entry_name, ctx.record_timestamp
+        );
         let mut read_all = || {
             while read_bytes < ctx.content_size {
                 let (buf, read) =
                     match read_in_chunks(&ctx.file_ref, ctx.offset, ctx.content_size, read_bytes) {
                         Ok((buf, read)) => (buf, read),
                         Err(e) => {
-                            error!(
-                                "Failed to read record {}/{}/{}: {}",
-                                ctx.bucket_name, ctx.entry_name, ctx.record_timestamp, e
-                            );
-                            tx.blocking_send(Err(e))?;
+                            error!("Failed to read record {}: {}", path, e);
+                            Self::blocking_send_with_timeout(&tx, Err(e))??;
                             break;
                         }
                     };
 
-                tx.blocking_send(Ok(buf.into()))?;
-
+                Self::blocking_send_with_timeout(&tx, Ok(Bytes::from(buf)))??;
                 read_bytes += read as u64;
             }
 
-            Ok::<(), SendError<_>>(())
+            Ok::<Result<(), SendError<_>>, ReductError>(Ok::<
+                (),
+                SendError<Result<Bytes, ReductError>>,
+            >(()))
         };
 
         if let Err(e) = read_all() {
@@ -184,6 +190,33 @@ impl RecordReader {
                 ctx.bucket_name, ctx.entry_name, ctx.record_timestamp, e
             )
         }
+    }
+
+    fn blocking_send_with_timeout(
+        tx: &Sender<Result<Bytes, ReductError>>,
+        mut msg: Result<Bytes, ReductError>,
+    ) -> Result<Result<(), SendError<Result<Bytes, ReductError>>>, ReductError> {
+        let now = Instant::now();
+
+        while now.elapsed() < IO_OPERATION_TIMEOUT {
+            match tx.try_send(msg) {
+                Ok(_) => {
+                    return Ok(Ok(()));
+                }
+                Err(TrySendError::Full(ret)) => {
+                    sleep(std::time::Duration::from_millis(1));
+                    msg = ret;
+                }
+                Err(TrySendError::Closed(ret)) => {
+                    return Ok(Err(SendError { 0: ret }));
+                }
+            }
+        }
+
+        Err(timeout!(
+            "Channel send timeout: {} s",
+            IO_OPERATION_TIMEOUT.as_secs()
+        ))
     }
 }
 

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -21,7 +21,7 @@ use reduct_base::{conflict, not_found, unprocessable_entity};
 
 pub(crate) const MAX_IO_BUFFER_SIZE: usize = 1024 * 512;
 pub(crate) const CHANNEL_BUFFER_SIZE: usize = 16;
-pub(crate) const IO_OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const IO_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Storage is the main entry point for the storage service.
 pub struct Storage {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

If a client crashes or freezes, it may leave a channel open between the API layer and the storage engine. This will cause a block, entry and bucket lock for many operations that require exclusive access to the resource. I've added a timeout for sending data through the channel so that the storage engine drops the reader if the channel is not being used.

Additionally, the internal timeout for IO operation was changed from 30 to 5 seconds. 

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
