### PR TITLE
Update web console to v1.14.0-beta.1

### DIFF
--- a/reductstore/build.rs
+++ b/reductstore/build.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to compile protos");
 
     #[cfg(feature = "web-console")]
-    download_web_console("v1.14.0-beta.0");
+    download_web_console("v1.14.0-beta.1");
     // get build time and commit
     let build_time = chrono::DateTime::<chrono::Utc>::from(SystemTime::now())
         .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update / dependency update

### What was changed?

- Updated bundled Web Console version in `reductstore/build.rs`
- Bumped download target from `v1.14.0-beta.0` to `v1.14.0-beta.1`

### Related issues

N/A

### Does this PR introduce a breaking change?

No

### Other information:

This change only updates the Web Console release artifact pulled at build time.