### PR TITLE
Prevent storage from crashing if block from WAL doesn't exist

### DIFF
--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -261,7 +261,10 @@ impl BlockManager {
         self.wal.append(block_id, WalEntry::RemoveBlock)?;
 
         let data_block_path = self.path_to_data(block_id);
-        FILE_CACHE.remove(&data_block_path)?;
+        if FILE_CACHE.try_exists(&data_block_path)? {
+            // it can be still in WAL only
+            FILE_CACHE.remove(&data_block_path)?;
+        }
 
         let desc_block_path = self.path_to_desc(block_id);
         if FILE_CACHE.try_exists(&desc_block_path)? {

--- a/reductstore/src/storage/block_manager/wal.rs
+++ b/reductstore/src/storage/block_manager/wal.rs
@@ -145,7 +145,7 @@ const STOP_MARKER: u8 = 255;
 impl Wal for WalImpl {
     fn append(&mut self, block_id: u64, entry: WalEntry) -> Result<(), ReductError> {
         let path = self.block_wal_path(block_id);
-        let file = if !path.exists() {
+        let file = if !FILE_CACHE.try_exists(&path)? {
             let wk = FILE_CACHE.write_or_create(&path, SeekFrom::Current(0))?;
             let file = wk.upgrade()?;
             // preallocate file to speed up writes


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

It is possible that the WAL wasn't cleaned after a block was removed. If this happens, the storage crashes when trying to remove an non-existent file after restarting.  Now we check if the file exists before trying to remove it. 


### Related issues

### Does this PR introduce a breaking change?

No

### Other information:
