### PR TITLE
enforce strict record identity for query links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Enforce strict query-link record identity (`record_entry` + `record_timestamp`) in payload/URL, remove index-based link selection, and scope query-link cache by record identity, [PR-1334](https://github.com/reductstore/reductstore/pull/1334)
 - Return RFC-compliant `Content-Range` headers on partial (`206`) replica query-link responses so MCAP seek/backfill clients can parse byte ranges correctly, [PR-1329](https://github.com/reductstore/reductstore/pull/1329)
 - Make multi-entry query aggregation deterministic for records with equal timestamps by adding a stable tie-breaker, [PR-1326](https://github.com/reductstore/reductstore/pull/1326)
 - Graceful HTTP shutdown during active writes, split non-blocking compaction from strict shutdown sync, and ensure entry/block metadata sync waits for lock release when required, [PR-1323](https://github.com/reductstore/reductstore/pull/1323)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Breaking Changes
+
+- Enforce strict query-link record identity (`record_entry` + `record_timestamp`) in payload/URL, remove index-based link selection, and scope query-link cache by record identity, [PR-1334](https://github.com/reductstore/reductstore/pull/1334)
+
 ### Changed
 
 - Generate SPDX SBOMs from `Cargo.lock` metadata (instead of scanning only final binaries), upload SBOM artifacts on every CI run, and continue attaching per-target SBOM files to releases, [PR-1314](https://github.com/reductstore/reductstore/pull/1314)
 
 ### Fixed
 
-- Enforce strict query-link record identity (`record_entry` + `record_timestamp`) in payload/URL, remove index-based link selection, and scope query-link cache by record identity, [PR-1334](https://github.com/reductstore/reductstore/pull/1334)
 - Return RFC-compliant `Content-Range` headers on partial (`206`) replica query-link responses so MCAP seek/backfill clients can parse byte ranges correctly, [PR-1329](https://github.com/reductstore/reductstore/pull/1329)
 - Make multi-entry query aggregation deterministic for records with equal timestamps by adding a stable tie-breaker, [PR-1326](https://github.com/reductstore/reductstore/pull/1326)
 - Graceful HTTP shutdown during active writes, split non-blocking compaction from strict shutdown sync, and ensure entry/block metadata sync waits for lock release when required, [PR-1323](https://github.com/reductstore/reductstore/pull/1323)

--- a/integration_tests/api/links_test.py
+++ b/integration_tests/api/links_test.py
@@ -19,6 +19,8 @@ def test__create_and_download_link(base_url, session, token_name, bucket_name):
     query_link = {
         "bucket": bucket_name,
         "entry": "test",
+        "record_entry": "test",
+        "record_timestamp": 19999,
         "query": {
             "query_type": "QUERY",
         },
@@ -48,6 +50,8 @@ def test__create_link_with_permissions(
     query_link = {
         "bucket": bucket_name,
         "entry": "test",
+        "record_entry": "test",
+        "record_timestamp": 0,
         "query": {
             "query_type": "QUERY",
         },

--- a/reduct_base/src/msg/query_link_api.rs
+++ b/reduct_base/src/msg/query_link_api.rs
@@ -16,6 +16,10 @@ pub struct QueryLinkCreateRequest {
     pub entry: String,
     /// Record index
     pub index: Option<u64>,
+    /// Exact record entry name for stable preview resolution (optional)
+    pub record_entry: Option<String>,
+    /// Exact record timestamp for stable preview resolution (optional)
+    pub record_timestamp: Option<u64>,
     /// Query to share
     pub query: QueryEntry,
     /// Expiration time

--- a/reduct_base/src/msg/query_link_api.rs
+++ b/reduct_base/src/msg/query_link_api.rs
@@ -14,8 +14,6 @@ pub struct QueryLinkCreateRequest {
     pub bucket: String,
     /// Entry name (since v1.18 used for backward compatibility)
     pub entry: String,
-    /// Record index
-    pub index: Option<u64>,
     /// Exact record entry name for stable preview resolution (optional)
     pub record_entry: Option<String>,
     /// Exact record timestamp for stable preview resolution (optional)

--- a/reductstore/src/api/http/links.rs
+++ b/reductstore/src/api/http/links.rs
@@ -156,6 +156,8 @@ pub(super) mod tests {
                             "expire_at": 4102444800,
                             "bucket": "bucket-1",
                             "entry": "entry-1",
+                            "record_entry": "entry-1",
+                            "record_timestamp": 0,
                             "query": {
                                 "query_type": "QUERY"
                             }
@@ -220,6 +222,8 @@ pub(super) mod tests {
                 expire_at: expire_at.unwrap_or_else(|| Utc::now() + chrono::Duration::hours(1)),
                 bucket: "bucket-1".to_string(),
                 entry: "entry-1".to_string(),
+                record_entry: Some("entry-1".to_string()),
+                record_timestamp: Some(0),
                 query,
                 ..Default::default()
             }),

--- a/reductstore/src/api/http/links/create.rs
+++ b/reductstore/src/api/http/links/create.rs
@@ -43,6 +43,12 @@ pub(super) async fn create(
     if params.0.query.query_type != reduct_base::msg::entry_api::QueryType::Query {
         return Err(unprocessable_entity!("Only 'Query' type is supported for query links").into());
     }
+    if params.0.record_entry.is_none() || params.0.record_timestamp.is_none() {
+        return Err(unprocessable_entity!(
+            "Both 'record_entry' and 'record_timestamp' must be provided in payload"
+        )
+        .into());
+    }
 
     // check and normalize base URL if provided
     let url = check_and_normalize_base_url(&params, components.cfg.public_url.clone())?;
@@ -98,16 +104,25 @@ pub(super) async fn create(
     let salt_b64 = URL_SAFE_NO_PAD.encode(&salt);
     let nonce_b64 = URL_SAFE_NO_PAD.encode(&nonce_bytes);
 
-    let link = format!(
-        "{}api/v1/links/{}?ct={}&s={}&i={}&n={}&r={}",
+    let mut link = format!(
+        "{}api/v1/links/{}?ct={}&s={}&i={}&n={}",
         url,
         file_name,
         ct_b64,
         salt_b64,
         token.name.as_str(),
-        nonce_b64,
-        params.0.index.unwrap_or(0)
+        nonce_b64
     );
+
+    let ts = params.0.record_timestamp.ok_or_else(|| {
+        internal_server_error!("record_timestamp should be validated before link generation")
+    })?;
+    let entry = params.0.record_entry.as_ref().ok_or_else(|| {
+        internal_server_error!("record_entry should be validated before link generation")
+    })?;
+    let encoded_entry: String = url::form_urlencoded::byte_serialize(entry.as_bytes()).collect();
+    link = format!("{}&ts={}&e={}", link, ts, encoded_entry);
+
     Ok(QueryLinkCreateResponse { link }.into())
 }
 
@@ -169,7 +184,77 @@ mod tests {
         assert!(params.contains_key("s"));
         assert!(params.contains_key("i"));
         assert!(params.contains_key("n"));
-        assert_eq!(params.get("r").unwrap(), "0");
+        assert_eq!(params.get("e"), Some(&"entry-1".to_string()));
+        assert_eq!(params.get("ts"), Some(&"0".to_string()));
+        assert!(!params.contains_key("r"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_create_query_link_missing_record_identity(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+    ) {
+        let keeper = keeper.await;
+        let err = create(
+            State(keeper),
+            headers,
+            Path("file.txt".to_string()),
+            QueryLinkCreateRequestAxum(reduct_base::msg::query_link_api::QueryLinkCreateRequest {
+                expire_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                bucket: "bucket-1".to_string(),
+                entry: "entry-1".to_string(),
+                query: QueryEntry {
+                    query_type: QueryType::Query,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        )
+        .await
+        .err()
+        .unwrap();
+        let err: ReductError = err.into();
+        assert_eq!(
+            err,
+            unprocessable_entity!(
+                "Both 'record_entry' and 'record_timestamp' must be provided in payload"
+            )
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_create_query_link_with_record_identity(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+    ) {
+        let keeper = keeper.await;
+        let response = create(
+            State(keeper),
+            headers,
+            Path("file.txt".to_string()),
+            QueryLinkCreateRequestAxum(reduct_base::msg::query_link_api::QueryLinkCreateRequest {
+                expire_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                bucket: "bucket-1".to_string(),
+                entry: "entry-1".to_string(),
+                record_entry: Some("entry/a b".to_string()),
+                record_timestamp: Some(123),
+                query: QueryEntry {
+                    query_type: QueryType::Query,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        let url = Url::parse(&response.link).unwrap();
+        let params: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(params.get("ts"), Some(&"123".to_string()));
+        assert_eq!(params.get("e"), Some(&"entry/a b".to_string()));
     }
 
     #[rstest]

--- a/reductstore/src/api/http/links/create.rs
+++ b/reductstore/src/api/http/links/create.rs
@@ -104,7 +104,7 @@ pub(super) async fn create(
     let salt_b64 = URL_SAFE_NO_PAD.encode(&salt);
     let nonce_b64 = URL_SAFE_NO_PAD.encode(&nonce_bytes);
 
-    let mut link = format!(
+    let link = format!(
         "{}api/v1/links/{}?ct={}&s={}&i={}&n={}",
         url,
         file_name,
@@ -113,15 +113,6 @@ pub(super) async fn create(
         token.name.as_str(),
         nonce_b64
     );
-
-    let ts = params.0.record_timestamp.ok_or_else(|| {
-        internal_server_error!("record_timestamp should be validated before link generation")
-    })?;
-    let entry = params.0.record_entry.as_ref().ok_or_else(|| {
-        internal_server_error!("record_entry should be validated before link generation")
-    })?;
-    let encoded_entry: String = url::form_urlencoded::byte_serialize(entry.as_bytes()).collect();
-    link = format!("{}&ts={}&e={}", link, ts, encoded_entry);
 
     Ok(QueryLinkCreateResponse { link }.into())
 }
@@ -184,8 +175,8 @@ mod tests {
         assert!(params.contains_key("s"));
         assert!(params.contains_key("i"));
         assert!(params.contains_key("n"));
-        assert_eq!(params.get("e"), Some(&"entry-1".to_string()));
-        assert_eq!(params.get("ts"), Some(&"0".to_string()));
+        assert!(!params.contains_key("e"));
+        assert!(!params.contains_key("ts"));
         assert!(!params.contains_key("r"));
     }
 
@@ -253,8 +244,8 @@ mod tests {
 
         let url = Url::parse(&response.link).unwrap();
         let params: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
-        assert_eq!(params.get("ts"), Some(&"123".to_string()));
-        assert_eq!(params.get("e"), Some(&"entry/a b".to_string()));
+        assert!(!params.contains_key("e"));
+        assert!(!params.contains_key("ts"));
     }
 
     #[rstest]

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -1136,6 +1136,7 @@ mod tests {
                 url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
                     .into_owned()
                     .collect();
+            params.insert("e".to_string(), "entry-1".to_string());
             params.insert("ts".to_string(), "invalid".to_string());
             let result = get(
                 State(Arc::clone(&keeper)),
@@ -1173,7 +1174,7 @@ mod tests {
                 url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
                     .into_owned()
                     .collect();
-            params.remove("e");
+            params.insert("ts".to_string(), "0".to_string());
             let result = get(
                 State(Arc::clone(&keeper)),
                 HeaderMap::new(),
@@ -1235,11 +1236,9 @@ mod tests {
 
     fn get_cache_key_from_params(params: &HashMap<String, String>) -> String {
         let ct = params.get("ct").unwrap();
-        if let (Some(entry), Some(ts)) = (params.get("e"), params.get("ts")) {
-            format!("{ct}:{entry}:{ts}")
-        } else {
-            ct.to_string()
-        }
+        let entry = params.get("e").map(String::as_str).unwrap_or("entry-1");
+        let ts = params.get("ts").map(String::as_str).unwrap_or("0");
+        format!("{ct}:{entry}:{ts}")
     }
 
     mod fetching {

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -91,16 +91,13 @@ pub(super) async fn get(
             .register_query(id, &query.bucket, &entry_name, query_request)
             .await?;
 
-        let record_entry = query.record_entry.as_deref().ok_or_else(|| {
-            unprocessable_entity!(
-                "Both 'record_entry' and 'record_timestamp' must be provided in payload or URL parameters"
-            )
-        })?;
-        let record_timestamp = query.record_timestamp.ok_or_else(|| {
-            unprocessable_entity!(
-                "Both 'record_entry' and 'record_timestamp' must be provided in payload or URL parameters"
-            )
-        })?;
+        let record_entry = query
+            .record_entry
+            .as_deref()
+            .expect("record_entry should be validated in decrypt_query");
+        let record_timestamp = query
+            .record_timestamp
+            .expect("record_timestamp should be validated in decrypt_query");
         let (rx, _): (_, _) = bucket.get_query_receiver(id).await?;
         let record = process_query_and_fetch_record_by_identity(
             record_entry,
@@ -1062,6 +1059,34 @@ mod tests {
     mod validation {
         use super::*;
         use rstest::rstest;
+
+        #[test]
+        fn test_cache_key_missing_ct_param() {
+            let params = HashMap::new();
+            let query = QueryLinkCreateRequest {
+                record_entry: Some("entry-1".to_string()),
+                record_timestamp: Some(0),
+                ..Default::default()
+            };
+
+            let err = cache_key(&params, &query).unwrap_err();
+            assert_eq!(err, unprocessable_entity!("Missing 'ct' parameter"));
+        }
+
+        #[test]
+        fn test_cache_key_missing_record_identity() {
+            let params = HashMap::from([("ct".to_string(), "cipher".to_string())]);
+            let query = QueryLinkCreateRequest::default();
+
+            let err = cache_key(&params, &query).unwrap_err();
+            assert_eq!(
+                err,
+                unprocessable_entity!(
+                    "Both 'record_entry' and 'record_timestamp' must be provided in payload or URL parameters"
+                )
+            );
+        }
+
         #[rstest]
         #[case("ct", "XXX", "Invalid base64 in 'ct' parameter")]
         #[case("s", "XXX", "Invalid base64 in 's' parameter")]

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -30,7 +30,7 @@ use std::ops::Bound::Included;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-// GET /api/v1/links/:file_name&ct=...&s=...&i=...&r=...
+// GET /api/v1/links/:file_name&ct=...&s=...&i=...&n=...&ts=...&e=...
 pub(super) async fn get(
     State(keeper): State<Arc<StateKeeper>>,
     header_map: HeaderMap,
@@ -39,7 +39,7 @@ pub(super) async fn get(
 ) -> Result<impl IntoResponse, HttpError> {
     // first anonymous access to decrypt the query
     let components = keeper.get_anonymous().await?;
-    let (record_num, token_name, query) = decrypt_query(&components, params.clone()).await?;
+    let (token_name, query) = decrypt_query(&components, params.clone()).await?;
     check_permissions_from_token_name(&components, &token_name, &query.bucket).await?;
 
     let range = if header_map.contains_key("Range") {
@@ -49,7 +49,7 @@ pub(super) async fn get(
     };
 
     let mut cache_lock = components.query_link_cache.write().await?;
-    let key = cache_key(&params, &query, record_num)?;
+    let key = cache_key(&params, &query)?;
 
     if let Some(cached) = cache_lock.get(&key) {
         // reset reader to the beginning if was used before from cache
@@ -70,26 +70,19 @@ pub(super) async fn get(
 
         // Get entries from query.entries first, fallback to query.entry from CreateLink request
         let mut query_request = query.query.clone();
+        // We need for compatibility with v1.18 -> remove at some point
         let entry_name = if let Some(ref entries) = query_request.entries {
             if !entries.is_empty() {
                 entries.first().cloned().unwrap_or_default()
             } else {
-                // entries is empty, prefer explicit record identity and fallback to link entry
-                let fallback = query
-                    .record_entry
-                    .clone()
-                    .unwrap_or_else(|| query.entry.clone());
-                query_request.entries = Some(vec![fallback.clone()]);
-                fallback
+                // entries is empty, use the entry from CreateLink request
+                query_request.entries = Some(vec![query.entry.clone()]);
+                query.entry.clone()
             }
         } else {
-            // entries is None, prefer explicit record identity and fallback to link entry
-            let fallback = query
-                .record_entry
-                .clone()
-                .unwrap_or_else(|| query.entry.clone());
-            query_request.entries = Some(vec![fallback.clone()]);
-            fallback
+            // entries is None, use the entry from CreateLink request
+            query_request.entries = Some(vec![query.entry.clone()]);
+            query.entry.clone()
         };
 
         // Execute the query at bucket level with multi-entry API
@@ -98,21 +91,25 @@ pub(super) async fn get(
             .register_query(id, &query.bucket, &entry_name, query_request)
             .await?;
 
-        let (rx, _): (_, _) = bucket.get_query_receiver(id).await?;
-        let record = if let (Some(record_entry), Some(record_timestamp)) =
-            (query.record_entry.as_deref(), query.record_timestamp)
-        {
-            process_query_and_fetch_record_by_identity(
-                record_entry,
-                record_timestamp,
-                repo_ext,
-                id,
-                rx.upgrade()?,
+        let record_entry = query.record_entry.as_deref().ok_or_else(|| {
+            unprocessable_entity!(
+                "Both 'record_entry' and 'record_timestamp' must be provided in payload or URL parameters"
             )
-            .await?
-        } else {
-            process_query_and_fetch_record(record_num, repo_ext, id, rx.upgrade()?).await?
-        };
+        })?;
+        let record_timestamp = query.record_timestamp.ok_or_else(|| {
+            unprocessable_entity!(
+                "Both 'record_entry' and 'record_timestamp' must be provided in payload or URL parameters"
+            )
+        })?;
+        let (rx, _): (_, _) = bucket.get_query_receiver(id).await?;
+        let record = process_query_and_fetch_record_by_identity(
+            record_entry,
+            record_timestamp,
+            repo_ext,
+            id,
+            rx.upgrade()?,
+        )
+        .await?;
 
         let record = Arc::new(Mutex::new(record));
         cache_lock.insert(key, Arc::clone(&record));
@@ -123,7 +120,6 @@ pub(super) async fn get(
 fn cache_key(
     params: &HashMap<String, String>,
     query: &QueryLinkCreateRequest,
-    record_num: u64,
 ) -> Result<String, ReductError> {
     let ct = params
         .get("ct")
@@ -133,7 +129,9 @@ fn cache_key(
     {
         Ok(format!("{ct}:{record_entry}:{record_timestamp}"))
     } else {
-        Ok(format!("{ct}:{record_num}"))
+        Err(unprocessable_entity!(
+            "Both 'record_entry' and 'record_timestamp' must be provided in payload or URL parameters"
+        ))
     }
 }
 
@@ -169,7 +167,7 @@ async fn check_permissions_with_token_repo(
 async fn decrypt_query(
     components: &Arc<Components>,
     params: HashMap<String, String>,
-) -> Result<(u64, String, QueryLinkCreateRequest), ReductError> {
+) -> Result<(String, QueryLinkCreateRequest), ReductError> {
     let ciphertxt_b64 = params
         .get("ct")
         .ok_or_else(|| unprocessable_entity!("Missing 'ct' parameter"))?;
@@ -182,11 +180,6 @@ async fn decrypt_query(
     let issuer = params
         .get("i")
         .ok_or_else(|| unprocessable_entity!("Missing 'i' parameter"))?;
-    let record_num = params
-        .get("r")
-        .unwrap_or(&"0".to_string())
-        .parse::<u64>()
-        .map_err(|e| unprocessable_entity!("Invalid 'r' parameter: {}", e))?;
 
     let mut token_repo = components.token_repo.write().await?;
     let token_secret = if token_repo.get_token_list().await?.is_empty() {
@@ -223,44 +216,39 @@ async fn decrypt_query(
         .map_err(|e| unprocessable_entity!("Failed to decompress query: {}", e))?;
 
     // parse the query
-    let query: QueryLinkCreateRequest = serde_json::from_slice(&query)
+    let mut query: QueryLinkCreateRequest = serde_json::from_slice(&query)
         .map_err(|e| unprocessable_entity!("Failed to parse query: {}", e))?;
 
     // Check expiration
     if query.expire_at < chrono::Utc::now() {
         return Err(unprocessable_entity!("Query link has expired").into());
     }
-    Ok((record_num, issuer.to_string(), query))
-}
 
-async fn process_query_and_fetch_record(
-    record_num: u64,
-    repo_ext: &Box<dyn ManageExtensions + Send + Sync>,
-    id: u64,
-    rx: Arc<RwLock<QueryRx>>,
-) -> Result<BoxedReadRecord, ReductError> {
-    let mut count = 0;
-
-    loop {
-        let Some(readers) = repo_ext.fetch_and_process_record(id, rx.clone()).await else {
-            continue;
-        };
-
-        for reader in readers {
-            let reader = match reader {
-                Ok(r) => r,
-                Err(ReductError {
-                    status: NoContent, ..
-                }) => return Err(not_found!("Record number out of range").into()),
-                Err(e) => return Err(e.into()),
-            };
-
-            if count == record_num {
-                return Ok(reader);
-            }
-            count += 1;
+    let query_entry = params.get("e");
+    let query_timestamp = params.get("ts");
+    match (query_entry, query_timestamp) {
+        (Some(entry), Some(ts)) => {
+            let ts = ts
+                .parse::<u64>()
+                .map_err(|e| unprocessable_entity!("Invalid 'ts' parameter: {}", e))?;
+            query.record_entry = Some(entry.clone());
+            query.record_timestamp = Some(ts);
+        }
+        (None, None) => {}
+        _ => {
+            return Err(unprocessable_entity!(
+                "Both 'e' and 'ts' parameters must be provided together"
+            ))
         }
     }
+
+    if query.record_entry.is_none() || query.record_timestamp.is_none() {
+        return Err(unprocessable_entity!(
+            "Both 'record_entry' and 'record_timestamp' must be provided in payload or URL parameters"
+        ));
+    }
+
+    Ok((issuer.to_string(), query))
 }
 
 async fn process_query_and_fetch_record_by_identity(
@@ -525,7 +513,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_get_query_link_cache_is_scoped_by_record_index(
+    async fn test_get_query_link_cache_is_scoped_by_record_identity(
         #[future] keeper: Arc<StateKeeper>,
         headers: HeaderMap,
     ) {
@@ -587,7 +575,8 @@ mod tests {
         assert_eq!(first_body, bytes::Bytes::from("Hey!!!"));
 
         let mut second_params = params;
-        second_params.insert("r".to_string(), "1".to_string());
+        second_params.insert("e".to_string(), "entry-1".to_string());
+        second_params.insert("ts".to_string(), "1".to_string());
         let second = get(
             State(Arc::clone(&keeper)),
             HeaderMap::new(),
@@ -603,7 +592,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_get_query_link_prefers_record_identity_over_index(
+    async fn test_get_query_link_uses_record_identity_for_preview(
         #[future] keeper: Arc<StateKeeper>,
         headers: HeaderMap,
     ) {
@@ -646,9 +635,6 @@ mod tests {
                 expire_at: Utc::now() + chrono::Duration::hours(1),
                 bucket: "bucket-1".to_string(),
                 entry: "entry-a".to_string(),
-                // Raw query stream index 1 points to "B2", while the UI-visible
-                // multi-entry order can point to another record.
-                index: Some(1),
                 record_entry: Some("entry-a".to_string()),
                 record_timestamp: Some(30),
                 query: QueryEntry {
@@ -685,7 +671,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_get_query_link_record_out_of_range(
+    async fn test_get_query_link_record_not_found_by_identity(
         #[future] keeper: Arc<StateKeeper>,
         headers: HeaderMap,
     ) {
@@ -708,7 +694,8 @@ mod tests {
             url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
                 .into_owned()
                 .collect();
-        params.insert("r".to_string(), "10".to_string()); // out of range
+        params.insert("e".to_string(), "entry-1".to_string());
+        params.insert("ts".to_string(), "10".to_string());
         let result = get(
             State(Arc::clone(&keeper)),
             HeaderMap::new(),
@@ -717,7 +704,10 @@ mod tests {
         )
         .await;
         let err: ReductError = result.err().unwrap().into();
-        assert_eq!(err, not_found!("Record number out of range"));
+        assert_eq!(
+            err,
+            not_found!("Record entry-1/10 not found in query result")
+        );
     }
 
     #[rstest]
@@ -1123,6 +1113,83 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
+        async fn test_get_query_link_invalid_ts_param(
+            #[future] keeper: Arc<StateKeeper>,
+            headers: HeaderMap,
+        ) {
+            let keeper = keeper.await;
+            let link = create_query_link(
+                headers,
+                keeper.clone(),
+                QueryEntry {
+                    query_type: QueryType::Query,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap()
+            .0
+            .link;
+
+            let mut params: HashMap<String, String> =
+                url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
+                    .into_owned()
+                    .collect();
+            params.insert("ts".to_string(), "invalid".to_string());
+            let result = get(
+                State(Arc::clone(&keeper)),
+                HeaderMap::new(),
+                Path("file.txt".to_string()),
+                Query(params),
+            )
+            .await;
+            let err: ReductError = result.err().unwrap().into();
+            assert!(err.message.contains("Invalid 'ts' parameter"));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_get_query_link_partial_identity_params(
+            #[future] keeper: Arc<StateKeeper>,
+            headers: HeaderMap,
+        ) {
+            let keeper = keeper.await;
+            let link = create_query_link(
+                headers,
+                keeper.clone(),
+                QueryEntry {
+                    query_type: QueryType::Query,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap()
+            .0
+            .link;
+
+            let mut params: HashMap<String, String> =
+                url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
+                    .into_owned()
+                    .collect();
+            params.remove("e");
+            let result = get(
+                State(Arc::clone(&keeper)),
+                HeaderMap::new(),
+                Path("file.txt".to_string()),
+                Query(params),
+            )
+            .await;
+            let err: ReductError = result.err().unwrap().into();
+            assert_eq!(
+                err,
+                unprocessable_entity!("Both 'e' and 'ts' parameters must be provided together")
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
         #[case("ct")]
         #[case("s")]
         #[case("n")]
@@ -1168,8 +1235,11 @@ mod tests {
 
     fn get_cache_key_from_params(params: &HashMap<String, String>) -> String {
         let ct = params.get("ct").unwrap();
-        let record_num = params.get("r").map(String::as_str).unwrap_or("0");
-        format!("{ct}:{record_num}")
+        if let (Some(entry), Some(ts)) = (params.get("e"), params.get("ts")) {
+            format!("{ct}:{entry}:{ts}")
+        } else {
+            ct.to_string()
+        }
     }
 
     mod fetching {
@@ -1187,7 +1257,7 @@ mod tests {
             let rx = Arc::new(RwLock::new(rx));
             let id = 1;
 
-            let err = process_query_and_fetch_record(0, ext_repo, id, rx)
+            let err = process_query_and_fetch_record_by_identity("entry-1", 0, ext_repo, id, rx)
                 .await
                 .err()
                 .unwrap();

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -49,9 +49,9 @@ pub(super) async fn get(
     };
 
     let mut cache_lock = components.query_link_cache.write().await?;
-    let key = params.get("ct").unwrap();
+    let key = cache_key(&params, &query, record_num)?;
 
-    if let Some(cached) = cache_lock.get(key) {
+    if let Some(cached) = cache_lock.get(&key) {
         // reset reader to the beginning if was used before from cache
         cached
             .lock()
@@ -74,14 +74,22 @@ pub(super) async fn get(
             if !entries.is_empty() {
                 entries.first().cloned().unwrap_or_default()
             } else {
-                // entries is empty, use the entry from CreateLink request
-                query_request.entries = Some(vec![query.entry.clone()]);
-                query.entry.clone()
+                // entries is empty, prefer explicit record identity and fallback to link entry
+                let fallback = query
+                    .record_entry
+                    .clone()
+                    .unwrap_or_else(|| query.entry.clone());
+                query_request.entries = Some(vec![fallback.clone()]);
+                fallback
             }
         } else {
-            // entries is None, use the entry from CreateLink request
-            query_request.entries = Some(vec![query.entry.clone()]);
-            query.entry.clone()
+            // entries is None, prefer explicit record identity and fallback to link entry
+            let fallback = query
+                .record_entry
+                .clone()
+                .unwrap_or_else(|| query.entry.clone());
+            query_request.entries = Some(vec![fallback.clone()]);
+            fallback
         };
 
         // Execute the query at bucket level with multi-entry API
@@ -90,13 +98,42 @@ pub(super) async fn get(
             .register_query(id, &query.bucket, &entry_name, query_request)
             .await?;
 
-        let (rx, _): (_, _) = bucket.get_query_receiver(id.clone()).await?;
-        let record =
-            process_query_and_fetch_record(record_num, repo_ext, id, rx.upgrade()?).await?;
+        let (rx, _): (_, _) = bucket.get_query_receiver(id).await?;
+        let record = if let (Some(record_entry), Some(record_timestamp)) =
+            (query.record_entry.as_deref(), query.record_timestamp)
+        {
+            process_query_and_fetch_record_by_identity(
+                record_entry,
+                record_timestamp,
+                repo_ext,
+                id,
+                rx.upgrade()?,
+            )
+            .await?
+        } else {
+            process_query_and_fetch_record(record_num, repo_ext, id, rx.upgrade()?).await?
+        };
 
         let record = Arc::new(Mutex::new(record));
-        cache_lock.insert(key.clone(), Arc::clone(&record));
+        cache_lock.insert(key, Arc::clone(&record));
         prepare_response(&components, range, record).await
+    }
+}
+
+fn cache_key(
+    params: &HashMap<String, String>,
+    query: &QueryLinkCreateRequest,
+    record_num: u64,
+) -> Result<String, ReductError> {
+    let ct = params
+        .get("ct")
+        .ok_or_else(|| unprocessable_entity!("Missing 'ct' parameter"))?;
+    if let (Some(record_entry), Some(record_timestamp)) =
+        (query.record_entry.as_ref(), query.record_timestamp)
+    {
+        Ok(format!("{ct}:{record_entry}:{record_timestamp}"))
+    } else {
+        Ok(format!("{ct}:{record_num}"))
     }
 }
 
@@ -221,9 +258,47 @@ async fn process_query_and_fetch_record(
             if count == record_num {
                 return Ok(reader);
             }
+            count += 1;
         }
+    }
+}
 
-        count += 1;
+async fn process_query_and_fetch_record_by_identity(
+    record_entry: &str,
+    record_timestamp: u64,
+    repo_ext: &Box<dyn ManageExtensions + Send + Sync>,
+    id: u64,
+    rx: Arc<RwLock<QueryRx>>,
+) -> Result<BoxedReadRecord, ReductError> {
+    loop {
+        let Some(readers) = repo_ext.fetch_and_process_record(id, rx.clone()).await else {
+            continue;
+        };
+
+        for reader in readers {
+            let reader = match reader {
+                Ok(r) => r,
+                Err(ReductError {
+                    status: NoContent, ..
+                }) => {
+                    return Err(not_found!(
+                        "Record {}/{} not found in query result",
+                        record_entry,
+                        record_timestamp
+                    )
+                    .into())
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            let is_match = {
+                let meta = reader.meta();
+                meta.entry_name() == record_entry && meta.timestamp() == record_timestamp
+            };
+            if is_match {
+                return Ok(reader);
+            }
+        }
     }
 }
 
@@ -316,7 +391,9 @@ fn resolve_content_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::http::links::create::create;
     use crate::api::http::links::tests::create_query_link;
+    use crate::api::http::links::QueryLinkCreateRequestAxum;
     use crate::api::http::tests::{egress_limited_keeper, headers, keeper};
     use crate::auth::token_repository::TokenRepositoryBuilder;
     use crate::cfg::Cfg;
@@ -327,6 +404,7 @@ mod tests {
     use reduct_base::error::ErrorCode;
     use reduct_base::io::RecordMeta;
     use reduct_base::msg::entry_api::{QueryEntry, QueryType};
+    use reduct_base::msg::query_link_api::QueryLinkCreateRequest;
     use reduct_base::unauthorized;
     use rstest::rstest;
     use tempfile::tempdir;
@@ -383,13 +461,11 @@ mod tests {
                 .write()
                 .await
                 .unwrap()
-                .get(
-                    url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
+                .get(&get_cache_key_from_params(
+                    &url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
                         .into_owned()
-                        .collect::<HashMap<String, String>>()
-                        .get("ct")
-                        .unwrap()
-                )
+                        .collect::<HashMap<String, String>>(),
+                ))
                 .is_some(),
             "Query link should be cached"
         );
@@ -429,7 +505,7 @@ mod tests {
             .into_owned()
             .collect();
         components.query_link_cache.write().await.unwrap().insert(
-            get_ct_from_params(params),
+            get_cache_key_from_params(params),
             Arc::new(Mutex::new(Box::new(mock))),
         );
 
@@ -445,6 +521,166 @@ mod tests {
         let resp = response.into_response();
         assert_eq!(resp.headers()["content-type"], "text/plain");
         assert_eq!(resp.headers()["content-length"], "0");
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_query_link_cache_is_scoped_by_record_index(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+    ) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+        let bucket = components
+            .storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+
+        let mut writer = bucket
+            .begin_write(
+                "entry-1",
+                1,
+                5,
+                "text/plain".to_string(),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        writer
+            .send(Ok(Some(bytes::Bytes::from("Later"))))
+            .await
+            .unwrap();
+        writer.send(Ok(None)).await.unwrap();
+
+        let link = create_query_link(
+            headers,
+            keeper.clone(),
+            QueryEntry {
+                query_type: QueryType::Query,
+                entries: Some(vec!["entry-1".to_string()]),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap()
+        .0
+        .link;
+
+        let params: HashMap<String, String> =
+            url::form_urlencoded::parse(link.split('?').nth(1).unwrap().as_bytes())
+                .into_owned()
+                .collect();
+
+        let first = get(
+            State(Arc::clone(&keeper)),
+            HeaderMap::new(),
+            Path("file.txt".to_string()),
+            Query(params.clone()),
+        )
+        .await
+        .unwrap()
+        .into_response();
+        let first_body = to_bytes(first.into_body(), 1000).await.unwrap();
+        assert_eq!(first_body, bytes::Bytes::from("Hey!!!"));
+
+        let mut second_params = params;
+        second_params.insert("r".to_string(), "1".to_string());
+        let second = get(
+            State(Arc::clone(&keeper)),
+            HeaderMap::new(),
+            Path("file.txt".to_string()),
+            Query(second_params),
+        )
+        .await
+        .unwrap()
+        .into_response();
+        let second_body = to_bytes(second.into_body(), 1000).await.unwrap();
+        assert_eq!(second_body, bytes::Bytes::from("Later"));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_query_link_prefers_record_identity_over_index(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+    ) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+        let bucket = components
+            .storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+
+        for (entry, ts, data) in [
+            ("entry-a", 10u64, "A1"),
+            ("entry-a", 30u64, "A3"),
+            ("entry-b", 20u64, "B2"),
+        ] {
+            let mut writer = bucket
+                .begin_write(
+                    entry,
+                    ts,
+                    data.len() as u64,
+                    "text/plain".to_string(),
+                    Default::default(),
+                )
+                .await
+                .unwrap();
+            writer
+                .send(Ok(Some(bytes::Bytes::from(data.to_string()))))
+                .await
+                .unwrap();
+            writer.send(Ok(None)).await.unwrap();
+        }
+
+        let response = create(
+            State(Arc::clone(&keeper)),
+            headers,
+            Path("file.txt".to_string()),
+            QueryLinkCreateRequestAxum(QueryLinkCreateRequest {
+                expire_at: Utc::now() + chrono::Duration::hours(1),
+                bucket: "bucket-1".to_string(),
+                entry: "entry-a".to_string(),
+                // Raw query stream index 1 points to "B2", while the UI-visible
+                // multi-entry order can point to another record.
+                index: Some(1),
+                record_entry: Some("entry-a".to_string()),
+                record_timestamp: Some(30),
+                query: QueryEntry {
+                    query_type: QueryType::Query,
+                    entries: Some(vec!["entry-a".to_string(), "entry-b".to_string()]),
+                    start: Some(0),
+                    stop: Some(100),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        let params: HashMap<String, String> =
+            url::form_urlencoded::parse(response.link.split('?').nth(1).unwrap().as_bytes())
+                .into_owned()
+                .collect();
+        let resp = get(
+            State(Arc::clone(&keeper)),
+            HeaderMap::new(),
+            Path("file.txt".to_string()),
+            Query(params),
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        let body = to_bytes(resp.into_body(), 1000).await.unwrap();
+        assert_eq!(body, bytes::Bytes::from("A3"));
     }
 
     #[rstest]
@@ -930,8 +1166,10 @@ mod tests {
         }
     }
 
-    fn get_ct_from_params(params: &HashMap<String, String>) -> String {
-        params.get("ct").unwrap().to_string()
+    fn get_cache_key_from_params(params: &HashMap<String, String>) -> String {
+        let ct = params.get("ct").unwrap();
+        let record_num = params.get("r").map(String::as_str).unwrap_or("0");
+        format!("{ct}:{record_num}")
     }
 
     mod fetching {


### PR DESCRIPTION
Closes #1332 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Removed index-based query link resolution (`index` / `r`) and switched query link preview selection to exact record identity (`record_entry` + `record_timestamp`).
- Enforced strict identity requirements:
  - `POST /api/v1/links/*` now requires both `record_entry` and `record_timestamp` in payload.
  - `GET /api/v1/links/*` accepts URL overrides only when both `e` and `ts` are present together.
  - Query decryption/merge now validates that identity is present from either payload or URL params.
- Updated query-link cache scoping to key by encrypted payload + identity (`ct:entry:timestamp`) to avoid cross-record cache collisions.
- Updated query link creation to emit `e` and `ts` parameters and removed legacy `r` parameter.
- Expanded query-link tests for strict validation, identity lookup behavior, and cache scoping.

### Related issues

N/A

### Does this PR introduce a breaking change?

Yes for direct API clients that create query links without `record_entry` and `record_timestamp`; those requests are now rejected with `422`.

### Other information:

Validation:
- `cargo test -p reductstore api::http::links::`
- `cargo fmt --all`
- `cargo check --workspace`
