### PR TITLE
docs: clarify Docker volume vs bind-mount for non-root container

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ The quickest way to get up and running is with our Docker image:
 docker run -p 8383:8383 -v reduct-data:/data reduct/store:latest
 ```
 
+If you prefer a bind mount instead of a Docker volume:
+
+```bash
+mkdir -p ./data
+sudo chown -R 10001:10001 ./data
+docker run -p 8383:8383 -v ${PWD}/data:/data reduct/store:latest
+```
+
 Alternatively, you can opt for Cargo:
 
 ```


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update

### What was changed?

- Rebased docs change on latest `main`.
- Kept the current quick start using Docker named volume (`reduct-data:/data`).
- Added an explicit bind-mount alternative with required host prep for non-root runtime:
  - `mkdir -p ./data`
  - `sudo chown -R 10001:10001 ./data`
  - `-v ${PWD}/data:/data`
- Clarified the UID/GID ownership requirement for v1.19+.

### Related issues

User report: bind-mounted Docker data directory permissions after non-root switch.

### Does this PR introduce a breaking change?

No.

### Other information:

Supersedes prior PR created from an older base branch.
