### PR TITLE
1197 bug fail to remove attachement when key is numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Restore `Unknown extension` validation for queries with `ext` when no extensions are loaded, [PR-1192](https://github.com/reductstore/reductstore/pull/1192)
+- Fix numeric attachment key matching in `when` conditions, [PR-1198](https://github.com/reductstore/reductstore/pull/1198)
 
 ## 1.18.5 - 2026-02-25
 

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -605,6 +605,19 @@ mod tests {
                 node.print()
             );
         }
+
+        #[rstest]
+        fn test_in_with_numeric_string_label_reference(parser: Parser) {
+            let json = serde_json::json!({
+                "$in": ["&key", "1"]
+            });
+            let (mut node, _) = parser.parse(json).unwrap();
+
+            let mut context = Context::default();
+            context.labels.insert("key", "1");
+
+            assert_eq!(node.apply(&context).unwrap(), Value::Bool(true));
+        }
     }
 
     #[fixture]

--- a/reductstore/src/storage/query/condition/value/cmp.rs
+++ b/reductstore/src/storage/query/condition/value/cmp.rs
@@ -3,6 +3,16 @@
 
 use crate::storage::query::condition::value::Value;
 
+fn parse_string_like(value: &str) -> Option<Value> {
+    if let Ok(parsed) = value.parse::<i64>() {
+        Some(Value::Int(parsed))
+    } else if let Ok(parsed) = value.parse::<f64>() {
+        Some(Value::Float(parsed))
+    } else {
+        None
+    }
+}
+
 impl PartialEq<Self> for Value {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -30,8 +40,8 @@ impl PartialEq<Self> for Value {
             (Value::Float(left), Value::Bool(right)) => *left == *right as i64 as f64,
 
             (Value::String(left), Value::String(right)) => left == right,
-            (Value::String(_), _) => false,
-            (_, Value::String(_)) => false,
+            (Value::String(left), right) => parse_string_like(left).is_some_and(|v| v == *right),
+            (left, Value::String(right)) => parse_string_like(right).is_some_and(|v| *left == v),
         }
     }
 }
@@ -63,8 +73,12 @@ impl PartialOrd for Value {
             (Value::Float(left), Value::Bool(right)) => left.partial_cmp(&(*right as i64 as f64)),
 
             (Value::String(left), Value::String(right)) => left.partial_cmp(right),
-            (Value::String(_), _) => None,
-            (_, Value::String(_)) => None,
+            (Value::String(left), right) => {
+                parse_string_like(left).and_then(|v| v.partial_cmp(right))
+            }
+            (left, Value::String(right)) => {
+                parse_string_like(right).and_then(|v| left.partial_cmp(&v))
+            }
         }
     }
 }
@@ -150,6 +164,10 @@ mod tests {
         #[case(Value::String("a".to_string()), Value::Int(1), false)]
         #[case(Value::String("a".to_string()), Value::Float(1.0), false)]
         #[case(Value::String("a".to_string()), Value::Duration(1), false)]
+        #[case(Value::String("1".to_string()), Value::Int(1), true)]
+        #[case(Value::String("1.0".to_string()), Value::Float(1.0), true)]
+        #[case(Value::String("true".to_string()), Value::Bool(true), false)]
+        #[case(Value::String("1".to_string()), Value::Duration(1), true)]
         fn partial_eq_string(#[case] left: Value, #[case] right: Value, #[case] expected: bool) {
             let result = left == right;
             assert_eq!(result, expected);
@@ -182,6 +200,7 @@ mod tests {
         #[case(Value::Bool(false), Value::String("string".to_string()), None)]
         #[case(Value::Bool(true), Value::String("true".to_string()), None)]
         #[case(Value::Bool(false), Value::String("true".to_string()), None)]
+        #[case(Value::Bool(true), Value::String("1".to_string()), Some(Ordering::Equal))]
         #[case(Value::Bool(true), Value::Duration(1), Some(Ordering::Equal))]
         #[case(Value::Bool(false), Value::Duration(1), Some(Ordering::Less))]
         #[case(Value::Bool(true), Value::Duration(0), Some(Ordering::Greater))]
@@ -211,6 +230,7 @@ mod tests {
         #[case(Value::Int(1), Value::Float(-1.0), Some(Ordering::Greater))]
         #[case(Value::Int(1), Value::String("string".to_string()), None)]
         #[case(Value::Int(-1), Value::String("string".to_string()), None)]
+        #[case(Value::Int(1), Value::String("1".to_string()), Some(Ordering::Equal))]
         #[case(Value::Int(1), Value::Duration(1), Some(Ordering::Equal))]
         #[case(Value::Int(-1), Value::Duration(1), Some(Ordering::Less))]
         #[case(Value::Int(1), Value::Duration(0), Some(Ordering::Greater))]


### PR DESCRIPTION
Closes #1197

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Fix numeric attachment key matching in `when` conditions

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
