### PR TITLE
CVE-2025-55159: Update slab up to 0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent data lost of unsynchronized files in case of power failure for unfinished blocks, [PR-901](
+- Prevent data lost of unsynchronized files in case of power failure for unfinished blocks, [PR-909](https://github.com/reductstore/reductstore/pull/909)
+
+### Security
+
+- CVE-2025-55159: Update slab up to 0.4.11, [PR-911](https://github.com/reductstore/reductstore/pull/911)
 
 ## [1.16.1] - 2025-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security

### What was changed?

https://nvd.nist.gov/vuln/detail/CVE-2025-55159

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
