### PR TITLE
Fix missing Content-Range on replica query-link range responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Return RFC-compliant `Content-Range` headers on partial (`206`) replica query-link responses so MCAP seek/backfill clients can parse byte ranges correctly, [PR-1329](https://github.com/reductstore/reductstore/pull/1329)
 - Make multi-entry query aggregation deterministic for records with equal timestamps by adding a stable tie-breaker and regression coverage, [PR-1326](https://github.com/reductstore/reductstore/pull/1326)
 - Graceful HTTP shutdown during active writes, split non-blocking compaction from strict shutdown sync, and ensure entry/block metadata sync waits for lock release when required, [PR-1323](https://github.com/reductstore/reductstore/pull/1323)
 - Reduce stale block metadata retention under high entry cardinality by introducing a shared global read cache with namespace-scoped invalidation and lock-read optimizations, [PR-1325](https://github.com/reductstore/reductstore/pull/1325)

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -365,8 +365,10 @@ mod tests {
         .unwrap();
 
         let resp = response.into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.headers()["content-type"], "text/plain");
         assert_eq!(resp.headers()["content-length"], "6");
+        assert!(!resp.headers().contains_key("content-range"));
         assert_eq!(resp.headers()["x-reduct-label-x"], "y");
 
         let body_bytes = to_bytes(resp.into_body(), 1000).await.unwrap();
@@ -612,6 +614,11 @@ mod tests {
         assert_eq!(
             resolve_content_range(&(Bound::Unbounded, Included(2)), 6),
             Some((0, 2))
+        );
+        assert_eq!(resolve_content_range(&(Included(3), Included(2)), 6), None);
+        assert_eq!(
+            resolve_content_range(&(Included(6), Bound::Unbounded), 6),
+            None
         );
         assert_eq!(
             resolve_content_range(&(Bound::Excluded(1), Included(2)), 6),

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -13,7 +13,7 @@ use aes_siv::aead::{Aead, KeyInit};
 use aes_siv::{Aes128SivAead, Nonce};
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{header::CONTENT_RANGE, HeaderValue, StatusCode};
 use axum::response::IntoResponse;
 use axum_extra::headers::{AcceptRanges, ContentLength, HeaderMap, HeaderMapExt, Range};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -242,6 +242,14 @@ async fn prepare_response(
             .satisfiable_ranges(initial_content_length)
             .collect::<VecDeque<_>>();
 
+        if ranges.is_empty() {
+            headers.insert(
+                CONTENT_RANGE,
+                HeaderValue::from_str(&format!("bytes */{}", initial_content_length)).unwrap(),
+            );
+            return Ok((StatusCode::RANGE_NOT_SATISFIABLE, headers, Body::empty()));
+        }
+
         let content_length = ranges
             .iter()
             .map(|(start, end)| match (start, end) {
@@ -254,8 +262,20 @@ async fn prepare_response(
 
         components.limits.check_egress(content_length).await?;
 
+        if let Some((start, end)) =
+            resolve_content_range(ranges.front().unwrap(), initial_content_length)
+        {
+            headers.insert(
+                CONTENT_RANGE,
+                HeaderValue::from_str(&format!(
+                    "bytes {}-{}/{}",
+                    start, end, initial_content_length
+                ))
+                .unwrap(),
+            );
+        }
+
         headers.typed_insert(ContentLength(content_length));
-        headers.typed_insert(range.clone());
 
         Ok((
             StatusCode::PARTIAL_CONTENT,
@@ -271,6 +291,18 @@ async fn prepare_response(
             headers,
             Body::from_stream(RecordStream::new(reader, false)),
         ))
+    }
+}
+
+fn resolve_content_range(
+    range: &(Bound<u64>, Bound<u64>),
+    initial_content_length: u64,
+) -> Option<(u64, u64)> {
+    match range {
+        (Included(s), Included(e)) => Some((*s, *e)),
+        (Included(s), Bound::Unbounded) => Some((*s, initial_content_length.saturating_sub(1))),
+        (Bound::Unbounded, Included(e)) => Some((0, *e)),
+        _ => None,
     }
 }
 
@@ -513,6 +545,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
         assert_eq!(resp.headers()["content-type"], "text/plain");
         assert_eq!(resp.headers()["content-length"], "3");
+        assert_eq!(resp.headers()["content-range"], "bytes 0-2/6");
         assert_eq!(resp.headers()["x-reduct-label-x"], "y");
 
         let body_bytes = to_bytes(resp.into_body(), 1000).await.unwrap();

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -238,7 +238,7 @@ async fn prepare_response(
     if let Some(range) = range {
         let initial_content_length = reader.lock().await.meta().content_length();
 
-        let ranges = range
+        let mut ranges = range
             .satisfiable_ranges(initial_content_length)
             .collect::<VecDeque<_>>();
 
@@ -250,14 +250,19 @@ async fn prepare_response(
             return Ok((StatusCode::RANGE_NOT_SATISFIABLE, headers, Body::empty()));
         }
 
+        ranges.retain(|range| resolve_content_range(range, initial_content_length).is_some());
+        if ranges.is_empty() {
+            headers.insert(
+                CONTENT_RANGE,
+                HeaderValue::from_str(&format!("bytes */{}", initial_content_length)).unwrap(),
+            );
+            return Ok((StatusCode::RANGE_NOT_SATISFIABLE, headers, Body::empty()));
+        }
+
         let content_length = ranges
             .iter()
-            .map(|(start, end)| match (start, end) {
-                (Included(s), Included(e)) => e - s + 1,
-                (Included(s), Bound::Unbounded) => initial_content_length - s,
-                (Bound::Unbounded, Included(e)) => e + 1,
-                _ => 0,
-            })
+            .filter_map(|range| resolve_content_range(range, initial_content_length))
+            .map(|(start, end)| end - start + 1)
             .sum();
 
         components.limits.check_egress(content_length).await?;
@@ -299,8 +304,10 @@ fn resolve_content_range(
     initial_content_length: u64,
 ) -> Option<(u64, u64)> {
     match range {
-        (Included(s), Included(e)) => Some((*s, *e)),
-        (Included(s), Bound::Unbounded) => Some((*s, initial_content_length.saturating_sub(1))),
+        (Included(s), Included(e)) if e >= s => Some((*s, *e)),
+        (Included(s), Bound::Unbounded) if *s < initial_content_length => {
+            Some((*s, initial_content_length.saturating_sub(1)))
+        }
         (Bound::Unbounded, Included(e)) => Some((0, *e)),
         _ => None,
     }
@@ -550,6 +557,66 @@ mod tests {
 
         let body_bytes = to_bytes(resp.into_body(), 1000).await.unwrap();
         assert_eq!(String::from_utf8_lossy(body_bytes.iter().as_slice()), "Hey");
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_query_link_range_not_satisfiable(
+        #[future] keeper: Arc<StateKeeper>,
+        mut headers: HeaderMap,
+    ) {
+        let keeper = keeper.await;
+        let link = create_query_link(
+            headers.clone(),
+            keeper.clone(),
+            QueryEntry {
+                query_type: QueryType::Query,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap()
+        .0
+        .link;
+
+        let params: HashMap<String, String> =
+            url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
+                .into_owned()
+                .collect();
+
+        headers.insert("range", HeaderValue::from_static("bytes=6-5"));
+        let response = get(
+            State(Arc::clone(&keeper)),
+            headers,
+            Path("file.txt".to_string()),
+            Query(params),
+        )
+        .await
+        .unwrap();
+
+        let resp = response.into_response();
+        assert_eq!(resp.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+        assert_eq!(resp.headers()["content-range"], "bytes */6");
+
+        let body_bytes = to_bytes(resp.into_body(), 1000).await.unwrap();
+        assert_eq!(body_bytes.len(), 0);
+    }
+
+    #[test]
+    fn test_resolve_content_range_variants() {
+        assert_eq!(
+            resolve_content_range(&(Included(1), Bound::Unbounded), 6),
+            Some((1, 5))
+        );
+        assert_eq!(
+            resolve_content_range(&(Bound::Unbounded, Included(2)), 6),
+            Some((0, 2))
+        );
+        assert_eq!(
+            resolve_content_range(&(Bound::Excluded(1), Included(2)), 6),
+            None
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #1328

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix (HTTP range response compliance for replica query links).

### What was changed?

- Updated `GET /api/v1/links/:file_name` query-link range response handling to include `Content-Range` on `206 Partial Content` responses.
- Removed incorrectly echoed `Range` response header for ranged requests.
- Added helper logic to resolve range bounds for `Content-Range` formatting.
- Extended range test coverage to assert `content-range: bytes 0-2/6`.

### Related issues

- https://github.com/reductstore/reductstore/issues/1328
- Plan comment: https://github.com/reductstore/reductstore/issues/1328#issuecomment-4241736726

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run locally:

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p reductstore test_get_query_link_range -- --nocapture`
