### PR TITLE
Fix empty batch workaround 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,7 +704,6 @@ jobs:
           asset_name: reductstore.${{ matrix.target }}.zip
           asset_content_type: application/zip
   benchmark:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Run benchmarks
     runs-on: ubuntu-latest
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent storage from crashing if block from WAL doesn't exist, [PR-954](https://github.com/reductstore/reductstore/pull/954)
 - Clear bucket settings before saving them, [PR-957](https://github.com/reductstore/reductstore/pull/957)
 - Fix reusing token in ReplicationSettings, [PR-962](https://github.com/reductstore/reductstore/pull/962)
+- Fix empty batch workaround, [PR-963](https://github.com/reductstore/reductstore/pull/963)
 
 ### Internal
 

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -19,7 +19,7 @@ use crate::storage::query::QueryRx;
 use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::io::BoxedReadRecord;
-use reduct_base::unprocessable_entity;
+use reduct_base::{no_content, unprocessable_entity};
 use std::collections::{HashMap, VecDeque};
 use std::pin::Pin;
 use std::str::FromStr;
@@ -176,6 +176,23 @@ async fn fetch_and_response_batched_records(
             || start_time.elapsed() > io_settings.batch_timeout
         {
             break;
+        }
+    }
+
+    // TODO: it's workaround
+    // check if the query is still alive
+    // unfortunately, we can start using a finished query so we need to check if it's still alive again
+    if readers.is_empty() {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        match bucket
+            .get_entry(entry_name)?
+            .upgrade()?
+            .get_query_receiver(query_id)
+        {
+            Err(err) if err.status() == ErrorCode::NotFound => {
+                return Err(no_content!("No more records").into());
+            }
+            _ => { /* query is still alive */ }
         }
     }
 

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -179,17 +179,6 @@ async fn fetch_and_response_batched_records(
         }
     }
 
-    // TODO: it's workaround
-    // check if the query is still alive
-    // unfortunately, we can start using a finished query so we need to check if it's still alive again
-    if readers.is_empty() {
-        tokio::time::sleep(Duration::from_millis(5)).await;
-        let _ = bucket
-            .get_entry(entry_name)?
-            .upgrade()?
-            .get_query_receiver(query_id)?;
-    }
-
     headers.insert("content-length", body_size.to_string().parse().unwrap());
     headers.insert("content-type", "application/octet-stream".parse().unwrap());
     headers.insert("x-reduct-last", last.to_string().parse().unwrap());

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -312,6 +312,7 @@ pub(super) fn check_name_convention(name: &str) -> Result<(), ReductError> {
 mod tests {
     use super::*;
     use crate::backend::Backend;
+    use crate::cfg::remote_storage::RemoteStorageConfig;
     use bytes::Bytes;
     use reduct_base::msg::bucket_api::QuotaType;
     use reduct_base::Labels;

--- a/reductstore/src/storage/storage.rs
+++ b/reductstore/src/storage/storage.rs
@@ -312,7 +312,6 @@ pub(super) fn check_name_convention(name: &str) -> Result<(), ReductError> {
 mod tests {
     use super::*;
     use crate::backend::Backend;
-    use crate::cfg::remote_storage::RemoteStorageConfig;
     use bytes::Bytes;
     use reduct_base::msg::bucket_api::QuotaType;
     use reduct_base::Labels;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

In 1.12.3 I've added a workaround that checks if we try to use dead query. It's happening because of the race condition and we can't syn the HTTP API and query thread. The workaround return 404 in this case, what was wrong. We should return 204. 

### Related issues

#621 

### Does this PR introduce a breaking change?

Yes, but the 404 was wrong.

### Other information:
