### PR TITLE
Fix crash with relative data path

### DIFF
--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -136,17 +136,12 @@ impl<EnvGetter: GetEnv> CfgParser<EnvGetter> {
             public_url,
             port,
             api_base_path,
-            data_path: PathBuf::from(env.get("RS_DATA_PATH", "/data".to_string()))
-                .canonicalize()
-                .unwrap(),
+            data_path: PathBuf::from(env.get("RS_DATA_PATH", "/data".to_string())),
             api_token: env.get_masked("RS_API_TOKEN", "".to_string()),
             cert_path,
             cert_key_path,
             license_path: env.get_optional("RS_LICENSE_PATH"),
-            ext_path: env
-                .get_optional::<String>("RS_EXT_PATH")
-                .map(PathBuf::from)
-                .map(|p| p.canonicalize().unwrap()),
+            ext_path: env.get_optional::<String>("RS_EXT_PATH").map(PathBuf::from),
             cors_allow_origin: Self::parse_cors_allow_origin(&mut env),
             buckets: Self::parse_buckets(&mut env),
             tokens: Self::parse_tokens(&mut env),

--- a/reductstore/src/cfg/remote_storage.rs
+++ b/reductstore/src/cfg/remote_storage.rs
@@ -48,8 +48,7 @@ impl<EnvGetter: GetEnv> CfgParser<EnvGetter> {
             },
             cache_path: env
                 .get_optional::<String>("RS_REMOTE_CACHE_PATH")
-                .map(PathBuf::from)
-                .map(|p| p.canonicalize().unwrap_or(p)),
+                .map(PathBuf::from),
             cache_size: env
                 .get_optional::<ByteSize>("RS_REMOTE_CACHE_SIZE")
                 .unwrap_or(ByteSize::gb(1))

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -70,7 +70,7 @@ impl StorageEngineBuilder {
         info!("Load {} bucket(s) in {:?}", buckets.len(), time.elapsed());
 
         StorageEngine {
-            data_path,
+            data_path: data_path.canonicalize().unwrap(),
             start_time: Instant::now(),
             buckets: Arc::new(RwLock::new(buckets)),
             license: self.license,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The storage crashed when the RS_DATA_PATH variable contained a relative path because the new storage backend cannot work with relative paths correctly. The PR canonicalises the paths in the configuration before using them. 

### Related issues

#919 

### Does this PR introduce a breaking change?

No

### Other information:
