### PR TITLE
Support for duration literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integrate ReductSelect v0.1.0, [PR-821](https://github.com/reductstore/reductstore/pull/821)
 - Integrate ReductRos v0.1.0, [PR-856](https://github.com/reductstore/reductstore/pull/856)
 - Filter buckets by read permission in server information, [PR-849](https://github.com/reductstore/reductstore/pull/849)
+- Support for duration literals, [PR-864](https://github.com/reductstore/reductstore/pull/864)
 
 ### Changed
 

--- a/reductstore/src/storage/query/condition/operators/misc/cast.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/cast.rs
@@ -14,7 +14,7 @@ pub(crate) struct Cast {
 impl Node for Cast {
     fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         let op = self.operands[0].apply(context)?;
-        let type_name = self.operands[1].apply(context)?.as_string()?;
+        let type_name = self.operands[1].apply(context)?.to_string();
         op.cast(type_name.as_str())
     }
 

--- a/reductstore/src/storage/query/condition/operators/misc/exists.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/exists.rs
@@ -15,7 +15,7 @@ impl Node for Exists {
     fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
         for operand in &mut self.operands {
             let value = operand.apply(context)?;
-            if !context.labels.contains_key(value.as_string()?.as_str()) {
+            if !context.labels.contains_key(value.to_string().as_str()) {
                 return Ok(Value::Bool(false));
             }
         }

--- a/reductstore/src/storage/query/condition/operators/misc/ref.rs
+++ b/reductstore/src/storage/query/condition/operators/misc/ref.rs
@@ -13,7 +13,7 @@ pub(crate) struct Ref {
 
 impl Node for Ref {
     fn apply(&mut self, context: &Context) -> Result<Value, ReductError> {
-        let label = self.operands[0].apply(context)?.as_string()?;
+        let label = self.operands[0].apply(context)?.to_string();
         context.labels.get(label.as_str()).map_or_else(
             || Err(not_found!("Label '{:?}' not found", label)),
             |v| Ok(Value::parse(v)),

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -250,7 +250,7 @@ mod tests {
     #[rstest]
     fn test_parse_duration(parser: Parser, context: Context) {
         let json = json!({
-            "$eq": ["1h", 3600]
+            "$eq": ["1h", 3600_000_000u64]
         });
         let mut node = parser.parse(&json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());

--- a/reductstore/src/storage/query/condition/value/arithmetic/abs.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/abs.rs
@@ -19,7 +19,7 @@ impl Abs for Value {
         match result {
             Value::Bool(s) => result = Value::Int(s as i64),
             Value::Int(s) => result = Value::Int(s.abs()),
-            Value::Float(s) => result = Value::Float(s.abs()),
+            Value::Float(s) | Value::Duration(s) => result = Value::Float(s.abs()),
             Value::String(_) => {
                 return Err(unprocessable_entity!(
                     "Cannot calculate absolute value of a string"
@@ -43,6 +43,7 @@ mod tests {
     #[case(Value::Float(-1.0), Value::Float(1.0))]
     #[case(Value::Float(0.0), Value::Float(0.0))]
     #[case(Value::Float(1.0), Value::Float(1.0))]
+    #[case(Value::Duration(1.0), Value::Duration(1.0))]
     fn test_abs(#[case] value: Value, #[case] expected: Value) {
         let result = value.abs().unwrap();
         assert_eq!(result, expected);

--- a/reductstore/src/storage/query/condition/value/arithmetic/abs.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/abs.rs
@@ -18,8 +18,8 @@ impl Abs for Value {
         let mut result = self;
         match result {
             Value::Bool(s) => result = Value::Int(s as i64),
-            Value::Int(s) => result = Value::Int(s.abs()),
-            Value::Float(s) | Value::Duration(s) => result = Value::Float(s.abs()),
+            Value::Int(s) | Value::Duration(s) => result = Value::Int(s.abs()),
+            Value::Float(s) => result = Value::Float(s.abs()),
             Value::String(_) => {
                 return Err(unprocessable_entity!(
                     "Cannot calculate absolute value of a string"
@@ -43,7 +43,7 @@ mod tests {
     #[case(Value::Float(-1.0), Value::Float(1.0))]
     #[case(Value::Float(0.0), Value::Float(0.0))]
     #[case(Value::Float(1.0), Value::Float(1.0))]
-    #[case(Value::Duration(1.0), Value::Duration(1.0))]
+    #[case(Value::Duration(-1), Value::Duration(1))]
     fn test_abs(#[case] value: Value, #[case] expected: Value) {
         let result = value.abs().unwrap();
         assert_eq!(result, expected);

--- a/reductstore/src/storage/query/condition/value/arithmetic/add.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/add.rs
@@ -29,7 +29,7 @@ impl Add for Value {
             Value::Bool(s) => match other {
                 Value::Bool(v) => result = Value::Int(s as i64 + v as i64),
                 Value::Int(v) => result = Value::Int(s as i64 + v),
-                Value::Float(v) => result = Value::Float(s as i8 as f64 + v),
+                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as i8 as f64 + v),
                 Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot add boolean to string"));
                 }
@@ -38,17 +38,20 @@ impl Add for Value {
             Value::Int(s) => match other {
                 Value::Bool(v) => result = Value::Int(s + v as i64),
                 Value::Int(v) => result = Value::Int(s + v),
-                Value::Float(v) => result = Value::Float(s as f64 + v),
+                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as f64 + v),
                 Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot add integer to string"));
                 }
             },
 
-            Value::Float(s) => match other {
+            Value::Float(s) | Value::Duration(s) => match other {
                 Value::Bool(v) => result = Value::Float(s + v as i8 as f64),
                 Value::Int(v) => result = Value::Float(s + v as f64),
-                Value::Float(v) => result = Value::Float(s + v),
+                Value::Float(v) | Value::Duration(v) => result = Value::Float(s + v),
                 Value::String(_) => {
+                    if let Value::Duration(_) = result {
+                        return Err(unprocessable_entity!("Cannot add duration to string"));
+                    }
                     return Err(unprocessable_entity!("Cannot add float to string"));
                 }
             },
@@ -65,6 +68,9 @@ impl Add for Value {
                     return Err(unprocessable_entity!("Cannot add string to float"));
                 }
                 Value::String(v) => result = Value::String(format!("{}{}", s, v)),
+                Value::Duration(_) => {
+                    return Err(unprocessable_entity!("Cannot add string to duration"));
+                }
             },
         }
 
@@ -80,6 +86,7 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(false), Value::Int(1))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(3))]
     #[case(Value::Bool(true), Value::Float(2.0), Value::Float(3.0))]
+    #[case(Value::Bool(true), Value::Duration(2.0), Value::Duration(3.0))]
     #[case(Value::Int(2), Value::Bool(true), Value::Int(3))]
     #[case(Value::Int(2), Value::Int(3), Value::Int(5))]
     #[case(Value::Int(2), Value::Float(3.0), Value::Float(5.0))]
@@ -95,9 +102,11 @@ mod tests {
     #[case(Value::Bool(true), Value::String("world".to_string()), unprocessable_entity!("Cannot add boolean to string"))]
     #[case(Value::Int(2), Value::String("world".to_string()), unprocessable_entity!("Cannot add integer to string"))]
     #[case(Value::Float(2.0), Value::String("world".to_string()), unprocessable_entity!("Cannot add float to string"))]
+    #[case(Value::Duration(2.0), Value::String("world".to_string()), unprocessable_entity!("Cannot add duration to string"))]
     #[case(Value::String("hello".to_string()), Value::Bool(true), unprocessable_entity!("Cannot add string to boolean"))]
     #[case(Value::String("hello".to_string()), Value::Int(2), unprocessable_entity!("Cannot add string to integer"))]
     #[case(Value::String("hello".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot add string to float"))]
+    #[case(Value::String("hello".to_string()), Value::Duration(2.0), unprocessable_entity!("Cannot add string to duration"))]
     fn test_add_err(#[case] a: Value, #[case] b: Value, #[case] expected: ReductError) {
         assert_eq!(a.add(b), Err(expected));
     }

--- a/reductstore/src/storage/query/condition/value/arithmetic/div.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/div.rs
@@ -52,12 +52,15 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(true), Value::Float(1.0))]
     #[case(Value::Bool(true), Value::Int(2), Value::Float(0.5))]
     #[case(Value::Bool(true), Value::Float(3.0), Value::Float(1.0 / 3.0))]
+    #[case(Value::Bool(true), Value::Duration(4.0), Value::Float(0.25))]
     #[case(Value::Int(4), Value::Bool(true), Value::Float(4.0))]
     #[case(Value::Int(5), Value::Int(2), Value::Float(2.5))]
     #[case(Value::Int(6), Value::Float(3.0), Value::Float(2.0))]
+    #[case(Value::Int(7), Value::Duration(2.0), Value::Float(3.5))]
     #[case(Value::Float(7.0), Value::Bool(true), Value::Float(7.0))]
     #[case(Value::Float(8.0), Value::Int(2), Value::Float(4.0))]
     #[case(Value::Float(9.0), Value::Float(3.0), Value::Float(3.0))]
+    #[case(Value::Float(10.0), Value::Duration(2.0), Value::Float(5.0))]
     fn divide_ok(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.divide(other).unwrap();
         assert_eq!(result, expected);
@@ -67,6 +70,7 @@ mod tests {
     #[case(Value::Bool(true), Value::String("xxx".to_string()))]
     #[case(Value::Int(1), Value::String("xxx".to_string()))]
     #[case(Value::Float(2.0), Value::String("xxx".to_string()))]
+    #[case(Value::Duration(3.0), Value::String("xxx".to_string()))]
     fn divide_by_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide(other);
         assert_eq!(
@@ -80,6 +84,7 @@ mod tests {
     #[case(Value::String("xxx".to_string()), Value::Int(1))]
     #[case(Value::String("xxx".to_string()), Value::Float(2.0))]
     #[case(Value::String("xxx".to_string()), Value::String("xxx".to_string()))]
+    #[case(Value::String("xxx".to_string()), Value::Duration(3.0))]
     fn divide_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide(other);
         assert_eq!(result, Err(unprocessable_entity!("Cannot divide string")));

--- a/reductstore/src/storage/query/condition/value/arithmetic/div.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/div.rs
@@ -52,15 +52,15 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(true), Value::Float(1.0))]
     #[case(Value::Bool(true), Value::Int(2), Value::Float(0.5))]
     #[case(Value::Bool(true), Value::Float(3.0), Value::Float(1.0 / 3.0))]
-    #[case(Value::Bool(true), Value::Duration(4.0), Value::Float(0.25))]
+    #[case(Value::Bool(true), Value::Duration(4), Value::Float(0.25))]
     #[case(Value::Int(4), Value::Bool(true), Value::Float(4.0))]
     #[case(Value::Int(5), Value::Int(2), Value::Float(2.5))]
     #[case(Value::Int(6), Value::Float(3.0), Value::Float(2.0))]
-    #[case(Value::Int(7), Value::Duration(2.0), Value::Float(3.5))]
+    #[case(Value::Int(7), Value::Duration(2), Value::Float(3.5))]
     #[case(Value::Float(7.0), Value::Bool(true), Value::Float(7.0))]
     #[case(Value::Float(8.0), Value::Int(2), Value::Float(4.0))]
     #[case(Value::Float(9.0), Value::Float(3.0), Value::Float(3.0))]
-    #[case(Value::Float(10.0), Value::Duration(2.0), Value::Float(5.0))]
+    #[case(Value::Float(10.0), Value::Duration(2), Value::Float(5.0))]
     fn divide_ok(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.divide(other).unwrap();
         assert_eq!(result, expected);
@@ -70,7 +70,7 @@ mod tests {
     #[case(Value::Bool(true), Value::String("xxx".to_string()))]
     #[case(Value::Int(1), Value::String("xxx".to_string()))]
     #[case(Value::Float(2.0), Value::String("xxx".to_string()))]
-    #[case(Value::Duration(3.0), Value::String("xxx".to_string()))]
+    #[case( Value::Duration(3), Value::String("xxx".to_string()))]
     fn divide_by_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide(other);
         assert_eq!(
@@ -84,7 +84,7 @@ mod tests {
     #[case(Value::String("xxx".to_string()), Value::Int(1))]
     #[case(Value::String("xxx".to_string()), Value::Float(2.0))]
     #[case(Value::String("xxx".to_string()), Value::String("xxx".to_string()))]
-    #[case(Value::String("xxx".to_string()), Value::Duration(3.0))]
+    #[case(Value::String("xxx".to_string()),  Value::Duration(3))]
     fn divide_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide(other);
         assert_eq!(result, Err(unprocessable_entity!("Cannot divide string")));

--- a/reductstore/src/storage/query/condition/value/arithmetic/div_num.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/div_num.rs
@@ -52,15 +52,15 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(true), Value::Int(1))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(0))]
     #[case(Value::Bool(true), Value::Float(3.0), Value::Int(0))]
-    #[case(Value::Bool(true), Value::Duration(4.0), Value::Int(0))]
+    #[case(Value::Bool(true), Value::Duration(4), Value::Int(0))]
     #[case(Value::Int(4), Value::Bool(true), Value::Int(4))]
     #[case(Value::Int(5), Value::Int(2), Value::Int(2))]
     #[case(Value::Int(6), Value::Float(3.0), Value::Int(2))]
-    #[case(Value::Int(7), Value::Duration(2.0), Value::Int(3))]
+    #[case(Value::Int(7), Value::Duration(2), Value::Int(3))]
     #[case(Value::Float(7.0), Value::Bool(true), Value::Int(7))]
     #[case(Value::Float(8.0), Value::Int(2), Value::Int(4))]
     #[case(Value::Float(9.0), Value::Float(3.0), Value::Int(3))]
-    #[case(Value::Float(10.0), Value::Duration(2.0), Value::Int(5))]
+    #[case(Value::Float(10.0), Value::Duration(2), Value::Int(5))]
     fn divide_ok(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.divide_num(other).unwrap();
         assert_eq!(result, expected);
@@ -70,7 +70,7 @@ mod tests {
     #[case(Value::Bool(true), Value::String("xxx".to_string()))]
     #[case(Value::Int(1), Value::String("xxx".to_string()))]
     #[case(Value::Float(2.0), Value::String("xxx".to_string()))]
-    #[case(Value::Duration(3.0), Value::String("xxx".to_string()))]
+    #[case( Value::Duration(3), Value::String("xxx".to_string()))]
     fn divide_by_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide_num(other);
         assert_eq!(
@@ -84,7 +84,7 @@ mod tests {
     #[case(Value::String("xxx".to_string()), Value::Int(1))]
     #[case(Value::String("xxx".to_string()), Value::Float(2.0))]
     #[case(Value::String("xxx".to_string()), Value::String("xxx".to_string()))]
-    #[case(Value::String("xxx".to_string()), Value::Duration(3.0))]
+    #[case(Value::String("xxx".to_string()),  Value::Duration(3))]
     fn divide_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide_num(other);
         assert_eq!(result, Err(unprocessable_entity!("Cannot divide string")));
@@ -93,7 +93,7 @@ mod tests {
     #[rstest]
     #[case(Value::Int(1), Value::Int(0))]
     #[case(Value::Float(1.0), Value::Float(0.0))]
-    #[case(Value::Duration(1.0), Value::Duration(0.0))]
+    #[case(Value::Duration(1), Value::Duration(0))]
     fn divide_by_zero(#[case] value: Value, #[case] other: Value) {
         let result = value.divide_num(other);
         assert_eq!(result, Err(unprocessable_entity!("Cannot divide by zero")));

--- a/reductstore/src/storage/query/condition/value/arithmetic/div_num.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/div_num.rs
@@ -52,12 +52,15 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(true), Value::Int(1))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(0))]
     #[case(Value::Bool(true), Value::Float(3.0), Value::Int(0))]
+    #[case(Value::Bool(true), Value::Duration(4.0), Value::Int(0))]
     #[case(Value::Int(4), Value::Bool(true), Value::Int(4))]
     #[case(Value::Int(5), Value::Int(2), Value::Int(2))]
     #[case(Value::Int(6), Value::Float(3.0), Value::Int(2))]
+    #[case(Value::Int(7), Value::Duration(2.0), Value::Int(3))]
     #[case(Value::Float(7.0), Value::Bool(true), Value::Int(7))]
     #[case(Value::Float(8.0), Value::Int(2), Value::Int(4))]
     #[case(Value::Float(9.0), Value::Float(3.0), Value::Int(3))]
+    #[case(Value::Float(10.0), Value::Duration(2.0), Value::Int(5))]
     fn divide_ok(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.divide_num(other).unwrap();
         assert_eq!(result, expected);
@@ -67,6 +70,7 @@ mod tests {
     #[case(Value::Bool(true), Value::String("xxx".to_string()))]
     #[case(Value::Int(1), Value::String("xxx".to_string()))]
     #[case(Value::Float(2.0), Value::String("xxx".to_string()))]
+    #[case(Value::Duration(3.0), Value::String("xxx".to_string()))]
     fn divide_by_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide_num(other);
         assert_eq!(
@@ -80,6 +84,7 @@ mod tests {
     #[case(Value::String("xxx".to_string()), Value::Int(1))]
     #[case(Value::String("xxx".to_string()), Value::Float(2.0))]
     #[case(Value::String("xxx".to_string()), Value::String("xxx".to_string()))]
+    #[case(Value::String("xxx".to_string()), Value::Duration(3.0))]
     fn divide_string(#[case] value: Value, #[case] other: Value) {
         let result = value.divide_num(other);
         assert_eq!(result, Err(unprocessable_entity!("Cannot divide string")));
@@ -88,6 +93,7 @@ mod tests {
     #[rstest]
     #[case(Value::Int(1), Value::Int(0))]
     #[case(Value::Float(1.0), Value::Float(0.0))]
+    #[case(Value::Duration(1.0), Value::Duration(0.0))]
     fn divide_by_zero(#[case] value: Value, #[case] other: Value) {
         let result = value.divide_num(other);
         assert_eq!(result, Err(unprocessable_entity!("Cannot divide by zero")));

--- a/reductstore/src/storage/query/condition/value/arithmetic/mult.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/mult.rs
@@ -28,31 +28,30 @@ impl Mult for Value {
         match result {
             Value::Bool(s) => match other {
                 Value::Bool(v) => result = Value::Int(s as i64 * v as i64),
-                Value::Int(v) => result = Value::Int(s as i64 * v),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as i8 as f64 * v),
+                Value::Int(v) | Value::Duration(v) => result = Value::Int(s as i64 * v),
+                Value::Float(v) => result = Value::Float(s as i8 as f64 * v),
                 Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot multiply boolean by string"));
                 }
             },
 
-            Value::Int(s) => match other {
+            Value::Int(s) | Value::Duration(s) => match other {
                 Value::Bool(v) => result = Value::Int(s * v as i64),
-                Value::Int(v) => result = Value::Int(s * v),
+                Value::Int(v) | Value::Duration(v) => result = Value::Int(s * v),
                 Value::Float(v) => result = Value::Float(s as f64 * v),
-                Value::String(_) => {
-                    return Err(unprocessable_entity!("Cannot multiply integer by string"));
-                }
-                Value::Duration(v) => result = Value::Duration(s as f64 * v),
-            },
-
-            Value::Float(s) | Value::Duration(s) => match other {
-                Value::Bool(v) => result = Value::Float(s * v as i8 as f64),
-                Value::Int(v) => result = Value::Float(s * v as f64),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s * v),
                 Value::String(_) => {
                     if let Value::Duration(_) = result {
                         return Err(unprocessable_entity!("Cannot multiply duration by string"));
                     }
+                    return Err(unprocessable_entity!("Cannot multiply integer by string"));
+                }
+            },
+
+            Value::Float(s) => match other {
+                Value::Bool(v) => result = Value::Float(s * v as i8 as f64),
+                Value::Int(v) | Value::Duration(v) => result = Value::Float(s * v as f64),
+                Value::Float(v) => result = Value::Float(s * v),
+                Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot multiply float by string"));
                 }
             },
@@ -91,15 +90,15 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(false), Value::Int(0))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(2))]
     #[case(Value::Bool(true), Value::Float(2.0), Value::Float(2.0))]
-    #[case(Value::Bool(true), Value::Duration(2.0), Value::Duration(2.0))]
+    #[case(Value::Bool(true), Value::Duration(2), Value::Duration(2))]
     #[case(Value::Int(2), Value::Bool(true), Value::Int(2))]
     #[case(Value::Int(2), Value::Int(2), Value::Int(4))]
     #[case(Value::Int(2), Value::Float(2.0), Value::Float(4.0))]
-    #[case(Value::Int(2), Value::Duration(2.0), Value::Duration(4.0))]
+    #[case(Value::Int(2), Value::Duration(2), Value::Duration(4))]
     #[case(Value::Float(2.0), Value::Bool(true), Value::Float(2.0))]
     #[case(Value::Float(2.0), Value::Int(2), Value::Float(4.0))]
     #[case(Value::Float(2.0), Value::Float(2.0), Value::Float(4.0))]
-    #[case(Value::Float(2.0), Value::Duration(2.0), Value::Duration(4.0))]
+    #[case(Value::Float(2.0), Value::Duration(2), Value::Duration(4))]
     fn multiply(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.multiply(other).unwrap();
         assert_eq!(result, expected);
@@ -109,12 +108,12 @@ mod tests {
     #[case(Value::Bool(true), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply boolean by string"))]
     #[case(Value::Int(2), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply integer by string"))]
     #[case(Value::Float(2.0), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply float by string"))]
-    #[case(Value::Duration(2.0), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply duration by string"))]
+    #[case(Value::Duration(2), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply duration by string"))]
     #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot multiply string by boolean"))]
     #[case(Value::String("string".to_string()), Value::Int(2), unprocessable_entity!("Cannot multiply string by integer"))]
     #[case(Value::String("string".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot multiply string by float"))]
     #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot multiply string by string"))]
-    #[case(Value::String("string".to_string()), Value::Duration(2.0), unprocessable_entity!("Cannot multiply string by duration"))]
+    #[case(Value::String("string".to_string()), Value::Duration(2), unprocessable_entity!("Cannot multiply string by duration"))]
     fn multiply_error(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
         let result = value.multiply(other);
         assert_eq!(result, Err(expected));

--- a/reductstore/src/storage/query/condition/value/arithmetic/rem.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/rem.rs
@@ -28,30 +28,30 @@ impl Rem for Value {
         match result {
             Value::Bool(s) => match other {
                 Value::Bool(v) => result = Value::Int(s as i64 % v as i64),
-                Value::Int(v) => result = Value::Int(s as i64 % v),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as i8 as f64 % v),
+                Value::Int(v) | Value::Duration(v) => result = Value::Int(s as i64 % v),
+                Value::Float(v) => result = Value::Float(s as i8 as f64 % v),
                 Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot divide boolean by string"));
                 }
             },
 
-            Value::Int(s) => match other {
+            Value::Int(s) | Value::Duration(s) => match other {
                 Value::Bool(v) => result = Value::Int(s % v as i64),
-                Value::Int(v) => result = Value::Int(s % v),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as f64 % v),
-                Value::String(_) => {
-                    return Err(unprocessable_entity!("Cannot divide integer by string"));
-                }
-            },
-
-            Value::Float(s) | Value::Duration(s) => match other {
-                Value::Bool(v) => result = Value::Float(s % v as i8 as f64),
-                Value::Int(v) => result = Value::Float(s % v as f64),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s % v),
+                Value::Int(v) | Value::Duration(v) => result = Value::Int(s % v),
+                Value::Float(v) => result = Value::Float(s as f64 % v),
                 Value::String(_) => {
                     if let Value::Duration(_) = result {
                         return Err(unprocessable_entity!("Cannot divide duration by string"));
                     }
+                    return Err(unprocessable_entity!("Cannot divide integer by string"));
+                }
+            },
+
+            Value::Float(s) => match other {
+                Value::Bool(v) => result = Value::Float(s % v as i8 as f64),
+                Value::Int(v) | Value::Duration(v) => result = Value::Float(s % v as f64),
+                Value::Float(v) => result = Value::Float(s % v),
+                Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot divide float by string"));
                 }
             },
@@ -81,11 +81,11 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(true), Value::Int(0))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(1))]
     #[case(Value::Bool(true), Value::Float(3.0), Value::Float(1.0))]
-    #[case(Value::Bool(true), Value::Duration(4.0), Value::Float(1.0))]
+    #[case(Value::Bool(true), Value::Duration(4), Value::Float(1.0))]
     #[case(Value::Int(4), Value::Bool(true), Value::Int(0))]
     #[case(Value::Int(5), Value::Int(2), Value::Int(1))]
     #[case(Value::Int(6), Value::Float(3.5), Value::Float(2.5))]
-    #[case(Value::Int(7), Value::Duration(2.0), Value::Float(1.0))]
+    #[case(Value::Int(7), Value::Duration(2), Value::Float(1.0))]
     #[case(Value::Float(7.0), Value::Bool(true), Value::Float(0.0))]
     #[case(Value::Float(8.0), Value::Int(3), Value::Float(2.0))]
     #[case(Value::Float(-9.0), Value::Float(3.5), Value::Float(-2.0))]
@@ -98,12 +98,12 @@ mod tests {
     #[case(Value::Bool(true), Value::String("string".to_string()), unprocessable_entity!("Cannot divide boolean by string"))]
     #[case(Value::Int(1), Value::String("string".to_string()), unprocessable_entity!("Cannot divide integer by string"))]
     #[case(Value::Float(2.0), Value::String("string".to_string()), unprocessable_entity!("Cannot divide float by string"))]
-    #[case(Value::Duration(3.0), Value::String("string".to_string()), unprocessable_entity!("Cannot divide duration by string"))]
+    #[case( Value::Duration(3), Value::String("string".to_string()), unprocessable_entity!("Cannot divide duration by string"))]
     #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot divide string by boolean"))]
     #[case(Value::String("string".to_string()), Value::Int(1), unprocessable_entity!("Cannot divide string by integer"))]
     #[case(Value::String("string".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot divide string by float"))]
     #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot divide string"))]
-    #[case(Value::String("string".to_string()), Value::Duration(3.0), unprocessable_entity!("Cannot divide string by duration"))]
+    #[case(Value::String("string".to_string()),  Value::Duration(3), unprocessable_entity!("Cannot divide string by duration"))]
     fn rem_err(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
         let result = value.remainder(other);
         assert_eq!(result, Err(expected));

--- a/reductstore/src/storage/query/condition/value/arithmetic/rem.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/rem.rs
@@ -29,7 +29,7 @@ impl Rem for Value {
             Value::Bool(s) => match other {
                 Value::Bool(v) => result = Value::Int(s as i64 % v as i64),
                 Value::Int(v) => result = Value::Int(s as i64 % v),
-                Value::Float(v) => result = Value::Float(s as i8 as f64 % v),
+                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as i8 as f64 % v),
                 Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot divide boolean by string"));
                 }
@@ -38,17 +38,20 @@ impl Rem for Value {
             Value::Int(s) => match other {
                 Value::Bool(v) => result = Value::Int(s % v as i64),
                 Value::Int(v) => result = Value::Int(s % v),
-                Value::Float(v) => result = Value::Float(s as f64 % v),
+                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as f64 % v),
                 Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot divide integer by string"));
                 }
             },
 
-            Value::Float(s) => match other {
+            Value::Float(s) | Value::Duration(s) => match other {
                 Value::Bool(v) => result = Value::Float(s % v as i8 as f64),
                 Value::Int(v) => result = Value::Float(s % v as f64),
-                Value::Float(v) => result = Value::Float(s % v),
+                Value::Float(v) | Value::Duration(v) => result = Value::Float(s % v),
                 Value::String(_) => {
+                    if let Value::Duration(_) = result {
+                        return Err(unprocessable_entity!("Cannot divide duration by string"));
+                    }
                     return Err(unprocessable_entity!("Cannot divide float by string"));
                 }
             },
@@ -57,9 +60,11 @@ impl Rem for Value {
                 return match other {
                     Value::Bool(_) => Err(unprocessable_entity!("Cannot divide string by boolean")),
                     Value::Int(_) => Err(unprocessable_entity!("Cannot divide string by integer")),
-
                     Value::Float(_) => Err(unprocessable_entity!("Cannot divide string by float")),
                     Value::String(_) => Err(unprocessable_entity!("Cannot divide string")),
+                    Value::Duration(_) => {
+                        Err(unprocessable_entity!("Cannot divide string by duration"))
+                    }
                 }
             }
         }
@@ -76,9 +81,11 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(true), Value::Int(0))]
     #[case(Value::Bool(true), Value::Int(2), Value::Int(1))]
     #[case(Value::Bool(true), Value::Float(3.0), Value::Float(1.0))]
+    #[case(Value::Bool(true), Value::Duration(4.0), Value::Float(1.0))]
     #[case(Value::Int(4), Value::Bool(true), Value::Int(0))]
     #[case(Value::Int(5), Value::Int(2), Value::Int(1))]
     #[case(Value::Int(6), Value::Float(3.5), Value::Float(2.5))]
+    #[case(Value::Int(7), Value::Duration(2.0), Value::Float(1.0))]
     #[case(Value::Float(7.0), Value::Bool(true), Value::Float(0.0))]
     #[case(Value::Float(8.0), Value::Int(3), Value::Float(2.0))]
     #[case(Value::Float(-9.0), Value::Float(3.5), Value::Float(-2.0))]
@@ -91,10 +98,12 @@ mod tests {
     #[case(Value::Bool(true), Value::String("string".to_string()), unprocessable_entity!("Cannot divide boolean by string"))]
     #[case(Value::Int(1), Value::String("string".to_string()), unprocessable_entity!("Cannot divide integer by string"))]
     #[case(Value::Float(2.0), Value::String("string".to_string()), unprocessable_entity!("Cannot divide float by string"))]
+    #[case(Value::Duration(3.0), Value::String("string".to_string()), unprocessable_entity!("Cannot divide duration by string"))]
     #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot divide string by boolean"))]
     #[case(Value::String("string".to_string()), Value::Int(1), unprocessable_entity!("Cannot divide string by integer"))]
     #[case(Value::String("string".to_string()), Value::Float(2.0), unprocessable_entity!("Cannot divide string by float"))]
     #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot divide string"))]
+    #[case(Value::String("string".to_string()), Value::Duration(3.0), unprocessable_entity!("Cannot divide string by duration"))]
     fn rem_err(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
         let result = value.remainder(other);
         assert_eq!(result, Err(expected));

--- a/reductstore/src/storage/query/condition/value/arithmetic/sub.rs
+++ b/reductstore/src/storage/query/condition/value/arithmetic/sub.rs
@@ -28,32 +28,32 @@ impl Sub for Value {
         match result {
             Value::Bool(s) => match other {
                 Value::Bool(v) => result = Value::Int(s as i64 - v as i64),
-                Value::Int(v) => result = Value::Int(s as i64 - v),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as i8 as f64 - v),
+                Value::Int(v) | Value::Duration(v) => result = Value::Int(s as i64 - v),
+                Value::Float(v) => result = Value::Float(s as i8 as f64 - v),
                 Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot subtract string from boolean"));
                 }
             },
 
-            Value::Int(s) => match other {
+            Value::Int(s) | Value::Duration(s) => match other {
                 Value::Bool(v) => result = Value::Int(s - v as i64),
-                Value::Int(v) => result = Value::Int(s - v),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s as f64 - v),
-                Value::String(_) => {
-                    return Err(unprocessable_entity!("Cannot subtract string from integer"));
-                }
-            },
-
-            Value::Float(s) | Value::Duration(s) => match other {
-                Value::Bool(v) => result = Value::Float(s - v as i8 as f64),
-                Value::Int(v) => result = Value::Float(s - v as f64),
-                Value::Float(v) | Value::Duration(v) => result = Value::Float(s - v),
+                Value::Int(v) | Value::Duration(v) => result = Value::Int(s - v),
+                Value::Float(v) => result = Value::Float(s as f64 - v),
                 Value::String(_) => {
                     if let Value::Duration(_) = result {
                         return Err(unprocessable_entity!(
                             "Cannot subtract string from duration"
                         ));
                     }
+                    return Err(unprocessable_entity!("Cannot subtract string from integer"));
+                }
+            },
+
+            Value::Float(s) => match other {
+                Value::Bool(v) => result = Value::Float(s - v as i8 as f64),
+                Value::Int(v) | Value::Duration(v) => result = Value::Float(s - v as f64),
+                Value::Float(v) => result = Value::Float(s - v),
+                Value::String(_) => {
                     return Err(unprocessable_entity!("Cannot subtract string from float"));
                 }
             },
@@ -90,15 +90,15 @@ mod tests {
     #[case(Value::Bool(true), Value::Bool(false), Value::Int(1))]
     #[case(Value::Bool(true), Value::Int(1), Value::Int(0))]
     #[case(Value::Bool(true), Value::Float(1.0), Value::Float(0.0))]
-    #[case(Value::Bool(true), Value::Duration(1.0), Value::Float(0.0))]
+    #[case(Value::Bool(true), Value::Duration(1), Value::Float(0.0))]
     #[case(Value::Int(1), Value::Bool(true), Value::Int(0))]
     #[case(Value::Int(1), Value::Int(1), Value::Int(0))]
     #[case(Value::Int(1), Value::Float(1.0), Value::Float(0.0))]
-    #[case(Value::Int(1), Value::Duration(1.0), Value::Float(0.0))]
+    #[case(Value::Int(1), Value::Duration(1), Value::Float(0.0))]
     #[case(Value::Float(1.0), Value::Bool(true), Value::Float(0.0))]
     #[case(Value::Float(1.0), Value::Int(1), Value::Float(0.0))]
     #[case(Value::Float(1.0), Value::Float(1.0), Value::Float(0.0))]
-    #[case(Value::Float(1.0), Value::Duration(1.0), Value::Float(0.0))]
+    #[case(Value::Float(1.0), Value::Duration(1), Value::Float(0.0))]
     fn sub(#[case] value: Value, #[case] other: Value, #[case] expected: Value) {
         let result = value.subtract(other).unwrap();
         assert_eq!(result, expected);
@@ -108,12 +108,12 @@ mod tests {
     #[case(Value::Bool(true), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from boolean"))]
     #[case(Value::Int(1), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from integer"))]
     #[case(Value::Float(1.0), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from float"))]
-    #[case(Value::Duration(1.0), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from duration"))]
+    #[case(Value::Duration(1), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string from duration"))]
     #[case(Value::String("string".to_string()), Value::Bool(true), unprocessable_entity!("Cannot subtract string from boolean"))]
     #[case(Value::String("string".to_string()), Value::Int(1), unprocessable_entity!("Cannot subtract string from integer"))]
     #[case(Value::String("string".to_string()), Value::Float(1.0), unprocessable_entity!("Cannot subtract string from float"))]
     #[case(Value::String("string".to_string()), Value::String("string".to_string()), unprocessable_entity!("Cannot subtract string"))]
-    #[case(Value::String("string".to_string()), Value::Duration(1.0), unprocessable_entity!("Cannot subtract string from duration"))]
+    #[case(Value::String("string".to_string()), Value::Duration(1), unprocessable_entity!("Cannot subtract string from duration"))]
 
     fn sub_err(#[case] value: Value, #[case] other: Value, #[case] expected: ReductError) {
         let result = value.subtract(other);

--- a/reductstore/src/storage/query/condition/value/cmp.rs
+++ b/reductstore/src/storage/query/condition/value/cmp.rs
@@ -8,15 +8,26 @@ impl PartialEq<Self> for Value {
         match (self, other) {
             (Value::Bool(left), Value::Bool(right)) => left == right,
             (Value::Bool(left), Value::Int(right)) => *left as i64 == *right,
-            (Value::Bool(left), Value::Float(right)) => *left as i64 as f64 == *right,
+            (Value::Bool(left), Value::Float(right) | Value::Duration(right)) => {
+                *left as i64 as f64 == *right
+            }
 
             (Value::Int(left), Value::Int(right)) => left == right,
             (Value::Int(left), Value::Bool(right)) => *left == *right as i64,
-            (Value::Int(left), Value::Float(right)) => *left as f64 == *right,
+            (Value::Int(left), Value::Float(right) | Value::Duration(right)) => {
+                *left as f64 == *right
+            }
 
-            (Value::Float(left), Value::Float(right)) => left == right,
-            (Value::Float(left), Value::Int(right)) => *left == *right as f64,
-            (Value::Float(left), Value::Bool(right)) => *left == *right as i64 as f64,
+            (
+                Value::Float(left) | Value::Duration(left),
+                Value::Float(right) | Value::Duration(right),
+            ) => left == right,
+            (Value::Float(left) | Value::Duration(left), Value::Int(right)) => {
+                *left == *right as f64
+            }
+            (Value::Float(left) | Value::Duration(left), Value::Bool(right)) => {
+                *left == *right as i64 as f64
+            }
 
             (Value::String(left), Value::String(right)) => left == right,
             (Value::String(_), _) => false,
@@ -30,15 +41,26 @@ impl PartialOrd for Value {
         match (self, other) {
             (Value::Bool(left), Value::Bool(right)) => left.partial_cmp(right),
             (Value::Bool(left), Value::Int(right)) => (*left as i64).partial_cmp(right),
-            (Value::Bool(left), Value::Float(right)) => (*left as i64 as f64).partial_cmp(right),
+            (Value::Bool(left), Value::Float(right) | Value::Duration(right)) => {
+                (*left as i64 as f64).partial_cmp(right)
+            }
 
             (Value::Int(left), Value::Int(right)) => left.partial_cmp(right),
             (Value::Int(left), Value::Bool(right)) => left.partial_cmp(&(*right as i64)),
-            (Value::Int(left), Value::Float(right)) => (*left as f64).partial_cmp(right),
+            (Value::Int(left), Value::Float(right) | Value::Duration(right)) => {
+                (*left as f64).partial_cmp(right)
+            }
 
-            (Value::Float(left), Value::Float(right)) => left.partial_cmp(right),
-            (Value::Float(left), Value::Int(right)) => left.partial_cmp(&(*right as f64)),
-            (Value::Float(left), Value::Bool(right)) => left.partial_cmp(&(*right as i64 as f64)),
+            (
+                Value::Float(left) | Value::Duration(left),
+                Value::Float(right) | Value::Duration(right),
+            ) => left.partial_cmp(right),
+            (Value::Float(left) | Value::Duration(left), Value::Int(right)) => {
+                left.partial_cmp(&(*right as f64))
+            }
+            (Value::Float(left) | Value::Duration(left), Value::Bool(right)) => {
+                left.partial_cmp(&(*right as i64 as f64))
+            }
 
             (Value::String(left), Value::String(right)) => left.partial_cmp(right),
             (Value::String(_), _) => None,
@@ -67,6 +89,7 @@ mod tests {
         #[case(Value::Bool(true), Value::String("string".to_string()), false)]
         #[case(Value::Bool(false), Value::String("string".to_string()), false)]
         #[case(Value::Bool(true), Value::String("true".to_string()), false)]
+        #[case(Value::Bool(true), Value::Duration(1.0), true)]
         fn partial_eq_bool(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
             let result = left == right;
             assert_eq!(result, expected);
@@ -88,6 +111,8 @@ mod tests {
         #[case(Value::Int(1), Value::Float(-1.0), false)]
         #[case(Value::Int(1), Value::String("string".to_string()), false)]
         #[case(Value::Int(-1), Value::String("string".to_string()), false)]
+        #[case(Value::Int(1), Value::Duration(1.0), true)]
+        #[case(Value::Int(-1), Value::Duration(1.0), false)]
         fn partial_eq_int(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
             let result = left == right;
             assert_eq!(result, expected);
@@ -109,6 +134,8 @@ mod tests {
         #[case(Value::Float(1.0), Value::Int(-1), false)]
         #[case(Value::Float(1.0), Value::String("string".to_string()), false)]
         #[case(Value::Float(-1.0), Value::String("string".to_string()), false)]
+        #[case(Value::Float(1.0), Value::Duration(1.0), true)]
+        #[case(Value::Float(-1.0), Value::Duration(1.0), false)]
         fn partial_eq_float(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
             let result = left == right;
             assert_eq!(result, expected);
@@ -122,6 +149,7 @@ mod tests {
         #[case(Value::String("a".to_string()), Value::Bool(false), false)]
         #[case(Value::String("a".to_string()), Value::Int(1), false)]
         #[case(Value::String("a".to_string()), Value::Float(1.0), false)]
+        #[case(Value::String("a".to_string()), Value::Duration(1.0), false)]
         fn partial_eq_string(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
             let result = left == right;
             assert_eq!(result, expected);
@@ -154,6 +182,9 @@ mod tests {
         #[case(Value::Bool(false), Value::String("string".to_string()), None)]
         #[case(Value::Bool(true), Value::String("true".to_string()), None)]
         #[case(Value::Bool(false), Value::String("true".to_string()), None)]
+        #[case(Value::Bool(true), Value::Duration(1.0), Some(Ordering::Equal))]
+        #[case(Value::Bool(false), Value::Duration(1.0), Some(Ordering::Less))]
+        #[case(Value::Bool(true), Value::Duration(0.0), Some(Ordering::Greater))]
         fn partial_cmp_bool(
             #[case] left: Value,
             #[case] right: Value,
@@ -180,6 +211,9 @@ mod tests {
         #[case(Value::Int(1), Value::Float(-1.0), Some(Ordering::Greater))]
         #[case(Value::Int(1), Value::String("string".to_string()), None)]
         #[case(Value::Int(-1), Value::String("string".to_string()), None)]
+        #[case(Value::Int(1), Value::Duration(1.0), Some(Ordering::Equal))]
+        #[case(Value::Int(-1), Value::Duration(1.0), Some(Ordering::Less))]
+        #[case(Value::Int(1), Value::Duration(0.0), Some(Ordering::Greater))]
         fn partial_cmp_int(
             #[case] left: Value,
             #[case] right: Value,
@@ -206,6 +240,8 @@ mod tests {
         #[case(Value::Float(1.0), Value::Int(-1), Some(Ordering::Greater))]
         #[case(Value::Float(1.0), Value::String("string".to_string()), None)]
         #[case(Value::Float(-1.0), Value::String("string".to_string()), None)]
+        #[case(Value::Float(1.0), Value::Duration(1.0), Some(Ordering::Equal))]
+        #[case(Value::Float(-1.0), Value::Duration(1.0), Some(Ordering::Less))]
         fn partial_cmp_float(
             #[case] left: Value,
             #[case] right: Value,
@@ -223,6 +259,7 @@ mod tests {
         #[case(Value::String("a".to_string()), Value::Bool(false), None)]
         #[case(Value::String("a".to_string()), Value::Int(1), None)]
         #[case(Value::String("a".to_string()), Value::Float(1.0), None)]
+        #[case(Value::String("a".to_string()), Value::Duration(1.0), None)]
         fn partial_cmp_string(
             #[case] left: Value,
             #[case] right: Value,

--- a/reductstore/src/storage/query/condition/value/duration_format.rs
+++ b/reductstore/src/storage/query/condition/value/duration_format.rs
@@ -13,7 +13,7 @@ use reduct_base::unprocessable_entity;
 /// # Returns
 ///
 /// A `Result` containing the parsed duration as `Value::Duration` or an error if the string is invalid.
-fn parse_single_duration(duration_string: &str) -> Result<Value, ReductError> {
+fn parse_single_duration(duration_string: &str) -> Result<i64, ReductError> {
     if duration_string.trim().is_empty() {
         return Err(unprocessable_entity!("Duration literal cannot be empty"));
     }
@@ -41,7 +41,7 @@ fn parse_single_duration(duration_string: &str) -> Result<Value, ReductError> {
             ))
         }
     };
-    Ok(Value::Duration(seconds))
+    Ok(seconds)
 }
 
 pub(crate) fn parse_duration(duration_string: &str) -> Result<Value, ReductError> {
@@ -51,9 +51,7 @@ pub(crate) fn parse_duration(duration_string: &str) -> Result<Value, ReductError
 
     let mut total_seconds = 0;
     for part in duration_string.split_whitespace() {
-        let Value::Duration(seconds) = parse_single_duration(part)? else {
-            return Err(unprocessable_entity!("Invalid duration part: {}", part));
-        };
+        let seconds = parse_single_duration(part)?;
         total_seconds += seconds;
     }
     Ok(Value::Duration(total_seconds))
@@ -88,18 +86,18 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    // #[case(0, "0us")]
-    // #[case(1, "1us")]
+    #[case(0, "0us")]
+    #[case(1, "1us")]
     #[case(-1, "-1us")]
-    // #[case(100, "100us")]
-    // #[case(100_000, "100ms")]
-    // #[case(1_000_000, "1s")]
-    // #[case(-1_000_000, "-1s")]
-    // #[case(60_000_000, "1m")]
-    // #[case(3_600_000_000, "1h")]
-    // #[case(86_400_000_000, "1d")]
-    // #[case(86_400_000_000 + 3_600_000_000, "1d 1h")]
-    // #[case(86_400_000_000 - 3_600_000_000 + 5, "23h 5us")]
+    #[case(100, "100us")]
+    #[case(100_000, "100ms")]
+    #[case(1_000_000, "1s")]
+    #[case(-1_000_000, "-1s")]
+    #[case(60_000_000, "1m")]
+    #[case(3_600_000_000, "1h")]
+    #[case(86_400_000_000, "1d")]
+    #[case(86_400_000_000 + 3_600_000_000, "1d 1h")]
+    #[case(86_400_000_000 - 3_600_000_000 + 5, "23h 5us")]
     fn test_fmt_duration(#[case] value: i64, #[case] literal: &str) {
         let value = Value::Duration(value);
         assert_eq!(parse_duration(literal).unwrap(), value);

--- a/reductstore/src/storage/query/condition/value/duration_format.rs
+++ b/reductstore/src/storage/query/condition/value/duration_format.rs
@@ -1,0 +1,133 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+use crate::storage::query::condition::value::Value;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+
+/// Parses a duration string into a `Value::Duration`.
+///
+/// # Arguments
+///
+/// * `duration_string` - The string representing the duration, e.g., "100ms", "2.5m", "1h".
+///
+/// # Returns
+///
+/// A `Result` containing the parsed duration as `Value::Duration` or an error if the string is invalid.
+fn parse_single_duration(duration_string: &str) -> Result<Value, ReductError> {
+    let duration_string = duration_string.trim();
+    let (num_part, unit_part) = duration_string
+        .chars()
+        .partition::<String, _>(|c| c.is_digit(10) || *c == '.' || *c == '-');
+    let value: f64 = num_part
+        .parse()
+        .map_err(|_| unprocessable_entity!("Invalid duration value: {}", duration_string))?;
+
+    let unit = unit_part.as_str();
+    let seconds = match unit {
+        "us" => value / 1_000_000.0,
+        "ms" => value / 1_000.0,
+        "s" => value,
+        "m" => value * 60.0,
+        "h" => value * 3600.0,
+        "d" => value * 86400.0,
+        _ => {
+            return Err(unprocessable_entity!(
+                "Invalid duration unit: {}",
+                unit_part
+            ))
+        }
+    };
+    Ok(Value::Duration(seconds))
+}
+
+pub(crate) fn parse_duration(duration_string: &str) -> Result<Value, ReductError> {
+    let mut total_seconds = 0.0;
+    for part in duration_string.split_whitespace() {
+        let Value::Duration(seconds) = parse_single_duration(part)? else {
+            return Err(unprocessable_entity!("Invalid duration part: {}", part));
+        };
+        total_seconds += seconds;
+    }
+    Ok(Value::Duration(total_seconds))
+}
+
+pub(super) fn fmt_duration(mut seconds: f64, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut parts = Vec::new();
+    let units = [
+        ("d", 86400.0),
+        ("h", 3600.0),
+        ("m", 60.0),
+        ("s", 1.0),
+        ("ms", 0.001),
+        ("us", 0.000001),
+    ];
+    for &(unit, unit_seconds) in &units {
+        if seconds >= unit_seconds {
+            let value = (seconds / unit_seconds).floor();
+            if value > 0.0 {
+                parts.push(format!("{}{}", value as u64, unit));
+                seconds -= value * unit_seconds;
+            }
+        }
+    }
+    if parts.is_empty() {
+        parts.push("0s".to_string());
+    }
+    write!(f, "{}", parts.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_parse_units() {
+        assert_eq!(
+            parse_single_duration("100us").unwrap(),
+            Value::Duration(0.0001)
+        );
+        assert_eq!(
+            parse_single_duration("100ms").unwrap(),
+            Value::Duration(0.1)
+        );
+        assert_eq!(
+            parse_single_duration("100s").unwrap(),
+            Value::Duration(100.0)
+        );
+        assert_eq!(
+            parse_single_duration("2.5m").unwrap(),
+            Value::Duration(150.0)
+        );
+        assert_eq!(
+            parse_single_duration("-1h").unwrap(),
+            Value::Duration(-3600.0)
+        );
+        assert_eq!(
+            parse_single_duration("1d").unwrap(),
+            Value::Duration(86400.0)
+        );
+    }
+
+    #[rstest]
+    fn test_parse_invalid_duration() {
+        assert_eq!(
+            parse_single_duration("100xyz").err().unwrap(),
+            unprocessable_entity!("Invalid duration unit: xyz")
+        );
+        assert_eq!(
+            parse_single_duration("abc").err().unwrap(),
+            unprocessable_entity!("Invalid duration value: abc")
+        );
+    }
+
+    #[rstest]
+    fn test_parse_duration() {
+        assert_eq!(
+            parse_duration("100ms 500us").unwrap(),
+            Value::Duration(0.1005)
+        );
+        assert_eq!(parse_duration("1h -30m").unwrap(), Value::Duration(1800.0));
+        assert_eq!(parse_duration("2d 3h").unwrap(), Value::Duration(183600.0));
+    }
+}

--- a/reductstore/src/storage/query/condition/value/duration_format.rs
+++ b/reductstore/src/storage/query/condition/value/duration_format.rs
@@ -12,7 +12,7 @@ use reduct_base::unprocessable_entity;
 ///
 /// # Returns
 ///
-/// A `Result` containing the parsed duration as `Value::Duration` or an error if the string is invalid.
+/// A `Result` containing the parsed duration as i64 (in microseconds) or an error if the string is invalid.
 fn parse_single_duration(duration_string: &str) -> Result<i64, ReductError> {
     if duration_string.trim().is_empty() {
         return Err(unprocessable_entity!("Duration literal cannot be empty"));
@@ -44,6 +44,14 @@ fn parse_single_duration(duration_string: &str) -> Result<i64, ReductError> {
     Ok(seconds)
 }
 
+/// Parses a duration string containing multiple parts (e.g., "100ms 500us") into a `Value::Duration`.
+/// # Arguments
+///
+/// * `duration_string` - The string representing the duration, which can contain multiple parts separated by whitespace.
+///
+/// # Returns
+///
+/// A `Result` containing the total duration as `Value::Duration` or an error if the string is invalid.
 pub(crate) fn parse_duration(duration_string: &str) -> Result<Value, ReductError> {
     if duration_string.trim().is_empty() {
         return Err(unprocessable_entity!("Duration literal cannot be empty"));
@@ -57,6 +65,16 @@ pub(crate) fn parse_duration(duration_string: &str) -> Result<Value, ReductError
     Ok(Value::Duration(total_seconds))
 }
 
+/// Formats a duration in microseconds into a human-readable string.
+///
+/// # Arguments
+///
+/// * `usec` - The duration in microseconds.
+/// * `f` - The formatter to write the output to.
+///
+/// # Returns
+///
+/// A `Result` indicating success or failure of the formatting operation.
 pub(super) fn fmt_duration(mut usec: i64, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     let mut parts = Vec::new();
     let units = [

--- a/reductstore/src/storage/query/condition/value/misc/cast.rs
+++ b/reductstore/src/storage/query/condition/value/misc/cast.rs
@@ -28,7 +28,7 @@ impl Cast for Value {
             "int" => self.as_int().map(Value::Int),
             "float" => self.as_float().map(Value::Float),
             "string" => Ok(Value::String(self.to_string())),
-            "duration" => self.as_float().map(Value::Duration),
+            "duration" => self.as_int().map(Value::Duration),
             _ => Err(unprocessable_entity!("Unknown type '{}'", type_name)),
         }
     }
@@ -45,29 +45,29 @@ mod tests {
     #[case("bool", Value::Int(1), Ok(Value::Bool(true)))]
     #[case("bool", Value::Float(1.0), Ok(Value::Bool(true)))]
     #[case("bool", Value::String("true".to_string()), Ok(Value::Bool(true)))]
-    #[case("bool", Value::Duration(1.0), Ok(Value::Bool(true)))]
+    #[case("bool", Value::Duration(1), Ok(Value::Bool(true)))]
     #[case("int", Value::Bool(true), Ok(Value::Int(1)))]
     #[case("int", Value::Int(1), Ok(Value::Int(1)))]
     #[case("int", Value::Float(1.0), Ok(Value::Int(1)))]
     #[case("int", Value::String("1".to_string()), Ok(Value::Int(1)))]
     #[case("int", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as integer")))]
-    #[case("int", Value::Duration(1.0), Ok(Value::Int(1)))]
+    #[case("int", Value::Duration(1), Ok(Value::Int(1)))]
     #[case("float", Value::Bool(true), Ok(Value::Float(1.0)))]
     #[case("float", Value::Int(1), Ok(Value::Float(1.0)))]
     #[case("float", Value::Float(1.0), Ok(Value::Float(1.0)))]
     #[case("float", Value::String("1.0".to_string()), Ok(Value::Float(1.0)))]
     #[case("float", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as float")))]
-    #[case("float", Value::Duration(1.0), Ok(Value::Float(1.0)))]
+    #[case("float", Value::Duration(1), Ok(Value::Float(1.0)))]
     #[case("string", Value::Bool(true), Ok(Value::String("true".to_string())))]
     #[case("string", Value::Int(1), Ok(Value::String("1".to_string())))]
     #[case("string", Value::Float(1.0), Ok(Value::String("1".to_string())))]
     #[case("string", Value::String("1".to_string()), Ok(Value::String("1".to_string())))]
-    #[case("string", Value::Duration(1.0), Ok(Value::String("1s".to_string())))]
-    #[case("duration", Value::Bool(true), Ok(Value::Duration(1.0)))]
-    #[case("duration", Value::Int(1), Ok(Value::Duration(1.0)))]
-    #[case("duration", Value::Float(1.0), Ok(Value::Duration(1.0)))]
-    #[case("duration", Value::String("1".to_string()), Ok(Value::Duration(1.0)))]
-    #[case("duration", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as float")))]
+    #[case("string", Value::Duration(1), Ok(Value::String("1us".to_string())))]
+    #[case("duration", Value::Bool(true), Ok(Value::Duration(1)))]
+    #[case("duration", Value::Int(1), Ok(Value::Duration(1)))]
+    #[case("duration", Value::Float(1.0), Ok(Value::Duration(1)))]
+    #[case("duration", Value::String("1".to_string()), Ok(Value::Duration(1)))]
+    #[case("duration", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as integer")))]
     #[case("unknown", Value::Bool(true), Err(unprocessable_entity!("Unknown type 'unknown'")))]
     fn test_cast(
         #[case] type_name: &str,

--- a/reductstore/src/storage/query/condition/value/misc/cast.rs
+++ b/reductstore/src/storage/query/condition/value/misc/cast.rs
@@ -27,7 +27,8 @@ impl Cast for Value {
             "bool" => self.as_bool().map(Value::Bool),
             "int" => self.as_int().map(Value::Int),
             "float" => self.as_float().map(Value::Float),
-            "string" => self.as_string().map(Value::String),
+            "string" => Ok(Value::String(self.to_string())),
+            "duration" => self.as_float().map(Value::Duration),
             _ => Err(unprocessable_entity!("Unknown type '{}'", type_name)),
         }
     }
@@ -44,20 +45,29 @@ mod tests {
     #[case("bool", Value::Int(1), Ok(Value::Bool(true)))]
     #[case("bool", Value::Float(1.0), Ok(Value::Bool(true)))]
     #[case("bool", Value::String("true".to_string()), Ok(Value::Bool(true)))]
+    #[case("bool", Value::Duration(1.0), Ok(Value::Bool(true)))]
     #[case("int", Value::Bool(true), Ok(Value::Int(1)))]
     #[case("int", Value::Int(1), Ok(Value::Int(1)))]
     #[case("int", Value::Float(1.0), Ok(Value::Int(1)))]
     #[case("int", Value::String("1".to_string()), Ok(Value::Int(1)))]
     #[case("int", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as integer")))]
+    #[case("int", Value::Duration(1.0), Ok(Value::Int(1)))]
     #[case("float", Value::Bool(true), Ok(Value::Float(1.0)))]
     #[case("float", Value::Int(1), Ok(Value::Float(1.0)))]
     #[case("float", Value::Float(1.0), Ok(Value::Float(1.0)))]
     #[case("float", Value::String("1.0".to_string()), Ok(Value::Float(1.0)))]
     #[case("float", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as float")))]
+    #[case("float", Value::Duration(1.0), Ok(Value::Float(1.0)))]
     #[case("string", Value::Bool(true), Ok(Value::String("true".to_string())))]
     #[case("string", Value::Int(1), Ok(Value::String("1".to_string())))]
     #[case("string", Value::Float(1.0), Ok(Value::String("1".to_string())))]
     #[case("string", Value::String("1".to_string()), Ok(Value::String("1".to_string())))]
+    #[case("string", Value::Duration(1.0), Ok(Value::String("1s".to_string())))]
+    #[case("duration", Value::Bool(true), Ok(Value::Duration(1.0)))]
+    #[case("duration", Value::Int(1), Ok(Value::Duration(1.0)))]
+    #[case("duration", Value::Float(1.0), Ok(Value::Duration(1.0)))]
+    #[case("duration", Value::String("1".to_string()), Ok(Value::Duration(1.0)))]
+    #[case("duration", Value::String("xx".to_string()), Err(unprocessable_entity!("Value 'xx' could not be parsed as float")))]
     #[case("unknown", Value::Bool(true), Err(unprocessable_entity!("Unknown type 'unknown'")))]
     fn test_cast(
         #[case] type_name: &str,

--- a/reductstore/src/storage/query/condition/value/string/contains.rs
+++ b/reductstore/src/storage/query/condition/value/string/contains.rs
@@ -20,8 +20,8 @@ pub(crate) trait Contains {
 
 impl Contains for Value {
     fn contains(self, other: Self) -> Result<bool, ReductError> {
-        let other = other.as_string()?;
-        let self_string = self.as_string()?;
+        let other = other.to_string();
+        let self_string = self.to_string();
         Ok(self_string.contains(&other))
     }
 }

--- a/reductstore/src/storage/query/condition/value/string/ends_with.rs
+++ b/reductstore/src/storage/query/condition/value/string/ends_with.rs
@@ -20,8 +20,8 @@ pub(crate) trait EndsWith {
 
 impl EndsWith for Value {
     fn ends_with(self, other: Self) -> Result<bool, ReductError> {
-        let other = other.as_string()?;
-        let self_string = self.as_string()?;
+        let other = other.to_string();
+        let self_string = self.to_string();
         Ok(self_string.ends_with(&other))
     }
 }

--- a/reductstore/src/storage/query/condition/value/string/starts_with.rs
+++ b/reductstore/src/storage/query/condition/value/string/starts_with.rs
@@ -20,8 +20,8 @@ pub(crate) trait StartsWith {
 
 impl StartsWith for Value {
     fn starts_with(self, other: Self) -> Result<bool, ReductError> {
-        let other = other.as_string()?;
-        let self_string = self.as_string()?;
+        let other = other.to_string();
+        let self_string = self.to_string();
         Ok(self_string.starts_with(&other))
     }
 }


### PR DESCRIPTION
Closes #863 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature 

### What was changed?

### What was changed?

- Extended the condition parser to recognize and parse duration literals such as "1h", "30m", and "45s" using a new parse_duration utility.
- Added a new Value::Duration variant to the query condition value system, allowing durations to be handled distinctly from integers or floats.
- Enhanced arithmetic and comparison operations to correctly interpret and process Value::Duration alongside other numeric types.
- Updated operators (e.g., EachT, Cast, Exists, Ref) to use a unified .to_string() method for value representation, ensuring compatibility with the new duration type.
- Improved internal and test coverage for duration parsing, arithmetic, and formatting, including new and updated unit tests for duration scenarios.
- 
### Related issues

#863  #802 

### Does this PR introduce a breaking change?

No

### Other information:
