### PR TITLE
fix stable entry order for batched reads with equal timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make multi-entry query aggregation deterministic for records with equal timestamps by adding a stable tie-breaker and regression coverage, [PR-1326](https://github.com/reductstore/reductstore/pull/1326)
 - Graceful HTTP shutdown during active writes, split non-blocking compaction from strict shutdown sync, and ensure entry/block metadata sync waits for lock release when required, [PR-1323](https://github.com/reductstore/reductstore/pull/1323)
 - Reduce stale block metadata retention under high entry cardinality by introducing a shared global read cache with namespace-scoped invalidation and lock-read optimizations, [PR-1325](https://github.com/reductstore/reductstore/pull/1325)
+- Make batch-v2 `/io/{bucket}/read` output deterministic for equal timestamps by ordering entries by name and adding Rust/API regression tests, [PR-1330](https://github.com/reductstore/reductstore/pull/1330)
 
 ## 1.19.1 - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add README header image and update the project subtitle to "High Performance Data Backbone for Robotics and Industrial IoT", [PR-1315](https://github.com/reductstore/reductstore/pull/1315)
 - Generate SPDX SBOMs from `Cargo.lock` metadata (instead of scanning only final binaries), upload SBOM artifacts on every CI run, and continue attaching per-target SBOM files to releases, [PR-1314](https://github.com/reductstore/reductstore/pull/1314)
 
 ### Fixed
 
 - Return RFC-compliant `Content-Range` headers on partial (`206`) replica query-link responses so MCAP seek/backfill clients can parse byte ranges correctly, [PR-1329](https://github.com/reductstore/reductstore/pull/1329)
-- Make multi-entry query aggregation deterministic for records with equal timestamps by adding a stable tie-breaker and regression coverage, [PR-1326](https://github.com/reductstore/reductstore/pull/1326)
+- Make multi-entry query aggregation deterministic for records with equal timestamps by adding a stable tie-breaker, [PR-1326](https://github.com/reductstore/reductstore/pull/1326)
 - Graceful HTTP shutdown during active writes, split non-blocking compaction from strict shutdown sync, and ensure entry/block metadata sync waits for lock release when required, [PR-1323](https://github.com/reductstore/reductstore/pull/1323)
 - Reduce stale block metadata retention under high entry cardinality by introducing a shared global read cache with namespace-scoped invalidation and lock-read optimizations, [PR-1325](https://github.com/reductstore/reductstore/pull/1325)
-- Make batch-v2 `/io/{bucket}/read` output deterministic for equal timestamps by ordering entries by name and adding Rust/API regression tests, [PR-1330](https://github.com/reductstore/reductstore/pull/1330)
+- Make batch-v2 `/io/{bucket}/read` output deterministic for equal timestamps by ordering entries by name, [PR-1330](https://github.com/reductstore/reductstore/pull/1330)
 
 ## 1.19.1 - 2026-04-08
 

--- a/integration_tests/api/io/read_test.py
+++ b/integration_tests/api/io/read_test.py
@@ -49,6 +49,49 @@ def test_read_batched_records_v2(base_url, session, bucket, entry_root):
     assert resp.content == b"BBBAA"
 
 
+def test_read_batched_records_v2_stable_order_for_equal_timestamps(
+    base_url, session, bucket
+):
+    entry_z = "z-entry"
+    entry_a = "a-entry"
+    headers = {
+        "x-reduct-entries": f"{entry_z},{entry_a}",
+        "x-reduct-start-ts": "1000",
+        "x-reduct-0-0": "2,text/plain",
+        "x-reduct-1-0": "2,text/plain",
+        "content-length": "4",
+    }
+    body = b"ZZ" + b"AA"
+    resp = session.post(f"{base_url}/io/{bucket}/write", data=body, headers=headers)
+    assert resp.status_code == 200
+
+    resp = session.post(
+        f"{base_url}/io/{bucket}/q",
+        json={
+            "query_type": "QUERY",
+            "entries": [entry_z, entry_a],
+            "start": 0,
+            "stop": 2000,
+        },
+    )
+    assert resp.status_code == 200
+    query_id = resp.json()["id"]
+
+    resp = session.get(
+        f"{base_url}/io/{bucket}/read", headers={"x-reduct-query-id": str(query_id)}
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["x-reduct-entries"] == (
+        f"{quote(entry_a, safe='')},{quote(entry_z, safe='')}"
+    )
+    assert resp.headers["x-reduct-start-ts"] == "1000"
+    assert resp.headers["x-reduct-0-0"].startswith("2,text/plain")
+    assert resp.headers["x-reduct-1-0"].startswith("2,text/plain")
+    assert resp.headers["x-reduct-last"] == "true"
+    assert resp.content == b"AAZZ"
+
+
 @requires_env("API_TOKEN")
 @pytest.mark.parametrize("entry_path", ["x", "x/y", "x/y/z"])
 def test_read_requires_bucket_read_permissions(

--- a/reductstore/src/api/http/io/read.rs
+++ b/reductstore/src/api/http/io/read.rs
@@ -240,11 +240,10 @@ async fn fetch_and_response_batched_records(
     }
 
     let mut ordered_entries: Vec<(usize, String)> = entries.into_iter().enumerate().collect();
-    ordered_entries.sort_by_key(|(idx, _)| {
-        (
-            first_ts_by_entry.get(idx).copied().unwrap_or(u64::MAX),
-            *idx,
-        )
+    ordered_entries.sort_by(|(idx_a, entry_a), (idx_b, entry_b)| {
+        let ts_a = first_ts_by_entry.get(idx_a).copied().unwrap_or(u64::MAX);
+        let ts_b = first_ts_by_entry.get(idx_b).copied().unwrap_or(u64::MAX);
+        ts_a.cmp(&ts_b).then_with(|| entry_a.cmp(entry_b))
     });
 
     let mut remapped_indices = HashMap::new();
@@ -489,6 +488,91 @@ mod tests {
         assert_eq!(resp_headers["x-reduct-start-ts"], "1000");
         assert_eq!(resp_headers["x-reduct-last"], "true");
         assert_eq!(body, Bytes::from("bbbaa"));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sorts_same_timestamp_entries_by_name(
+        #[future] keeper: Arc<StateKeeper>,
+        path_to_bucket_1: Path<HashMap<String, String>>,
+        mut headers: HeaderMap,
+    ) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+        let bucket = components
+            .storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+
+        for (entry, ts, data) in [("z-entry", 1000u64, "zz"), ("a-entry", 1000u64, "aa")] {
+            let mut writer = bucket
+                .begin_write(
+                    entry,
+                    ts,
+                    data.len() as u64,
+                    "text/plain".to_string(),
+                    Default::default(),
+                )
+                .await
+                .unwrap();
+            writer
+                .send(Ok(Some(Bytes::from(data.to_string()))))
+                .await
+                .unwrap();
+            writer.send(Ok(None)).await.unwrap();
+        }
+
+        let request = QueryEntry {
+            query_type: QueryType::Query,
+            entries: Some(vec!["z-entry".into(), "a-entry".into()]),
+            start: Some(1000),
+            ..Default::default()
+        };
+        let path = Path(path_to_bucket_1.0.clone());
+        let response = query(
+            State(keeper.clone()),
+            headers.clone(),
+            path,
+            QueryEntryAxum(request),
+        )
+        .await
+        .unwrap()
+        .into_response();
+        let QueryInfo { id } =
+            from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+
+        headers.insert(
+            QUERY_ID_HEADER,
+            http::HeaderValue::from_str(&id.to_string()).unwrap(),
+        );
+
+        let response = read_batched_records(
+            State(keeper.clone()),
+            headers,
+            path_to_bucket_1,
+            MethodExtractor::new("GET"),
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        let resp_headers = response.headers().clone();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+        assert_eq!(resp_headers["x-reduct-entries"], "a-entry,z-entry");
+        assert!(resp_headers["x-reduct-0-0"]
+            .to_str()
+            .unwrap()
+            .starts_with("2,"));
+        assert!(resp_headers["x-reduct-1-0"]
+            .to_str()
+            .unwrap()
+            .starts_with("2,"));
+        assert_eq!(resp_headers["x-reduct-start-ts"], "1000");
+        assert_eq!(resp_headers["x-reduct-last"], "true");
+        assert_eq!(body, Bytes::from("aazz"));
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Fixed batched read entry ordering when multiple entries share the same first record timestamp.
- Changed ordering logic in `read_batched_records` to sort by first timestamp and then by entry name for deterministic output.
- Added Rust unit test coverage for equal-timestamp ordering (`sorts_same_timestamp_entries_by_name`).
- Added API integration test coverage for stable ordering (`test_read_batched_records_v2_stable_order_for_equal_timestamps`).

### Related issues

-

### Does this PR introduce a breaking change?

No.

### Other information:

- Validation run locally:
  - `cargo test -p reductstore sorts_same_timestamp_entries_by_name`
  - `pytest integration_tests/api/io/read_test.py -k stable_order_for_equal_timestamps`
