### PR TITLE
Downgrade write_batched channel-closed message to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `--version` (`-V`) CLI option to the `reductstore` server binary to print the version and exit successfully from shared launcher code, [PR-1343](https://github.com/reductstore/reductstore/pull/1343)
 
+### Fixed
+
+- Downgrade `write_batched` log severity for closed writer-channel handoff from error to warning to reduce noisy false-positive error bursts under expected stream abort/backpressure scenarios, [PR-1356](https://github.com/reductstore/reductstore/pull/1356)
+
 ## 1.19.5- 2026-04-21
 
 ### Fixed

--- a/reductstore/src/api/http/entry/write_batched.rs
+++ b/reductstore/src/api/http/entry/write_batched.rs
@@ -16,7 +16,7 @@ use crate::api::http::StateKeeper;
 use crate::api::limits::limit_scope_from_client_ip;
 use crate::replication::{Transaction, TransactionNotification};
 use crate::storage::entry::RecordDrainer;
-use log::{debug, error};
+use log::{debug, warn};
 use reduct_base::batch::{parse_batched_header, sort_headers_by_time, RecordHeader};
 use reduct_base::error::ReductError;
 use reduct_base::io::{RecordMeta, WriteRecord};
@@ -235,7 +235,7 @@ async fn spawn_getting_writers(
                     writer,
                 })
                 .await
-                .map_err(|err| error!("Failed to send the writer: {}", err))
+                .map_err(|err| warn!("Failed to send the writer: {}", err))
                 .unwrap_or(());
         }
         error_map


### PR DESCRIPTION
Closes #1338

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / logging severity adjustment.

### What was changed?

- Changed log level in batched write path from `error` to `warn` when the internal writer channel is already closed.
- Updated `reductstore/src/api/http/entry/write_batched.rs`:
  - `use log::{debug, error};` → `use log::{debug, warn};`
  - `error!("Failed to send the writer: {}", err)` → `warn!(...)`

This keeps expected stream-abort/backpressure situations from flooding error telemetry while preserving visibility.

### Related issues

- https://github.com/reductstore/reductstore/issues/1338

### Does this PR introduce a breaking change?

No.

### Other information:

No functional behavior changes; logging level only.