### PR TITLE
Support for "#ctx_before" and "#ctx_after" directives,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integrate ReductRos v0.1.0, [PR-856](https://github.com/reductstore/reductstore/pull/856)
 - Filter buckets by read permission in server information, [PR-849](https://github.com/reductstore/reductstore/pull/849)
 - Support for duration literals, [PR-864](https://github.com/reductstore/reductstore/pull/864)
+- Support for "#ctx_before" and "#ctx_after" directives, [PR-866](https://github.com/reductstore/reductstore/pull/866)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integrate ReductRos v0.1.0, [PR-856](https://github.com/reductstore/reductstore/pull/856)
 - Filter buckets by read permission in server information, [PR-849](https://github.com/reductstore/reductstore/pull/849)
 - Support for duration literals, [PR-864](https://github.com/reductstore/reductstore/pull/864)
-- Support for "#ctx_before" and "#ctx_after" directives, [PR-866](https://github.com/reductstore/reductstore/pull/866)
+- Support for `#ctx_before` and `#ctx_after` directives, [PR-866](https://github.com/reductstore/reductstore/pull/866)
 
 ### Changed
 

--- a/integration_tests/api/bucket_api_test.py
+++ b/integration_tests/api/bucket_api_test.py
@@ -1,4 +1,5 @@
 import json
+from time import sleep
 
 from .conftest import requires_env, auth_headers
 

--- a/reduct_base/src/io.rs
+++ b/reduct_base/src/io.rs
@@ -2,6 +2,7 @@ use crate::error::ReductError;
 use crate::{internal_server_error, Labels};
 use async_trait::async_trait;
 use bytes::Bytes;
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio::runtime::Handle;
 
@@ -40,8 +41,11 @@ impl BuilderRecordMeta {
         self
     }
 
-    pub fn labels(mut self, labels: Labels) -> Self {
-        self.labels = labels;
+    pub fn labels<T: ToString>(mut self, labels: HashMap<T, T>) -> Self {
+        self.labels = labels
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
         self
     }
 
@@ -55,8 +59,11 @@ impl BuilderRecordMeta {
         self
     }
 
-    pub fn computed_labels(mut self, computed_labels: Labels) -> Self {
-        self.computed_labels = computed_labels;
+    pub fn computed_labels<T: ToString>(mut self, computed_labels: HashMap<T, T>) -> Self {
+        self.computed_labels = computed_labels
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
         self
     }
 

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -9,6 +9,7 @@ use axum::extract::{Path, State};
 use axum_extra::headers::HeaderMap;
 
 use reduct_base::batch::{parse_batched_header, sort_headers_by_time};
+use reduct_base::io::RecordMeta;
 use reduct_base::Labels;
 
 use crate::api::entry::common::err_to_batched_header;
@@ -81,7 +82,10 @@ pub(crate) async fn update_batched_records(
                 replication_repo.notify(TransactionNotification {
                     bucket: bucket_name.clone(),
                     entry: entry_name.clone(),
-                    labels: new_labels,
+                    meta: RecordMeta::builder()
+                        .timestamp(time)
+                        .labels(new_labels)
+                        .build(),
                     event: Transaction::UpdateRecord(time),
                 })?;
             }

--- a/reductstore/src/api/entry/update_single.rs
+++ b/reductstore/src/api/entry/update_single.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
 use axum_extra::headers::HeaderMap;
-
+use reduct_base::io::RecordMeta;
 use reduct_base::Labels;
 
 use crate::api::entry::common::parse_timestamp_from_query;
@@ -81,7 +81,10 @@ pub(crate) async fn update_record(
         .notify(TransactionNotification {
             bucket: bucket.clone(),
             entry: entry_name.clone(),
-            labels: batched_result.get(&ts).unwrap().clone()?,
+            meta: RecordMeta::builder()
+                .timestamp(ts)
+                .labels(batched_result.get(&ts).unwrap().clone()?.clone())
+                .build(),
             event: Transaction::UpdateRecord(ts),
         })?;
 

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -19,7 +19,7 @@ use crate::storage::storage::IO_OPERATION_TIMEOUT;
 use log::{debug, error};
 use reduct_base::batch::{parse_batched_header, sort_headers_by_time, RecordHeader};
 use reduct_base::error::ReductError;
-use reduct_base::io::WriteRecord;
+use reduct_base::io::{RecordMeta, WriteRecord};
 use reduct_base::{bad_request, internal_server_error, unprocessable_entity};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -107,7 +107,10 @@ pub(crate) async fn write_batched_records(
                             TransactionNotification {
                                 bucket: bucket_name.clone(),
                                 entry: entry_name.clone(),
-                                labels: ctx.header.labels.clone(),
+                                meta: RecordMeta::builder()
+                                    .timestamp(ctx.time)
+                                    .labels(ctx.header.labels.clone())
+                                    .build(),
                                 event: Transaction::WriteRecord(ctx.time),
                             },
                         )?;

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -15,6 +15,7 @@ use crate::storage::storage::IO_OPERATION_TIMEOUT;
 use futures_util::StreamExt;
 use log::{debug, error};
 use reduct_base::error::ReductError;
+use reduct_base::io::RecordMeta;
 use reduct_base::{bad_request, unprocessable_entity, Labels};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -117,7 +118,7 @@ pub(crate) async fn write_record(
                 .notify(TransactionNotification {
                     bucket: bucket.clone(),
                     entry: path.get("entry_name").unwrap().to_string(),
-                    labels,
+                    meta: RecordMeta::builder().timestamp(ts).labels(labels).build(),
                     event: WriteRecord(ts),
                 })?;
             Ok(())

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -113,7 +113,7 @@ impl ManageExtensions for ExtRepository {
 
             // check if the query has references to computed labels and no extension is found
             let condition = if let Some(condition) = ext_query.remove("when") {
-                let node = Parser::new().parse(&condition)?;
+                let node = Parser::new().parse(condition)?;
                 Some(node)
             } else {
                 None

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -11,7 +11,7 @@ use crate::storage::query::QueryRx;
 use async_trait::async_trait;
 use dlopen2::wrapper::{Container, WrapperApi};
 use futures_util::StreamExt;
-use reduct_base::error::ErrorCode::{Interrupt, NoContent};
+use reduct_base::error::ErrorCode::NoContent;
 use reduct_base::error::ReductError;
 use reduct_base::ext::{
     BoxedCommiter, BoxedProcessor, BoxedReadRecord, BoxedRecordStream, ExtSettings, IoExtension,
@@ -19,8 +19,6 @@ use reduct_base::ext::{
 use reduct_base::msg::entry_api::QueryEntry;
 use reduct_base::{no_content, unprocessable_entity};
 use std::collections::HashMap;
-use std::env::var;
-use std::iter::Filter;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
@@ -295,9 +293,8 @@ impl ManageExtensions for ExtRepository {
 }
 
 use crate::ext::filter::DummyFilter;
-use crate::storage::query::filters::{FilterRecord, RecordFilter, WhenFilter};
+use crate::storage::query::filters::{RecordFilter, WhenFilter};
 pub(crate) use create::create_ext_repository;
-use reduct_base::io::ReadRecord;
 
 #[cfg(test)]
 pub(super) mod tests {

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -670,7 +670,7 @@ pub(super) mod tests {
 
             assert_eq!(records.len(), 1, "Should return one record");
 
-            let mut record = records.first_mut().unwrap();
+            let record = records.first_mut().unwrap();
             assert_eq!(record.read().await, None);
 
             assert_eq!(

--- a/reductstore/src/ext/ext_repository/create.rs
+++ b/reductstore/src/ext/ext_repository/create.rs
@@ -56,13 +56,13 @@ pub fn create_ext_repository(
                 &self,
                 _query_id: u64,
                 query_rx: Arc<AsyncRwLock<QueryRx>>,
-            ) -> Option<Result<BoxedReadRecord, ReductError>> {
+            ) -> Option<Result<Vec<BoxedReadRecord>, ReductError>> {
                 let result = query_rx
                     .write()
                     .await
                     .recv()
                     .await
-                    .map(|record| record.map(|r| Box::new(r) as BoxedReadRecord));
+                    .map(|record| record.map(|r| vec![Box::new(r) as BoxedReadRecord]));
 
                 if result.is_none() {
                     // If no record is available, return a no content error to finish the query.

--- a/reductstore/src/ext/filter.rs
+++ b/reductstore/src/ext/filter.rs
@@ -64,7 +64,7 @@ mod tests {
     fn test_filter_record(mocked_record: BoxedReadRecord) {
         assert_eq!(mocked_record.state(), Finished as i32);
         assert_eq!(mocked_record.timestamp(), 0);
-        assert!(!mocked_record.labels().is_empty());
+        assert!(mocked_record.labels().is_empty());
         assert!(!mocked_record.computed_labels().is_empty());
     }
 }

--- a/reductstore/src/ext/filter.rs
+++ b/reductstore/src/ext/filter.rs
@@ -1,13 +1,13 @@
 // Copyright 2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use crate::storage::query::condition::{BoxedNode, Context};
+use crate::storage::query::condition::{BoxedNode, Context, Directives};
 use reduct_base::error::ReductError;
 use reduct_base::ext::BoxedReadRecord;
 use std::collections::HashMap;
 
 pub(super) struct ExtWhenFilter {
-    condition: Option<BoxedNode>,
+    condition: Option<(BoxedNode, Directives)>,
     strict: bool,
 }
 
@@ -16,7 +16,7 @@ pub(super) struct ExtWhenFilter {
 /// It is used in the `ext` module to filter records after they processed by extension,
 /// and it puts computed labels into the context.
 impl ExtWhenFilter {
-    pub fn new(condition: Option<BoxedNode>, strict: bool) -> Self {
+    pub fn new(condition: Option<(BoxedNode, Directives)>, strict: bool) -> Self {
         ExtWhenFilter { condition, strict }
     }
 
@@ -61,6 +61,7 @@ impl ExtWhenFilter {
             .condition
             .as_mut()
             .unwrap()
+            .0
             .apply(&context)?
             .as_bool()?)
     }

--- a/reductstore/src/ext/filter.rs
+++ b/reductstore/src/ext/filter.rs
@@ -59,4 +59,12 @@ mod tests {
             "Dummy filter should pass all records"
         );
     }
+
+    #[rstest]
+    fn test_filter_record(mocked_record: BoxedReadRecord) {
+        assert_eq!(mocked_record.state(), Finished as i32);
+        assert_eq!(mocked_record.timestamp(), 0);
+        assert!(!mocked_record.labels().is_empty());
+        assert!(!mocked_record.computed_labels().is_empty());
+    }
 }

--- a/reductstore/src/ext/filter.rs
+++ b/reductstore/src/ext/filter.rs
@@ -45,11 +45,9 @@ impl FilterRecord for BoxedReadRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ext::ext_repository::tests::{mocked_record, MockRecord};
-    use crate::storage::query::condition::Parser;
+    use crate::ext::ext_repository::tests::mocked_record;
 
     use rstest::rstest;
-    use serde_json::json;
 
     #[rstest]
     fn test_dummy_filter(mocked_record: BoxedReadRecord) {

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -1,16 +1,17 @@
 // Copyright 2023-2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use std::sync::Arc;
-
 use crate::cfg::replication::ReplicationConfig;
 use crate::replication::replication_task::ReplicationTask;
 use crate::storage::storage::Storage;
+use log::Metadata;
 use reduct_base::error::ReductError;
+use reduct_base::io::RecordMeta;
 use reduct_base::msg::replication_api::{
     FullReplicationInfo, ReplicationInfo, ReplicationSettings,
 };
 use reduct_base::Labels;
+use std::sync::Arc;
 
 mod diagnostics;
 pub mod proto;
@@ -74,7 +75,7 @@ impl TryFrom<u8> for Transaction {
 pub struct TransactionNotification {
     pub bucket: String,
     pub entry: String,
-    pub labels: Labels,
+    pub meta: RecordMeta,
     pub event: Transaction,
 }
 pub trait ManageReplications {

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -4,13 +4,11 @@
 use crate::cfg::replication::ReplicationConfig;
 use crate::replication::replication_task::ReplicationTask;
 use crate::storage::storage::Storage;
-use log::Metadata;
 use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;
 use reduct_base::msg::replication_api::{
     FullReplicationInfo, ReplicationInfo, ReplicationSettings,
 };
-use reduct_base::Labels;
 use std::sync::Arc;
 
 mod diagnostics;

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -675,7 +675,7 @@ mod tests {
 
     mod notify {
         use super::*;
-        use reduct_base::io::{ReadRecord, RecordMeta};
+        use reduct_base::io::RecordMeta;
 
         #[rstest]
         fn test_notify_replication(mut repo: ReplicationRepository, settings: ReplicationSettings) {

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -304,7 +304,7 @@ impl ReplicationRepository {
 
         // check syntax of when condition
         if let Some(when) = &settings.when {
-            if let Err(e) = Parser::new().parse(when) {
+            if let Err(e) = Parser::new().parse(when.clone()) {
                 return Err(unprocessable_entity!(
                     "Invalid replication condition: {}",
                     e

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -626,6 +626,7 @@ mod tests {
 
     mod get {
         use super::*;
+        use reduct_base::io::RecordMeta;
 
         #[rstest]
         fn test_get_replication(mut repo: ReplicationRepository, settings: ReplicationSettings) {
@@ -635,7 +636,7 @@ mod tests {
                 repl.notify(TransactionNotification {
                     bucket: "bucket-1".to_string(),
                     entry: "entry-1".to_string(),
-                    labels: Labels::default(),
+                    meta: RecordMeta::builder().build(),
                     event: WriteRecord(0),
                 })
                 .unwrap();

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -194,6 +194,10 @@ impl ManageReplications for ReplicationRepository {
 
     fn notify(&mut self, notification: TransactionNotification) -> Result<(), ReductError> {
         for (_, replication) in self.replications.iter_mut() {
+            if replication.settings().src_bucket != notification.bucket {
+                continue; // skip if the replication is not for the source bucket
+            }
+
             let _ = replication.notify(notification.clone())?;
         }
         Ok(())

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -333,10 +333,10 @@ mod tests {
 
     use bytes::Bytes;
 
-    use mockall::mock;
-    use rstest::*;
-
     use crate::core::file_cache::FILE_CACHE;
+    use mockall::mock;
+    use reduct_base::io::RecordMeta;
+    use rstest::*;
 
     use crate::replication::remote_bucket::ErrorRecordMap;
     use crate::replication::Transaction;
@@ -610,7 +610,7 @@ mod tests {
         TransactionNotification {
             bucket: "src".to_string(),
             entry: "test1".to_string(),
-            labels: Labels::new(),
+            meta: RecordMeta::builder().timestamp(10).build(),
             event: Transaction::WriteRecord(10),
         }
     }

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -225,7 +225,7 @@ impl ReplicationTask {
             if !lock.contains_key(&notification.entry) {
                 lock.insert(
                     notification.entry.clone(),
-                    TransactionFilter::new(self.name(), self.settings.clone()),
+                    TransactionFilter::try_new(self.name(), self.settings.clone())?,
                 );
             }
 

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -151,10 +151,10 @@ impl TransactionFilter {
 
 #[cfg(test)]
 mod tests {
+    use crate::replication::Transaction;
+    use reduct_base::io::RecordMeta;
     use reduct_base::Labels;
     use rstest::*;
-
-    use crate::replication::Transaction;
 
     use super::*;
 

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -5,11 +5,13 @@ use log::warn;
 use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;
 use reduct_base::msg::replication_api::ReplicationSettings;
+use reduct_base::Labels;
+use std::collections::HashMap;
 
 use crate::replication::TransactionNotification;
 use crate::storage::query::condition::Parser;
 use crate::storage::query::filters::{
-    apply_filters_recursively, EachNFilter, EachSecondFilter, ExcludeLabelFilter,
+    apply_filters_recursively, EachNFilter, EachSecondFilter, ExcludeLabelFilter, GetMeta,
     IncludeLabelFilter, RecordFilter, WhenFilter,
 };
 
@@ -21,13 +23,25 @@ pub(super) struct TransactionFilter {
     query_filters: Vec<Filter>,
 }
 
-impl Into<RecordMeta> for TransactionNotification {
-    fn into(self) -> RecordMeta {
-        RecordMeta::builder()
-            .timestamp(self.event.into_timestamp())
-            .state(0)
-            .labels(self.labels)
-            .build()
+impl GetMeta for TransactionNotification {
+    fn timestamp(&self) -> u64 {
+        self.meta.timestamp()
+    }
+
+    fn labels(&self) -> HashMap<&String, &String> {
+        self.meta.labels().iter().map(|(k, v)| (k, v)).collect()
+    }
+
+    fn computed_labels(&self) -> HashMap<&String, &String> {
+        self.meta
+            .computed_labels()
+            .iter()
+            .map(|(k, v)| (k, v))
+            .collect()
+    }
+
+    fn state(&self) -> i32 {
+        self.meta.state()
     }
 }
 

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -3,9 +3,7 @@
 
 use log::warn;
 use reduct_base::error::ReductError;
-use reduct_base::io::RecordMeta;
 use reduct_base::msg::replication_api::ReplicationSettings;
-use reduct_base::Labels;
 use std::collections::HashMap;
 
 use crate::replication::TransactionNotification;

--- a/reductstore/src/storage/query/condition.rs
+++ b/reductstore/src/storage/query/condition.rs
@@ -65,4 +65,5 @@ impl Debug for BoxedNode {
     }
 }
 
+pub(crate) use parser::Directives;
 pub(crate) use parser::Parser;

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -260,7 +260,7 @@ mod tests {
         let json = json!({
         "$and": [true, {"$gt": [20, 10]}]
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
@@ -269,7 +269,7 @@ mod tests {
         let json = json!({
             "&label": {"$gt": 10}
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         let context = Context::new(0, HashMap::from_iter(vec![("label", "20")]), HashMap::new());
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
@@ -279,7 +279,7 @@ mod tests {
         let json = json!({
             "$and": [1, -2]
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
@@ -288,7 +288,7 @@ mod tests {
         let json = json!({
             "$and": [1.1, -2.2]
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
@@ -297,7 +297,7 @@ mod tests {
         let json = json!({
             "$and": ["a","b"]
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
@@ -306,7 +306,7 @@ mod tests {
         let json = json!({
             "$eq": ["1h", 3600_000_000u64]
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         assert!(node.apply(&context).unwrap().as_bool().unwrap());
     }
 
@@ -319,7 +319,7 @@ mod tests {
             ]
         }        );
 
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         let context = Context::new(
             0,
             HashMap::from_iter(vec![("label", "true")]),
@@ -336,7 +336,7 @@ mod tests {
                 1
             ]
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         assert_eq!(node.apply(&context).unwrap(), Value::Int(1));
     }
 
@@ -345,7 +345,7 @@ mod tests {
         let json = json!({
         "$limit": 100
         });
-        let mut node = parser.parse(&json).unwrap();
+        let (mut node, _) = parser.parse(json).unwrap();
         assert_eq!(node.apply(&context).unwrap(), Value::Int(1));
     }
 
@@ -354,7 +354,7 @@ mod tests {
         let json = json!( {
             "$xx": [true, true]
         });
-        let result = parser.parse(&json);
+        let result = parser.parse(json);
         assert_eq!(
             result.err().unwrap().to_string(),
             "[UnprocessableEntity] Operator '$xx' not supported"
@@ -369,7 +369,7 @@ mod tests {
                     "x": "y"
                 }
             }        );
-        let result = parser.parse(&json);
+        let result = parser.parse(json);
         assert_eq!(
             result.err().unwrap().to_string(),
             "[UnprocessableEntity] Object notation must have exactly one operator"
@@ -383,7 +383,7 @@ mod tests {
                 "$in": [10, 20]
             }
         });
-        let result = parser.parse(&json);
+        let result = parser.parse(json);
         assert_eq!(
             result.err().unwrap().to_string(),
             "[UnprocessableEntity] Array type is not supported: [10,20]"
@@ -397,7 +397,7 @@ mod tests {
                 "$and": null
             }
         });
-        let result = parser.parse(&json);
+        let result = parser.parse(json);
         assert_eq!(
             result.err().unwrap().to_string(),
             "[UnprocessableEntity] Null type is not supported: null"
@@ -409,7 +409,7 @@ mod tests {
         let json = json!({
             "and": [true, true]
         });
-        let result = parser.parse(&json);
+        let result = parser.parse(json);
         assert_eq!(
             result.err().unwrap().to_string(),
             "[UnprocessableEntity] Operator 'and' must start with '$'"
@@ -474,7 +474,7 @@ mod tests {
                 operands
             ))
             .unwrap();
-            let mut node = parser.parse(&json).unwrap();
+            let (mut node, _) = parser.parse(json).unwrap();
             assert!(
                 node.apply(&context).unwrap().as_bool().unwrap(),
                 "{}",

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 pub(crate) struct Parser {}
 
 pub(crate) type Directives = HashMap<String, Value>;
-static DIRECTIVES: [&str; 1] = ["#before"];
+static DIRECTIVES: [&str; 2] = ["#ctx_before", "#ctx_after"];
 
 impl Parser {
     /// Parses a JSON object into a condition tree.

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -416,6 +416,35 @@ mod tests {
         );
     }
 
+    mod parse_directives {
+        use super::*;
+        use rstest::rstest;
+
+        #[rstest]
+        fn test_parse_directives(parser: Parser) {
+            let json = json!({
+                "#ctx_before": "1h",
+                "#ctx_after": "2h"
+            });
+            let (_, directives) = parser.parse(json).unwrap();
+            assert_eq!(directives.len(), 2);
+            assert_eq!(directives["#ctx_before"], Value::Duration(3600_000_000));
+            assert_eq!(directives["#ctx_after"], Value::Duration(7200_000_000));
+        }
+
+        #[rstest]
+        fn test_parse_invalid_directive(parser: Parser) {
+            let json = json!({
+                "#invalid_directive": "value"
+            });
+            let result = parser.parse(json);
+            assert_eq!(
+                result.err().unwrap().to_string(),
+                "[UnprocessableEntity] Directive '#invalid_directive' is not supported"
+            );
+        }
+    }
+
     mod parse_operators {
         use super::*;
         #[rstest]

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -10,25 +10,52 @@ pub(crate) mod time_range;
 pub(crate) mod when;
 
 /// Trait for record filters in queries.
-pub trait RecordFilter {
+pub trait RecordFilter<R: Into<RecordMeta>> {
     /// Filter the record by condition.
     ///
     /// # Arguments
     ///
     /// * `record` - The record metadata to filter.
+    /// * `ctx` - The context for the filter, which can be used to pass additional information.
     ///
     /// # Returns
     ///
-    /// * `Ok(true)` if the record passes the filter, `Ok(false)` otherwise.
-    /// * Err(`ReductError::Interrupt`) if the filter is interrupted
-    /// * `Err(ReductError)` if an error occurs during filtering.
-    fn filter(&mut self, record: &RecordMeta) -> Result<bool, ReductError>;
+    /// * `Ok(Some(Vec<(R, Self::Ctx)>))` - returns a vector of records and their contexts if the record matches the filter. Empty vector if no records match.
+    /// * `Ok(None)` - if the filtering is interrupted e.g. $limit operator is reached.
+    /// * `Err(ReductError)` - if an error occurs during filtering.
+    fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError>;
 }
 
+pub(crate) fn apply_filters_recursively<R: Into<RecordMeta>>(
+    filters: &mut [Box<dyn RecordFilter<R> + Send + Sync>],
+    notifications: Vec<R>,
+    index: usize,
+) -> Result<Option<Vec<R>>, ReductError> {
+    if index == filters.len() {
+        return Ok(Some(notifications));
+    }
+
+    for notification in notifications {
+        match filters[index].filter(notification)? {
+            Some(notifications) => {
+                if !notifications.is_empty() {
+                    return apply_filters_recursively(filters, notifications, index + 1);
+                }
+            }
+
+            None => return Ok(None),
+        }
+    }
+
+    Ok(Some(vec![]))
+}
+
+use crate::replication::TransactionNotification;
 pub(crate) use each_n::EachNFilter;
 pub(crate) use each_s::EachSecondFilter;
 pub(crate) use exclude::ExcludeLabelFilter;
 pub(crate) use include::IncludeLabelFilter;
+use log::warn;
 pub(crate) use record_state::RecordStateFilter;
 use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 pub(crate) use time_range::TimeRangeFilter;
 pub(crate) use when::WhenFilter;
 
-///
+/// A trait to access record metadata for filtering purposes with minimal overhead.
 pub(crate) trait FilterRecord {
     fn state(&self) -> i32;
 
@@ -75,6 +75,7 @@ pub(crate) fn apply_filters_recursively<R: FilterRecord>(
 
 mod tests {
     use super::*;
+    use reduct_base::io::RecordMeta;
 
     #[derive(Debug, Clone, PartialEq)]
     pub(super) struct TestFilterRecord {

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -15,7 +15,6 @@ pub(crate) use exclude::ExcludeLabelFilter;
 pub(crate) use include::IncludeLabelFilter;
 pub(crate) use record_state::RecordStateFilter;
 use reduct_base::error::ReductError;
-use reduct_base::io::RecordMeta;
 use std::collections::HashMap;
 pub(crate) use time_range::TimeRangeFilter;
 pub(crate) use when::WhenFilter;

--- a/reductstore/src/storage/query/filters.rs
+++ b/reductstore/src/storage/query/filters.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 ReductSoftware UG
+// Copyright 2023-2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
 pub(crate) mod each_n;

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{GetMeta, RecordFilter};
 use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;
 
@@ -20,7 +20,7 @@ impl EachNFilter {
     }
 }
 
-impl<R: Into<RecordMeta>> RecordFilter<R> for EachNFilter {
+impl<R: GetMeta> RecordFilter<R> for EachNFilter {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
         let ret = self.count % self.n == 0;
         self.count += 1;

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -3,7 +3,6 @@
 
 use crate::storage::query::filters::{FilterRecord, RecordFilter};
 use reduct_base::error::ReductError;
-use reduct_base::io::RecordMeta;
 
 /// Filter that passes every N-th record
 pub struct EachNFilter {

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -20,11 +20,15 @@ impl EachNFilter {
     }
 }
 
-impl RecordFilter for EachNFilter {
-    fn filter(&mut self, _record: &RecordMeta) -> Result<bool, ReductError> {
+impl<R: Into<RecordMeta>> RecordFilter<R> for EachNFilter {
+    fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
         let ret = self.count % self.n == 0;
         self.count += 1;
-        Ok(ret)
+        if ret {
+            Ok(Some(vec![record]))
+        } else {
+            Ok(Some(vec![]))
+        }
     }
 }
 

--- a/reductstore/src/storage/query/filters/each_n.rs
+++ b/reductstore/src/storage/query/filters/each_n.rs
@@ -34,8 +34,8 @@ impl<R: FilterRecord> RecordFilter<R> for EachNFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/each_s.rs
+++ b/reductstore/src/storage/query/filters/each_s.rs
@@ -40,8 +40,8 @@ impl<R: FilterRecord> RecordFilter<R> for EachSecondFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/each_s.rs
+++ b/reductstore/src/storage/query/filters/each_s.rs
@@ -3,7 +3,6 @@
 
 use crate::storage::query::filters::{FilterRecord, RecordFilter};
 use reduct_base::error::ReductError;
-use reduct_base::io::RecordMeta;
 
 /// Filter that passes every N-th record
 pub struct EachSecondFilter {

--- a/reductstore/src/storage/query/filters/each_s.rs
+++ b/reductstore/src/storage/query/filters/each_s.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{GetMeta, RecordFilter};
 use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;
 
@@ -23,12 +23,11 @@ impl EachSecondFilter {
     }
 }
 
-impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for EachSecondFilter {
+impl<R: GetMeta> RecordFilter<R> for EachSecondFilter {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
-        let meta: RecordMeta = record.clone().into();
-        let ret = meta.timestamp() as i64 - self.last_time >= (self.s * 1_000_000.0) as i64;
+        let ret = record.timestamp() as i64 - self.last_time >= (self.s * 1_000_000.0) as i64;
         if ret {
-            self.last_time = meta.timestamp().clone() as i64;
+            self.last_time = record.timestamp().clone() as i64;
         }
 
         if ret {

--- a/reductstore/src/storage/query/filters/each_s.rs
+++ b/reductstore/src/storage/query/filters/each_s.rs
@@ -23,14 +23,19 @@ impl EachSecondFilter {
     }
 }
 
-impl RecordFilter for EachSecondFilter {
-    fn filter(&mut self, record: &RecordMeta) -> Result<bool, ReductError> {
-        let ret = record.timestamp() as i64 - self.last_time >= (self.s * 1_000_000.0) as i64;
+impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for EachSecondFilter {
+    fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
+        let meta: RecordMeta = record.clone().into();
+        let ret = meta.timestamp() as i64 - self.last_time >= (self.s * 1_000_000.0) as i64;
         if ret {
-            self.last_time = record.timestamp().clone() as i64;
+            self.last_time = meta.timestamp().clone() as i64;
         }
 
-        Ok(ret)
+        if ret {
+            Ok(Some(vec![record]))
+        } else {
+            Ok(Some(vec![]))
+        }
     }
 }
 

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -2,7 +2,6 @@
 // Licensed under the Business Source License 1.1
 
 use reduct_base::error::ReductError;
-use reduct_base::io::RecordMeta;
 use reduct_base::Labels;
 
 use crate::storage::query::filters::{FilterRecord, RecordFilter};

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -5,7 +5,7 @@ use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;
 use reduct_base::Labels;
 
-use crate::storage::query::filters::RecordFilter;
+use crate::storage::query::filters::{GetMeta, RecordFilter};
 
 /// Filter that excludes records with specific labels
 pub struct ExcludeLabelFilter {
@@ -27,13 +27,14 @@ impl ExcludeLabelFilter {
     }
 }
 
-impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for ExcludeLabelFilter {
+impl<R: GetMeta> RecordFilter<R> for ExcludeLabelFilter {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
-        let meta = record.clone().into();
-        let result = !self
-            .labels
-            .iter()
-            .all(|(key, value)| meta.labels().iter().any(|(k, v)| k == key && v == value));
+        let result = !self.labels.iter().all(|(key, value)| {
+            record
+                .labels()
+                .iter()
+                .any(|(k, v)| *k == key && *v == value)
+        });
         if result {
             Ok(Some(vec![record]))
         } else {

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -45,8 +45,8 @@ impl<R: FilterRecord> RecordFilter<R> for ExcludeLabelFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/exclude.rs
+++ b/reductstore/src/storage/query/filters/exclude.rs
@@ -27,14 +27,18 @@ impl ExcludeLabelFilter {
     }
 }
 
-impl RecordFilter for ExcludeLabelFilter {
-    fn filter(&mut self, record: &RecordMeta) -> Result<bool, ReductError> {
+impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for ExcludeLabelFilter {
+    fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
+        let meta = record.clone().into();
         let result = !self
             .labels
             .iter()
-            .all(|(key, value)| record.labels().iter().any(|(k, v)| k == key && v == value));
-
-        Ok(result)
+            .all(|(key, value)| meta.labels().iter().any(|(k, v)| k == key && v == value));
+        if result {
+            Ok(Some(vec![record]))
+        } else {
+            Ok(Some(vec![]))
+        }
     }
 }
 

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -4,7 +4,7 @@
 use reduct_base::error::ReductError;
 use reduct_base::Labels;
 
-use crate::storage::query::filters::{FilterRecord, RecordFilter, RecordMeta};
+use crate::storage::query::filters::{FilterRecord, RecordFilter};
 
 /// Filter that excludes records with specific labels
 pub struct IncludeLabelFilter {

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -48,6 +48,7 @@ mod tests {
     use super::*;
 
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -26,14 +26,19 @@ impl IncludeLabelFilter {
     }
 }
 
-impl RecordFilter for IncludeLabelFilter {
-    fn filter(&mut self, record: &RecordMeta) -> Result<bool, ReductError> {
+impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for IncludeLabelFilter {
+    fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
+        let meta = record.clone().into();
         let result = self
             .labels
             .iter()
-            .all(|(key, value)| record.labels().iter().any(|(k, v)| k == key && v == value));
+            .all(|(key, value)| meta.labels().iter().any(|(k, v)| k == key && v == value));
 
-        Ok(result)
+        if result {
+            Ok(Some(vec![record]))
+        } else {
+            Ok(Some(vec![]))
+        }
     }
 }
 

--- a/reductstore/src/storage/query/filters/include.rs
+++ b/reductstore/src/storage/query/filters/include.rs
@@ -4,7 +4,7 @@
 use reduct_base::error::ReductError;
 use reduct_base::Labels;
 
-use crate::storage::query::filters::{RecordFilter, RecordMeta};
+use crate::storage::query::filters::{GetMeta, RecordFilter, RecordMeta};
 
 /// Filter that excludes records with specific labels
 pub struct IncludeLabelFilter {
@@ -26,13 +26,14 @@ impl IncludeLabelFilter {
     }
 }
 
-impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for IncludeLabelFilter {
+impl<R: GetMeta> RecordFilter<R> for IncludeLabelFilter {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
-        let meta = record.clone().into();
-        let result = self
-            .labels
-            .iter()
-            .all(|(key, value)| meta.labels().iter().any(|(k, v)| k == key && v == value));
+        let result = self.labels.iter().all(|(key, value)| {
+            record
+                .labels()
+                .iter()
+                .any(|(k, v)| *k == key && *v == value)
+        });
 
         if result {
             Ok(Some(vec![record]))

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -26,10 +26,15 @@ impl RecordStateFilter {
     }
 }
 
-impl RecordFilter for RecordStateFilter {
-    fn filter(&mut self, record: &RecordMeta) -> Result<bool, ReductError> {
-        let result = record.state() == self.state as i32;
-        Ok(result)
+impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for RecordStateFilter {
+    fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
+        let meta = record.clone().into();
+        let result = meta.state() == self.state as i32;
+        if result {
+            Ok(Some(vec![record]))
+        } else {
+            Ok(Some(vec![]))
+        }
     }
 }
 

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -4,7 +4,7 @@
 use crate::storage::proto::record::State;
 use reduct_base::error::ReductError;
 
-use crate::storage::query::filters::{RecordFilter, RecordMeta};
+use crate::storage::query::filters::{GetMeta, RecordFilter, RecordMeta};
 
 /// Filter that passes records with a specific state
 pub struct RecordStateFilter {
@@ -26,10 +26,9 @@ impl RecordStateFilter {
     }
 }
 
-impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for RecordStateFilter {
+impl<R: GetMeta> RecordFilter<R> for RecordStateFilter {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
-        let meta = record.clone().into();
-        let result = meta.state() == self.state as i32;
+        let result = record.state() == self.state as i32;
         if result {
             Ok(Some(vec![record]))
         } else {

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -4,7 +4,7 @@
 use crate::storage::proto::record::State;
 use reduct_base::error::ReductError;
 
-use crate::storage::query::filters::{FilterRecord, RecordFilter, RecordMeta};
+use crate::storage::query::filters::{FilterRecord, RecordFilter};
 
 /// Filter that passes records with a specific state
 pub struct RecordStateFilter {

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -4,7 +4,7 @@
 use crate::storage::proto::record::State;
 use reduct_base::error::ReductError;
 
-use crate::storage::query::filters::{GetMeta, RecordFilter, RecordMeta};
+use crate::storage::query::filters::{FilterRecord, RecordFilter, RecordMeta};
 
 /// Filter that passes records with a specific state
 pub struct RecordStateFilter {
@@ -26,7 +26,7 @@ impl RecordStateFilter {
     }
 }
 
-impl<R: GetMeta> RecordFilter<R> for RecordStateFilter {
+impl<R: FilterRecord> RecordFilter<R> for RecordStateFilter {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
         let result = record.state() == self.state as i32;
         if result {
@@ -42,20 +42,35 @@ mod tests {
     use super::*;
     use crate::storage::proto::record::State;
 
+    use crate::storage::query::filters::tests::TestFilterRecord;
     use rstest::*;
 
     #[rstest]
     fn test_record_state_filter() {
         let mut filter = RecordStateFilter::new(State::Finished);
 
-        let meta = RecordMeta::builder().state(State::Finished as i32).build();
-        assert!(filter.filter(&meta).unwrap(), "Record should pass");
+        let record: TestFilterRecord = RecordMeta::builder()
+            .state(State::Finished as i32)
+            .build()
+            .into();
+        assert_eq!(
+            filter.filter(record.clone()).unwrap(),
+            Some(vec![record]),
+            "Record should pass"
+        );
     }
 
     #[rstest]
     fn test_record_state_filter_no_records() {
         let mut filter = RecordStateFilter::new(State::Finished);
-        let meta = RecordMeta::builder().state(State::Started as i32).build();
-        assert!(!filter.filter(&meta).unwrap(), "Record should not pass");
+        let record: TestFilterRecord = RecordMeta::builder()
+            .state(State::Started as i32)
+            .build()
+            .into();
+        assert_eq!(
+            filter.filter(record).unwrap(),
+            Some(vec![]),
+            "Record should not pass"
+        );
     }
 }

--- a/reductstore/src/storage/query/filters/record_state.rs
+++ b/reductstore/src/storage/query/filters/record_state.rs
@@ -43,6 +43,7 @@ mod tests {
     use crate::storage::proto::record::State;
 
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -26,16 +26,20 @@ impl TimeRangeFilter {
     }
 }
 
-impl RecordFilter for TimeRangeFilter {
-    fn filter(&mut self, record: &RecordMeta) -> Result<bool, ReductError> {
-        let ts = record.timestamp() as u64;
+impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for TimeRangeFilter {
+    fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
+        let ts = record.clone().into().timestamp() as u64;
         let ret = ts >= self.start && ts < self.stop;
         if ret {
             // Ensure that we don't return the same record twice
             self.start = ts + 1;
         }
 
-        Ok(ret)
+        if ret {
+            Ok(Some(vec![record]))
+        } else {
+            Ok(Some(vec![]))
+        }
     }
 }
 

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use crate::storage::query::filters::{FilterRecord, RecordFilter, RecordMeta};
+use crate::storage::query::filters::{FilterRecord, RecordFilter};
 use reduct_base::error::ReductError;
 
 /// Filter that passes records with a timestamp within a specific range

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use crate::storage::query::filters::{RecordFilter, RecordMeta};
+use crate::storage::query::filters::{GetMeta, RecordFilter, RecordMeta};
 use reduct_base::error::ReductError;
 
 /// Filter that passes records with a timestamp within a specific range
@@ -26,9 +26,9 @@ impl TimeRangeFilter {
     }
 }
 
-impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for TimeRangeFilter {
+impl<R: GetMeta> RecordFilter<R> for TimeRangeFilter {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
-        let ts = record.clone().into().timestamp() as u64;
+        let ts = record.timestamp();
         let ret = ts >= self.start && ts < self.stop;
         if ret {
             // Ensure that we don't return the same record twice

--- a/reductstore/src/storage/query/filters/time_range.rs
+++ b/reductstore/src/storage/query/filters/time_range.rs
@@ -48,6 +48,7 @@ mod tests {
     use super::*;
 
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -3,8 +3,7 @@
 
 use crate::storage::query::condition::{BoxedNode, Context, Directives};
 use crate::storage::query::filters::when::Padding::Records;
-use crate::storage::query::filters::{FilterRecord, RecordFilter, RecordMeta};
-use log::debug;
+use crate::storage::query::filters::{FilterRecord, RecordFilter};
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::internal_server_error;
 use std::collections::VecDeque;

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -1,25 +1,63 @@
 // Copyright 2023-2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use crate::storage::query::condition::{BoxedNode, Context};
+use crate::storage::query::condition::{BoxedNode, Context, Directives};
+use crate::storage::query::filters::when::Padding::Records;
 use crate::storage::query::filters::{RecordFilter, RecordMeta};
 use reduct_base::error::{ErrorCode, ReductError};
+use std::collections::VecDeque;
 
-/// A node representing a when filter with a condition.
-pub struct WhenFilter {
-    condition: BoxedNode,
-    strict: bool,
+enum Padding {
+    Records(usize),
 }
 
-impl WhenFilter {
-    pub fn new(condition: BoxedNode, strict: bool) -> Self {
-        WhenFilter { condition, strict }
+/// A node representing a when filter with a condition.
+pub struct WhenFilter<R> {
+    condition: BoxedNode,
+    strict: bool,
+    buffer: VecDeque<R>,
+    before: Padding,
+}
+
+impl<R> WhenFilter<R> {
+    pub fn try_new(
+        condition: BoxedNode,
+        directives: Directives,
+        strict: bool,
+    ) -> Result<Self, ReductError> {
+        let before = if let Some(before) = directives.get("#before") {
+            let before = before.as_int()?;
+            if before < 0 {
+                return Err(ReductError::unprocessable_entity(
+                    "Padding before must be non-negative",
+                ));
+            }
+            Records(before as usize)
+        } else {
+            Records(1) // Default to 0 records before
+        };
+
+        Ok(Self {
+            condition,
+            strict,
+            buffer: VecDeque::new(),
+            before,
+        })
     }
 }
 
-impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for WhenFilter {
+impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for WhenFilter<R> {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
         let meta = record.clone().into();
+        self.buffer.push_back(record);
+        match self.before {
+            Padding::Records(n) => {
+                if self.buffer.len() > n {
+                    self.buffer.pop_front();
+                }
+            }
+        }
+
         let context = Context::new(
             meta.timestamp(),
             meta.labels()
@@ -31,6 +69,7 @@ impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for WhenFilter {
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect(),
         );
+
         let result = match self.condition.apply(&context) {
             Ok(value) => value.as_bool()?,
             Err(err) => {
@@ -48,7 +87,7 @@ impl<R: Into<RecordMeta> + Clone> RecordFilter<R> for WhenFilter {
         };
 
         if result {
-            Ok(Some(vec![record]))
+            Ok(Some(self.buffer.drain(..).collect()))
         } else {
             Ok(Some(vec![]))
         }
@@ -69,7 +108,7 @@ mod tests {
         let json = serde_json::from_str(r#"{"$and": [true, "&label"]}"#).unwrap();
         let condition = parser.parse(&json).unwrap();
 
-        let mut filter = WhenFilter::new(condition);
+        let mut filter = WhenFilter::try_new(condition);
 
         let meta = RecordMeta::builder()
             .timestamp(0)

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -4,6 +4,7 @@
 use crate::storage::query::condition::{BoxedNode, Context, Directives};
 use crate::storage::query::filters::when::Padding::Records;
 use crate::storage::query::filters::{GetMeta, RecordFilter, RecordMeta};
+use log::debug;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::internal_server_error;
 use std::collections::VecDeque;
@@ -33,7 +34,7 @@ impl<R> WhenFilter<R> {
                     "Padding before must be non-negative",
                 ));
             }
-            Records(before as usize)
+            Records(before as usize + 1)
         } else {
             Records(1) // Default to 0 records before
         };
@@ -74,6 +75,8 @@ impl<R: GetMeta> RecordFilter<R> for WhenFilter<R> {
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect(),
         );
+
+        debug!("Context: {:?}", context);
 
         let result = match self.condition.apply(&context) {
             Ok(value) => value.as_bool()?,

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -16,8 +16,11 @@ enum Padding {
 pub struct WhenFilter<R> {
     condition: BoxedNode,
     strict: bool,
-    buffer: VecDeque<R>,
     before: Padding,
+    after: Padding,
+
+    ctx_buffer: VecDeque<R>,
+    ctx_after_count: i64,
 }
 
 impl<R> WhenFilter<R> {
@@ -26,41 +29,58 @@ impl<R> WhenFilter<R> {
         directives: Directives,
         strict: bool,
     ) -> Result<Self, ReductError> {
-        let before = if let Some(before) = directives.get("#before") {
+        let before = if let Some(before) = directives.get("#ctx_before") {
             let before = before.as_int()?;
             if before < 0 {
                 return Err(ReductError::unprocessable_entity(
                     "Padding before must be non-negative",
                 ));
             }
-            Records(before as usize + 1)
+            Records(before as usize)
         } else {
-            Records(1) // Default to 0 records before
+            Records(0) // Default to 0 records before
+        };
+
+        let after = if let Some(after) = directives.get("#ctx_after") {
+            let after = after.as_int()?;
+            if after < 0 {
+                return Err(ReductError::unprocessable_entity(
+                    "Padding after must be non-negative",
+                ));
+            }
+            Records(after as usize)
+        } else {
+            Records(0) // Default to 0 records after
         };
 
         Ok(Self {
             condition,
             strict,
-            buffer: VecDeque::new(),
             before,
+            after,
+            ctx_buffer: VecDeque::new(),
+            ctx_after_count: 0,
         })
     }
 }
 
 impl<R: FilterRecord> RecordFilter<R> for WhenFilter<R> {
     fn filter(&mut self, record: R) -> Result<Option<Vec<R>>, ReductError> {
-        self.buffer.push_back(record);
+        // Put the record into the context buffer
+        self.ctx_buffer.push_back(record);
         match self.before {
             Padding::Records(n) => {
-                if self.buffer.len() > n {
-                    self.buffer.pop_front();
+                if self.ctx_buffer.len() > n + 1 {
+                    self.ctx_buffer.pop_front();
                 }
             }
         }
 
-        let record = self.buffer.back().ok_or(internal_server_error!(
+        let record = self.ctx_buffer.back().ok_or(internal_server_error!(
             "Buffer is empty, but we expected at least one record to be present."
         ))?;
+
+        // Prepare the context for the condition evaluation
         let context = Context::new(
             record.timestamp(),
             record
@@ -91,10 +111,24 @@ impl<R: FilterRecord> RecordFilter<R> for WhenFilter<R> {
             }
         };
 
-        if result {
-            Ok(Some(self.buffer.drain(..).collect()))
+        if self.check_after_ctx(result) {
+            Ok(Some(self.ctx_buffer.drain(..).collect()))
         } else {
             Ok(Some(vec![]))
+        }
+    }
+}
+
+impl<R: FilterRecord> WhenFilter<R> {
+    fn check_after_ctx(&mut self, condition: bool) -> bool {
+        match self.after {
+            Padding::Records(n) => {
+                self.ctx_after_count -= 1;
+                if condition {
+                    self.ctx_after_count = n as i64;
+                }
+                self.ctx_after_count >= 0
+            }
         }
     }
 }
@@ -102,30 +136,112 @@ impl<R: FilterRecord> RecordFilter<R> for WhenFilter<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     use crate::storage::query::condition::Parser;
     use crate::storage::query::filters::tests::TestFilterRecord;
     use reduct_base::io::RecordMeta;
-    use reduct_base::Labels;
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
+    use serde_json::json;
 
     #[rstest]
-    fn filter() {
-        let parser = Parser::new();
-        let json = serde_json::from_str(r#"{"$and": [true, "&label"]}"#).unwrap();
-        let (condition, directives) = parser.parse(json).unwrap();
+    fn filter(parser: Parser, record_true: TestFilterRecord) {
+        let (condition, directives) = parser
+            .parse(json!({
+                "$and": [true, "&label"]
+            }))
+            .unwrap();
 
         let mut filter = WhenFilter::try_new(condition, directives, true).unwrap();
 
-        let record: TestFilterRecord = RecordMeta::builder()
-            .timestamp(0)
-            .labels(Labels::from_iter(vec![(
-                "label".to_string(),
-                "true".to_string(),
-            )]))
+        let result = filter.filter(record_true.clone()).unwrap();
+        assert_eq!(result, Some(vec![record_true]));
+    }
+
+    #[rstest]
+    fn filter_ctx_before_n(
+        parser: Parser,
+        record_true: TestFilterRecord,
+        record_false: TestFilterRecord,
+    ) {
+        let (condition, directives) = parser
+            .parse(json!({
+                "#ctx_before": 2,
+                "$and": [true, "&label"]
+            }))
+            .unwrap();
+
+        let mut filter = WhenFilter::try_new(condition, directives, true).unwrap();
+
+        let result = filter.filter(record_false.clone()).unwrap();
+        assert_eq!(result, Some(vec![]));
+
+        let result = filter.filter(record_false.clone()).unwrap();
+        assert_eq!(result, Some(vec![]));
+
+        let result = filter.filter(record_false.clone()).unwrap();
+        assert_eq!(result, Some(vec![]));
+
+        let result = filter.filter(record_true.clone()).unwrap();
+        assert_eq!(
+            result,
+            Some(vec![
+                record_false.clone(),
+                record_false,
+                record_true.clone()
+            ])
+        );
+
+        let result = filter.filter(record_true.clone()).unwrap();
+        assert_eq!(result, Some(vec![record_true]));
+    }
+
+    #[rstest]
+    fn filter_ctx_after_n(
+        parser: Parser,
+        record_true: TestFilterRecord,
+        record_false: TestFilterRecord,
+    ) {
+        let (condition, directives) = parser
+            .parse(json!({
+                "#ctx_after": 2,
+                "$and": [true, "&label"]
+            }))
+            .unwrap();
+
+        let mut filter = WhenFilter::try_new(condition, directives, true).unwrap();
+
+        let result = filter.filter(record_true.clone()).unwrap();
+        assert_eq!(result, Some(vec![record_true.clone()]));
+
+        let result = filter.filter(record_false.clone()).unwrap();
+        assert_eq!(result, Some(vec![record_false.clone()]));
+
+        let result = filter.filter(record_false.clone()).unwrap();
+        assert_eq!(result, Some(vec![record_false]));
+
+        let result = filter.filter(record_true.clone()).unwrap();
+        assert_eq!(result, Some(vec![record_true]));
+    }
+
+    #[fixture]
+    fn parser() -> Parser {
+        Parser::new()
+    }
+
+    #[fixture]
+    fn record_true() -> TestFilterRecord {
+        RecordMeta::builder()
+            .labels(HashMap::from_iter(vec![("label", "true")]))
             .build()
-            .into();
-        let result = filter.filter(record.clone()).unwrap();
-        assert_eq!(result, Some(vec![record]));
+            .into()
+    }
+
+    #[fixture]
+    fn record_false() -> TestFilterRecord {
+        RecordMeta::builder()
+            .labels(HashMap::from_iter(vec![("label", "false")]))
+            .build()
+            .into()
     }
 }

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -105,6 +105,7 @@ mod tests {
 
     use crate::storage::query::condition::Parser;
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
     use reduct_base::Labels;
     use rstest::rstest;
 

--- a/reductstore/src/storage/query/filters/when/ctx_after.rs
+++ b/reductstore/src/storage/query/filters/when/ctx_after.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::filters::when::Padding;
+use crate::storage::query::filters::when::Padding::{Duration, Records};
+
+/// Context for managing records after a condition is checked in a `when` filter.
+pub(super) struct CtxAfter {
+    after: Padding,
+    count: i64,
+    last_ts: Option<u64>,
+}
+
+impl CtxAfter {
+    pub fn new(after: Padding) -> Self {
+        CtxAfter {
+            after,
+            count: 0,
+            last_ts: None,
+        }
+    }
+
+    /// Checks the condition against the context, updating the state based on the padding type.
+    pub(crate) fn check(&mut self, condition: bool, time: u64) -> bool {
+        match self.after {
+            Records(n) => {
+                self.count -= 1;
+                if condition {
+                    self.count = n as i64;
+                }
+                self.count >= 0
+            }
+            Duration(us) => {
+                if condition {
+                    self.last_ts = Some(time);
+                }
+
+                self.last_ts.is_some_and(|last_ts| last_ts + us >= time)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ctx_after_records() {
+        let mut ctx = CtxAfter::new(Records(3));
+        assert!(ctx.check(true, 1000));
+        assert!(ctx.check(false, 2000));
+        assert!(ctx.check(false, 3000));
+        assert!(ctx.check(false, 4000));
+        assert!(!ctx.check(false, 5000)); // Should be false after 3 records
+    }
+
+    #[test]
+    fn test_ctx_after_duration() {
+        let mut ctx = CtxAfter::new(Duration(5000));
+        assert!(ctx.check(true, 1000));
+        assert!(ctx.check(false, 2000));
+        assert!(ctx.check(false, 6000)); // Should still be true due to duration
+        assert!(!ctx.check(false, 7000)); // Should be false after duration expires
+    }
+}

--- a/reductstore/src/storage/query/filters/when/ctx_before.rs
+++ b/reductstore/src/storage/query/filters/when/ctx_before.rs
@@ -39,7 +39,7 @@ impl CtxBefore {
                 let mut first_record_ts = ctx_buffer.front().unwrap().timestamp();
                 let last_record_ts = ctx_buffer.back().unwrap().timestamp();
                 while last_record_ts - first_record_ts > us {
-                    ctx_buffer.pop_front().unwrap().timestamp();
+                    ctx_buffer.pop_front().unwrap();
                     first_record_ts = ctx_buffer.front().map_or(0, |r| r.timestamp());
                 }
             }

--- a/reductstore/src/storage/query/filters/when/ctx_before.rs
+++ b/reductstore/src/storage/query/filters/when/ctx_before.rs
@@ -1,0 +1,105 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::filters::when::Padding;
+use crate::storage::query::filters::when::Padding::{Duration, Records};
+use crate::storage::query::filters::FilterRecord;
+use std::collections::VecDeque;
+
+/// Context for managing records before a condition is checked in a `when` filter.
+pub(super) struct CtxBefore {
+    before: Padding,
+}
+
+impl CtxBefore {
+    pub fn new(before: Padding) -> Self {
+        CtxBefore { before }
+    }
+
+    /// Queues a record into the context buffer, managing the size based on the `before` padding.
+    ///
+    /// Note: we need to keep the buffer outside of the filter to allow use reference to the first record
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx_buffer` - A mutable reference to the buffer where records are stored.
+    /// * `record` - The record to be queued.
+    pub(crate) fn queue_record<R>(&self, ctx_buffer: &mut VecDeque<R>, record: R)
+    where
+        R: FilterRecord,
+    {
+        ctx_buffer.push_back(record);
+        match self.before {
+            Records(n) => {
+                if ctx_buffer.len() > n + 1 {
+                    ctx_buffer.pop_front();
+                }
+            }
+            Duration(us) => {
+                let mut first_record_ts = ctx_buffer.front().unwrap().timestamp();
+                let last_record_ts = ctx_buffer.back().unwrap().timestamp();
+                while last_record_ts - first_record_ts > us {
+                    ctx_buffer.pop_front().unwrap().timestamp();
+                    first_record_ts = ctx_buffer.front().map_or(0, |r| r.timestamp());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::filters::tests::TestFilterRecord;
+    use reduct_base::io::RecordMeta;
+    use rstest::*;
+
+    #[rstest]
+    fn test_ctx_before_records() {
+        let ctx = CtxBefore::new(Records(2));
+        let mut buffer = VecDeque::new();
+        let record: TestFilterRecord = RecordMeta::builder().build().into();
+
+        ctx.queue_record(&mut buffer, record.clone());
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer.front(), Some(&record));
+
+        ctx.queue_record(&mut buffer, record.clone());
+        assert_eq!(buffer.len(), 2);
+
+        ctx.queue_record(&mut buffer, record.clone());
+        assert_eq!(buffer.len(), 3);
+
+        ctx.queue_record(&mut buffer, record.clone());
+        assert_eq!(buffer.len(), 3, "Should not exceed 3 records");
+    }
+
+    #[rstest]
+    fn test_ctx_before_duration() {
+        let ctx = CtxBefore::new(Duration(5000));
+        let mut buffer = VecDeque::new();
+        let record1: TestFilterRecord = RecordMeta::builder().timestamp(1000).build().into();
+        let record2: TestFilterRecord = RecordMeta::builder().timestamp(6000).build().into();
+        let record3: TestFilterRecord = RecordMeta::builder().timestamp(6001).build().into();
+
+        ctx.queue_record(&mut buffer, record1.clone());
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(buffer.front(), Some(&record1));
+
+        ctx.queue_record(&mut buffer, record2.clone());
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer.front(), Some(&record1));
+
+        ctx.queue_record(&mut buffer, record3.clone());
+        assert_eq!(
+            buffer.len(),
+            2,
+            "Should remove the first record after 5000ms"
+        );
+        assert_eq!(
+            buffer.front(),
+            Some(&record2),
+            "Should keep the second record"
+        );
+    }
+}

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 ReductSoftware UG
+// Copyright 2023-2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
 use crate::storage::block_manager::{BlockManager, BlockRef};

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -65,8 +65,12 @@ impl HistoricalQuery {
 
         if let Some(when) = options.when {
             let parser = Parser::new();
-            let condition = parser.parse(&when)?;
-            filters.push(Box::new(WhenFilter::new(condition, options.strict)));
+            let (condition, directives) = parser.parse(when)?;
+            filters.push(Box::new(WhenFilter::try_new(
+                condition,
+                directives,
+                options.strict,
+            )?));
         }
 
         Ok(HistoricalQuery {

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -10,10 +10,12 @@ use crate::storage::proto::{record::State as RecordState, ts_to_us, Record};
 use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::condition::Parser;
 use crate::storage::query::filters::{
-    EachNFilter, EachSecondFilter, ExcludeLabelFilter, IncludeLabelFilter, RecordFilter,
-    RecordStateFilter, TimeRangeFilter, WhenFilter,
+    apply_filters_recursively, EachNFilter, EachSecondFilter, ExcludeLabelFilter,
+    IncludeLabelFilter, RecordFilter, RecordStateFilter, TimeRangeFilter, WhenFilter,
 };
 use reduct_base::error::{ErrorCode, ReductError};
+
+type Filter = Box<dyn RecordFilter<Record> + Send + Sync>;
 
 pub struct HistoricalQuery {
     /// The start time of the query.
@@ -25,7 +27,7 @@ pub struct HistoricalQuery {
     /// The current block that is being read. Cached to avoid loading the same block multiple times.
     current_block: Option<BlockRef>,
     /// Filters
-    filters: Vec<Box<dyn RecordFilter + Send + Sync>>,
+    filters: Vec<Filter>,
     /// Request only metadata without the content.
     only_metadata: bool,
     /// Strict mode
@@ -40,7 +42,7 @@ impl HistoricalQuery {
         stop_time: u64,
         options: QueryOptions,
     ) -> Result<Self, ReductError> {
-        let mut filters: Vec<Box<dyn RecordFilter + Send + Sync>> = vec![
+        let mut filters: Vec<Filter> = vec![
             Box::new(TimeRangeFilter::new(start_time, stop_time)),
             Box::new(RecordStateFilter::new(RecordState::Finished)),
         ];
@@ -64,7 +66,7 @@ impl HistoricalQuery {
         if let Some(when) = options.when {
             let parser = Parser::new();
             let condition = parser.parse(&when)?;
-            filters.push(Box::new(WhenFilter::new(condition)));
+            filters.push(Box::new(WhenFilter::new(condition, options.strict)));
         }
 
         Ok(HistoricalQuery {
@@ -114,10 +116,9 @@ impl Query for HistoricalQuery {
                 let block_ref = bm.load_block(block_id)?;
 
                 self.current_block = Some(block_ref);
-                let (mut found_records, continue_query) =
-                    self.filter_records_from_current_block()?;
-                self.is_interrupted = !continue_query;
+                let mut found_records = self.filter_records_from_current_block()?;
                 found_records.sort_by_key(|rec| ts_to_us(rec.timestamp.as_ref().unwrap()));
+
                 self.records_from_current_block.extend(found_records);
                 if !self.records_from_current_block.is_empty() {
                     break;
@@ -146,43 +147,23 @@ impl Query for HistoricalQuery {
 }
 
 impl HistoricalQuery {
-    fn filter_records_from_current_block(&mut self) -> Result<(Vec<Record>, bool), ReductError> {
+    fn filter_records_from_current_block(&mut self) -> Result<Vec<Record>, ReductError> {
         let block = self.current_block.as_ref().unwrap().read()?;
         let mut filtered_records = Vec::new();
         for record in block.record_index().values() {
-            let mut include_record = true;
-            for filter in self.filters.iter_mut() {
-                match filter.filter(&record.clone().into()) {
-                    Ok(false) => {
-                        include_record = false;
-                        break;
-                    }
-                    Ok(true) => {}
-
-                    Err(err) => {
-                        // if the filter is interrupted, we return what we have
-                        // and notify the caller to stop the query
-                        if err.status == ErrorCode::Interrupt {
-                            return Ok((filtered_records, false));
-                        }
-
-                        if self.strict {
-                            // in strict mode, we return an error if a filter fails
-                            return Err(err);
-                        }
-
-                        // in non-strict mode, we ignore the record with the failed filter
-                        include_record = false;
-                        break;
-                    }
+            match apply_filters_recursively(self.filters.as_mut_slice(), vec![record.clone()], 0)? {
+                Some(records) => {
+                    filtered_records.extend(records);
                 }
-            }
-            if include_record {
-                filtered_records.push(record.clone());
+                None => {
+                    // If the filtering is interrupted, we stop processing further records.
+                    self.is_interrupted = true;
+                    return Ok(vec![]);
+                }
             }
         }
 
-        Ok((filtered_records, true))
+        Ok(filtered_records)
     }
 }
 

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -7,14 +7,14 @@ use crate::storage::proto::{record::State as RecordState, ts_to_us, Record};
 use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::condition::Parser;
 use crate::storage::query::filters::{
-    apply_filters_recursively, EachNFilter, EachSecondFilter, ExcludeLabelFilter, GetMeta,
+    apply_filters_recursively, EachNFilter, EachSecondFilter, ExcludeLabelFilter, FilterRecord,
     IncludeLabelFilter, RecordFilter, RecordStateFilter, TimeRangeFilter, WhenFilter,
 };
 use reduct_base::error::{ErrorCode, ReductError};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, RwLock};
 
-impl GetMeta for Record {
+impl FilterRecord for Record {
     fn state(&self) -> i32 {
         self.state
     }
@@ -176,7 +176,7 @@ impl HistoricalQuery {
                 None => {
                     // If the filtering is interrupted, we stop processing further records.
                     self.is_interrupted = true;
-                    return Ok(vec![]);
+                    break;
                 }
             }
         }

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -10,7 +10,7 @@ use crate::storage::query::filters::{
     apply_filters_recursively, EachNFilter, EachSecondFilter, ExcludeLabelFilter, FilterRecord,
     IncludeLabelFilter, RecordFilter, RecordStateFilter, TimeRangeFilter, WhenFilter,
 };
-use reduct_base::error::{ErrorCode, ReductError};
+use reduct_base::error::ReductError;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, RwLock};
 


### PR DESCRIPTION
Closes #802

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What's Changed

- Added support for `#ctx_before` and `#ctx_after` directives.
- These new directives allow users to insert context lines before or after matched patterns, enhancing control over contextual data extraction.
- Updated parser logic to recognize and correctly process these new directives alongside existing ones.
- Extended tests to cover cases with `#ctx_before` and `#ctx_after`, ensuring expected behavior and backwards compatibility.
- Documentation updated to describe usage and examples for the new directives.


### Related issues

#802  https://github.com/reductstore/website/pull/212

### Does this PR introduce a breaking change?

No

### Other information:
