### PR TITLE
Fix  $limit operator in extension context

### DIFF
--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -213,6 +213,25 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
+        async fn test_no_http_error() {
+            let error = HttpError::new(ErrorCode::Interrupt, "Test error");
+            let resp = error.into_response();
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(
+                resp.headers().get("content-type").unwrap(),
+                HeaderValue::from_static("application/json")
+            );
+            assert_eq!(
+                resp.headers().get("x-reduct-error").unwrap(),
+                HeaderValue::from_static("Test error")
+            );
+
+            let body: Bytes = to_bytes(resp.into_body(), 1000).await.unwrap();
+            assert_eq!(body, Bytes::from(r#"{"detail": "Test error"}"#))
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_http_json_format() {
             let error = HttpError::new(ErrorCode::BadRequest, "Test \"error\"");
             let resp = error.into_response();

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -26,6 +26,7 @@ use axum::{middleware::from_fn, Router};
 use bucket::create_bucket_api_routes;
 use entry::create_entry_api_routes;
 use hyper::http::HeaderValue;
+use log::warn;
 use middleware::{default_headers, print_statuses};
 pub use reduct_base::error::ErrorCode;
 use reduct_base::error::ReductError as BaseHttpError;
@@ -84,7 +85,14 @@ impl IntoResponse for HttpError {
         let body = format!("{{\"detail\": \"{}\"}}", converted_quotes);
 
         // its often easiest to implement `IntoResponse` by calling other implementations
-        let mut resp = (StatusCode::from_u16(err.status as u16).unwrap(), body).into_response();
+        let http_code = if (err.status as i16) < 0 {
+            warn!("Invalid status code: {}", err.status);
+            StatusCode::INTERNAL_SERVER_ERROR
+        } else {
+            StatusCode::from_u16(err.status as u16).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+        };
+
+        let mut resp = (http_code, body).into_response();
         resp.headers_mut()
             .insert("content-type", "application/json".parse().unwrap());
         resp.headers_mut()

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -228,7 +228,7 @@ impl ManageExtensions for ExtRepository {
                         Err(e) => {
                             if e.status == Interrupt {
                                 query.current_stream = None;
-                                query.commiter.flush().await
+                                None
                             } else {
                                 Some(Err(e))
                             }
@@ -284,8 +284,9 @@ pub(super) mod tests {
 
     use crate::storage::entry::RecordReader;
     use crate::storage::proto::Record;
-    use mockall::mock;
+    use async_stream::stream;
     use mockall::predicate::eq;
+    use mockall::{mock, predicate};
     use prost_wkt_types::Timestamp;
     use reduct_base::io::{ReadChunk, ReadRecord, RecordMeta};
     use reduct_base::msg::server_api::ServerInfo;
@@ -744,6 +745,85 @@ pub(super) mod tests {
                 "and we are done"
             );
         }
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_process_a_record_limit(
+        record_reader: RecordReader,
+        mut mock_ext: MockIoExtension,
+        mut processor: Box<MockProcessor>,
+        mut commiter: Box<MockCommiter>,
+    ) {
+        processor.expect_process_record().return_once(|_| {
+            let stream = stream! {
+                yield Ok(MockRecord::boxed("key", "val"));
+                yield Ok(MockRecord::boxed("key", "val"));
+            };
+            Ok(Box::new(stream) as BoxedRecordStream)
+        });
+
+        commiter.expect_commit_record().return_once(|_| {
+            Some(Ok(
+                Box::new(MockRecord::new("key", "val")) as BoxedReadRecord
+            ))
+        });
+        commiter.expect_flush().return_once(|| None).times(1);
+
+        mock_ext
+            .expect_query()
+            .with(eq("bucket"), eq("entry"), predicate::always())
+            .return_once(|_, _, _| Ok((processor, commiter)));
+
+        let query = QueryEntry {
+            ext: Some(json!({
+                "test1": {},
+                "when": {"$limit": 1},
+            })),
+            ..Default::default()
+        };
+
+        let mocked_ext_repo = mocked_ext_repo("test1", mock_ext);
+
+        mocked_ext_repo
+            .register_query(1, "bucket", "entry", query)
+            .await
+            .unwrap();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(2);
+        tx.send(Ok(record_reader)).await.unwrap();
+        tx.send(Err(no_content!(""))).await.unwrap();
+
+        let query_rx = Arc::new(AsyncRwLock::new(rx));
+
+        assert!(mocked_ext_repo
+            .fetch_and_process_record(1, query_rx.clone())
+            .await
+            .is_none());
+
+        mocked_ext_repo
+            .fetch_and_process_record(1, query_rx.clone())
+            .await
+            .unwrap()
+            .expect("Should return a record");
+
+        assert!(
+            mocked_ext_repo
+                .fetch_and_process_record(1, query_rx.clone())
+                .await
+                .is_none(),
+            "Flush should not return any records"
+        );
+
+        assert_eq!(
+            mocked_ext_repo
+                .fetch_and_process_record(1, query_rx)
+                .await
+                .unwrap()
+                .err()
+                .unwrap(),
+            no_content!("")
+        );
     }
 
     #[fixture]

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -8,7 +8,7 @@ use crate::storage::proto::Record;
 use crate::storage::storage::{CHANNEL_BUFFER_SIZE, IO_OPERATION_TIMEOUT, MAX_IO_BUFFER_SIZE};
 use async_trait::async_trait;
 use bytes::Bytes;
-use log::error;
+use log::{debug, error};
 use reduct_base::error::ReductError;
 use reduct_base::io::{ReadChunk, ReadRecord, RecordMeta};
 use reduct_base::{internal_server_error, timeout};
@@ -167,9 +167,10 @@ impl RecordReader {
         };
 
         if let Err(e) = read_all() {
-            error!(
+            // it's debug level because extensions may stop reading records intentionally
+            debug!(
                 "Failed to send record {}/{}/{}: {}",
-                ctx.bucket_name, ctx.entry_name, ctx.record_timestamp, e
+                ctx.bucket_name, ctx.entry_name, ctx.record_timestamp, e.message
             )
         }
     }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The $limit operator returns `Interupted ` error when the limit is reached. This error wasn't handled properly in the extension repository.

### Related issues

#826 

### Does this PR introduce a breaking change?

No

### Other information:
