### PR TITLE
add global storage size limit across all buckets

### DIFF
--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -942,6 +942,86 @@ pub(crate) mod tests {
         Arc::new(StateKeeper::new(Arc::new(LockFileBuilder::noop()), rx))
     }
 
+    pub(crate) async fn keeper_with_engine_limit(max_storage_size: u64) -> Arc<StateKeeper> {
+        let mut cfg = Cfg {
+            data_path: tempfile::tempdir().unwrap().keep(),
+            api_token: "init-token".to_string(),
+            ..Cfg::default()
+        };
+        cfg.engine_config.max_storage_size = Some(max_storage_size);
+
+        let storage = StorageEngine::builder()
+            .with_data_path(cfg.data_path.clone())
+            .with_cfg(cfg.clone())
+            .build()
+            .await;
+        let mut token_repo = TokenRepositoryBuilder::new(cfg.clone())
+            .build(cfg.data_path.clone())
+            .await;
+
+        storage
+            .create_bucket("bucket-1", BucketSettings::default())
+            .await
+            .unwrap();
+        storage
+            .create_bucket("bucket-2", BucketSettings::default())
+            .await
+            .unwrap();
+
+        let permissions = Permissions {
+            read: vec!["bucket-1".to_string(), "bucket-2".to_string()],
+            write: vec!["bucket-1".to_string(), "bucket-2".to_string()],
+            ..Default::default()
+        };
+
+        token_repo
+            .generate_token(
+                "test",
+                TokenCreateRequest {
+                    permissions,
+                    expires_at: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let storage = Arc::new(storage);
+        let replication_repo = ReplicationRepoBuilder::new(cfg.clone())
+            .build(Arc::clone(&storage))
+            .await;
+
+        #[cfg(feature = "web-console")]
+        let console_bytes: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/console.zip"));
+        #[cfg(not(feature = "web-console"))]
+        let console_bytes: &[u8] = &[];
+
+        let components = Components {
+            storage: Arc::clone(&storage),
+            auth: TokenAuthorization::new("inti-token"),
+            token_repo: AsyncRwLock::new(token_repo),
+            console: create_asset_manager(console_bytes),
+            replication_repo: AsyncRwLock::new(replication_repo),
+            ext_repo: create_ext_repository(
+                None,
+                vec![],
+                ExtSettings::builder()
+                    .server_info(ServerInfo::default())
+                    .build(),
+                cfg.io_conf.clone(),
+                Some(Arc::clone(&storage)),
+            )
+            .expect("Failed to create extension repo"),
+            cfg,
+            query_link_cache: AsyncRwLock::new(Cache::new(8, Duration::from_secs(60))),
+            limits: crate::api::limits::LimitsBuilder::new().build(),
+        };
+
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        tx.send(components).await.unwrap();
+
+        Arc::new(StateKeeper::new(Arc::new(LockFileBuilder::noop()), rx))
+    }
+
     #[fixture]
     pub(crate) async fn keeper() -> Arc<StateKeeper> {
         keeper_with_limits(LimitsConfig::default()).await
@@ -972,6 +1052,11 @@ pub(crate) mod tests {
             ..Default::default()
         })
         .await
+    }
+
+    #[fixture]
+    pub(crate) async fn storage_limited_keeper() -> Arc<StateKeeper> {
+        keeper_with_engine_limit(0).await
     }
 
     #[fixture]

--- a/reductstore/src/api/http/entry/write_batched.rs
+++ b/reductstore/src/api/http/entry/write_batched.rs
@@ -13,7 +13,6 @@ use futures_util::StreamExt;
 use crate::api::http::entry::common::err_to_batched_header;
 use crate::api::http::StateKeeper;
 use crate::replication::{Transaction, TransactionNotification};
-use crate::storage::bucket::Bucket;
 use crate::storage::entry::RecordDrainer;
 use log::{debug, error};
 use reduct_base::batch::{parse_batched_header, sort_headers_by_time, RecordHeader};
@@ -202,19 +201,22 @@ async fn spawn_getting_writers(
 ) -> Result<(Receiver<WriteContext>, JoinHandle<ErrorMap>), ReductError> {
     let (tx_writer, rx_writer) = tokio::sync::mpsc::channel(64);
 
-    let bucket = components
-        .storage
-        .get_bucket(&bucket_name)
-        .await?
-        .upgrade_and_unwrap();
-
+    let storage = Arc::clone(&components.storage);
+    let bucket_name = bucket_name.to_string();
     let entry_name = entry_name.to_string();
     let spawn_handler = tokio::spawn(async move {
         let mut error_map = BTreeMap::new();
 
         for (time, header) in timed_headers.into_iter() {
-            let writer =
-                start_writing(&entry_name, bucket.clone(), time, &header, &mut error_map).await;
+            let writer = start_writing(
+                &entry_name,
+                &bucket_name,
+                storage.clone(),
+                time,
+                &header,
+                &mut error_map,
+            )
+            .await;
 
             tx_writer
                 .send(WriteContext {
@@ -281,17 +283,19 @@ fn check_and_get_content_length(
 
 async fn start_writing(
     entry_name: &str,
-    bucket: Arc<Bucket>,
+    bucket_name: &str,
+    storage: Arc<crate::storage::engine::StorageEngine>,
     time: u64,
     record_header: &RecordHeader,
     error_map: &mut BTreeMap<u64, ReductError>,
 ) -> Box<dyn WriteRecord + Sync + Send> {
     let get_writer = async {
-        bucket
+        storage
             .begin_write(
+                bucket_name,
                 entry_name,
                 time,
-                record_header.content_length.clone(),
+                record_header.content_length,
                 record_header.content_type.clone(),
                 record_header.labels.clone(),
             )

--- a/reductstore/src/api/http/entry/write_single.rs
+++ b/reductstore/src/api/http/entry/write_single.rs
@@ -65,9 +65,10 @@ pub(super) async fn write_record(
         }
 
         let sender = {
-            let bucket = components.storage.get_bucket(&bucket).await?.upgrade()?;
-            bucket
+            components
+                .storage
                 .begin_write(
+                    &bucket,
                     path.get("entry_name").unwrap(),
                     ts,
                     content_size,
@@ -138,7 +139,9 @@ pub(super) async fn write_record(
 mod tests {
     use super::*;
 
-    use crate::api::http::tests::{empty_body, ingress_limited_keeper, keeper, path_to_entry_1};
+    use crate::api::http::tests::{
+        empty_body, ingress_limited_keeper, keeper, path_to_entry_1, storage_limited_keeper,
+    };
 
     use axum_extra::headers::{Authorization, HeaderMapExt};
     use reduct_base::error::ErrorCode;
@@ -286,6 +289,34 @@ mod tests {
         let err: ReductError = err.into();
         assert_eq!(err.status, ErrorCode::TooManyRequests);
         assert!(err.message.contains("ingress bytes"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_write_storage_limit_exceeded(
+        #[future] storage_limited_keeper: Arc<StateKeeper>,
+        mut headers: HeaderMap,
+        path_to_entry_1: Path<HashMap<String, String>>,
+    ) {
+        headers.insert("content-length", "1".parse().unwrap());
+
+        let err = write_record(
+            State(storage_limited_keeper.await),
+            headers,
+            path_to_entry_1,
+            Query(HashMap::from_iter(vec![(
+                "ts".to_string(),
+                "2".to_string(),
+            )])),
+            Body::from("a"),
+        )
+        .await
+        .err()
+        .unwrap();
+
+        let err: ReductError = err.into();
+        assert_eq!(err.status, ErrorCode::InternalServerError);
+        assert_eq!(err.message, "storage limit exceeded");
     }
 
     #[fixture]

--- a/reductstore/src/api/http/io/write.rs
+++ b/reductstore/src/api/http/io/write.rs
@@ -6,7 +6,6 @@ use crate::api::http::Components;
 use crate::api::http::{HttpError, StateKeeper};
 use crate::auth::policy::WriteAccessPolicy;
 use crate::replication::{Transaction, TransactionNotification};
-use crate::storage::bucket::Bucket;
 use crate::storage::entry::RecordDrainer;
 use axum::body::Body;
 use axum::body::BodyDataStream;
@@ -266,19 +265,17 @@ async fn spawn_getting_writers(
 ) -> Result<(Receiver<WriteContext>, JoinHandle<ErrorMap>), ReductError> {
     let (tx_writer, rx_writer) = tokio::sync::mpsc::channel(64);
 
-    let bucket = components
-        .storage
-        .get_bucket(&bucket_name)
-        .await?
-        .upgrade_and_unwrap();
+    let storage = Arc::clone(&components.storage);
+    let bucket_name = bucket_name.to_string();
 
     let spawn_handler = tokio::spawn(async move {
         let mut error_map: ErrorMap = ErrorMap::new();
 
         for record in records.into_iter() {
             let writer = start_writing(
+                &bucket_name,
                 &record.record.entry,
-                bucket.clone(),
+                storage.clone(),
                 record.record.timestamp,
                 &record.record.header,
                 &mut error_map,
@@ -325,8 +322,9 @@ async fn write_chunk(
 }
 
 async fn start_writing(
+    bucket_name: &str,
     entry_name: &str,
-    bucket: Arc<Bucket>,
+    storage: Arc<crate::storage::engine::StorageEngine>,
     time: u64,
     record_header: &reduct_base::batch::RecordHeader,
     error_map: &mut ErrorMap,
@@ -334,11 +332,12 @@ async fn start_writing(
     delta: u64,
 ) -> Box<dyn WriteRecord + Sync + Send> {
     let get_writer = async {
-        bucket
+        storage
             .begin_write(
+                bucket_name,
                 entry_name,
                 time,
-                record_header.content_length.clone(),
+                record_header.content_length,
                 record_header.content_type.clone(),
                 record_header.labels.clone(),
             )

--- a/reductstore/src/api/zenoh/subscriber.rs
+++ b/reductstore/src/api/zenoh/subscriber.rs
@@ -73,15 +73,17 @@ impl SubscriberPipeline {
             self.bucket, entry_name, ts, content_size, content_type
         );
 
-        let bucket = self
+        let mut writer = self
             .components
             .storage
-            .get_bucket(&self.bucket)
-            .await?
-            .upgrade()?;
-
-        let mut writer = bucket
-            .begin_write(&entry_name, ts, content_size, content_type, labels.clone())
+            .begin_write(
+                &self.bucket,
+                &entry_name,
+                ts,
+                content_size,
+                content_type,
+                labels.clone(),
+            )
             .await?;
 
         writer.send(Ok(Some(payload))).await?;

--- a/reductstore/src/cfg/storage_engine.rs
+++ b/reductstore/src/cfg/storage_engine.rs
@@ -3,6 +3,7 @@
 
 use crate::cfg::{CfgParser, ExtCfgBounds};
 use crate::core::env::{Env, GetEnv};
+use bytesize::ByteSize;
 use std::time::Duration;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -10,6 +11,7 @@ pub struct StorageEngineConfig {
     pub compaction_interval: Duration,
     pub replica_update_interval: Duration,
     pub enable_integrity_checks: bool,
+    pub max_storage_size: Option<u64>,
 }
 
 const DEFAULT_COMPACTION_INTERVAL_SECS: u64 = 60;
@@ -21,6 +23,7 @@ impl Default for StorageEngineConfig {
             compaction_interval: Duration::from_secs(DEFAULT_COMPACTION_INTERVAL_SECS),
             replica_update_interval: Duration::from_secs(DEFAULT_REPLICA_UPDATE_INTERVAL_SECS),
             enable_integrity_checks: true,
+            max_storage_size: None,
         }
     }
 }
@@ -39,6 +42,9 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             enable_integrity_checks: env
                 .get_optional::<bool>("RS_ENGINE_ENABLE_INTEGRITY_CHECKS")
                 .unwrap_or(true),
+            max_storage_size: env
+                .get_optional::<ByteSize>("RS_ENGINE_MAX_STORAGE_SIZE")
+                .map(|size| size.as_u64()),
         }
     }
 }
@@ -67,11 +73,16 @@ mod tests {
             .expect_get()
             .with(eq("RS_ENGINE_ENABLE_INTEGRITY_CHECKS"))
             .return_const(Ok("false".to_string()));
+        env_getter
+            .expect_get()
+            .with(eq("RS_ENGINE_MAX_STORAGE_SIZE"))
+            .return_const(Ok("10GB".to_string()));
 
         let expected = StorageEngineConfig {
             compaction_interval: Duration::from_secs(120),
             replica_update_interval: Duration::from_secs(45),
             enable_integrity_checks: false,
+            max_storage_size: Some(10_000_000_000),
         };
 
         assert_eq!(
@@ -94,5 +105,21 @@ mod tests {
             expected,
             CfgParser::<MockEnvGetter>::parse_storage_engine_config(&mut Env::new(env_getter))
         );
+    }
+
+    #[rstest]
+    fn uses_unlimited_storage_when_max_storage_size_invalid() {
+        let mut env_getter = MockEnvGetter::new();
+        env_getter
+            .expect_get()
+            .with(eq("RS_ENGINE_MAX_STORAGE_SIZE"))
+            .return_const(Ok("wrong".to_string()));
+        env_getter
+            .expect_get()
+            .return_const(Err(VarError::NotPresent));
+
+        let cfg =
+            CfgParser::<MockEnvGetter>::parse_storage_engine_config(&mut Env::new(env_getter));
+        assert_eq!(cfg.max_storage_size, None);
     }
 }

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -255,7 +255,33 @@ impl Bucket {
     ///
     /// * `Sender<Result<Bytes, ReductError>>` - The sender to send the record content in chunks.
     /// * `HTTPError` - The error if any.
-    pub async fn begin_write(
+    #[cfg(not(test))]
+    pub(in crate::storage) async fn begin_write(
+        self: &Arc<Self>,
+        name: &str,
+        time: u64,
+        content_size: u64,
+        content_type: String,
+        labels: Labels,
+    ) -> Result<Box<dyn WriteRecord + Sync + Send>, ReductError> {
+        self.begin_write_impl(name, time, content_size, content_type, labels)
+            .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn begin_write(
+        self: &Arc<Self>,
+        name: &str,
+        time: u64,
+        content_size: u64,
+        content_type: String,
+        labels: Labels,
+    ) -> Result<Box<dyn WriteRecord + Sync + Send>, ReductError> {
+        self.begin_write_impl(name, time, content_size, content_type, labels)
+            .await
+    }
+
+    async fn begin_write_impl(
         self: &Arc<Self>,
         name: &str,
         time: u64,

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -11,9 +11,12 @@ use crate::storage::folder_keeper::{DiscoveryDepth, FolderKeeper};
 use async_trait::async_trait;
 use log::{debug, error, info};
 use reduct_base::error::ReductError;
+use reduct_base::io::WriteRecord;
 use reduct_base::msg::bucket_api::BucketSettings;
 use reduct_base::msg::server_api::{BucketInfoList, Defaults, License, ServerInfo};
-use reduct_base::{conflict, forbidden, not_found, unprocessable_entity};
+use reduct_base::{
+    conflict, forbidden, internal_server_error, not_found, unprocessable_entity, Labels,
+};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -168,6 +171,53 @@ impl StorageEngine {
             },
             license: self.license.clone(),
         })
+    }
+
+    pub(crate) async fn begin_write(
+        &self,
+        bucket_name: &str,
+        entry_name: &str,
+        time: u64,
+        content_size: u64,
+        content_type: String,
+        labels: Labels,
+    ) -> Result<Box<dyn WriteRecord + Sync + Send>, ReductError> {
+        self.ensure_storage_limit(content_size).await?;
+        let bucket = self.get_bucket(bucket_name).await?.upgrade()?;
+        bucket
+            .begin_write(entry_name, time, content_size, content_type, labels)
+            .await
+    }
+
+    async fn total_usage(&self) -> Result<u64, ReductError> {
+        let buckets = self.buckets.read().await?;
+        let infos = buckets
+            .values()
+            .map(|bucket| bucket.clone().info())
+            .collect::<Vec<_>>();
+
+        let mut usage = 0u64;
+        for task in infos {
+            usage += task.await?.info.size;
+        }
+
+        Ok(usage)
+    }
+
+    pub(crate) async fn ensure_storage_limit(
+        &self,
+        incoming_bytes: u64,
+    ) -> Result<(), ReductError> {
+        let Some(limit) = self.cfg.engine_config.max_storage_size else {
+            return Ok(());
+        };
+
+        let usage = self.total_usage().await?;
+        if usage.saturating_add(incoming_bytes) > limit {
+            return Err(internal_server_error!("storage limit exceeded"));
+        }
+
+        Ok(())
     }
 
     /// Creat a new bucket.
@@ -424,6 +474,7 @@ mod tests {
     use super::*;
 
     use bytes::Bytes;
+    use reduct_base::io::ReadRecord;
     use reduct_base::msg::bucket_api::QuotaType;
     use reduct_base::Labels;
     use rstest::{fixture, rstest};
@@ -482,6 +533,65 @@ mod tests {
                 license: None,
             }
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_storage_limit_exceeded(#[future] storage: Arc<StorageEngine>) {
+        let storage = storage.await;
+        let bucket = storage
+            .create_bucket("test-limit", BucketSettings::default())
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+
+        let mut writer = bucket
+            .begin_write("entry", 1, 10, "text/plain".to_string(), Labels::new())
+            .await
+            .unwrap();
+        writer
+            .send(Ok(Some(Bytes::from("0123456789"))))
+            .await
+            .unwrap();
+        writer.send(Ok(None)).await.unwrap();
+
+        let mut cfg = storage.cfg.clone();
+        cfg.engine_config.max_storage_size = Some(1);
+        let limited = Arc::new(
+            StorageEngine::builder()
+                .with_data_path(storage.data_path.clone())
+                .with_cfg(cfg)
+                .build()
+                .await,
+        );
+
+        let err = limited
+            .begin_write(
+                "test-limit",
+                "entry-2",
+                2,
+                1,
+                "text/plain".to_string(),
+                Labels::new(),
+            )
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err.status(),
+            reduct_base::error::ErrorCode::InternalServerError
+        );
+        assert_eq!(err.message, "storage limit exceeded");
+
+        let record = limited
+            .get_bucket("test-limit")
+            .await
+            .unwrap()
+            .upgrade_and_unwrap()
+            .begin_read("entry", 1)
+            .await
+            .unwrap();
+        assert_eq!(record.meta().content_length(), 10);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #1142

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature / safety hardening

### What was changed?

- Added `RS_ENGINE_MAX_STORAGE_SIZE` to storage engine config with SI parsing via `bytesize` (`KB/MB/GB/TB`).
- Added centralized write guard in `StorageEngine`:
  - `ensure_storage_limit(incoming_bytes)`
  - `begin_write(...)` now checks global usage before delegating to bucket writes.
- Wired write entry points to use `StorageEngine::begin_write(...)` so all ingest paths share the same global limit behavior:
  - HTTP single write
  - HTTP batched write (`entry` and `io` endpoints)
  - Zenoh subscriber ingestion
- Restricted `Bucket::begin_write` visibility for production so non-storage layers use storage-level writes.
- Added tests for config parsing, storage-limit rejection, and HTTP 500 response (`storage limit exceeded`).

### Related issues

- https://github.com/reductstore/reductstore/issues/1142

### Does this PR introduce a breaking change?

No. The default remains unlimited when `RS_ENGINE_MAX_STORAGE_SIZE` is unset.

### Other information:

Validated with:

- `cargo fmt --all`
- `cargo test -p reductstore parses_engine_config_from_env -- --nocapture`
- `cargo test -p reductstore uses_unlimited_storage_when_max_storage_size_invalid -- --nocapture`
- `cargo test -p reductstore test_storage_limit_exceeded -- --nocapture`
- `cargo test -p reductstore test_write_storage_limit_exceeded -- --nocapture`
