### PR TITLE
Fix directive parsing and order of operators in conditional query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fix directive parsing and order of operators in conditional query, [PR-899](https://github.com/reductstore/reductstore/pull/899)
+
 ## [1.16.0] - 2025-07-31
 
 ### Added

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -38,7 +38,7 @@ hex = "0.4.3"
 prost-wkt-types = "0.6.1"
 rand = "0.9.2"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.141"
+serde_json = { version = "1.0.141", features = ["preserve_order"] }
 regex = "1.11.1"
 bytes = "1.10.1"
 axum = { version = "0.8.4", features = ["default", "macros"] }

--- a/reductstore/src/storage/query/condition.rs
+++ b/reductstore/src/storage/query/condition.rs
@@ -1,7 +1,6 @@
 // Copyright 2024 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
-use crate::storage::query::condition::value::Value;
 use reduct_base::error::ReductError;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -67,3 +66,4 @@ impl Debug for BoxedNode {
 
 pub(crate) use parser::Directives;
 pub(crate) use parser::Parser;
+pub(crate) use value::Value;

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -116,7 +116,7 @@ impl Parser {
 
         // Remove directives from the original JSON object
         for key in keys_to_remove {
-            json.as_object_mut().unwrap().remove(&key);
+            json.as_object_mut().unwrap().shift_remove(&key);
         }
         Ok(directives)
     }

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -503,6 +503,31 @@ mod tests {
                 "[UnprocessableEntity] Directive '#invalid_directive' is not supported"
             );
         }
+
+        #[rstest]
+        fn test_parse_object_directive(parser: Parser) {
+            let json = json!({
+                "#ctx_before": {"invalid": "object"}
+            });
+            let result = parser.parse(json);
+            assert_eq!(
+                result.err().unwrap().to_string(),
+                "[UnprocessableEntity] Directive '#ctx_before' cannot be an object"
+            );
+        }
+
+        #[rstest]
+        fn test_parse_null_directive(parser: Parser) {
+            let json = json!({
+                "#ctx_before": null
+            });
+
+            let result = parser.parse(json);
+            assert_eq!(
+                result.err().unwrap().to_string(),
+                "[UnprocessableEntity] Directive '#ctx_before' cannot be null"
+            );
+        }
     }
 
     mod parse_operators {

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -175,7 +175,6 @@ mod tests {
                 "$limit": [1]
                 }))
                 .unwrap();
-            println!("Condition: {:?}", condition);
 
             let mut filter = WhenFilter::try_new(condition, directives, true).unwrap();
 

--- a/reductstore/src/storage/query/filters/when.rs
+++ b/reductstore/src/storage/query/filters/when.rs
@@ -9,11 +9,9 @@ use crate::storage::query::condition::{BoxedNode, Context, Directives};
 use crate::storage::query::filters::when::ctx_after::CtxAfter;
 use crate::storage::query::filters::when::ctx_before::CtxBefore;
 use crate::storage::query::filters::when::select_labels::LabelSelector;
-use crate::storage::query::filters::when::Padding::{Duration, Records};
 use crate::storage::query::filters::{FilterRecord, RecordFilter};
 use reduct_base::error::{ErrorCode, ReductError};
-use reduct_base::unprocessable_entity;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 
 pub(super) enum Padding {
     Records(usize),
@@ -103,7 +101,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    use crate::storage::query::condition::{Directives, Parser};
+    use crate::storage::query::condition::Parser;
     use crate::storage::query::filters::tests::TestFilterRecord;
     use reduct_base::io::RecordMeta;
     use rstest::{fixture, rstest};

--- a/reductstore/src/storage/query/filters/when/ctx_after.rs
+++ b/reductstore/src/storage/query/filters/when/ctx_after.rs
@@ -1,8 +1,11 @@
 // Copyright 2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+use crate::storage::query::condition::Value;
 use crate::storage::query::filters::when::Padding;
 use crate::storage::query::filters::when::Padding::{Duration, Records};
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
 
 /// Context for managing records after a condition is checked in a `when` filter.
 pub(super) struct CtxAfter {
@@ -12,12 +15,38 @@ pub(super) struct CtxAfter {
 }
 
 impl CtxAfter {
-    pub fn new(after: Padding) -> Self {
-        CtxAfter {
+    pub fn try_new(directive: Option<Vec<Value>>) -> Result<Self, ReductError> {
+        let after = match directive {
+            Some(after) => {
+                if after.len() != 1 {
+                    return Err(unprocessable_entity!("#ctx_after must be a single value"));
+                }
+                let after_val = after.first().unwrap();
+
+                let val = after_val.as_int().map_err(|e| {
+                    unprocessable_entity!(
+                        "#ctx_after must be an integer or duration: {}",
+                        e.message
+                    )
+                })?;
+
+                if val < 0 {
+                    return Err(unprocessable_entity!("#ctx_after must be non-negative",));
+                }
+                if after_val.is_duration() {
+                    Duration(val as u64)
+                } else {
+                    Records(val as usize)
+                }
+            }
+            None => Records(0), // Default to 0 records after
+        };
+
+        Ok(CtxAfter {
             after,
             count: 0,
             last_ts: None,
-        }
+        })
     }
 
     /// Checks the condition against the context, updating the state based on the padding type.
@@ -47,7 +76,7 @@ mod tests {
 
     #[test]
     fn test_ctx_after_records() {
-        let mut ctx = CtxAfter::new(Records(3));
+        let mut ctx = CtxAfter::try_new(Some(vec![Value::Int(3)])).unwrap();
         assert!(ctx.check(true, 1000));
         assert!(ctx.check(false, 2000));
         assert!(ctx.check(false, 3000));
@@ -57,10 +86,34 @@ mod tests {
 
     #[test]
     fn test_ctx_after_duration() {
-        let mut ctx = CtxAfter::new(Duration(5000));
+        let mut ctx = CtxAfter::try_new(Some(vec![Value::Duration(5000)])).unwrap();
         assert!(ctx.check(true, 1000));
         assert!(ctx.check(false, 2000));
         assert!(ctx.check(false, 6000)); // Should still be true due to duration
         assert!(!ctx.check(false, 7000)); // Should be false after duration expires
+    }
+
+    #[test]
+    fn test_ctx_after_invalid() {
+        let result = CtxAfter::try_new(Some(vec![Value::Int(-1)]));
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("#ctx_after must be non-negative")
+        );
+
+        let result = CtxAfter::try_new(Some(vec![Value::String("invalid".to_string())]));
+        assert_eq!(result.err().unwrap(), unprocessable_entity!("#ctx_after must be an integer or duration: Value 'invalid' could not be parsed as integer"));
+
+        let result = CtxAfter::try_new(Some(vec![Value::Int(1), Value::Int(2)]));
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("#ctx_after must be a single value")
+        );
+
+        let result = CtxAfter::try_new(Some(vec![]));
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("#ctx_after must be a single value")
+        );
     }
 }

--- a/reductstore/src/storage/query/filters/when/ctx_before.rs
+++ b/reductstore/src/storage/query/filters/when/ctx_before.rs
@@ -1,9 +1,12 @@
 // Copyright 2025 ReductSoftware UG
 // Licensed under the Business Source License 1.1
 
+use crate::storage::query::condition::Value;
 use crate::storage::query::filters::when::Padding;
 use crate::storage::query::filters::when::Padding::{Duration, Records};
 use crate::storage::query::filters::FilterRecord;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
 use std::collections::VecDeque;
 
 /// Context for managing records before a condition is checked in a `when` filter.
@@ -12,8 +15,38 @@ pub(super) struct CtxBefore {
 }
 
 impl CtxBefore {
-    pub fn new(before: Padding) -> Self {
-        CtxBefore { before }
+    pub fn try_new(directive: Option<Vec<Value>>) -> Result<Self, ReductError> {
+        let before = match directive {
+            Some(before) => {
+                if before.len() != 1 {
+                    return Err(unprocessable_entity!("#ctx_before must be a single value"));
+                }
+
+                let before_val = before.first().unwrap();
+                let val = before_val.as_int().map_err(|e| {
+                    unprocessable_entity!(
+                        "#ctx_before must be an integer or duration: {}",
+                        e.message
+                    )
+                })?;
+                if val < 0 {
+                    return Err(unprocessable_entity!("#ctx_before must be non-negative",));
+                }
+
+                if before_val.is_duration() {
+                    Duration(val as u64)
+                } else {
+                    Records(val as usize)
+                }
+            }
+
+            None => {
+                // Default to 0 records before if no padding is specified
+                Records(0)
+            }
+        };
+
+        Ok(CtxBefore { before })
     }
 
     /// Queues a record into the context buffer, managing the size based on the `before` padding.
@@ -51,12 +84,13 @@ impl CtxBefore {
 mod tests {
     use super::*;
     use crate::storage::query::filters::tests::TestFilterRecord;
+    use crate::storage::query::filters::when::ctx_after::CtxAfter;
     use reduct_base::io::RecordMeta;
     use rstest::*;
 
     #[rstest]
     fn test_ctx_before_records() {
-        let ctx = CtxBefore::new(Records(2));
+        let ctx = CtxBefore::try_new(Some(vec![Value::Int(2)])).unwrap();
         let mut buffer = VecDeque::new();
         let record: TestFilterRecord = RecordMeta::builder().build().into();
 
@@ -76,7 +110,7 @@ mod tests {
 
     #[rstest]
     fn test_ctx_before_duration() {
-        let ctx = CtxBefore::new(Duration(5000));
+        let ctx = CtxBefore::try_new(Some(vec![Value::Duration(5000)])).unwrap();
         let mut buffer = VecDeque::new();
         let record1: TestFilterRecord = RecordMeta::builder().timestamp(1000).build().into();
         let record2: TestFilterRecord = RecordMeta::builder().timestamp(6000).build().into();
@@ -100,6 +134,30 @@ mod tests {
             buffer.front(),
             Some(&record2),
             "Should keep the second record"
+        );
+    }
+
+    #[test]
+    fn test_ctx_after_invalid() {
+        let result = CtxBefore::try_new(Some(vec![Value::Int(-1)]));
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("#ctx_before must be non-negative")
+        );
+
+        let result = CtxBefore::try_new(Some(vec![Value::String("invalid".to_string())]));
+        assert_eq!(result.err().unwrap(), unprocessable_entity!("#ctx_before must be an integer or duration: Value 'invalid' could not be parsed as integer"));
+
+        let result = CtxBefore::try_new(Some(vec![Value::Int(1), Value::Int(2)]));
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("#ctx_before must be a single value")
+        );
+
+        let result = CtxBefore::try_new(Some(vec![]));
+        assert_eq!(
+            result.err().unwrap(),
+            unprocessable_entity!("#ctx_before must be a single value")
         );
     }
 }

--- a/reductstore/src/storage/query/filters/when/ctx_before.rs
+++ b/reductstore/src/storage/query/filters/when/ctx_before.rs
@@ -84,7 +84,7 @@ impl CtxBefore {
 mod tests {
     use super::*;
     use crate::storage::query::filters::tests::TestFilterRecord;
-    use crate::storage::query::filters::when::ctx_after::CtxAfter;
+
     use reduct_base::io::RecordMeta;
     use rstest::*;
 

--- a/reductstore/src/storage/query/filters/when/select_labels.rs
+++ b/reductstore/src/storage/query/filters/when/select_labels.rs
@@ -1,0 +1,120 @@
+// Copyright 2025 ReductSoftware UG
+// Licensed under the Business Source License 1.1
+
+use crate::storage::query::condition::Value;
+use crate::storage::query::filters::FilterRecord;
+use reduct_base::error::ReductError;
+use reduct_base::unprocessable_entity;
+use std::collections::{HashMap, HashSet};
+
+pub(super) struct LabelSelector {
+    labels: HashSet<String>,
+}
+
+impl LabelSelector {
+    pub fn try_new(directive: Option<Vec<Value>>) -> Result<Self, ReductError> {
+        let labels = match directive {
+            Some(labels) => {
+                if labels.is_empty() {
+                    return Err(unprocessable_entity!(
+                        "#select_labels must contain at least one label"
+                    ));
+                }
+
+                for label in &labels {
+                    if !label.is_string() {
+                        return Err(unprocessable_entity!(
+                            "#select_labels must contain only string values"
+                        ));
+                    }
+                }
+
+                labels
+                    .into_iter()
+                    .map(|label| label.to_string())
+                    .collect::<HashSet<String>>()
+            }
+            None => HashSet::new(), // Default to no labels selected
+        };
+
+        Ok(LabelSelector { labels })
+    }
+
+    pub fn select_labels<F: FilterRecord>(&self, mut record: F) -> F {
+        if !self.labels.is_empty() {
+            let filtered_labels = record
+                .labels()
+                .into_iter()
+                .filter(|(k, _)| self.labels.contains(k.as_str()))
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect::<HashMap<String, String>>();
+
+            record.set_labels(filtered_labels);
+        }
+
+        record
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::query::filters::tests::TestFilterRecord;
+    use crate::storage::query::filters::FilterRecord;
+    use reduct_base::io::RecordMeta;
+    use reduct_base::Labels;
+    use rstest::{fixture, rstest};
+
+    #[rstest]
+    fn test_label_selector(record: TestFilterRecord) {
+        let selector =
+            LabelSelector::try_new(Some(vec![Value::String("label1".to_string())])).unwrap();
+
+        let filtered_record = selector.select_labels(record);
+        assert_eq!(filtered_record.labels().len(), 1);
+        assert!(filtered_record.labels().contains_key(&"label1".to_string()));
+    }
+
+    #[rstest]
+    fn test_label_selector_empty(record: TestFilterRecord) {
+        let selector = LabelSelector::try_new(None).unwrap();
+
+        let filtered_record = selector.select_labels(record.clone());
+        assert_eq!(
+            filtered_record.labels(),
+            record.labels(),
+            "should be unchanged"
+        );
+    }
+
+    #[rstest]
+    fn test_new_label_selector_invalid() {
+        let result = LabelSelector::try_new(Some(vec![Value::Int(42)]));
+        assert!(
+            result.is_err(),
+            "should return an error for non-string values"
+        );
+    }
+
+    #[rstest]
+    fn test_new_label_selector_empty() {
+        let result = LabelSelector::try_new(Some(vec![]));
+        assert!(
+            result.is_err(),
+            "should return an error for empty label list"
+        );
+    }
+
+    #[fixture]
+    fn record() -> TestFilterRecord {
+        RecordMeta::builder()
+            .timestamp(1234567890)
+            .state(1)
+            .labels(Labels::from_iter(vec![
+                ("label1".to_string(), "value1".to_string()),
+                ("label2".to_string(), "value2".to_string()),
+            ]))
+            .build()
+            .into()
+    }
+}


### PR DESCRIPTION
Closes #894

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix + refactoring

### What was changed?

The query parser broke the order of operators after directive parsing.   The PR fixes this by preserving the order of operators. Additionally, it refactors the parser and moves the directive checks to the directives modules.

### Related issues

#894 #866 #888

### Does this PR introduce a breaking change?

No

### Other information:
