### PR TITLE
graceful shutdown during active writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add README header image and update the project subtitle to "High Performance Data Backbone for Robotics and Industrial IoT", [PR-1315](https://github.com/reductstore/reductstore/pull/1315)
 - Generate SPDX SBOMs from `Cargo.lock` metadata (instead of scanning only final binaries), upload SBOM artifacts on every CI run, and continue attaching per-target SBOM files to releases, [PR-1314](https://github.com/reductstore/reductstore/pull/1314)
 
+### Fixed
+
+- Graceful HTTP shutdown during active writes, split non-blocking compaction from strict shutdown sync, and ensure entry/block metadata sync waits for lock release when required, [PR-1323](https://github.com/reductstore/reductstore/pull/1323)
+
 ## 1.19.1 - 2026-04-08
 
 ### Changed

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -6,6 +6,7 @@ use crate::api::http::AxumAppBuilder;
 use crate::api::zenoh;
 use crate::cfg::{CfgParser, ExtCfgBounds, ExtCfgParser};
 use crate::core::env::StdEnvGetter;
+use crate::core::sync::set_rwlock_timeout;
 use crate::storage::engine::StorageEngine;
 use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
@@ -140,6 +141,10 @@ where
     if let Some(handle) = zenoh_runtime {
         handle.shutdown().await;
     }
+
+    // remote synchronization can lock resources for a long time,
+    // so we set rwlock timeout to 1 hour to avoid panics during shutdown
+    set_rwlock_timeout(Duration::from_hours(1));
     state_keeper
         .get_anonymous()
         .await

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+static SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_pareser: Parser)
 where
     Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
@@ -153,7 +155,7 @@ where
 async fn shutdown_ctrl_c(server_handle: Handle<SocketAddr>) {
     tokio::signal::ctrl_c().await.unwrap();
     info!("Received Ctrl-C, shutting down server...");
-    server_handle.shutdown();
+    server_handle.graceful_shutdown(Some(SHUTDOWN_TIMEOUT));
 }
 
 #[cfg(unix)]
@@ -163,7 +165,7 @@ async fn shutdown_signal(server_handle: Handle<SocketAddr>) {
         .recv()
         .await;
     info!("Received termination signal, shutting down server...");
-    server_handle.shutdown();
+    server_handle.graceful_shutdown(Some(SHUTDOWN_TIMEOUT));
 }
 
 #[cfg(test)]

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -72,6 +72,12 @@ pub(crate) struct Bucket {
     queries: AsyncRwLock<HashMap<u64, MultiEntryQuery>>,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum EntryMaintenanceMode {
+    Compact,
+    SyncFs,
+}
+
 impl Bucket {
     /// Create a new Bucket
     ///
@@ -322,14 +328,29 @@ impl Bucket {
         }
     }
 
-    /// Sync all entries to the file system
+    /// Compact all entries in the bucket without blocking active writers.
+    pub async fn compact(&self) -> Result<(), ReductError> {
+        debug!("Compact metainformation in bucket '{}'", self.name);
+        self.run_entry_maintenance(EntryMaintenanceMode::Compact)
+            .await
+    }
+
+    /// Sync all entries to the file system.
+    ///
+    /// This method waits for active writers and should be used only for strict
+    /// durability points (for example graceful shutdown).
     pub async fn sync_fs(&self) -> Result<(), ReductError> {
+        debug!("Sync bucket '{}'with backend", self.name);
+        self.run_entry_maintenance(EntryMaintenanceMode::SyncFs)
+            .await
+    }
+
+    async fn run_entry_maintenance(&self, mode: EntryMaintenanceMode) -> Result<(), ReductError> {
         if self.cfg.role == InstanceRole::Replica {
             return Ok(());
         }
 
         let bucket_name = self.name.clone();
-        debug!("Syncing bucket '{}'", bucket_name);
         let time_start = Instant::now();
 
         self.save_settings().await?;
@@ -337,9 +358,13 @@ impl Bucket {
         let entries = self.entries.clone();
         let mut count = 0usize;
         for entry in entries.read().await?.values() {
-            if let Err(err) = entry.compact().await {
+            let result = match mode {
+                EntryMaintenanceMode::Compact => entry.compact().await,
+                EntryMaintenanceMode::SyncFs => entry.sync_fs().await,
+            };
+            if let Err(err) = result {
                 error!(
-                    "Failed to compact entry '{}' in bucket '{}': {}",
+                    "Failed to compact/sync entry '{}' in bucket '{}': {}",
                     entry.name(),
                     bucket_name,
                     err
@@ -348,7 +373,7 @@ impl Bucket {
             count += 1;
         }
         debug!(
-            "Bucket '{}' synced {} entries in {:?}",
+            "Bucket '{}' processed {} entries in {:?}",
             bucket_name,
             count,
             Instant::now().duration_since(time_start)

--- a/reductstore/src/storage/bucket/read_only.rs
+++ b/reductstore/src/storage/bucket/read_only.rs
@@ -223,6 +223,24 @@ mod tests {
             let compact_result = read_only_bucket.rename_entry("test-1", "new-name").await;
             assert_eq!(compact_result.err().unwrap(), err);
         }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_maintenance_operations_are_noop_on_replica(
+            #[future] primary_bucket: Arc<Bucket>,
+        ) {
+            let primary_bucket = primary_bucket.await;
+            let mut cfg = primary_bucket.cfg().clone();
+            cfg.role = InstanceRole::Replica;
+            let read_only_bucket = Arc::new(
+                Bucket::restore(primary_bucket.path().clone(), cfg.clone())
+                    .await
+                    .unwrap(),
+            );
+
+            read_only_bucket.compact().await.unwrap();
+            read_only_bucket.sync_fs().await.unwrap();
+        }
     }
 
     mod reload_before {

--- a/reductstore/src/storage/bucket/rename_entry.rs
+++ b/reductstore/src/storage/bucket/rename_entry.rs
@@ -127,7 +127,7 @@ impl Bucket {
 
         for (_, _, entry) in &renamed_children {
             entry.ensure_not_deleting().await?;
-            entry.compact().await?;
+            entry.sync_fs().await?;
         }
 
         folder_keeper.rename_folder(old_name, new_name).await?;

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -120,6 +120,12 @@ pub struct StorageEngine {
     folder_keeper: Arc<FolderKeeper>,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum BucketMaintenanceMode {
+    Compact,
+    SyncFs,
+}
+
 impl StorageEngine {
     pub fn builder() -> StorageEngineBuilder {
         StorageEngineBuilder {
@@ -398,13 +404,19 @@ impl StorageEngine {
     }
 
     pub async fn sync_fs(&self) -> Result<(), ReductError> {
-        self.compact().await?;
+        self.run_bucket_maintenance(BucketMaintenanceMode::SyncFs)
+            .await?;
         FILE_CACHE.force_sync_all().await?;
         Ok(())
     }
 
     /// Update index from WALs and remove them
     pub async fn compact(&self) -> Result<(), ReductError> {
+        self.run_bucket_maintenance(BucketMaintenanceMode::Compact)
+            .await
+    }
+
+    async fn run_bucket_maintenance(&self, mode: BucketMaintenanceMode) -> Result<(), ReductError> {
         if self.cfg.role == InstanceRole::Replica {
             return Ok(());
         }
@@ -418,14 +430,23 @@ impl StorageEngine {
             .map(|bucket| Arc::clone(bucket))
             .collect::<Vec<_>>();
         for bucket in buckets {
-            handlers.push(tokio::spawn(async move { bucket.sync_fs().await }));
+            handlers.push(tokio::spawn(async move {
+                match mode {
+                    BucketMaintenanceMode::Compact => bucket.compact().await,
+                    BucketMaintenanceMode::SyncFs => bucket.sync_fs().await,
+                }
+            }));
         }
 
         for handler in handlers {
             match handler.await.unwrap() {
                 Ok(_) => {}
                 Err(e) => {
-                    error!("Failed to sync bucket: {}", e);
+                    let action = match mode {
+                        BucketMaintenanceMode::Compact => "compact",
+                        BucketMaintenanceMode::SyncFs => "sync",
+                    };
+                    error!("Failed to {} bucket: {}", action, e);
                 }
             }
         }

--- a/reductstore/src/storage/engine/read_only.rs
+++ b/reductstore/src/storage/engine/read_only.rs
@@ -214,6 +214,7 @@ mod tests {
     mod forbidden {
         use super::*;
         use reduct_base::forbidden;
+
         #[rstest]
         #[serial]
         #[tokio::test]
@@ -244,6 +245,27 @@ mod tests {
                 .rename_bucket("bucket-1".to_string(), "bucket-renamed".to_string())
                 .await;
             assert_eq!(result.err().unwrap(), err);
+        }
+
+        #[rstest]
+        #[serial]
+        #[tokio::test]
+        async fn test_maintenance_operations_are_noop_on_replica(
+            #[future] primary_engine: Arc<StorageEngine>,
+        ) {
+            let primary_engine = primary_engine.await;
+            let mut cfg = primary_engine.cfg().clone();
+            cfg.role = InstanceRole::Replica;
+            let read_only_engine = Arc::new(
+                StorageEngine::builder()
+                    .with_cfg(cfg.clone())
+                    .with_data_path(cfg.data_path.clone())
+                    .build()
+                    .await,
+            );
+
+            read_only_engine.compact().await.unwrap();
+            read_only_engine.sync_fs().await.unwrap();
         }
     }
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -339,6 +339,15 @@ impl Entry {
         }
     }
 
+    /// Flushes entry metadata and block index to the storage backend.
+    ///
+    /// Unlike [`Self::compact`], this method waits for the block manager lock and
+    /// must be used for strict sync points (e.g. graceful shutdown).
+    pub async fn sync_fs(&self) -> Result<(), ReductError> {
+        let mut bm = self.block_manager.write().await?;
+        bm.save_cache_metadata_on_disk().await
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -503,6 +512,42 @@ mod tests {
             assert_eq!(info.name, "entry");
             assert_eq!(info.record_count, 2);
             assert_eq!(info.size, 88);
+        }
+    }
+
+    mod compact {
+        use super::*;
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_compact_skips_when_block_manager_busy(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            let _guard = entry.block_manager.write().await.unwrap();
+
+            tokio::time::timeout(Duration::from_millis(200), entry.compact())
+                .await
+                .expect("compact should not block while block manager is busy")
+                .unwrap();
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_sync_fs_waits_for_block_manager(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            write_stub_record(&entry, 1).await;
+
+            let guard = entry.block_manager.write().await.unwrap();
+            let entry_to_sync = entry.clone();
+            let sync_task = tokio::spawn(async move { entry_to_sync.sync_fs().await });
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            assert!(
+                !sync_task.is_finished(),
+                "sync_fs must wait for block manager lock"
+            );
+
+            drop(guard);
+            sync_task.await.unwrap().unwrap();
         }
     }
 


### PR DESCRIPTION
Closes #1322

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Switched HTTP signal handlers from immediate shutdown to graceful shutdown with a 10s timeout.
- Added a dedicated strict sync path for shutdown:
  - `Entry::sync_fs()` now waits for the block manager lock and persists metadata/index.
  - Bucket and storage maintenance flows were split into `compact` vs `sync_fs` modes.
- Kept periodic/background maintenance non-blocking by preserving compact behavior.
- Updated rename flow to use strict `sync_fs` before folder rename.
- Added tests to verify:
  - `compact()` does not block when block manager is busy.
  - `sync_fs()` waits for lock release.
- Increased rwlock timeout during shutdown to avoid panic under long remote synchronization.

### Related issues

- https://github.com/reductstore/reductstore/issues/1322

### Does this PR introduce a breaking change?

No.

### Other information:

Observed issue during continuous writes and process termination was `Failed to send the writer: channel closed` around shutdown. This PR addresses shutdown behavior to reduce in-flight write disruption.
