### PR TITLE
harden ci trust context for fork PR secret safety

### DIFF
--- a/.github/actions/aws-cargo-cache/action.yml
+++ b/.github/actions/aws-cargo-cache/action.yml
@@ -10,10 +10,12 @@ inputs:
     default: 'ci'
   access-key-id:
     description: 'AWS Access Key ID'
-    required: true
+    required: false
+    default: ''
   secret-access-key:
     description: 'AWS Secret Access Key'
-    required: true
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -36,6 +38,7 @@ runs:
     #        aws-region: eu-central
 
     - name: Use cache for Cargo
+      if: ${{ inputs.access-key-id != '' && inputs.secret-access-key != '' }}
       uses: runs-on/cache@v4
       with:
         path: |

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -6,7 +6,8 @@ inputs:
     required: true
   action_github_token:
     description: 'GitHub token for setup-protoc.'
-    required: true
+    required: false
+    default: ''
   target:
     description: 'Target triple.'
     required: true
@@ -18,10 +19,12 @@ inputs:
     required: true
   access-key-id:
     description: 'AWS Access Key ID'
-    required: true
+    required: false
+    default: ''
   secret-access-key:
     description: 'AWS Secret Access Key'
-    required: true
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -41,17 +44,19 @@ runs:
       run: rustup target add ${{ inputs.target }}
 
     - name: Install gcc
-      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+      if: ${{ startsWith(inputs.os, 'ubuntu-') }}
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.compiler }}
+        if [ -n "${{ inputs.compiler }}" ]; then
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.compiler }}
+        fi
 
     - name: Install gcc
-      if: ${{ startsWith(matrix.os, 'macos-') && matrix.compiler != '' }}
+      if: ${{ startsWith(inputs.os, 'macos-') && inputs.compiler != '' }}
       shell: bash
       run: |
-        brew install ${{ matrix.compiler }}
+        brew install ${{ inputs.compiler }}
 
     - uses: ilammy/setup-nasm@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
       - CHANGELOG.md
 
 permissions:
-  id-token: write
   contents: read
 
 
@@ -25,9 +24,100 @@ env:
   AWS_LC_SYS_USE_PREBUILT: 0
 
 jobs:
