### PR TITLE
Pass server information to extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Added
+
+- Pass server information to extensions, [PR-816](https://github.com/reductstore/reductstore/pull/816)
+
 ### Changed
 
 - Add "@" prefix to computed labels, [PR-815](https://github.com/reductstore/reductstore/pull/815)

--- a/reduct_base/src/ext.rs
+++ b/reduct_base/src/ext.rs
@@ -19,6 +19,8 @@ pub use process_status::ProcessStatus;
 pub use ext_settings::{ExtSettings, ExtSettingsBuilder};
 pub type BoxedReadRecord = Box<dyn ReadRecord + Send + Sync>;
 
+pub const EXTENSION_API_VERSION: &str = "0.2";
+
 /// The trait for the IO extension.
 ///
 /// This trait is used to register queries and process records in a pipeline of extensions.

--- a/reduct_base/src/ext/ext_settings.rs
+++ b/reduct_base/src/ext/ext_settings.rs
@@ -3,41 +3,52 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::msg::server_api::ServerInfo;
+
 /// Settings for initializing an extension.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ExtSettings {
     /// The log level for the extension.
     log_level: String,
-}
-
-impl Default for ExtSettings {
-    fn default() -> Self {
-        Self {
-            log_level: "INFO".to_string(),
-        }
-    }
+    server_info: ServerInfo,
 }
 
 /// Builder for `ExtSettings`.
 pub struct ExtSettingsBuilder {
-    settings: ExtSettings,
+    log_level: String,
+    server_info: Option<ServerInfo>,
 }
 
 impl ExtSettingsBuilder {
     /// Creates a new `ExtSettingsBuilder`.
     fn new() -> Self {
         Self {
-            settings: ExtSettings::default(),
+            log_level: "INFO".to_string(),
+            server_info: None,
         }
     }
     /// Sets the log level for the extension.
     pub fn log_level(mut self, log_level: &str) -> Self {
-        self.settings.log_level = log_level.to_string();
+        self.log_level = log_level.to_string();
         self
     }
 
+    /// Sets the server info for the extension.
+    pub fn server_info(mut self, server_info: ServerInfo) -> Self {
+        self.server_info = Some(server_info);
+        self
+    }
+
+    /// Builds the `ExtSettings`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the server info is not set.
     pub fn build(self) -> ExtSettings {
-        self.settings
+        ExtSettings {
+            log_level: self.log_level,
+            server_info: self.server_info.expect("Server info must be set"),
+        }
     }
 }
 
@@ -45,6 +56,11 @@ impl ExtSettings {
     /// Returns the log level for the extension.
     pub fn log_level(&self) -> &str {
         &self.log_level
+    }
+
+    /// Returns the server info for the extension.
+    pub fn server_info(&self) -> &ServerInfo {
+        &self.server_info
     }
 
     /// Creates a new `ExtSettingsBuilder`.
@@ -59,8 +75,15 @@ mod tests {
 
     #[test]
     fn test_ext_settings_builder() {
-        let settings = ExtSettings::builder().log_level("info").build();
+        let settings = ExtSettings::builder()
+            .log_level("INFO")
+            .server_info(ServerInfo {
+                version: "1.0".to_string(),
+                ..ServerInfo::default()
+            })
+            .build();
 
-        assert_eq!(settings.log_level(), "info");
+        assert_eq!(settings.log_level(), "INFO");
+        assert_eq!(settings.server_info().version, "1.0");
     }
 }

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -159,6 +159,11 @@ fn configure_cors(cors_allow_origin: &Vec<String>) -> CorsLayer {
 
 #[cfg(test)]
 mod tests {
+    use crate::asset::asset_manager::create_asset_manager;
+    use crate::auth::token_repository::create_token_repository;
+    use crate::cfg::replication::ReplicationConfig;
+    use crate::ext::ext_repository::create_ext_repository;
+    use crate::replication::create_replication_repo;
     use axum::body::Body;
     use axum::extract::Path;
     use axum_extra::headers::{Authorization, HeaderMap, HeaderMapExt};
@@ -166,15 +171,10 @@ mod tests {
     use reduct_base::ext::ExtSettings;
     use reduct_base::msg::bucket_api::BucketSettings;
     use reduct_base::msg::replication_api::ReplicationSettings;
+    use reduct_base::msg::server_api::ServerInfo;
     use reduct_base::msg::token_api::Permissions;
     use rstest::fixture;
     use std::collections::HashMap;
-
-    use crate::asset::asset_manager::create_asset_manager;
-    use crate::auth::token_repository::create_token_repository;
-    use crate::cfg::replication::ReplicationConfig;
-    use crate::ext::ext_repository::create_ext_repository;
-    use crate::replication::create_replication_repo;
 
     use super::*;
 
@@ -283,8 +283,13 @@ mod tests {
             base_path: "/".to_string(),
             replication_repo: RwLock::new(replication_repo),
             io_settings: IoConfig::default(),
-            ext_repo: create_ext_repository(None, ExtSettings::default())
-                .expect("Failed to create extension repo"),
+            ext_repo: create_ext_repository(
+                None,
+                ExtSettings::builder()
+                    .server_info(ServerInfo::default())
+                    .build(),
+            )
+            .expect("Failed to create extension repo"),
         };
 
         Arc::new(components)

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -283,6 +283,7 @@ mod tests {
     use crate::ext::ext_repository::create_ext_repository;
     use reduct_base::ext::ExtSettings;
     use reduct_base::io::{ReadRecord, RecordMeta};
+    use reduct_base::msg::server_api::ServerInfo;
     use reduct_base::Labels;
     use rstest::*;
     use tempfile::tempdir;
@@ -519,7 +520,13 @@ mod tests {
 
     #[fixture]
     fn ext_repository() -> BoxedManageExtensions {
-        create_ext_repository(Some(tempdir().unwrap().into_path()), ExtSettings::default()).unwrap()
+        create_ext_repository(
+            Some(tempdir().unwrap().into_path()),
+            ExtSettings::builder()
+                .server_info(ServerInfo::default())
+                .build(),
+        )
+        .unwrap()
     }
 
     mod stream_wrapper {

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -90,6 +90,8 @@ impl<EnvGetter: GetEnv> Cfg<EnvGetter> {
             None
         };
 
+        let server_info = storage.info()?;
+
         Ok(Components {
             storage,
             token_repo: tokio::sync::RwLock::new(token_repo),
@@ -98,7 +100,10 @@ impl<EnvGetter: GetEnv> Cfg<EnvGetter> {
             replication_repo: tokio::sync::RwLock::new(replication_engine),
             ext_repo: create_ext_repository(
                 ext_path,
-                ExtSettings::builder().log_level(&self.log_level).build(),
+                ExtSettings::builder()
+                    .log_level(&self.log_level)
+                    .server_info(server_info)
+                    .build(),
             )?,
 
             base_path: self.api_base_path.clone(),

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -335,6 +335,7 @@ pub(super) mod tests {
     use mockall::predicate::eq;
     use prost_wkt_types::Timestamp;
     use reduct_base::io::{ReadChunk, ReadRecord, RecordMeta};
+    use reduct_base::msg::server_api::ServerInfo;
     use serde_json::json;
     use std::fs;
     use tempfile::tempdir;
@@ -342,6 +343,7 @@ pub(super) mod tests {
 
     mod load {
         use super::*;
+        use reduct_base::msg::server_api::ServerInfo;
         #[log_test(rstest)]
         fn test_load_extension(ext_repo: ExtRepository) {
             assert_eq!(ext_repo.extension_map.len(), 1);
@@ -381,7 +383,9 @@ pub(super) mod tests {
 
         #[fixture]
         fn ext_settings() -> ExtSettings {
-            ExtSettings::default()
+            ExtSettings::builder()
+                .server_info(ServerInfo::default())
+                .build()
         }
 
         #[fixture]
@@ -819,7 +823,9 @@ pub(super) mod tests {
     }
 
     fn mocked_ext_repo(name: &str, mock_ext: MockIoExtension) -> ExtRepository {
-        let ext_settings = ExtSettings::default();
+        let ext_settings = ExtSettings::builder()
+            .server_info(ServerInfo::default())
+            .build();
         let mut ext_repo =
             ExtRepository::try_load(&tempdir().unwrap().into_path(), ext_settings).unwrap();
         ext_repo.extension_map.insert(


### PR DESCRIPTION
Closes #811

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The extension engine passes information about the server to extensions during their initialization.

### Related issues

#762 

### Does this PR introduce a breaking change?

No

### Other information:
