### PR TITLE
Remove deprecated `x-reduct-last` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix hanging query request if no extension registered, [PR-830](https://github.com/reductstore/reductstore/pull/830)
 - Fix `$limit` operator in extension context, [PR-848](https://github.com/reductstore/reductstore/pull/848)
 
+### Removed
+
+- `x-reduct-last` header from query response, [PR-876](https://github.com/reductstore/reductstore/pull/876)
+
 ## [1.15.6] - 2025-06-25
 
 ### Fixed

--- a/integration_tests/api/entry_api/query_test.py
+++ b/integration_tests/api/entry_api/query_test.py
@@ -63,14 +63,12 @@ def test_query_entry_next(base_url, session, bucket):
     assert resp.status_code == 200
     assert resp.content == b"some_data"
     assert resp.headers["x-reduct-time"] == "1000"
-    assert resp.headers["x-reduct-last"] == "0"
 
     resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
 
     assert resp.status_code == 200
     assert resp.content == b"some_data"
     assert resp.headers["x-reduct-time"] == "1100"
-    assert resp.headers["x-reduct-last"] == "0"
 
     resp = session.get(f"{base_url}/b/{bucket}/entry?q={query_id}")
     assert resp.status_code == 204

--- a/integration_tests/api/entry_api/read_write_record_test.py
+++ b/integration_tests/api/entry_api/read_write_record_test.py
@@ -50,7 +50,6 @@ def test_read_write_entries_big_blob_ok(base_url, session, bucket):
 
     assert resp.headers["content-type"] == "application/octet-stream"
     assert resp.headers["x-reduct-time"] == str(ts)
-    assert resp.headers["x-reduct-last"] == "1"
 
 
 @requires_env("API_TOKEN")
@@ -111,7 +110,6 @@ def test_latest_record(base_url, session, bucket):
     assert resp.status_code == 200
     assert resp.content == b"some_data2"
     assert resp.headers["x-reduct-time"] == "1010"
-    assert resp.headers["x-reduct-last"] == "1"
 
 
 def test_read_write_big_blob(base_url, session, bucket):

--- a/reductstore/src/api/entry/read_query.rs
+++ b/reductstore/src/api/entry/read_query.rs
@@ -84,7 +84,7 @@ mod tests {
             .upgrade()
             .unwrap();
         let mut rx = rx.write().await;
-        assert!(rx.recv().await.unwrap().unwrap().meta().last());
+        assert!(rx.recv().await.unwrap().is_ok());
 
         assert_eq!(
             rx.recv().await.unwrap().err().unwrap().status,

--- a/reductstore/src/api/entry/read_query.rs
+++ b/reductstore/src/api/entry/read_query.rs
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
     use crate::api::tests::{components, headers, path_to_entry_1};
     use reduct_base::error::ErrorCode;
-    use reduct_base::io::ReadRecord;
+
     use rstest::*;
 
     #[rstest]

--- a/reductstore/src/api/entry/read_query_post.rs
+++ b/reductstore/src/api/entry/read_query_post.rs
@@ -50,7 +50,7 @@ mod tests {
     use crate::core::weak::Weak;
     use crate::storage::query::QueryRx;
     use reduct_base::error::{ErrorCode, ReductError};
-    use reduct_base::io::ReadRecord;
+
     use reduct_base::msg::entry_api::QueryType;
     use rstest::*;
     use serde_json::json;

--- a/reductstore/src/api/entry/read_query_post.rs
+++ b/reductstore/src/api/entry/read_query_post.rs
@@ -76,7 +76,7 @@ mod tests {
             .upgrade()
             .unwrap();
         let mut rx = rx.write().await;
-        assert!(rx.recv().await.unwrap().unwrap().meta().last());
+        assert!(rx.recv().await.unwrap().is_ok());
         assert_eq!(
             rx.recv().await.unwrap().err().unwrap().status,
             ErrorCode::NoContent

--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -24,7 +24,6 @@ use hyper::http::HeaderValue;
 use reduct_base::bad_request;
 use reduct_base::io::ReadRecord;
 use std::collections::HashMap;
-use std::i64;
 use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -86,7 +85,6 @@ async fn fetch_and_response_single_record(
         );
         headers.insert("content-length", HeaderValue::from(meta.content_length()));
         headers.insert("x-reduct-time", HeaderValue::from(meta.timestamp()));
-        headers.insert("x-reduct-last", HeaderValue::from(i64::from(meta.last())));
         headers
     };
 
@@ -387,7 +385,6 @@ mod tests {
                         labels: vec![],
                         content_type: "".to_string(),
                     },
-                    false,
                 ),
                 empty_body: false,
             };

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -874,7 +874,7 @@ pub(super) mod tests {
             }),
             ..Default::default()
         };
-        RecordReader::form_record(record, false)
+        RecordReader::form_record(record)
     }
 
     #[fixture]

--- a/reductstore/src/replication/remote_bucket.rs
+++ b/reductstore/src/replication/remote_bucket.rs
@@ -203,7 +203,7 @@ pub(super) mod tests {
         let (_tx, rx) = tokio::sync::mpsc::channel(1);
         let mut rec = Record::default();
         rec.timestamp = Some(Timestamp::default());
-        let record = RecordReader::form_record_with_rx(rx, rec, false);
+        let record = RecordReader::form_record_with_rx(rx, rec);
         remote_bucket.write_batch("test", vec![(record, Transaction::WriteRecord(0))])
     }
 }

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -500,8 +500,8 @@ mod tests {
 
         (
             vec![
-                RecordReader::form_record_with_rx(rx1, rec1, false),
-                RecordReader::form_record_with_rx(rx2, rec2, false),
+                RecordReader::form_record_with_rx(rx1, rec1),
+                RecordReader::form_record_with_rx(rx2, rec2),
             ],
             vec![tx1, tx2],
         )

--- a/reductstore/src/replication/remote_bucket/states/bucket_available.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_available.rs
@@ -394,7 +394,6 @@ mod tests {
                     content_type: "text/plain".to_string(),
                     state: 0,
                 },
-                false,
             ),
             Transaction::WriteRecord(0),
         )
