### PR TITLE
Ignore size of body when batch only metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing of empty read\write token permissions, [PR-983](https://github.com/reductstore/reductstore/pull/983)
 - Fix removing records for S3 backend, [PR-984](https://github.com/reductstore/reductstore/pull/984)
 - Fix error message during acquiring lock file, [PR-985](https://github.com/reductstore/reductstore/pull/985)
+- Ignore size of body when batch only metadata, [PR-993](https://github.com/reductstore/reductstore/pull/993)
 
 ### Internal
 

--- a/reductstore/src/api/entry/read_batched.rs
+++ b/reductstore/src/api/entry/read_batched.rs
@@ -600,7 +600,10 @@ mod tests {
             let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
 
             assert_eq!(body.len(), 0);
-            assert_eq!(header_size, 88);
+            assert_eq!(
+                header_size, 88,
+                "should sand 85 records in headers + 3 default headers"
+            );
         }
 
         async fn build_bucket_and_query(


### PR DESCRIPTION
Closes #993

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR fixes the incorrect behavior when batching records with only metadata. Now, the HTTP API ignores the size of the body and sends the maximum number of records per batch.

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

No

### Other information:
