### PR TITLE
Filter buckets by read permission in server information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pass server information to extensions, [PR-816](https://github.com/reductstore/reductstore/pull/816)
 - Integrate ReductSelect v0.1.0, [PR-821](https://github.com/reductstore/reductstore/pull/821)
-- Filter buckets by read permission, [PR-849](https://github.com/reductstore/reductstore/pull/849)
+- Filter buckets by read permission in server information, [PR-849](https://github.com/reductstore/reductstore/pull/849)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pass server information to extensions, [PR-816](https://github.com/reductstore/reductstore/pull/816)
 - Integrate ReductSelect v0.1.0, [PR-821](https://github.com/reductstore/reductstore/pull/821)
+- Filter buckets by read permission, [PR-849](https://github.com/reductstore/reductstore/pull/849)
 
 ### Changed
 

--- a/integration_tests/api/bucket_api_test.py
+++ b/integration_tests/api/bucket_api_test.py
@@ -79,7 +79,12 @@ def test__create_bucket_custom(base_url, session, bucket_name):
 
 @requires_env("API_TOKEN")
 def test__get_bucket_with_authenticated_token(
-    base_url, session, bucket_name, token_without_permissions
+    base_url,
+    session,
+    bucket_name,
+    token_without_permissions,
+    token_read_bucket,
+    token_write_bucket,
 ):
     """Needs an authenticated token"""
     session.post(f"{base_url}/b/{bucket_name}")
@@ -90,7 +95,17 @@ def test__get_bucket_with_authenticated_token(
     resp = session.get(
         f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
     )
+    assert resp.status_code == 403
+
+    resp = session.get(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket)
+    )
     assert resp.status_code == 200
+
+    resp = session.get(
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket)
+    )
+    assert resp.status_code == 403
 
 
 def test__get_bucket_stats(base_url, session, bucket_name):

--- a/reductstore/src/api/bucket/create.rs
+++ b/reductstore/src/api/bucket/create.rs
@@ -17,7 +17,7 @@ pub(crate) async fn create_bucket(
     headers: HeaderMap,
     settings: BucketSettingsAxum,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
     components
         .storage
         .create_bucket(&bucket_name, settings.into())?;

--- a/reductstore/src/api/bucket/get.rs
+++ b/reductstore/src/api/bucket/get.rs
@@ -17,7 +17,7 @@ pub(crate) async fn get_bucket(
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<FullBucketInfoAxum, HttpError> {
-    check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
+    check_permissions(&components, &headers, AuthenticatedPolicy {}).await?;
     let bucket_info = components.storage.get_bucket(&bucket_name)?.upgrade()?;
     Ok(bucket_info.info()?.into())
 }

--- a/reductstore/src/api/bucket/head.rs
+++ b/reductstore/src/api/bucket/head.rs
@@ -15,7 +15,7 @@ pub(crate) async fn head_bucket(
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
+    check_permissions(&components, &headers, AuthenticatedPolicy {}).await?;
     components.storage.get_bucket(&bucket_name)?;
     Ok(())
 }

--- a/reductstore/src/api/bucket/remove.rs
+++ b/reductstore/src/api/bucket/remove.rs
@@ -16,7 +16,7 @@ pub(crate) async fn remove_bucket(
     Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
     components.storage.remove_bucket(&bucket_name).await?;
     components
         .token_repo

--- a/reductstore/src/api/bucket/rename.rs
+++ b/reductstore/src/api/bucket/rename.rs
@@ -17,7 +17,7 @@ pub(crate) async fn rename_bucket(
     headers: HeaderMap,
     request: Json<RenameBucket>,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
     components
         .storage
         .rename_bucket(&bucket_name, &request.new_name)

--- a/reductstore/src/api/bucket/update.rs
+++ b/reductstore/src/api/bucket/update.rs
@@ -16,7 +16,7 @@ pub(crate) async fn update_bucket(
     headers: HeaderMap,
     settings: BucketSettingsAxum,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     Ok(components
         .storage

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -44,7 +44,7 @@ pub(crate) async fn read_batched_records(
     let entry_name = path.get("entry_name").unwrap();
     check_permissions(
         &components,
-        headers,
+        &headers,
         ReadAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/read_query.rs
+++ b/reductstore/src/api/entry/read_query.rs
@@ -25,7 +25,7 @@ pub(crate) async fn read_query(
 
     check_permissions(
         &components,
-        headers,
+        &headers,
         ReadAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/read_query_post.rs
+++ b/reductstore/src/api/entry/read_query_post.rs
@@ -24,7 +24,7 @@ pub(crate) async fn read_query_json(
 
     check_permissions(
         &components,
-        headers,
+        &headers,
         ReadAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -42,7 +42,7 @@ pub(crate) async fn read_record(
     let entry_name = path.get("entry_name").unwrap();
     check_permissions(
         &components,
-        headers,
+        &headers,
         ReadAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/remove_batched.rs
+++ b/reductstore/src/api/entry/remove_batched.rs
@@ -25,7 +25,7 @@ pub(crate) async fn remove_batched_records(
     let bucket_name = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        &headers.clone(),
+        &headers,
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/remove_batched.rs
+++ b/reductstore/src/api/entry/remove_batched.rs
@@ -25,7 +25,7 @@ pub(crate) async fn remove_batched_records(
     let bucket_name = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        headers.clone(),
+        &headers.clone(),
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/remove_entry.rs
+++ b/reductstore/src/api/entry/remove_entry.rs
@@ -22,7 +22,7 @@ pub(crate) async fn remove_entry(
 
     check_permissions(
         &components,
-        headers,
+        &headers,
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/remove_query.rs
+++ b/reductstore/src/api/entry/remove_query.rs
@@ -27,7 +27,7 @@ pub(crate) async fn remove_query(
 
     check_permissions(
         &components,
-        headers,
+        &headers,
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/remove_query_post.rs
+++ b/reductstore/src/api/entry/remove_query_post.rs
@@ -32,7 +32,7 @@ pub(crate) async fn remove_query_json(
 
     check_permissions(
         &components,
-        headers,
+        &headers,
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/remove_single.rs
+++ b/reductstore/src/api/entry/remove_single.rs
@@ -22,7 +22,7 @@ pub(crate) async fn remove_record(
     let bucket = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        &headers.clone(),
+        &headers,
         WriteAccessPolicy {
             bucket: bucket.clone(),
         },

--- a/reductstore/src/api/entry/remove_single.rs
+++ b/reductstore/src/api/entry/remove_single.rs
@@ -22,7 +22,7 @@ pub(crate) async fn remove_record(
     let bucket = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        headers.clone(),
+        &headers.clone(),
         WriteAccessPolicy {
             bucket: bucket.clone(),
         },

--- a/reductstore/src/api/entry/rename_entry.rs
+++ b/reductstore/src/api/entry/rename_entry.rs
@@ -23,7 +23,7 @@ pub(crate) async fn rename_entry(
 
     check_permissions(
         &components,
-        headers,
+        &headers,
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -29,7 +29,7 @@ pub(crate) async fn update_batched_records(
     let bucket_name = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        &headers.clone(),
+        &headers,
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -29,7 +29,7 @@ pub(crate) async fn update_batched_records(
     let bucket_name = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        headers.clone(),
+        &headers.clone(),
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/update_single.rs
+++ b/reductstore/src/api/entry/update_single.rs
@@ -28,7 +28,7 @@ pub(crate) async fn update_record(
     let bucket = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        &headers.clone(),
+        &headers,
         WriteAccessPolicy {
             bucket: bucket.clone(),
         },

--- a/reductstore/src/api/entry/update_single.rs
+++ b/reductstore/src/api/entry/update_single.rs
@@ -28,7 +28,7 @@ pub(crate) async fn update_record(
     let bucket = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        headers.clone(),
+        &headers.clone(),
         WriteAccessPolicy {
             bucket: bucket.clone(),
         },

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -45,7 +45,7 @@ pub(crate) async fn write_batched_records(
     let bucket_name = path.get("bucket_name").unwrap().clone();
     check_permissions(
         &components,
-        headers.clone(),
+        &headers.clone(),
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -45,7 +45,7 @@ pub(crate) async fn write_batched_records(
     let bucket_name = path.get("bucket_name").unwrap().clone();
     check_permissions(
         &components,
-        &headers.clone(),
+        &headers,
         WriteAccessPolicy {
             bucket: bucket_name.clone(),
         },

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -31,7 +31,7 @@ pub(crate) async fn write_record(
     let bucket = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
-        headers.clone(),
+        &headers.clone(),
         WriteAccessPolicy {
             bucket: bucket.clone(),
         },

--- a/reductstore/src/api/middleware.rs
+++ b/reductstore/src/api/middleware.rs
@@ -63,7 +63,7 @@ pub async fn print_statuses(
 
 pub(crate) async fn check_permissions<P>(
     components: &Components,
-    headers: HeaderMap,
+    headers: &HeaderMap,
     policy: P,
 ) -> Result<(), HttpError>
 where

--- a/reductstore/src/api/replication/create.rs
+++ b/reductstore/src/api/replication/create.rs
@@ -16,7 +16,7 @@ pub(crate) async fn create_replication(
     headers: HeaderMap,
     settings: ReplicationSettingsAxum,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     components
         .replication_repo

--- a/reductstore/src/api/replication/get.rs
+++ b/reductstore/src/api/replication/get.rs
@@ -15,7 +15,7 @@ pub(crate) async fn get_replication(
     Path(replication_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<ReplicationFullInfoAxum, HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     let info = components
         .replication_repo

--- a/reductstore/src/api/replication/list.rs
+++ b/reductstore/src/api/replication/list.rs
@@ -16,7 +16,7 @@ pub(crate) async fn list_replications(
     State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<ReplicationListAxum, HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     let mut list = ReplicationListAxum::default();
 

--- a/reductstore/src/api/replication/remove.rs
+++ b/reductstore/src/api/replication/remove.rs
@@ -15,7 +15,7 @@ pub(crate) async fn remove_replication(
     Path(replication_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     components
         .replication_repo

--- a/reductstore/src/api/replication/update.rs
+++ b/reductstore/src/api/replication/update.rs
@@ -16,7 +16,7 @@ pub(crate) async fn update_replication(
     headers: HeaderMap,
     settings: ReplicationSettingsAxum,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     components
         .replication_repo

--- a/reductstore/src/api/server/info.rs
+++ b/reductstore/src/api/server/info.rs
@@ -15,7 +15,7 @@ pub(crate) async fn info(
     State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<ServerInfoAxum, HttpError> {
-    check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
+    check_permissions(&components, &headers, AuthenticatedPolicy {}).await?;
 
     Ok(components.storage.info()?.into())
 }

--- a/reductstore/src/api/server/list.rs
+++ b/reductstore/src/api/server/list.rs
@@ -1,12 +1,13 @@
-// Copyright 2023-2024 ReductSoftware UG
+// Copyright 2023-2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
 use crate::api::middleware::check_permissions;
 use crate::api::server::BucketInfoListAxum;
 use crate::api::{Components, HttpError};
-use crate::auth::policy::AuthenticatedPolicy;
+use crate::auth::policy::{AuthenticatedPolicy, ReadAccessPolicy};
 use axum::extract::State;
 use axum_extra::headers::HeaderMap;
+use reduct_base::msg::server_api::BucketInfoList;
 use std::sync::Arc;
 
 // GET /list
@@ -14,16 +15,38 @@ pub(crate) async fn list(
     State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<BucketInfoListAxum, HttpError> {
-    check_permissions(&components, headers, AuthenticatedPolicy {}).await?;
+    check_permissions(&components, &headers, AuthenticatedPolicy {}).await?;
 
-    let list = components.storage.get_bucket_list()?;
-    Ok(list.into())
+    let mut filtered_by_read_permission = vec![];
+
+    for bucket in components.storage.get_bucket_list()?.buckets {
+        // Filter out buckets that are not visible to the user
+        if check_permissions(
+            &components,
+            &headers,
+            ReadAccessPolicy {
+                bucket: bucket.name.clone(),
+            },
+        )
+        .await
+        .is_ok()
+        {
+            filtered_by_read_permission.push(bucket);
+        }
+    }
+
+    Ok(BucketInfoList {
+        buckets: filtered_by_read_permission,
+    }
+    .into())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::api::tests::{components, headers};
+    use axum::http::HeaderValue;
+    use reduct_base::msg::token_api::Permissions;
     use rstest::rstest;
 
     #[rstest]
@@ -31,5 +54,31 @@ mod tests {
     async fn test_list(#[future] components: Arc<Components>, headers: HeaderMap) {
         let list = list(State(components.await), headers).await.unwrap();
         assert_eq!(list.0.buckets.len(), 2);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_filtered_list(#[future] components: Arc<Components>, mut headers: HeaderMap) {
+        let components = components.await;
+        let token = components
+            .token_repo
+            .write()
+            .await
+            .generate_token(
+                "with-one-bucket",
+                Permissions {
+                    read: vec!["bucket-1".to_string()],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {}", token.value)).unwrap(),
+        );
+        let list = list(State(components), headers).await.unwrap();
+        assert_eq!(list.0.buckets.len(), 1);
+        assert_eq!(list.0.buckets[0].name, "bucket-1");
     }
 }

--- a/reductstore/src/api/token/create.rs
+++ b/reductstore/src/api/token/create.rs
@@ -16,7 +16,7 @@ pub(crate) async fn create_token(
     headers: HeaderMap,
     permissions: PermissionsAxum,
 ) -> Result<TokenCreateResponseAxum, HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     Ok(TokenCreateResponseAxum(
         components

--- a/reductstore/src/api/token/get.rs
+++ b/reductstore/src/api/token/get.rs
@@ -15,7 +15,7 @@ pub(crate) async fn get_token(
     Path(token_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<TokenAxum, HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     let mut token = components
         .token_repo

--- a/reductstore/src/api/token/list.rs
+++ b/reductstore/src/api/token/list.rs
@@ -15,7 +15,7 @@ pub(crate) async fn list_tokens(
     State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<TokenListAxum, HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
     let token_repo = components.token_repo.read().await;
 
     let mut list = TokenListAxum::default();

--- a/reductstore/src/api/token/me.rs
+++ b/reductstore/src/api/token/me.rs
@@ -15,7 +15,7 @@ pub(crate) async fn me(
     State(components): State<Arc<Components>>,
     headers: HeaderMap,
 ) -> Result<TokenAxum, HttpError> {
-    check_permissions(&components, headers.clone(), AuthenticatedPolicy {}).await?;
+    check_permissions(&components, &headers.clone(), AuthenticatedPolicy {}).await?;
     let header = match headers.get("Authorization") {
         Some(header) => header.to_str().ok(),
         None => None,

--- a/reductstore/src/api/token/remove.rs
+++ b/reductstore/src/api/token/remove.rs
@@ -14,7 +14,7 @@ pub(crate) async fn remove_token(
     Path(token_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
-    check_permissions(&components, headers, FullAccessPolicy {}).await?;
+    check_permissions(&components, &headers, FullAccessPolicy {}).await?;
 
     Ok(components
         .token_repo


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR introduces a filter on the bucket list in the GET /list endpoint. It checks the read permissions for the client and only returns buckets that the client is allowed to access.


### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