+  trust_context:
+    name: Determine CI trust context
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork_pr: ${{ steps.set.outputs.is_fork_pr }}
+      run_fork_ci: ${{ steps.set.outputs.run_fork_ci }}
+      run_trusted_ci: ${{ steps.set.outputs.run_trusted_ci }}
+      run_secret_jobs: ${{ steps.set.outputs.run_secret_jobs }}
+    steps:
+      - name: Check rerun actor permission
+        id: permission
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const username = context.payload.triggering_actor || context.actor;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              core.setOutput('level', data.permission || 'none');
+            } catch (error) {
+              core.info(`Could not resolve collaborator permission for ${username}: ${error.message}`);
+              core.setOutput('level', 'none');
+            }
+
+      - name: Set trust outputs
+        id: set
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor || github.actor }}
+          TRIGGERING_PERMISSION: ${{ steps.permission.outputs.level || 'none' }}
+        run: |
+          set -euo pipefail
+
+          is_fork_pr=false
+          run_fork_ci=false
+          run_trusted_ci=false
+          run_secret_jobs=false
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            run_trusted_ci=true
+            run_secret_jobs=true
+          elif [ "$PR_HEAD_REPOSITORY" = "$REPOSITORY" ]; then
+            run_trusted_ci=true
+            run_secret_jobs=true
+          else
+            is_fork_pr=true
+            case "$TRIGGERING_PERMISSION" in
+              admin|maintain|write)
+                run_fork_ci=true
+                ;;
+            esac
+          fi
+
+          {
+            echo "is_fork_pr=$is_fork_pr"
+            echo "run_fork_ci=$run_fork_ci"
+            echo "run_trusted_ci=$run_trusted_ci"
+            echo "run_secret_jobs=$run_secret_jobs"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$is_fork_pr" = true ] && [ "$run_fork_ci" != true ]; then
+            {
+              echo "Fork PR CI is paused."
+              echo "A maintainer with write access must review the changes and rerun this workflow."
+              echo "Triggering actor: $TRIGGERING_ACTOR"
+              echo "Resolved permission: ${TRIGGERING_PERMISSION:-none}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  fork_ci_waiting_for_approval:
+    name: Fork PR approval required
+    runs-on: ubuntu-latest
+    needs:
+      - trust_context
+    if: ${{ needs.trust_context.outputs.is_fork_pr == 'true' && needs.trust_context.outputs.run_fork_ci != 'true' }}
+    steps:
+      - name: Stop until a maintainer reruns CI
+        run: |
+          echo "Fork PR CI is paused until a maintainer with write access reruns this workflow."
+          exit 1
+
   rust_fmt:
     runs-on: ubuntu-latest
     name: Rust Linter
+    needs:
+      - trust_context
+    if: ${{ needs.trust_context.outputs.run_trusted_ci == 'true' || needs.trust_context.outputs.run_fork_ci == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Check code
@@ -37,7 +127,9 @@ jobs:
     name: Build Binaries
     runs-on: ${{ matrix.os }}
     needs:
+      - trust_context
       - rust_fmt
+    if: ${{ needs.trust_context.outputs.run_trusted_ci == 'true' }}
     strategy:
       matrix:
         target:
@@ -73,18 +165,35 @@ jobs:
       - uses: ./.github/actions/build-binaries
         with:
           minimal_rust_version: ${{ vars.MINIMAL_RUST_VERSION }}
-          action_github_token: ${{ secrets.ACTION_GITHUB_TOKEN }}
+          action_github_token: ${{ github.token }}
           target: ${{ matrix.target }}
           os: ${{ matrix.os }}
           compiler: ${{ matrix.compiler }}
           access-key-id: ${{ secrets.S3_CACHE_ACCESS_KEY }}
           secret-access-key: ${{ secrets.S3_CACHE_SECRET_KEY }}
 
+  build_binaries_fork:
+    name: Build Binaries (Fork PR)
+    runs-on: ubuntu-22.04
+    needs:
+      - trust_context
+      - rust_fmt
+    if: ${{ needs.trust_context.outputs.run_fork_ci == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-binaries
+        with:
+          minimal_rust_version: ${{ vars.MINIMAL_RUST_VERSION }}
+          action_github_token: ${{ github.token }}
+          target: x86_64-unknown-linux-gnu
+          os: ubuntu-22.04
+          compiler: gcc
+
   unit_tests:
     name: Run Unit Tests
     needs:
-      - rust_fmt
       - build_binaries
+    if: ${{ needs.build_binaries.result == 'success' }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, windows-2022, macos-14 ]
@@ -107,10 +216,29 @@ jobs:
           os: ${{ matrix.os }}
           target: ${{ matrix.target }}
 
+  unit_tests_fork:
+    name: Run Unit Tests (Fork PR)
+    needs:
+      - build_binaries_fork
+    if: ${{ needs.build_binaries_fork.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      RUST_BACKTRACE: 1
+      RUST_LOG: debug
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/unit-tests
+        with:
+          os: ubuntu-24.04
+          target: x86_64-unknown-linux-gnu
+
   coverage:
     name: Generate Code Coverage
     needs:
+      - trust_context
       - rust_fmt
+    if: ${{ needs.trust_context.outputs.run_secret_jobs == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -127,7 +255,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           target: ${{ matrix.target }}
-          action_github_token: ${{ secrets.ACTION_GITHUB_TOKEN }}
+          action_github_token: ${{ github.token }}
 
       - name: Upload coverage to Codecov
         continue-on-error: true
@@ -144,6 +272,7 @@ jobs:
     needs:
       - rust_fmt
       - build_binaries
+      - unit_tests
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -368,6 +497,9 @@ jobs:
   check_tag:
     runs-on: ubuntu-latest
     name: Check tag
+    needs:
+      - trust_context
+    if: ${{ needs.trust_context.outputs.run_trusted_ci == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Check tag
@@ -656,7 +788,7 @@ jobs:
       - uses: arduino/setup-protoc@v1
         with:
           version: "3.x"
-          repo-token: ${{ secrets.ACTION_GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
       - name: Login
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Generate SPDX SBOMs from `Cargo.lock` metadata (instead of scanning only final binaries), upload SBOM artifacts on every CI run, and continue attaching per-target SBOM files to releases, [PR-1314](https://github.com/reductstore/reductstore/pull/1314)
+- Harden CI trust context for fork PRs by gating secret-dependent jobs, requiring maintainer reruns for untrusted forks, and making cache credentials optional in composite actions, [PR-1333](https://github.com/reductstore/reductstore/pull/1333)
 
 ### Fixed
 


### PR DESCRIPTION
Closes #1331

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / CI hardening

### What was changed?

- Added a new `trust_context` job to classify runs as trusted CI, fork CI with maintainer rerun approval, or blocked fork CI.
- Prevented secrets from being used on untrusted fork PR runs by gating secret-dependent jobs and creating dedicated fork-safe build/test jobs.
- Made AWS cache credentials optional in composite actions and skipped cache usage when credentials are absent.
- Switched setup-protoc token usage to `github.token` and fixed composite action input references (`matrix.*` -> `inputs.*`) for compiler installation.

### Related issues

- https://github.com/reductstore/reductstore/issues/1331

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:
- Reviewed workflow/control-flow changes via `git diff origin/main...HEAD`.
- Confirmed fork PR behavior now requires maintainer rerun before running CI paths.
