### PR TITLE
fix: enforce replication mode override during provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support `RS_REPLICATION_<ID>_MODE` in provisioning to set replication mode (`enabled|paused|disabled`) declaratively from environment variables, [PR-1243](https://github.com/reductstore/reductstore/pull/1243)
 - Support hierarchical entry paths and preserve nested tree recovery, [PR-1185](https://github.com/reductstore/reductstore/pull/1185)
 - Store attachments in system `$meta` entries with strategy-based behavior and replication coverage, [PR-1186](https://github.com/reductstore/reductstore/pull/1186)
 - Zenoh API for ingestion and query, [PR-1157](https://github.com/reductstore/reductstore/pull/1157)

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -23,11 +23,9 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         for (name, settings) in &self.cfg.replications {
             if let Err(e) = repo.create_replication(&name, settings.clone()).await {
                 if e.status() == ErrorCode::Conflict {
-                    let mut settings = settings.clone();
-                    if let Ok(info) = repo.get_info(&name).await {
-                        settings.mode = info.info.mode;
-                    }
-                    repo.update_replication(&name, settings).await?;
+                    // Always enforce mode from provisioning config, even if replication
+                    // metadata already exists in .replication.
+                    repo.update_replication(&name, settings.clone()).await?;
                 } else {
                     error!("Failed to provision replication '{}': {}", name, e);
                     continue;

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -149,6 +149,21 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             {
                 replication.when = Some(when);
             }
+
+            if let Some(mode) = env.get_optional::<String>(&format!("RS_REPLICATION_{}_MODE", id)) {
+                match mode.to_lowercase().as_str() {
+                    "enabled" => replication.mode = ReplicationMode::Enabled,
+                    "paused" => replication.mode = ReplicationMode::Paused,
+                    "disabled" => replication.mode = ReplicationMode::Disabled,
+                    _ => {
+                        error!(
+                            "Replication '{}' has invalid mode '{}'. Drop it.",
+                            name, mode
+                        );
+                        unfinished_replications.push(id.clone());
+                    }
+                }
+            }
         }
 
         replications
@@ -226,6 +241,81 @@ mod tests {
             Some(serde_json::json!({"$and": [true, false]}))
         );
         assert!(repl_info.info.is_provisioned);
+    }
+
+    #[log_test(rstest)]
+    #[tokio::test]
+    async fn test_replications_with_mode(mut env_with_replications: MockEnvGetter) {
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_SRC_BUCKET"))
+            .return_const(Ok("bucket1".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_DST_BUCKET"))
+            .return_const(Ok("bucket2".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_DST_HOST"))
+            .return_const(Ok("http://localhost".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_MODE"))
+            .return_const(Ok("paused".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .return_const(Err(VarError::NotPresent));
+
+        let components = CfgParser::from_env(env_with_replications, "0.0.0")
+            .await
+            .build()
+            .await
+            .unwrap();
+        let repo = components.replication_repo.read().await.unwrap();
+        let repl_info = repo.get_info("replication1").await.unwrap();
+
+        assert_eq!(repl_info.info.mode, ReplicationMode::Paused);
+    }
+
+    #[log_test(rstest)]
+    #[tokio::test]
+    async fn test_replications_drop_invalid_mode(mut env_with_replications: MockEnvGetter) {
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_SRC_BUCKET"))
+            .return_const(Ok("bucket1".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_DST_BUCKET"))
+            .return_const(Ok("bucket2".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_DST_HOST"))
+            .return_const(Ok("http://localhost".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_MODE"))
+            .return_const(Ok("bogus".to_string()));
+
+        env_with_replications
+            .expect_get()
+            .return_const(Err(VarError::NotPresent));
+
+        let components = CfgParser::from_env(env_with_replications, "0.0.0")
+            .await
+            .build()
+            .await
+            .unwrap();
+        let repo = components.replication_repo.read().await.unwrap();
+
+        assert_eq!(repo.replications().await.unwrap().len(), 0);
     }
 
     #[log_test(rstest)]


### PR DESCRIPTION
Closes #1242

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Fixed replication provisioning so `RS_REPLICATION_<id>_MODE` always overrides persisted replication mode.
- Before this fix, mode was only applied on the first startup (when no `.replication` metadata existed).
- On conflict with existing replication, provisioning now updates with configured settings directly instead of preserving the old stored mode.
- Added coverage for parsing replication mode from env and invalid mode rejection.

### Related issues

- https://github.com/reductstore/reductstore/issues/1242

### Does this PR introduce a breaking change?

No.

### Other information:

Could not run tests in this environment because the repository lockfile requires a newer cargo lockfile format support (`-Znext-lockfile-bump` / matching toolchain).