### PR TITLE
Treat HTTP 429 as recoverable in replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Count usage limits per connection to avoid starvation of health checks, [PR-1341](https://github.com/reductstore/reductstore/pull/1341)
+- Treat replication HTTP 429 (Too Many Requests) as transient remote-unavailable so throttled batches stay queued for retry instead of being dropped, [PR-1342](https://github.com/reductstore/reductstore/pull/1342)
 
 ## 1.19.3 - 2026-04-16
 

--- a/reductstore/src/replication/remote_bucket/states/bucket_available.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_available.rs
@@ -39,7 +39,8 @@ impl BucketAvailableState {
             | ErrorCode::ConnectionError
             | ErrorCode::BadGateway
             | ErrorCode::ServiceUnavailable
-            | ErrorCode::GatewayTimeout => {
+            | ErrorCode::GatewayTimeout
+            | ErrorCode::TooManyRequests => {
                 debug!(
                     "Failed to write record to remote bucket {}{}: {}",
                     self.bucket.server_url(),
@@ -243,6 +244,7 @@ mod tests {
     #[case(ErrorCode::BadGateway)]
     #[case(ErrorCode::ServiceUnavailable)]
     #[case(ErrorCode::GatewayTimeout)]
+    #[case(ErrorCode::TooManyRequests)]
     #[tokio::test]
     async fn test_write_record_conn_err(
         #[case] err: ErrorCode,
@@ -272,6 +274,7 @@ mod tests {
     #[case(ErrorCode::BadGateway)]
     #[case(ErrorCode::ServiceUnavailable)]
     #[case(ErrorCode::GatewayTimeout)]
+    #[case(ErrorCode::TooManyRequests)]
     #[tokio::test]
     async fn test_update_record_conn_err(
         #[case] err: ErrorCode,

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -331,6 +331,43 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    async fn test_replication_429_keeps_transactions(mut remote_bucket: MockRmBucket) {
+        remote_bucket
+            .expect_write_batch()
+            .returning(|_, _| Err(ReductError::new(ErrorCode::TooManyRequests, "slow down")));
+        remote_bucket.expect_is_active().return_const(false);
+        let mut sender = build_sender(remote_bucket, settings()).await;
+
+        let transaction = Transaction::WriteRecord(10);
+        imitate_write_record(&sender, &transaction, 5).await;
+
+        assert_eq!(
+            sender.run().await.unwrap(),
+            SyncState::NotAvailable(vec![(
+                Err(ReductError::new(ErrorCode::TooManyRequests, "slow down")),
+                1,
+            )])
+        );
+
+        assert_eq!(
+            sender
+                .log_map
+                .read()
+                .await
+                .unwrap()
+                .get("test")
+                .unwrap()
+                .read()
+                .await
+                .unwrap()
+                .front(1)
+                .await,
+            Ok(vec![transaction]),
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
     async fn test_replication_not_found(
         mut remote_bucket: MockRmBucket,
         settings: ReplicationSettings,


### PR DESCRIPTION
Closes #1340

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Treat `ErrorCode::TooManyRequests` (HTTP 429) as a recoverable remote-bucket error in replication state handling.
- Transition replication remote bucket to unavailable state on 429, so the sender retries later instead of finalizing the batch as failed in the current cycle.
- Added tests in `bucket_available` to verify 429 is classified as recoverable for both write and update batch paths.
- Added `replication_sender` regression test to verify transactions are kept in the log when 429 occurs.

### Related issues

- https://github.com/reductstore/reductstore/issues/1340
- Plan comment: https://github.com/reductstore/reductstore/issues/1340#issuecomment-4282166085

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run:
- `cargo test -p reductstore bucket_available::tests::test_write_record_conn_err -- --nocapture`
- `cargo test -p reductstore bucket_available::tests::test_update_record_conn_err -- --nocapture`
- `cargo test -p reductstore replication_sender::tests::test_replication_429_keeps_transactions -- --nocapture`