### PR TITLE
Support for wild card in write/read tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filter buckets by read permission in server information, [PR-849](https://github.com/reductstore/reductstore/pull/849)
 - Support for duration literals, [PR-864](https://github.com/reductstore/reductstore/pull/864)
 - Support for `#ctx_before` and `#ctx_after` directives, [PR-866](https://github.com/reductstore/reductstore/pull/866)
-- Support for wild card in write/read tokens, [PR-877](https://github.com/reductstore/reductstore/pull/877)
+- Support for wildcards in write/read token permissions, [PR-877](https://github.com/reductstore/reductstore/pull/877)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filter buckets by read permission in server information, [PR-849](https://github.com/reductstore/reductstore/pull/849)
 - Support for duration literals, [PR-864](https://github.com/reductstore/reductstore/pull/864)
 - Support for `#ctx_before` and `#ctx_after` directives, [PR-866](https://github.com/reductstore/reductstore/pull/866)
+- Support for wild card in write/read tokens, [PR-877](https://github.com/reductstore/reductstore/pull/877)
 
 ### Changed
 

--- a/integration_tests/api/bucket_api_test.py
+++ b/integration_tests/api/bucket_api_test.py
@@ -46,7 +46,8 @@ def test__create_bucket_with_full_access_token(
     assert resp.status_code == 401
 
     resp = session.post(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+        f"{base_url}/b/{bucket_name}",
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
@@ -94,17 +95,18 @@ def test__get_bucket_with_authenticated_token(
     assert resp.status_code == 401
 
     resp = session.get(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+        f"{base_url}/b/{bucket_name}",
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.get(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket)
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket.value)
     )
     assert resp.status_code == 200
 
     resp = session.get(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket)
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket.value)
     )
     assert resp.status_code == 403
 
@@ -201,17 +203,18 @@ def test__update_bucket_with_full_access_token(
     assert resp.status_code == 401
 
     resp = session.put(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+        f"{base_url}/b/{bucket_name}",
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.put(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket)
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket.value)
     )
     assert resp.status_code == 403
 
     resp = session.put(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket)
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket.value)
     )
     assert resp.status_code == 403
 
@@ -242,17 +245,18 @@ def test__remove_bucket_with_full_access_token(
     assert resp.status_code == 401
 
     resp = session.delete(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+        f"{base_url}/b/{bucket_name}",
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.delete(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket)
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_read_bucket.value)
     )
     assert resp.status_code == 403
 
     resp = session.delete(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket)
+        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_write_bucket.value)
     )
     assert resp.status_code == 403
 
@@ -283,7 +287,8 @@ def test__head_bucket_with_full_access_token(
     assert resp.status_code == 401
 
     resp = session.head(
-        f"{base_url}/b/{bucket_name}", headers=auth_headers(token_without_permissions)
+        f"{base_url}/b/{bucket_name}",
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 200
 
@@ -327,20 +332,20 @@ def test__rename_bucket_with_full_access_token(
     resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",
         json={"new_name": new_bucket_name},
-        headers=auth_headers(token_without_permissions),
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",
         json={"new_name": new_bucket_name},
-        headers=auth_headers(token_read_bucket),
+        headers=auth_headers(token_read_bucket.value),
     )
     assert resp.status_code == 403
 
     resp = session.put(
         f"{base_url}/b/{bucket_name}/rename",
         json={"new_name": new_bucket_name},
-        headers=auth_headers(token_write_bucket),
+        headers=auth_headers(token_write_bucket.value),
     )
     assert resp.status_code == 403

--- a/integration_tests/api/conftest.py
+++ b/integration_tests/api/conftest.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import secrets
+from collections import namedtuple
 from typing import Callable
 
 import pytest
@@ -75,9 +76,12 @@ def _make_token_permissions(session, base_url, token_generator):
     permissions = {
         "full_access": False,
     }
-    resp = session.post(f"{base_url}/tokens/{token_generator()}", json=permissions)
+    name = token_generator()
+    resp = session.post(f"{base_url}/tokens/{name}", json=permissions)
     assert resp.status_code == 200
-    return json.loads(resp.content)["value"]
+    return namedtuple("Token", ["name", "value"])(
+        name, json.loads(resp.content)["value"]
+    )
 
 
 @pytest.fixture(name="token_read_bucket")
@@ -87,9 +91,12 @@ def _make_token_read_bucket(session, base_url, bucket_name, token_generator):
         "full_access": False,
         "read": [bucket_name],
     }
-    resp = session.post(f"{base_url}/tokens/{token_generator()}", json=permissions)
+    name = token_generator()
+    resp = session.post(f"{base_url}/tokens/{name}", json=permissions)
     assert resp.status_code == 200
-    return json.loads(resp.content)["value"]
+    return namedtuple("Token", ["name", "value"])(
+        name, json.loads(resp.content)["value"]
+    )
 
 
 @pytest.fixture(name="token_write_bucket")
@@ -100,6 +107,9 @@ def _make_token_write_bucket(session, base_url, bucket_name, token_generator):
         "full_access": False,
         "write": [bucket_name],
     }
-    resp = session.post(f"{base_url}/tokens/{token_generator()}", json=permissions)
+    name = token_generator()
+    resp = session.post(f"{base_url}/tokens/{name}", json=permissions)
     assert resp.status_code == 200
-    return json.loads(resp.content)["value"]
+    return namedtuple("Token", ["name", "value"])(
+        name, json.loads(resp.content)["value"]
+    )

--- a/integration_tests/api/entry_api/entry_test.py
+++ b/integration_tests/api/entry_api/entry_test.py
@@ -1,4 +1,4 @@
-from ..conftest import requires_env
+from ..conftest import requires_env, auth_headers
 
 
 def test_remove_entry(base_url, session, bucket):
@@ -29,19 +29,19 @@ def test_remove_with_bucket_write_permissions(
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry",
-        headers={"Authorization": f"Bearer {token_without_permissions}"},
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry",
-        headers={"Authorization": f"Bearer {token_read_bucket}"},
+        headers=auth_headers(token_read_bucket.value),
     )
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry",
-        headers={"Authorization": f"Bearer {token_write_bucket}"},
+        headers=auth_headers(token_write_bucket.value),
     )
     assert resp.status_code == 200
 
@@ -74,27 +74,27 @@ def test_rename_with_bucket_write_permissions(
     token_read_bucket,
     token_write_bucket,
 ):
-    """Needs write permissions to rename entry"""
+    """Needs to write permissions to rename entry"""
     resp = session.post(f"{base_url}/b/{bucket}/entry?ts=1000", data="some_data1")
     assert resp.status_code == 200
 
     resp = session.put(
         f"{base_url}/b/{bucket}/entry/rename",
         json={"new_name": "new_name"},
-        headers={"Authorization": f"Bearer {token_without_permissions}"},
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.put(
         f"{base_url}/b/{bucket}/entry/rename",
         json={"new_name": "new_name"},
-        headers={"Authorization": f"Bearer {token_read_bucket}"},
+        headers=auth_headers(token_read_bucket.value),
     )
     assert resp.status_code == 403
 
     resp = session.put(
         f"{base_url}/b/{bucket}/entry/rename",
         json={"new_name": "new_name"},
-        headers={"Authorization": f"Bearer {token_write_bucket}"},
+        headers=auth_headers(token_write_bucket.value),
     )
     assert resp.status_code == 200

--- a/integration_tests/api/entry_api/query_test.py
+++ b/integration_tests/api/entry_api/query_test.py
@@ -292,20 +292,20 @@ def test__query_with_read_token(
 
     resp = session.get(
         f"{base_url}/b/{bucket}/entry/q",
-        headers=auth_headers(token_without_permissions),
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.post(
         f"{base_url}/b/{bucket}/entry/q",
-        headers=auth_headers(token_read_bucket),
+        headers=auth_headers(token_read_bucket.value),
         json={"query_type": "QUERY"},
     )
     assert resp.status_code == 404  # no data
 
     resp = session.post(
         f"{base_url}/b/{bucket}/entry/q",
-        headers=auth_headers(token_write_bucket),
+        headers=auth_headers(token_write_bucket.value),
         json={"query_type": "QUERY"},
     )
     assert resp.status_code == 403

--- a/integration_tests/api/entry_api/read_write_record_test.py
+++ b/integration_tests/api/entry_api/read_write_record_test.py
@@ -67,17 +67,19 @@ def test__read_with_read_token(
 
     resp = session.get(
         f"{base_url}/b/{bucket}/entry?ts=1000",
-        headers=auth_headers(token_without_permissions),
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.get(
-        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_read_bucket)
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        headers=auth_headers(token_read_bucket.value),
     )
     assert resp.status_code == 404  # no data
 
     resp = session.get(
-        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_write_bucket)
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        headers=auth_headers(token_write_bucket.value),
     )
     assert resp.status_code == 403
 
@@ -150,7 +152,7 @@ def test__write_with_write_token(
     token_read_bucket,
     token_write_bucket,
 ):
-    """Needs write permissions to write"""
+    """Needs to write permissions to write"""
     resp = session.post(
         f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers("")
     )
@@ -158,17 +160,19 @@ def test__write_with_write_token(
 
     resp = session.post(
         f"{base_url}/b/{bucket}/entry?ts=1000",
-        headers=auth_headers(token_without_permissions),
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
 
     resp = session.post(
-        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_read_bucket)
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        headers=auth_headers(token_read_bucket.value),
     )
     assert resp.status_code == 403
 
     resp = session.post(
-        f"{base_url}/b/{bucket}/entry?ts=1000", headers=auth_headers(token_write_bucket)
+        f"{base_url}/b/{bucket}/entry?ts=1000",
+        headers=auth_headers(token_write_bucket.value),
     )
     assert resp.status_code == 200
 
@@ -178,7 +182,6 @@ def test__head_entry_with_full_access_token(
     base_url,
     session,
     bucket,
-    token_without_permissions,
     token_write_bucket,
     token_read_bucket,
 ):
@@ -189,12 +192,13 @@ def test__head_entry_with_full_access_token(
     resp = session.post(
         f"{base_url}/b/{bucket}/{entry_name}?ts={ts}",
         data=dummy_data,
-        headers=auth_headers(token_write_bucket),
+        headers=auth_headers(token_write_bucket.value),
     )
     assert resp.status_code == 200
 
     resp = session.head(
-        f"{base_url}/b/{bucket}/{entry_name}", headers=auth_headers(token_read_bucket)
+        f"{base_url}/b/{bucket}/{entry_name}",
+        headers=auth_headers(token_read_bucket.value),
     )
     assert resp.status_code == 200
     assert len(resp.content) == 0

--- a/integration_tests/api/entry_api/remove_record_test.py
+++ b/integration_tests/api/entry_api/remove_record_test.py
@@ -1,5 +1,5 @@
 import pytest
-from ..conftest import requires_env
+from ..conftest import requires_env, auth_headers
 
 
 @pytest.fixture(name="write_data")
@@ -92,21 +92,21 @@ def test_remove_record_with_permission(
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry?ts={ts1}",
-        headers={"Authorization": f"Bearer {token_without_permissions}"},
+        headers=auth_headers(token_without_permissions.value),
     )
 
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry?ts={ts1}",
-        headers={"Authorization": f"Bearer {token_read_bucket}"},
+        headers=auth_headers(token_read_bucket.value),
     )
 
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry?ts={ts1}",
-        headers={"Authorization": f"Bearer {token_write_bucket}"},
+        headers=auth_headers(token_write_bucket.value),
     )
 
     assert resp.status_code == 200
@@ -126,21 +126,21 @@ def test_remove_records_in_batch_with_permission(
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry/batch",
-        headers={"Authorization": f"Bearer {token_without_permissions}"},
+        headers=auth_headers(token_without_permissions.value),
     )
 
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry/batch",
-        headers={"Authorization": f"Bearer {token_read_bucket}"},
+        headers=auth_headers(token_read_bucket.value),
     )
 
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry/batch",
-        headers={"Authorization": f"Bearer {token_write_bucket}"},
+        headers=auth_headers(token_write_bucket.value),
     )
 
     assert resp.status_code == 200
@@ -160,21 +160,21 @@ def test_remove_records_query_with_permission(
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry/q?start={ts1}&stop={ts2 + 1}",
-        headers={"Authorization": f"Bearer {token_without_permissions}"},
+        headers=auth_headers(token_without_permissions.value),
     )
 
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry/q?start={ts1}&stop={ts2 + 1}",
-        headers={"Authorization": f"Bearer {token_read_bucket}"},
+        headers=auth_headers(token_read_bucket.value),
     )
 
     assert resp.status_code == 403
 
     resp = session.delete(
         f"{base_url}/b/{bucket}/entry/q?start={ts1}&stop={ts2 + 1}",
-        headers={"Authorization": f"Bearer {token_write_bucket}"},
+        headers=auth_headers(token_write_bucket.value),
     )
 
     assert resp.status_code == 200

--- a/integration_tests/api/server_api_test.py
+++ b/integration_tests/api/server_api_test.py
@@ -51,7 +51,7 @@ def test__authorized_info(base_url, session, token_without_permissions):
     assert resp.status_code == 401
 
     resp = session.get(
-        f"{base_url}/info", headers=auth_headers(token_without_permissions)
+        f"{base_url}/info", headers=auth_headers(token_without_permissions.value)
     )
     assert resp.status_code == 200
 
@@ -80,7 +80,7 @@ def test__authorized_list(base_url, session, token_without_permissions):
     assert resp.status_code == 401
 
     resp = session.get(
-        f"{base_url}/list", headers=auth_headers(token_without_permissions)
+        f"{base_url}/list", headers=auth_headers(token_without_permissions.value)
     )
     assert resp.status_code == 200
 

--- a/integration_tests/api/token_api_test.py
+++ b/integration_tests/api/token_api_test.py
@@ -36,10 +36,13 @@ def test__creat_token_with_full_access(
     resp = session.post(
         f"{base_url}/tokens/{token_name}",
         json=permissions,
-        headers=auth_headers(token_without_permissions),
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
-    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
+    assert (
+        resp.headers["x-reduct-error"]
+        == f"Token '{token_without_permissions.name}' doesn't have full access"
+    )
 
 
 @requires_env("API_TOKEN")
@@ -63,10 +66,13 @@ def test__list_token_with_full_access(base_url, session, token_without_permissio
     assert resp.status_code == 401
 
     resp = session.get(
-        f"{base_url}/tokens", headers=auth_headers(token_without_permissions)
+        f"{base_url}/tokens", headers=auth_headers(token_without_permissions.value)
     )
     assert resp.status_code == 403
-    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
+    assert (
+        resp.headers["x-reduct-error"]
+        == f"Token '{token_without_permissions.name}' doesn't have full access"
+    )
 
 
 @requires_env("API_TOKEN")
@@ -104,10 +110,14 @@ def test__get_token_with_full_access(base_url, session, token_without_permission
     assert resp.status_code == 401
 
     resp = session.get(
-        f"{base_url}/tokens/token-name", headers=auth_headers(token_without_permissions)
+        f"{base_url}/tokens/token-name",
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
-    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
+    assert (
+        resp.headers["x-reduct-error"]
+        == f"Token '{token_without_permissions.name}' doesn't have full access"
+    )
 
 
 @requires_env("API_TOKEN")
@@ -133,7 +143,11 @@ def test__delete_token_with_full_access(base_url, session, token_without_permiss
     assert resp.status_code == 401
 
     resp = session.delete(
-        f"{base_url}/tokens/token-name", headers=auth_headers(token_without_permissions)
+        f"{base_url}/tokens/token-name",
+        headers=auth_headers(token_without_permissions.value),
     )
     assert resp.status_code == 403
-    assert resp.headers["x-reduct-error"] == "Token doesn't have full access"
+    assert (
+        resp.headers["x-reduct-error"]
+        == f"Token '{token_without_permissions.name}' doesn't have full access"
+    )

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -294,6 +294,16 @@ macro_rules! bad_request {
 }
 
 #[macro_export]
+macro_rules! forbidden {
+    ($msg:expr, $($arg:tt)*) => {
+        ReductError::forbidden(&format!($msg, $($arg)*))
+    };
+    ($msg:expr) => {
+        ReductError::forbidden($msg)
+    };
+}
+
+#[macro_export]
 macro_rules! unprocessable_entity {
     ($msg:expr, $($arg:tt)*) => {
         ReductError::unprocessable_entity(&format!($msg, $($arg)*))

--- a/reductstore/src/api/bucket/get.rs
+++ b/reductstore/src/api/bucket/get.rs
@@ -21,7 +21,7 @@ pub(crate) async fn get_bucket(
         &components,
         &headers,
         ReadAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: &bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -46,7 +46,7 @@ pub(crate) async fn read_batched_records(
         &components,
         &headers,
         ReadAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: &bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/read_query.rs
+++ b/reductstore/src/api/entry/read_query.rs
@@ -27,7 +27,7 @@ pub(crate) async fn read_query(
         &components,
         &headers,
         ReadAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: &bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/read_query_post.rs
+++ b/reductstore/src/api/entry/read_query_post.rs
@@ -26,7 +26,7 @@ pub(crate) async fn read_query_json(
         &components,
         &headers,
         ReadAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: &bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/read_single.rs
+++ b/reductstore/src/api/entry/read_single.rs
@@ -43,7 +43,7 @@ pub(crate) async fn read_record(
         &components,
         &headers,
         ReadAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: &bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/remove_batched.rs
+++ b/reductstore/src/api/entry/remove_batched.rs
@@ -27,7 +27,7 @@ pub(crate) async fn remove_batched_records(
         &components,
         &headers,
         WriteAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/remove_entry.rs
+++ b/reductstore/src/api/entry/remove_entry.rs
@@ -24,7 +24,7 @@ pub(crate) async fn remove_entry(
         &components,
         &headers,
         WriteAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/remove_query.rs
+++ b/reductstore/src/api/entry/remove_query.rs
@@ -29,7 +29,7 @@ pub(crate) async fn remove_query(
         &components,
         &headers,
         WriteAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/remove_query_post.rs
+++ b/reductstore/src/api/entry/remove_query_post.rs
@@ -34,7 +34,7 @@ pub(crate) async fn remove_query_json(
         &components,
         &headers,
         WriteAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/remove_single.rs
+++ b/reductstore/src/api/entry/remove_single.rs
@@ -20,14 +20,7 @@ pub(crate) async fn remove_record(
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<(), HttpError> {
     let bucket = path.get("bucket_name").unwrap();
-    check_permissions(
-        &components,
-        &headers,
-        WriteAccessPolicy {
-            bucket: bucket.clone(),
-        },
-    )
-    .await?;
+    check_permissions(&components, &headers, WriteAccessPolicy { bucket }).await?;
 
     let ts = parse_timestamp_from_query(&params)?;
     let entry_name = path.get("entry_name").unwrap();

--- a/reductstore/src/api/entry/rename_entry.rs
+++ b/reductstore/src/api/entry/rename_entry.rs
@@ -25,7 +25,7 @@ pub(crate) async fn rename_entry(
         &components,
         &headers,
         WriteAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/update_batched.rs
+++ b/reductstore/src/api/entry/update_batched.rs
@@ -32,7 +32,7 @@ pub(crate) async fn update_batched_records(
         &components,
         &headers,
         WriteAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/update_single.rs
+++ b/reductstore/src/api/entry/update_single.rs
@@ -26,14 +26,7 @@ pub(crate) async fn update_record(
     _: Body,
 ) -> Result<(), HttpError> {
     let bucket = path.get("bucket_name").unwrap();
-    check_permissions(
-        &components,
-        &headers,
-        WriteAccessPolicy {
-            bucket: bucket.clone(),
-        },
-    )
-    .await?;
+    check_permissions(&components, &headers, WriteAccessPolicy { bucket }).await?;
 
     let ts = parse_timestamp_from_query(&params)?;
 

--- a/reductstore/src/api/entry/write_batched.rs
+++ b/reductstore/src/api/entry/write_batched.rs
@@ -42,12 +42,12 @@ pub(crate) async fn write_batched_records(
     Path(path): Path<HashMap<String, String>>,
     body: Body,
 ) -> Result<impl IntoResponse, HttpError> {
-    let bucket_name = path.get("bucket_name").unwrap().clone();
+    let bucket_name = path.get("bucket_name").unwrap();
     check_permissions(
         &components,
         &headers,
         WriteAccessPolicy {
-            bucket: bucket_name.clone(),
+            bucket: bucket_name,
         },
     )
     .await?;

--- a/reductstore/src/api/entry/write_single.rs
+++ b/reductstore/src/api/entry/write_single.rs
@@ -30,14 +30,7 @@ pub(crate) async fn write_record(
     body: Body,
 ) -> Result<(), HttpError> {
     let bucket = path.get("bucket_name").unwrap();
-    check_permissions(
-        &components,
-        &headers.clone(),
-        WriteAccessPolicy {
-            bucket: bucket.clone(),
-        },
-    )
-    .await?;
+    check_permissions(&components, &headers.clone(), WriteAccessPolicy { bucket }).await?;
 
     let mut stream = body.into_data_stream();
 

--- a/reductstore/src/api/server/list.rs
+++ b/reductstore/src/api/server/list.rs
@@ -25,7 +25,7 @@ pub(crate) async fn list(
             &components,
             &headers,
             ReadAccessPolicy {
-                bucket: bucket.name.clone(),
+                bucket: &bucket.name,
             },
         )
         .await

--- a/reductstore/src/auth/policy.rs
+++ b/reductstore/src/auth/policy.rs
@@ -73,14 +73,8 @@ impl Policy for ReadAccessPolicy<'_> {
             return Ok(());
         }
 
-        for bucket in &permissions.read {
-            // Check if the token has read access for the specified bucket with wildcard support
-            let wildcard_bucket = bucket.ends_with('*');
-            if bucket == &self.bucket
-                || (wildcard_bucket && self.bucket.starts_with(&bucket[..bucket.len() - 1]))
-            {
-                return Ok(());
-            }
+        if check_bucket_permissions(&permissions.read, self.bucket) {
+            return Ok(());
         }
 
         Err(forbidden!(
@@ -105,14 +99,8 @@ impl Policy for WriteAccessPolicy<'_> {
             return Ok(());
         }
 
-        for bucket in &permissions.write {
-            // Check if the token has write access for the specified bucket with wildcard support
-            let wildcard_bucket = bucket.ends_with('*');
-            if bucket == &self.bucket
-                || (wildcard_bucket && self.bucket.starts_with(&bucket[..bucket.len() - 1]))
-            {
-                return Ok(());
-            }
+        if check_bucket_permissions(&permissions.write, self.bucket) {
+            return Ok(());
         }
 
         Err(forbidden!(
@@ -121,6 +109,19 @@ impl Policy for WriteAccessPolicy<'_> {
             self.bucket
         ))
     }
+}
+
+fn check_bucket_permissions(token_list: &Vec<String>, bucket: &str) -> bool {
+    for token_bucket in token_list {
+        // Check if the token has access for the specified bucket with wildcard support
+        let wildcard_bucket = token_bucket.ends_with('*');
+        if token_bucket == bucket
+            || (wildcard_bucket && bucket.starts_with(&token_bucket[..token_bucket.len() - 1]))
+        {
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/reductstore/src/auth/policy.rs
+++ b/reductstore/src/auth/policy.rs
@@ -198,6 +198,9 @@ mod tests {
         );
 
         token.permissions.as_mut().unwrap().read = vec!["bucket*".to_string()];
+        assert!(policy.validate(Ok(token.clone())).is_ok());
+
+        token.permissions.as_mut().unwrap().read = vec!["*".to_string()];
         assert!(policy.validate(Ok(token)).is_ok());
 
         assert_eq!(
@@ -233,6 +236,9 @@ mod tests {
         );
 
         token.permissions.as_mut().unwrap().write = vec!["bucket*".to_string()];
+        assert!(policy.validate(Ok(token.clone())).is_ok());
+
+        token.permissions.as_mut().unwrap().write = vec!["*".to_string()];
         assert!(policy.validate(Ok(token)).is_ok());
 
         assert_eq!(


### PR DESCRIPTION
Closes #875

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature 

### What was changed?

- **Added wildcard support for tokens:**  
  The authentication and authorization system now supports wildcards (`*`) in both read and write tokens. This allows administrators to grant permissions to multiple buckets or resources using a single token pattern, simplifying token management.

- **Updated token validation logic:**  
  The logic for matching bucket/resource names against token permissions has been enhanced to properly interpret and enforce wildcard patterns.

- **Extended tests:**  
  New test cases have been added to verify correct behavior with various wildcard scenarios, ensuring that both specific and wildcard-based tokens are handled as expected.

- **Documentation updated:**  
  Relevant documentation and API descriptions have been updated to reflect the new wildcard capabilities for tokens.

**Summary:**  
You can now use tokens like `read:bucket-*` or `write:*` to grant access to multiple resources at once, making permission management more flexible and scalable.

### Related issues

#875 

### Does this PR introduce a breaking change?

No

### Other information:
