### PR TITLE
fix(replication): keep queue on 503 Service Unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Treat replication destination `503 Service Unavailable` as a transient remote-unavailable error so replication keeps queued transactions buffered instead of dropping them, [PR-1337](https://github.com/reductstore/reductstore/pull/1337)
+
 ## 1.19.2 - 2026-04-15
 
 ### Breaking Changes

--- a/reductstore/src/replication/remote_bucket/states/bucket_available.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_available.rs
@@ -35,7 +35,11 @@ impl BucketAvailableState {
         // if it is a network error, we can retry got to unavailable state and wait
 
         match err.status {
-            ErrorCode::Timeout | ErrorCode::ConnectionError | ErrorCode::ServiceUnavailable => {
+            ErrorCode::Timeout
+            | ErrorCode::ConnectionError
+            | ErrorCode::BadGateway
+            | ErrorCode::ServiceUnavailable
+            | ErrorCode::GatewayTimeout => {
                 debug!(
                     "Failed to write record to remote bucket {}{}: {}",
                     self.bucket.server_url(),
@@ -236,7 +240,9 @@ mod tests {
     #[test_log::test(rstest)]
     #[case(ErrorCode::Timeout)]
     #[case(ErrorCode::ConnectionError)]
+    #[case(ErrorCode::BadGateway)]
     #[case(ErrorCode::ServiceUnavailable)]
+    #[case(ErrorCode::GatewayTimeout)]
     #[tokio::test]
     async fn test_write_record_conn_err(
         #[case] err: ErrorCode,
@@ -263,7 +269,9 @@ mod tests {
     #[test_log::test(rstest)]
     #[case(ErrorCode::Timeout)]
     #[case(ErrorCode::ConnectionError)]
+    #[case(ErrorCode::BadGateway)]
     #[case(ErrorCode::ServiceUnavailable)]
+    #[case(ErrorCode::GatewayTimeout)]
     #[tokio::test]
     async fn test_update_record_conn_err(
         #[case] err: ErrorCode,

--- a/reductstore/src/replication/remote_bucket/states/bucket_available.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_available.rs
@@ -35,7 +35,7 @@ impl BucketAvailableState {
         // if it is a network error, we can retry got to unavailable state and wait
 
         match err.status {
-            ErrorCode::Timeout | ErrorCode::ConnectionError => {
+            ErrorCode::Timeout | ErrorCode::ConnectionError | ErrorCode::ServiceUnavailable => {
                 debug!(
                     "Failed to write record to remote bucket {}{}: {}",
                     self.bucket.server_url(),
@@ -236,6 +236,7 @@ mod tests {
     #[test_log::test(rstest)]
     #[case(ErrorCode::Timeout)]
     #[case(ErrorCode::ConnectionError)]
+    #[case(ErrorCode::ServiceUnavailable)]
     #[tokio::test]
     async fn test_write_record_conn_err(
         #[case] err: ErrorCode,
@@ -262,6 +263,7 @@ mod tests {
     #[test_log::test(rstest)]
     #[case(ErrorCode::Timeout)]
     #[case(ErrorCode::ConnectionError)]
+    #[case(ErrorCode::ServiceUnavailable)]
     #[tokio::test]
     async fn test_update_record_conn_err(
         #[case] err: ErrorCode,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Treat `ServiceUnavailable` (HTTP 503) from remote replication writes/updates as a transient connectivity-style error.
- Move replication remote bucket state to `BucketUnavailableState` on 503 (same behavior as timeout/connection errors).
- Add regression coverage in `bucket_available` state tests for both write and update paths with `ErrorCode::ServiceUnavailable`.

This prevents replication sender from treating 503 as an active/non-retryable state and dropping queued transactions from the local replication log.

### Related issues

Observed in production (`orion` -> `play`) where replication received 503 and did not buffer as expected.

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with targeted tests:

- `cargo test -p reductstore test_write_record_conn_err`
- `cargo test -p reductstore test_update_record_conn_err`
