### PR TITLE
chore(stable): apply cargo-audit and dependabot dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.18.10 - 2026-03-27
+
+### Changed
+
+- Update `Cargo.lock` dependencies on `stable` using Dependabot bumps (`aws-credential-types`, `futures-util`, `quote`, `chrono`) plus `cargo audit` remediations (`aws-lc-rs/aws-lc-sys`, `rustls-webpki`, `quinn-proto`, `time`), [PR-1251](https://github.com/reductstore/reductstore/pull/1251)
+
 ## 1.18.9 - 2026-03-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.18.9"
+version = "1.18.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.18.9"
+version = "1.18.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.18.9"
+version = "1.18.10"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.18.9"
+version = "1.18.10"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.89.0"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Dependency/security maintenance for `stable`

### What was changed?

This PR updates `Cargo.lock` on the `stable` branch by combining:

- Dependabot-targeted bumps (matching open Dependabot PRs for `stable`):
  - `aws-credential-types` → `1.2.14` (PR #1225)
  - `futures-util` → `0.3.32` (PR #1226)
  - `quote` → `1.0.45` (PR #1227)
  - `chrono` → `0.4.44` (PR #1228)
- Additional `cargo audit` remediations:
  - `aws-lc-rs` → `1.16.2` (and `aws-lc-sys` → `0.39.0`)
  - `rustls-webpki` → `0.103.10`
  - `quinn-proto` → `0.11.14`
  - `time` → `0.3.47`

Also normalized `zip` from `7.3.0` (yanked) to `7.2.0` via resolver update.

### Related issues

- https://github.com/reductstore/reductstore/security/dependabot
- https://github.com/reductstore/reductstore/pull/1225
- https://github.com/reductstore/reductstore/pull/1226
- https://github.com/reductstore/reductstore/pull/1227
- https://github.com/reductstore/reductstore/pull/1228

### Does this PR introduce a breaking change?

No.

### Other information:

`cargo audit` on `stable` now reports **no vulnerabilities** (only two yanked-crypto warnings in transitive prerelease crypto crates).
