### PR TITLE
Release v1.18.1 (replace yanked 1.18.0 crates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.18.1 - 2026-02-04
+
+### Internal
+
+- v1.18.0 crates were published earlier by mistake, must be corrected to v1.18.1
+
 ## 1.18.0 - 2026-02-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.89.0"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Release / version bump (internal)

### What was changed?

- Bumped workspace and crate versions to 1.18.1.
- Added a 1.18.1 changelog entry noting the re-release after 1.18.0 was yanked.

### Related issues

None.

### Does this PR introduce a breaking change?

No.

### Other information:

No tests were run for this release-only change.
