### PR TITLE
chore: enforce least-privilege GITHUB_TOKEN permissions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
       - CHANGELOG.md
 
 permissions:
-  id-token: write
   contents: read
 
 
@@ -508,6 +507,9 @@ jobs:
   push_image_dockerhub:
     runs-on: ubuntu-latest
     name: Build image and push it to DockerHub Registry
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - check_tag
       - http_api_tests


### PR DESCRIPTION
Closes #1349

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Chore / CI security hardening.

### What was changed?

- Removed workflow-level `id-token: write` from `.github/workflows/ci.yml`.
- Kept default workflow permission at `contents: read`.
- Added job-level `permissions` for `push_image_dockerhub` with:
  - `contents: read`
  - `id-token: write`

This keeps the workflow default least-privilege while preserving OIDC capability only where required.

### Related issues

- https://github.com/reductstore/reductstore/issues/1349

### Does this PR introduce a breaking change?

No breaking changes expected. This only scopes GitHub token permissions.

### Other information:

Validation run:
- `cargo fmt --all`
- `cargo check --workspace`

Implementation plan: https://github.com/reductstore/reductstore/issues/1349#issuecomment-4305532612