### PR TITLE
feat(token): reject ambiguous ttl+expires_at token requests

### DIFF
--- a/integration_tests/api/token_api_test.py
+++ b/integration_tests/api/token_api_test.py
@@ -68,6 +68,37 @@ def test__create_v2_token(base_url, session, token_name, bucket_name):
 
 
 @requires_env("API_TOKEN")
+def test__create_v2_token_rejects_ttl_and_expires_at_together(
+    base_url, session, token_name, bucket_name
+):
+    """Should reject ambiguous token lifetime definition"""
+    resp = session.post(f"{base_url}/b/{bucket_name}")
+    assert resp.status_code == 200
+
+    permissions = {
+        "full_access": True,
+        "read": [bucket_name],
+        "write": [bucket_name],
+    }
+    expires_at = (datetime.now(timezone.utc) + timedelta(days=1)).replace(microsecond=0)
+
+    resp = session.post(
+        f"{base_url}/tokens/{token_name}",
+        json={
+            "permissions": permissions,
+            "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
+            "ttl": 3600,
+            "ip_allowlist": [],
+        },
+    )
+    assert resp.status_code == 422
+    assert (
+        resp.headers["x-reduct-error"]
+        == "Only one lifetime policy is allowed: either 'ttl' or 'expires_at'"
+    )
+
+
+@requires_env("API_TOKEN")
 def test__creat_token_with_full_access(
     base_url, session, token_name, token_without_permissions
 ):

--- a/reduct_base/src/msg/token_api.rs
+++ b/reduct_base/src/msg/token_api.rs
@@ -50,8 +50,10 @@ pub struct Token {
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 pub struct TokenCreateRequest {
     pub permissions: Permissions,
+    /// Absolute expiration timestamp (UTC). Mutually exclusive with `ttl`.
     #[serde(default)]
     pub expires_at: Option<DateTime<Utc>>,
+    /// Inactivity TTL in seconds. Mutually exclusive with `expires_at`.
     #[serde(default)]
     pub ttl: Option<u64>,
     #[serde(default)]

--- a/reductstore/src/auth/token_repository/repo.rs
+++ b/reductstore/src/auth/token_repository/repo.rs
@@ -295,6 +295,12 @@ impl ManageTokens for TokenRepository {
             return Err(unprocessable_entity!("Token TTL must be greater than zero"));
         }
 
+        if ttl.is_some() && expires_at.is_some() {
+            return Err(unprocessable_entity!(
+                "Only one lifetime policy is allowed: either 'ttl' or 'expires_at'"
+            ));
+        }
+
         let expires_at = expires_at
             .map(|expires_at| {
                 if expires_at < created_at {
@@ -659,6 +665,32 @@ mod tests {
             assert_eq!(
                 token.err().unwrap(),
                 unprocessable_entity!("Token expiration date must not be in the past")
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_create_token_rejects_ttl_and_expires_at_together(
+            #[future] repo: BoxedTokenRepository,
+        ) {
+            let mut repo = repo.await;
+            let token = repo
+                .generate_token(
+                    "test-exp-ttl",
+                    TokenCreateRequest {
+                        permissions: Permissions::default(),
+                        expires_at: Some(chrono::Utc::now() + chrono::Duration::days(1)),
+                        ttl: Some(3600),
+                        ip_allowlist: vec![],
+                    },
+                )
+                .await;
+
+            assert_eq!(
+                token.err().unwrap(),
+                unprocessable_entity!(
+                    "Only one lifetime policy is allowed: either 'ttl' or 'expires_at'"
+                )
             );
         }
 


### PR DESCRIPTION
Closes #1290

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature hardening / API validation improvement.

### What was changed?

- Enforced token lifetime policy exclusivity in token creation: requests with both `ttl` and `expires_at` now return `422 Unprocessable Entity`.
- Added repository unit test coverage for the conflict case in `TokenRepository::generate_token`.
- Added integration API test to verify HTTP behavior and returned error message.
- Updated token API message docs to state that `ttl` and `expires_at` are mutually exclusive.

### Related issues

- Epic: #1088
- Release plan: #1068
- Implemented issue: #1290

### Does this PR introduce a breaking change?

No breaking protocol changes. It adds stricter validation for ambiguous create-token requests that previously passed through.

### Other information:

Validation and formatting run locally:
- `cargo test -p reductstore auth::token_repository::repo::tests::create_token::test_create_token_rejects_ttl_and_expires_at_together -- --nocapture`
- `cargo fmt --all -- --check`
