### PR TITLE
fix(io): make multi-entry equal-timestamp ordering deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make multi-entry query aggregation deterministic for records with equal timestamps by adding a stable tie-breaker and regression coverage, [PR-1326](https://github.com/reductstore/reductstore/pull/1326)
 - Graceful HTTP shutdown during active writes, split non-blocking compaction from strict shutdown sync, and ensure entry/block metadata sync waits for lock release when required, [PR-1323](https://github.com/reductstore/reductstore/pull/1323)
 
 ## 1.19.1 - 2026-04-08

--- a/reductstore/src/storage/bucket/query.rs
+++ b/reductstore/src/storage/bucket/query.rs
@@ -253,16 +253,19 @@ impl Bucket {
                 break;
             }
 
-            let next = pending_readers
+            let next_entry = pending_readers
                 .iter()
                 .filter_map(|(name, reader)| {
                     reader
                         .as_ref()
-                        .map(|r| (name.clone(), r.meta().timestamp()))
+                        .map(|r| (name.as_str(), r.meta().timestamp()))
                 })
-                .min_by_key(|(_, ts)| *ts);
+                .min_by(|(name_a, ts_a), (name_b, ts_b)| {
+                    ts_a.cmp(ts_b).then_with(|| name_a.cmp(name_b))
+                })
+                .map(|(name, _)| name.to_string());
 
-            if let Some((entry_name, _)) = next {
+            if let Some(entry_name) = next_entry {
                 if let Some(reader) = pending_readers
                     .get_mut(&entry_name)
                     .and_then(|opt| opt.take())
@@ -345,6 +348,30 @@ mod tests {
                 ("entry-b".to_string(), 25),
                 ("entry-a".to_string(), 30),
             ]
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn deterministic_order_for_equal_timestamps(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "entry-b", 10, b"b").await.unwrap();
+        write(&bucket, "entry-a", 10, b"a").await.unwrap();
+
+        let query = QueryEntry {
+            query_type: QueryType::Query,
+            entries: Some(vec!["entry-b".into(), "entry-a".into()]),
+            ..Default::default()
+        };
+
+        let id = bucket.query(query).await.unwrap();
+        let (rx, _) = bucket.get_query_receiver(id).await.unwrap();
+
+        let records = collect_records(rx).await;
+
+        assert_eq!(
+            records,
+            vec![("entry-a".to_string(), 10), ("entry-b".to_string(), 10),]
         );
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

This patch makes multi-entry query ordering deterministic when multiple entries have the same timestamp.

- In `reductstore/src/storage/bucket/query.rs`, the aggregator previously selected the next record using only timestamp (`min_by_key`), while iterating a `HashMap`.
- For equal timestamps, `HashMap` iteration order could produce different output ordering across runs.
- The selector now uses a stable tie-breaker: `(timestamp, entry_name)`.
- Added a regression test `deterministic_order_for_equal_timestamps` to lock this behavior.

### Related issues

Conversation report from Anthony about non-deterministic ordering for equal timestamps in multi-entry reads.

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with:

- `cargo test -p reductstore deterministic_order_for_equal_timestamps -- --nocapture`
- `cargo test -p reductstore sorts_entries_by_first_timestamp -- --nocapture`
