### PR TITLE
update extensions for rust 1.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Integrate S3 Storage Backend, [PR-919](https://github.com/reductstore/reductstore/pull/919)
 
+### Changed
+
+- Update extensions for Rust 1.89: ros-ext v0.3.0, select v0.5.0, [PR-921](https://github.com/reductstore/reductstore/pull/921)
+
 ## [1.16.3] - 2025-08-22
 
 ### Fixed

--- a/reductstore/build.rs
+++ b/reductstore/build.rs
@@ -30,10 +30,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     download_web_console("v1.11.2");
 
     #[cfg(feature = "select-ext")]
-    download_ext("select-ext", "v0.4.2");
+    download_ext("select-ext", "v0.5.0");
 
     #[cfg(feature = "ros-ext")]
-    download_ext("ros-ext", "v0.2.1");
+    download_ext("ros-ext", "v0.3.0");
 
     // get build time and commit
     let build_time = chrono::DateTime::<chrono::Utc>::from(SystemTime::now())


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Update

### What was changed?

Update the extensions to the version that was built using Rust 1.89

### Related issues

https://github.com/reductstore/select-ext/pull/31

https://github.com/reductstore/ros-ext/pull/42

### Does this PR introduce a breaking change?


No

### Other information:
