### PR TITLE
Add --version CLI option to reductstore server binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--version` (`-V`) CLI option to the `reductstore` server binary to print the version and exit successfully from shared launcher code, [PR-1343](https://github.com/reductstore/reductstore/pull/1343)
+
 ## 1.19.5- 2026-04-21
 
 ### Fixed

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -20,11 +20,26 @@ use tokio::sync::mpsc;
 
 static SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn has_version_flag<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter()
+        .skip(1)
+        .any(|arg| matches!(arg.as_ref(), "--version" | "-V"))
+}
+
 pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_pareser: Parser)
 where
     Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
 {
     let version: &str = env!("CARGO_PKG_VERSION");
+
+    if has_version_flag(std::env::args()) {
+        println!("{}", version);
+        return;
+    }
 
     Logger::init("INFO");
     info!(
@@ -222,6 +237,15 @@ mod tests {
     use tokio::time::sleep;
 
     static STOP_SERVER: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
+
+    #[test]
+    fn test_has_version_flag() {
+        assert!(has_version_flag(vec!["reductstore", "--version"]));
+        assert!(has_version_flag(vec!["reductstore", "-V"]));
+        assert!(!has_version_flag(vec!["reductstore"]));
+        assert!(!has_version_flag(vec!["reductstore", "--verbose"]));
+    }
+
     pub(super) async fn shutdown_server(handle: Handle<SocketAddr>) {
         while !*STOP_SERVER.lock().await {
             sleep(Duration::from_millis(10)).await;

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -49,8 +49,15 @@ pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_pares
 where
     Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
 {
-    let version: &str = env!("CARGO_PKG_VERSION");
+    launch_server_with_version(ext_cfg_pareser, env!("CARGO_PKG_VERSION")).await;
+}
 
+pub async fn launch_server_with_version<Parser, ExtCfg: ExtCfgBounds + 'static>(
+    ext_cfg_pareser: Parser,
+    version: &str,
+) where
+    Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
+{
     if maybe_print_version(std::env::args(), version, std::io::stdout()) {
         return;
     }

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -242,8 +242,17 @@ mod tests {
     fn test_has_version_flag() {
         assert!(has_version_flag(vec!["reductstore", "--version"]));
         assert!(has_version_flag(vec!["reductstore", "-V"]));
+        assert!(has_version_flag(vec![
+            "reductstore",
+            "--config",
+            "cfg.yml",
+            "--version"
+        ]));
+
         assert!(!has_version_flag(vec!["reductstore"]));
         assert!(!has_version_flag(vec!["reductstore", "--verbose"]));
+        assert!(!has_version_flag(vec!["--version"])); // first arg is binary name and must be ignored
+        assert!(!has_version_flag(Vec::<&str>::new()));
     }
 
     pub(super) async fn shutdown_server(handle: Handle<SocketAddr>) {

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -12,6 +12,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use log::{error, info};
 use reduct_base::logger::Logger;
+use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -30,14 +31,27 @@ where
         .any(|arg| matches!(arg.as_ref(), "--version" | "-V"))
 }
 
+fn maybe_print_version<I, S, W>(args: I, version: &str, mut writer: W) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+    W: Write,
+{
+    if has_version_flag(args) {
+        let _ = writeln!(writer, "{version}");
+        true
+    } else {
+        false
+    }
+}
+
 pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_pareser: Parser)
 where
     Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
 {
     let version: &str = env!("CARGO_PKG_VERSION");
 
-    if has_version_flag(std::env::args()) {
-        println!("{}", version);
+    if maybe_print_version(std::env::args(), version, std::io::stdout()) {
         return;
     }
 
@@ -253,6 +267,25 @@ mod tests {
         assert!(!has_version_flag(vec!["reductstore", "--verbose"]));
         assert!(!has_version_flag(vec!["--version"])); // first arg is binary name and must be ignored
         assert!(!has_version_flag(Vec::<&str>::new()));
+    }
+
+    #[test]
+    fn test_maybe_print_version() {
+        let mut output = Vec::new();
+        assert!(maybe_print_version(
+            vec!["reductstore", "--version"],
+            "1.2.3",
+            &mut output
+        ));
+        assert_eq!(String::from_utf8(output).unwrap(), "1.2.3\n");
+
+        let mut output = Vec::new();
+        assert!(!maybe_print_version(
+            vec!["reductstore"],
+            "1.2.3",
+            &mut output
+        ));
+        assert!(output.is_empty());
     }
 
     pub(super) async fn shutdown_server(handle: Handle<SocketAddr>) {


### PR DESCRIPTION
Closes #1338

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added lightweight CLI flag detection in the shared launcher path.
- Added support for `--version` (and `-V`) to print `CARGO_PKG_VERSION` and exit with code 0 before server initialization.
- Added unit tests for version-flag detection.

Because this is implemented in the shared launcher logic, downstream Pro binaries inherit the behavior automatically without separate implementation.

### Related issues

- https://github.com/reductstore/reductstore/issues/1338

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run:
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p reductstore launcher::tests::test_has_version_flag`
- `cargo run -p reductstore -- --version`