@@ -414,7 +413,6 @@ mod tests {
                     content_type: "text/plain".to_string(),
                     state: 0,
                 },
-                false,
             ),
             Transaction::UpdateRecord(0),
         )

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -955,13 +955,9 @@ mod tests {
             assert_eq!(record.state, 1);
 
             // read content
-            let mut reader = RecordReader::try_new(
-                Arc::clone(&block_manager),
-                block_ref.clone(),
-                record_time,
-                false,
-            )
-            .unwrap();
+            let mut reader =
+                RecordReader::try_new(Arc::clone(&block_manager), block_ref.clone(), record_time)
+                    .unwrap();
 
             let mut received = BytesMut::new();
             while let Some(Ok(chunk)) = reader.blocking_read() {

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -49,7 +49,7 @@ impl Entry {
                 ));
             }
 
-            RecordReader::try_new(block_manager, block_ref, time, true)
+            RecordReader::try_new(block_manager, block_ref, time)
         })
     }
 }

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -152,13 +152,12 @@ impl Query for HistoricalQuery {
         let block = self.current_block.as_ref().unwrap();
 
         if self.only_metadata {
-            Ok(RecordReader::form_record(record.clone(), false))
+            Ok(RecordReader::form_record(record.clone()))
         } else {
             RecordReader::try_new(
                 Arc::clone(&block_manager),
                 block.clone(),
                 ts_to_us(&record.timestamp.unwrap()),
-                false,
             )
         }
     }

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -35,15 +35,7 @@ impl Query for LimitedQuery {
         }
 
         self.limit_count -= 1;
-        let reader = self.query.next(block_manager);
-        if self.limit_count == 0 {
-            reader.map(|mut r| {
-                r.set_last(true);
-                r
-            })
-        } else {
-            reader
-        }
+        self.query.next(block_manager)
     }
 }
 
@@ -69,7 +61,6 @@ mod tests {
 
         let reader = query.next(block_manager.clone()).unwrap();
         assert_eq!(reader.meta().timestamp(), 0);
-        assert!(reader.meta().last());
 
         assert_eq!(
             query.next(block_manager).err(),


### PR DESCRIPTION
Closes #874 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Removing old deprecated feature

### What was changed?

The header `x-reduct-last` is removed from the query API.

### Related issues

No

### Does this PR introduce a breaking change?

Yes, for very old systems. The official SDKs don't use it anymore.

### Other information:
