### PR TITLE
Rebuild block index if orphan block descriptor find

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
 
       - name: Save docker logs
         if: always()
-        run: docker logs current | zip > /tmp/docker-log.zip
+        run: docker logs reductstore | zip > /tmp/docker-log.zip
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Web Console up to v1.10.1, [PR-828](https://github.com/reductstore/reductstore/pull/828)
 
+### Fixed
+
+- Rebuild block index if orphan block descriptor find, [PR-829](https://github.com/reductstore/reductstore/pull/829)
+
 ## [1.15.1] - 2025-05-15
 
 ### Fixed

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -695,11 +695,11 @@ mod tests {
         }
 
         #[rstest]
-        fn test_recovery_without_index(entry_fix: (Entry, PathBuf)) {
+        fn test_recovery_with_orphan_block(entry_fix: (Entry, PathBuf)) {
             let (entry, path) = entry_fix;
             let mut wal = create_wal(path.clone());
 
-            // Block #1 was appended
+            // Block #1 was appended without index
             wal.append(
                 1,
                 WalEntry::WriteRecord(Record {
@@ -724,7 +724,11 @@ mod tests {
             let block = entry.block_manager.write().unwrap().load_block(1).unwrap();
             let block = block.read().unwrap();
 
-            assert_eq!(block.record_count(), 1);
+            assert_eq!(
+                block.record_count(),
+                2,
+                "should rebuild index and add the block"
+            );
         }
 
         #[fixture]


### PR DESCRIPTION
Closes #827 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix/Feature

### What was changed?

The PR introduces additional checks to see if the index has the same blocks as found on the disk.
If a block is missing from the index, it's rebuilt.

### Related issues

#827 

### Does this PR introduce a breaking change?

No

### Other information:
