### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# NOTE: Replace the team handles below with your actual GitHub org/team names.
+#
+# Everything is owned by maintainers...
+* @reductstore/maintainers
+
+# ...except `.github/`, which is owned by DevOps.
+/.github/ @reductstore/devops


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Maintenance / repo settings

### What was changed?

- Add `.github/CODEOWNERS` to define default code ownership.
- Set `.github/` ownership to `@reductstore/devops` and everything else to `@reductstore/maintainers`.

### Related issues

https://github.com/reductstore/security/issues/14

### Does this PR introduce a breaking change?

No.

### Other information:

- CHANGELOG update will be committed after PR creation to include the PR number.
