### PR TITLE
limit in-flight readers/writers and reduce storage sync contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add optional in-flight IO limits (`RS_IO_MAX_WRITERS_IN_FLIGHT`, `RS_IO_MAX_READERS_IN_FLIGHT`) to bound concurrent storage read/write operations, plus lock-contention and sync-path optimizations in storage/file cache internals, [PR-1357](https://github.com/reductstore/reductstore/pull/1357)
+
 ## 1.19.5- 2026-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.19.5"
+version = "1.19.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.19.5"
+version = "1.19.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.19.5"
+version = "1.19.6"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.19.5"
+version = "1.19.6"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.89.0"

--- a/reductstore/src/api/http/entry/read_single.rs
+++ b/reductstore/src/api/http/entry/read_single.rs
@@ -102,10 +102,17 @@ async fn fetch_and_response_single_record(
             .limits
             .check_egress_for(scope, reader.meta().content_length())
             .await?;
+        let headers = make_headers_from_reader(reader.meta());
+        return Ok((
+            headers,
+            Body::from_stream(RecordStream::new(
+                Arc::new(Mutex::new(Box::new(reader))),
+                empty_body,
+            )),
+        ));
     }
 
     let headers = make_headers_from_reader(reader.meta());
-
     Ok((
         headers,
         Body::from_stream(RecordStream::new(

--- a/reductstore/src/api/limits.rs
+++ b/reductstore/src/api/limits.rs
@@ -578,6 +578,7 @@ mod tests {
                 api_requests_per_window: Some(WindowLimit::new(1, Duration::from_secs(3600))),
                 ingress_bytes_per_window: Some(WindowLimit::new(3, Duration::from_secs(3600))),
                 egress_bytes_per_window: Some(WindowLimit::new(5, Duration::from_secs(3600))),
+                ..LimitsConfig::default()
             })
             .build();
 

--- a/reductstore/src/audit/repo.rs
+++ b/reductstore/src/audit/repo.rs
@@ -169,64 +169,32 @@ mod tests {
         token_name: &str,
         timestamp: u64,
     ) -> AuditEvent {
-        let entry_name = audit_entry_name(token_name);
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-
-        loop {
-            match repo.storage.get_bucket(AUDIT_BUCKET_NAME).await {
-                Ok(bucket) => {
-                    let bucket = bucket.upgrade_and_unwrap();
-                    match bucket.begin_read(&entry_name, timestamp).await {
-                        Ok(mut reader) => {
-                            let record = reader.read_chunk().unwrap().unwrap();
-                            return serde_json::from_slice(&record).unwrap();
-                        }
-                        Err(err)
-                            if err.status == ErrorCode::NotFound
-                                || err.status == ErrorCode::TooEarly => {}
-                        Err(err) => panic!("{err}"),
-                    }
-                }
-                Err(err)
-                    if err.status == ErrorCode::NotFound || err.status == ErrorCode::TooEarly => {}
-                Err(err) => panic!("{err}"),
-            }
-
-            if tokio::time::Instant::now() >= deadline {
-                panic!("Audit event '{entry_name}' at {timestamp} was not flushed");
-            }
-
-            sleep(Duration::from_millis(50)).await;
-        }
+        let bucket = repo
+            .storage
+            .get_bucket(AUDIT_BUCKET_NAME)
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+        let mut reader = bucket
+            .begin_read(&audit_entry_name(token_name), timestamp)
+            .await
+            .unwrap();
+        let record = reader.read_chunk().unwrap().unwrap();
+        serde_json::from_slice(&record).unwrap()
     }
 
     async fn read_audit_labels(repo: &AuditRepository, token_name: &str, timestamp: u64) -> Labels {
-        let entry_name = audit_entry_name(token_name);
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-
-        loop {
-            match repo.storage.get_bucket(AUDIT_BUCKET_NAME).await {
-                Ok(bucket) => {
-                    let bucket = bucket.upgrade_and_unwrap();
-                    match bucket.begin_read(&entry_name, timestamp).await {
-                        Ok(reader) => return reader.meta().labels().clone(),
-                        Err(err)
-                            if err.status == ErrorCode::NotFound
-                                || err.status == ErrorCode::TooEarly => {}
-                        Err(err) => panic!("{err}"),
-                    }
-                }
-                Err(err)
-                    if err.status == ErrorCode::NotFound || err.status == ErrorCode::TooEarly => {}
-                Err(err) => panic!("{err}"),
-            }
-
-            if tokio::time::Instant::now() >= deadline {
-                panic!("Audit labels for '{entry_name}' at {timestamp} were not flushed");
-            }
-
-            sleep(Duration::from_millis(50)).await;
-        }
+        let bucket = repo
+            .storage
+            .get_bucket(AUDIT_BUCKET_NAME)
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+        let reader = bucket
+            .begin_read(&audit_entry_name(token_name), timestamp)
+            .await
+            .unwrap();
+        reader.meta().labels().clone()
     }
 
     async fn audit_record_exists(repo: &AuditRepository, token_name: &str, timestamp: u64) -> bool {
@@ -370,57 +338,6 @@ mod tests {
         assert_eq!(
             labels,
             Labels::from([("status".to_string(), "200".to_string())])
-        );
-    }
-
-    #[rstest]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn read_event_waits_for_worker_when_audit_bucket_is_missing(
-        #[future] repo: AuditRepository,
-    ) {
-        let mut repo = repo.await;
-
-        repo.log_event(make_event(
-            "token-wait",
-            "GET",
-            "/api/v1/b/test",
-            200,
-            "",
-            7,
-        ))
-        .await
-        .unwrap();
-
-        let event = read_audit_event(&repo, "token-wait", 7).await;
-        assert_eq!(event.token_name, "token-wait");
-    }
-
-    #[rstest]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn read_labels_waits_for_worker_when_audit_entry_is_missing(
-        #[future] repo: AuditRepository,
-    ) {
-        let mut repo = repo.await;
-        repo.storage
-            .create_system_bucket(AUDIT_BUCKET_NAME, BucketSettings::default())
-            .await
-            .unwrap();
-
-        repo.log_event(make_event(
-            "token-labels",
-            "GET",
-            "/api/v1/b/test",
-            201,
-            "",
-            8,
-        ))
-        .await
-        .unwrap();
-
-        let labels = read_audit_labels(&repo, "token-labels", 8).await;
-        assert_eq!(
-            labels,
-            Labels::from([("status".to_string(), "201".to_string())])
         );
     }
 

--- a/reductstore/src/audit/repo.rs
+++ b/reductstore/src/audit/repo.rs
@@ -169,32 +169,64 @@ mod tests {
         token_name: &str,
         timestamp: u64,
     ) -> AuditEvent {
-        let bucket = repo
-            .storage
-            .get_bucket(AUDIT_BUCKET_NAME)
-            .await
-            .unwrap()
-            .upgrade_and_unwrap();
-        let mut reader = bucket
-            .begin_read(&audit_entry_name(token_name), timestamp)
-            .await
-            .unwrap();
-        let record = reader.read_chunk().unwrap().unwrap();
-        serde_json::from_slice(&record).unwrap()
+        let entry_name = audit_entry_name(token_name);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+        loop {
+            match repo.storage.get_bucket(AUDIT_BUCKET_NAME).await {
+                Ok(bucket) => {
+                    let bucket = bucket.upgrade_and_unwrap();
+                    match bucket.begin_read(&entry_name, timestamp).await {
+                        Ok(mut reader) => {
+                            let record = reader.read_chunk().unwrap().unwrap();
+                            return serde_json::from_slice(&record).unwrap();
+                        }
+                        Err(err)
+                            if err.status == ErrorCode::NotFound
+                                || err.status == ErrorCode::TooEarly => {}
+                        Err(err) => panic!("{err}"),
+                    }
+                }
+                Err(err)
+                    if err.status == ErrorCode::NotFound || err.status == ErrorCode::TooEarly => {}
+                Err(err) => panic!("{err}"),
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                panic!("Audit event '{entry_name}' at {timestamp} was not flushed");
+            }
+
+            sleep(Duration::from_millis(50)).await;
+        }
     }
 
     async fn read_audit_labels(repo: &AuditRepository, token_name: &str, timestamp: u64) -> Labels {
-        let bucket = repo
-            .storage
-            .get_bucket(AUDIT_BUCKET_NAME)
-            .await
-            .unwrap()
-            .upgrade_and_unwrap();
-        let reader = bucket
-            .begin_read(&audit_entry_name(token_name), timestamp)
-            .await
-            .unwrap();
-        reader.meta().labels().clone()
+        let entry_name = audit_entry_name(token_name);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+        loop {
+            match repo.storage.get_bucket(AUDIT_BUCKET_NAME).await {
+                Ok(bucket) => {
+                    let bucket = bucket.upgrade_and_unwrap();
+                    match bucket.begin_read(&entry_name, timestamp).await {
+                        Ok(reader) => return reader.meta().labels().clone(),
+                        Err(err)
+                            if err.status == ErrorCode::NotFound
+                                || err.status == ErrorCode::TooEarly => {}
+                        Err(err) => panic!("{err}"),
+                    }
+                }
+                Err(err)
+                    if err.status == ErrorCode::NotFound || err.status == ErrorCode::TooEarly => {}
+                Err(err) => panic!("{err}"),
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                panic!("Audit labels for '{entry_name}' at {timestamp} were not flushed");
+            }
+
+            sleep(Duration::from_millis(50)).await;
+        }
     }
 
     async fn audit_record_exists(repo: &AuditRepository, token_name: &str, timestamp: u64) -> bool {

--- a/reductstore/src/audit/repo.rs
+++ b/reductstore/src/audit/repo.rs
@@ -375,6 +375,57 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
+    async fn read_event_waits_for_worker_when_audit_bucket_is_missing(
+        #[future] repo: AuditRepository,
+    ) {
+        let mut repo = repo.await;
+
+        repo.log_event(make_event(
+            "token-wait",
+            "GET",
+            "/api/v1/b/test",
+            200,
+            "",
+            7,
+        ))
+        .await
+        .unwrap();
+
+        let event = read_audit_event(&repo, "token-wait", 7).await;
+        assert_eq!(event.token_name, "token-wait");
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_labels_waits_for_worker_when_audit_entry_is_missing(
+        #[future] repo: AuditRepository,
+    ) {
+        let mut repo = repo.await;
+        repo.storage
+            .create_system_bucket(AUDIT_BUCKET_NAME, BucketSettings::default())
+            .await
+            .unwrap();
+
+        repo.log_event(make_event(
+            "token-labels",
+            "GET",
+            "/api/v1/b/test",
+            201,
+            "",
+            8,
+        ))
+        .await
+        .unwrap();
+
+        let labels = read_audit_labels(&repo, "token-labels", 8).await;
+        assert_eq!(
+            labels,
+            Labels::from([("status".to_string(), "201".to_string())])
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
     async fn creates_system_bucket_when_missing(#[future] repo: AuditRepository) {
         let repo = repo.await;
 

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -612,6 +612,7 @@ mod tests {
                     1_000_000_000,
                     Duration::from_secs(3600),
                 )),
+                ..LimitsConfig::default()
             }
         );
     }

--- a/reductstore/src/cfg/io.rs
+++ b/reductstore/src/cfg/io.rs
@@ -28,6 +28,10 @@ pub struct IoConfig {
     pub batch_records_timeout: Duration,
     /// Maximum time to wait for an IO operation to complete
     pub operation_timeout: Duration,
+    /// Maximum number of in-flight writers for storage engine.
+    pub max_writers_in_flight: Option<usize>,
+    /// Maximum number of in-flight readers for storage engine.
+    pub max_readers_in_flight: Option<usize>,
 }
 
 impl Default for IoConfig {
@@ -39,6 +43,8 @@ impl Default for IoConfig {
             batch_timeout: Duration::from_secs(DEFAULT_BATCH_TIMEOUT_S),
             batch_records_timeout: Duration::from_secs(DEFAULT_BATCH_RECORDS_TIMEOUT_S),
             operation_timeout: Duration::from_secs(DEFAULT_OPERATION_TIMEOUT_S),
+            max_writers_in_flight: None,
+            max_readers_in_flight: None,
         }
     }
 }
@@ -69,6 +75,12 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                 env.get_optional("RS_IO_OPERATION_TIMEOUT")
                     .unwrap_or(DEFAULT_OPERATION_TIMEOUT_S),
             ),
+            max_writers_in_flight: env
+                .get_optional::<usize>("RS_IO_MAX_WRITERS_IN_FLIGHT")
+                .filter(|value| *value > 0),
+            max_readers_in_flight: env
+                .get_optional::<usize>("RS_IO_MAX_READERS_IN_FLIGHT")
+                .filter(|value| *value > 0),
         }
     }
 }
@@ -109,6 +121,14 @@ mod tests {
             .expect_get()
             .with(eq("RS_IO_OPERATION_TIMEOUT"))
             .return_const(Ok("60".to_string()));
+        env_getter
+            .expect_get()
+            .with(eq("RS_IO_MAX_WRITERS_IN_FLIGHT"))
+            .return_const(Ok("2".to_string()));
+        env_getter
+            .expect_get()
+            .with(eq("RS_IO_MAX_READERS_IN_FLIGHT"))
+            .return_const(Ok("3".to_string()));
 
         let io_settings = IoConfig {
             batch_max_size: 1000000,
@@ -117,6 +137,8 @@ mod tests {
             batch_timeout: Duration::from_secs(10),
             batch_records_timeout: Duration::from_secs(5),
             operation_timeout: Duration::from_secs(60),
+            max_writers_in_flight: Some(2),
+            max_readers_in_flight: Some(3),
         };
 
         assert_eq!(

--- a/reductstore/src/cfg/limits.rs
+++ b/reductstore/src/cfg/limits.rs
@@ -191,6 +191,7 @@ mod tests {
                     512_000_000,
                     std::time::Duration::from_secs(3600)
                 )),
+                ..LimitsConfig::default()
             }
         );
     }
@@ -226,6 +227,7 @@ mod tests {
                     2_000_000_000,
                     std::time::Duration::from_secs(1)
                 )),
+                ..LimitsConfig::default()
             }
         );
     }
@@ -261,6 +263,7 @@ mod tests {
                     10_000_000,
                     std::time::Duration::from_millis(1)
                 )),
+                ..LimitsConfig::default()
             }
         );
     }
@@ -296,6 +299,7 @@ mod tests {
                     4_096,
                     std::time::Duration::from_secs(3600)
                 )),
+                ..LimitsConfig::default()
             }
         );
     }

--- a/reductstore/src/core/cache.rs
+++ b/reductstore/src/core/cache.rs
@@ -170,6 +170,7 @@ impl<K: Eq + Hash + Clone, V> Cache<K, V> {
         self.store.keys().collect()
     }
 
+    #[allow(dead_code)]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
         self.store.iter_mut().map(|(k, v)| (k, &mut v.value))
     }

--- a/reductstore/src/core/cache.rs
+++ b/reductstore/src/core/cache.rs
@@ -174,6 +174,10 @@ impl<K: Eq + Hash + Clone, V> Cache<K, V> {
         self.store.iter_mut().map(|(k, v)| (k, &mut v.value))
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.store.iter().map(|(k, v)| (k, &v.value))
+    }
+
     fn discard_old_descriptors(&mut self) -> Vec<(K, V)> {
         // remove old descriptors
         let mut removed = Vec::new();

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -1173,6 +1173,96 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
+        async fn skips_file_locked_for_write_when_collecting_sync_candidates(tmp_dir: PathBuf) {
+            let file_path = tmp_dir.join("test_locked_write_sync_candidate.txt");
+            let backend = build_backend(|mock| {
+                expect_path(mock, &tmp_dir, 1);
+                expect_try_exists(mock, &file_path, false, 1);
+                expect_update_local_cache(mock, &file_path, AccessMode::ReadWrite, 1);
+                mock.expect_invalidate_locally_cached_files()
+                    .returning(Vec::new)
+                    .times(1);
+            });
+            let cache = build_cache(backend);
+            {
+                let mut file_ref = cache
+                    .write_or_create(&file_path, SeekFrom::Start(0))
+                    .await
+                    .unwrap();
+                file_ref.write_all(b"test").unwrap();
+            }
+
+            let file = cache
+                .cache
+                .read()
+                .await
+                .unwrap()
+                .get(&file_path)
+                .unwrap()
+                .clone();
+            let _write_guard = file.write().await.unwrap();
+            let sync_interval = Some(Arc::new(RwLock::new(Duration::from_millis(0))));
+
+            FileCache::sync_rw_and_unused_files(
+                &cache.read_only,
+                &cache.backend,
+                &cache.cache,
+                &sync_interval,
+            )
+            .await
+            .unwrap();
+
+            drop(_write_guard);
+            assert!(!file.read().await.unwrap().is_synced());
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn skips_file_locked_for_read_when_syncing_candidates(tmp_dir: PathBuf) {
+            let file_path = tmp_dir.join("test_locked_read_sync_candidate.txt");
+            let backend = build_backend(|mock| {
+                expect_path(mock, &tmp_dir, 1);
+                expect_try_exists(mock, &file_path, false, 1);
+                expect_update_local_cache(mock, &file_path, AccessMode::ReadWrite, 1);
+                mock.expect_invalidate_locally_cached_files()
+                    .returning(Vec::new)
+                    .times(1);
+            });
+            let cache = build_cache(backend);
+            {
+                let mut file_ref = cache
+                    .write_or_create(&file_path, SeekFrom::Start(0))
+                    .await
+                    .unwrap();
+                file_ref.write_all(b"test").unwrap();
+            }
+
+            let file = cache
+                .cache
+                .read()
+                .await
+                .unwrap()
+                .get(&file_path)
+                .unwrap()
+                .clone();
+            let _read_guard = file.read().await.unwrap();
+            let sync_interval = Some(Arc::new(RwLock::new(Duration::from_millis(0))));
+
+            FileCache::sync_rw_and_unused_files(
+                &cache.read_only,
+                &cache.backend,
+                &cache.cache,
+                &sync_interval,
+            )
+            .await
+            .unwrap();
+
+            drop(_read_guard);
+            assert!(!file.read().await.unwrap().is_synced());
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_remove_invalidated_files(tmp_dir: PathBuf) {
             let file_path = tmp_dir.join("test_invalidated_file.txt");
             let backend = build_backend(|mock| {

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -150,8 +150,33 @@ impl FileCache {
             debug!("Removed invalidated file {:?} from cache and storage", path);
         }
 
-        let cache = cache.read().await?;
-        for (path, file) in cache.iter() {
+        let mut files_to_sync = vec![];
+        {
+            let cache = cache.read().await?;
+            for (path, file) in cache.iter() {
+                let file_lock = if force {
+                    file.read().await?
+                } else {
+                    let Some(file) = file.try_read() else {
+                        continue;
+                    };
+                    file
+                };
+
+                // Sync only writeable files that are not synced yet
+                // and are not used by other threads
+                if file_lock.mode() != &AccessMode::ReadWrite
+                    || file_lock.is_synced()
+                    || (!force && file_lock.last_synced().elapsed() < sync_interval)
+                {
+                    continue;
+                }
+
+                files_to_sync.push((path.clone(), file.clone()));
+            }
+        }
+
+        for (path, file) in files_to_sync {
             let mut file_lock = if force {
                 file.write().await?
             } else {
@@ -160,15 +185,6 @@ impl FileCache {
                 };
                 file
             };
-
-            // Sync only writeable files that are not synced yet
-            // and are not used by other threads
-            if file_lock.mode() != &AccessMode::ReadWrite
-                || file_lock.is_synced()
-                || (!force && file_lock.last_synced().elapsed() < sync_interval)
-            {
-                continue;
-            }
 
             if let Err(err) = file_lock.sync_all().await {
                 warn!("Failed to sync file {}: {}", path.display(), err);

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -385,26 +385,31 @@ impl FileCache {
             return Ok(());
         }
 
+        let remove_from_backend = async |path| {
+            let backend = self.backend.read().await?.clone();
+            backend.remove(path).await?;
+            Ok::<(), ReductError>(())
+        };
+
         // We hold the lock to ensure that no other operations are being performed on the file
-        let _lock = {
-            let mut cache = self.cache.write().await?;
-            if let Some(file) = cache.remove(path) {
-                if let Some(lock) = file.try_write_owned() {
-                    Some(lock)
-                } else {
-                    cache.insert(path.clone(), file);
+        let cache = self.cache.read().await?;
+        if let Some(file) = cache.get(path).cloned() {
+            drop(cache);
+            match file.write().await {
+                Ok(_) => {
+                    self.cache.write().await?.remove(path);
+                    remove_from_backend(path).await?;
+                }
+                Err(_) => {
                     return Err(internal_server_error!(
                         "Cannot remove file {} because it is in use",
                         path.display()
-                    ));
+                    ))
                 }
-            } else {
-                None
             }
-        };
-
-        let backend = self.backend.read().await?.clone();
-        backend.remove(path).await?;
+        } else {
+            remove_from_backend(path).await?;
+        }
 
         Ok(())
     }

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -129,8 +129,6 @@ impl FileCache {
             return Ok(());
         }
 
-        let mut cache = cache.write().await?;
-
         let force = sync_interval.is_none();
         let sync_interval = sync_interval
             .as_ref()
@@ -141,6 +139,7 @@ impl FileCache {
             .invalidate_locally_cached_files()
             .await;
         for path in invalidated_files {
+            let mut cache = cache.write().await?;
             if let Some(file) = cache.remove(&path) {
                 if let Err(err) = file.write_owned().await?.sync_all().await {
                     warn!("Failed to sync invalidated file {:?}: {}", path, err);
@@ -151,7 +150,8 @@ impl FileCache {
             debug!("Removed invalidated file {:?} from cache and storage", path);
         }
 
-        for (path, file) in cache.iter_mut() {
+        let cache = cache.read().await?;
+        for (path, file) in cache.iter() {
             let mut file_lock = if force {
                 file.write().await?
             } else {

--- a/reductstore/src/storage.rs
+++ b/reductstore/src/storage.rs
@@ -8,3 +8,5 @@ pub mod proto;
 mod block_manager;
 mod folder_keeper;
 pub mod query;
+
+pub(crate) mod in_flight;

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -293,22 +293,36 @@ impl BlockManager {
             let block = block.read().await?;
             (block.block_id(), block.size())
         };
-        /* resize data block then sync descriptor and data */
-        let path = self.path_to_data(block_id);
-        {
-            let mut data_block = FILE_CACHE
-                .write_or_create(&path, SeekFrom::Current(0))
-                .await?;
-            data_block.set_len(block_size)?;
-            data_block.sync_all().await?;
-        }
 
-        {
-            let mut descr_block = FILE_CACHE
-                .write_or_create(&self.path_to_desc(block_id), SeekFrom::Current(0))
-                .await?;
-            descr_block.sync_all().await?;
-        }
+        let data_path = self.path_to_data(block_id);
+        let desc_path = self.path_to_desc(block_id);
+
+        let sync_block = async move {
+            /* resize data block then sync descriptor and data */
+            {
+                let mut data_block = FILE_CACHE
+                    .write_or_create(&data_path, SeekFrom::Current(0))
+                    .await?;
+                data_block.set_len(block_size)?;
+                data_block.sync_all().await?;
+            }
+
+            {
+                let mut descr_block = FILE_CACHE
+                    .write_or_create(&desc_path, SeekFrom::Current(0))
+                    .await?;
+                descr_block.sync_all().await?;
+            }
+
+            Ok::<(), ReductError>(())
+        };
+
+        tokio::spawn(async move {
+            // spawn to avoid blocking entry
+            if let Err(err) = sync_block.await {
+                error!("{}", err)
+            }
+        });
 
         Ok(())
     }

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -311,7 +311,6 @@ impl BlockManager {
                 let mut data_block = FILE_CACHE
                     .write_or_create(&data_path, SeekFrom::Current(0))
                     .await?;
-                data_block.set_len(block_size)?;
                 data_block.sync_all().await?;
             }
 

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -920,13 +920,17 @@ mod tests {
 
             block_manager.finish_block(loaded_block).await.unwrap();
 
-            let file = std::fs::File::open(
-                block_manager
-                    .path
-                    .join(format!("{}{}", block_id, DATA_FILE_EXT)),
-            )
-            .unwrap();
-            assert_eq!(file.metadata().unwrap().len(), 0);
+            let path = block_manager
+                .path
+                .join(format!("{}{}", block_id, DATA_FILE_EXT));
+            for _ in 0..100 {
+                if std::fs::metadata(&path).unwrap().len() == 0 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+
+            assert_eq!(std::fs::metadata(path).unwrap().len(), 0);
         }
 
         #[rstest]

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -297,8 +297,16 @@ impl BlockManager {
         let data_path = self.path_to_data(block_id);
         let desc_path = self.path_to_desc(block_id);
 
+        {
+            // resize imminently for better testing.
+            let mut data_block = FILE_CACHE
+                .write_or_create(&data_path, SeekFrom::Current(0))
+                .await?;
+            data_block.set_len(block_size)?;
+        }
+
         let sync_block = async move {
-            /* resize data block then sync descriptor and data */
+            /* sync descriptor and data */
             {
                 let mut data_block = FILE_CACHE
                     .write_or_create(&data_path, SeekFrom::Current(0))

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -1218,6 +1218,7 @@ mod tests {
                 block_ref.clone(),
                 record_time,
                 None,
+                None,
             )
             .await
             .unwrap();

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -26,6 +26,7 @@ use crate::storage::entry::{
     is_system_meta_entry, Entry, EntrySettings, META_ENTRY_MAX_BLOCK_SIZE,
 };
 use crate::storage::folder_keeper::FolderKeeper;
+use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::proto::BucketSettings as ProtoBucketSettings;
 use log::{debug, error};
 use prost::bytes::Bytes;
@@ -70,6 +71,7 @@ pub(crate) struct Bucket {
     status: AsyncRwLock<ResourceStatus>,
     #[allow(dead_code)]
     queries: AsyncRwLock<HashMap<u64, MultiEntryQuery>>,
+    io_limiter: InFlightIoLimiter,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -91,11 +93,23 @@ impl Bucket {
     /// # Returns
     ///
     /// * `Bucket` - The bucket or an HTTPError
+    #[allow(dead_code)]
     pub(crate) async fn try_build(
         name: &str,
         path: &PathBuf,
         settings: BucketSettings,
         cfg: Cfg,
+    ) -> Result<Bucket, ReductError> {
+        let io_limiter = InFlightIoLimiter::from_cfg(&cfg);
+        Self::try_build_with_limiter(name, path, settings, cfg, io_limiter).await
+    }
+
+    pub(crate) async fn try_build_with_limiter(
+        name: &str,
+        path: &PathBuf,
+        settings: BucketSettings,
+        cfg: Cfg,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Bucket, ReductError> {
         let path = path.join(name);
         let settings = Self::fill_settings(settings, Self::defaults());
@@ -112,6 +126,7 @@ impl Bucket {
             last_replica_sync: AsyncRwLock::new(Instant::now()),
             folder_keeper: Arc::new(folder_keeper),
             queries: AsyncRwLock::new(HashMap::new()),
+            io_limiter,
         };
 
         bucket.save_settings().await?;
@@ -128,7 +143,17 @@ impl Bucket {
     /// # Returns
     ///
     /// * `Bucket` - The bucket or an HTTPError
+    #[allow(dead_code)]
     pub async fn restore(path: PathBuf, cfg: Cfg) -> Result<Bucket, ReductError> {
+        let io_limiter = InFlightIoLimiter::from_cfg(&cfg);
+        Self::restore_with_limiter(path, cfg, io_limiter).await
+    }
+
+    pub async fn restore_with_limiter(
+        path: PathBuf,
+        cfg: Cfg,
+        io_limiter: InFlightIoLimiter,
+    ) -> Result<Bucket, ReductError> {
         let mut file = FILE_CACHE
             .read(&path.join(SETTINGS_NAME), SeekFrom::Start(0))
             .await?;
@@ -152,12 +177,13 @@ impl Bucket {
                     .strip_prefix(&path)
                     .unwrap_or(entry_path.as_path()),
             );
-            let handler = Entry::restore(
+            let handler = Entry::restore_with_limiter(
                 entry_path,
                 entry_name.clone(),
                 bucket_name.clone(),
                 settings_for_entry(&entry_name, &settings),
                 cfg.clone(),
+                io_limiter.clone(),
             );
 
             task_set.push(handler);
@@ -182,6 +208,7 @@ impl Bucket {
             cfg,
             folder_keeper: Arc::new(folder_keeper),
             queries: AsyncRwLock::new(HashMap::new()),
+            io_limiter,
         })
     }
 

--- a/reductstore/src/storage/bucket/get_entry.rs
+++ b/reductstore/src/storage/bucket/get_entry.rs
@@ -40,11 +40,12 @@ impl Bucket {
             } else {
                 self.folder_keeper.add_folder(&prefix).await?;
                 let entry = Arc::new(
-                    Entry::try_build(
+                    Entry::try_build_with_limiter(
                         &prefix,
                         self.path.clone(),
                         settings_for_entry(&prefix, &settings),
                         self.cfg.clone(),
+                        self.io_limiter.clone(),
                     )
                     .await?,
                 );

--- a/reductstore/src/storage/bucket/read_only.rs
+++ b/reductstore/src/storage/bucket/read_only.rs
@@ -57,7 +57,7 @@ impl ReadOnlyMode for Bucket {
                     .strip_prefix(self.path())
                     .unwrap_or(entry_path.as_path()),
             );
-            let handler = Entry::restore(
+            let handler = Entry::restore_with_limiter(
                 entry_path,
                 entry_name,
                 self.name().to_string(),
@@ -66,6 +66,7 @@ impl ReadOnlyMode for Bucket {
                     max_block_records: settings.max_block_records.unwrap(),
                 },
                 self.cfg.clone(),
+                self.io_limiter.clone(),
             );
 
             task_set.push(handler);

--- a/reductstore/src/storage/bucket/rename_entry.rs
+++ b/reductstore/src/storage/bucket/rename_entry.rs
@@ -25,12 +25,13 @@ impl Bucket {
                     .strip_prefix(&self.path)
                     .unwrap_or(entry_path.as_path()),
             );
-            task_set.push(Entry::restore(
+            task_set.push(Entry::restore_with_limiter(
                 entry_path,
                 entry_name.clone(),
                 self.name.clone(),
                 settings_for_entry(&entry_name, settings),
                 self.cfg.clone(),
+                self.io_limiter.clone(),
             ));
         }
 

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -8,6 +8,7 @@ use crate::core::sync::AsyncRwLock;
 use crate::core::weak::Weak;
 use crate::storage::bucket::Bucket;
 use crate::storage::folder_keeper::{DiscoveryDepth, FolderKeeper};
+use crate::storage::in_flight::InFlightIoLimiter;
 use async_trait::async_trait;
 use log::{debug, error, info};
 use reduct_base::error::ReductError;
@@ -66,6 +67,7 @@ impl StorageEngineBuilder {
     pub async fn build(self) -> StorageEngine {
         let cfg = self.cfg.expect("Config must be set");
         let data_path = self.data_path.expect("Data path must be set");
+        let io_limiter = InFlightIoLimiter::from_cfg(&cfg);
 
         if !FILE_CACHE.try_exists(&data_path).await.unwrap_or(false) {
             info!("Folder {:?} doesn't exist. Create it.", data_path);
@@ -84,7 +86,8 @@ impl StorageEngineBuilder {
             .await
             .expect("Failed to list folders")
         {
-            match Bucket::restore(path.clone(), cfg.clone()).await {
+            match Bucket::restore_with_limiter(path.clone(), cfg.clone(), io_limiter.clone()).await
+            {
                 Ok(bucket) => {
                     let bucket = Arc::new(bucket);
                     buckets.insert(bucket.name().to_string(), bucket);
@@ -105,6 +108,7 @@ impl StorageEngineBuilder {
             cfg,
             last_replica_sync: AsyncRwLock::new(Instant::now()),
             folder_keeper: Arc::new(folder_keeper),
+            io_limiter,
         }
     }
 }
@@ -118,6 +122,7 @@ pub struct StorageEngine {
     cfg: Cfg,
     last_replica_sync: AsyncRwLock<Instant>,
     folder_keeper: Arc<FolderKeeper>,
+    io_limiter: InFlightIoLimiter,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -258,8 +263,16 @@ impl StorageEngine {
         }
 
         self.folder_keeper.add_folder(name).await?;
-        let bucket =
-            Arc::new(Bucket::try_build(name, &self.data_path, settings, self.cfg.clone()).await?);
+        let bucket = Arc::new(
+            Bucket::try_build_with_limiter(
+                name,
+                &self.data_path,
+                settings,
+                self.cfg.clone(),
+                self.io_limiter.clone(),
+            )
+            .await?,
+        );
         buckets.insert(name.to_string(), Arc::clone(&bucket));
 
         Ok(bucket.into())
@@ -377,7 +390,7 @@ impl StorageEngine {
         folder_keeper.rename_folder(&old_name, &new_name).await?;
 
         buckets.remove(&old_name);
-        let bucket = Bucket::restore(new_path, cfg).await?;
+        let bucket = Bucket::restore_with_limiter(new_path, cfg, self.io_limiter.clone()).await?;
         buckets.insert(new_name.to_string(), Arc::new(bucket));
         debug!("Bucket '{}' is renamed to '{}'", old_name, new_name);
         Ok(())

--- a/reductstore/src/storage/engine/read_only.rs
+++ b/reductstore/src/storage/engine/read_only.rs
@@ -56,7 +56,13 @@ impl ReadOnlyMode for StorageEngine {
             }
 
             // Restore new bucket
-            match Bucket::restore(path.clone(), self.cfg.clone()).await {
+            match Bucket::restore_with_limiter(
+                path.clone(),
+                self.cfg.clone(),
+                self.io_limiter.clone(),
+            )
+            .await
+            {
                 Ok(bucket) => {
                     let bucket = Arc::new(bucket);
                     new_buckets.insert(bucket.name().to_string(), bucket);

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -200,6 +200,7 @@ impl Entry {
             stop,
             options.clone(),
             self.cfg.io_conf.clone(),
+            self.io_limiter.clone(),
         )?;
 
         let io_settings = query.as_ref().io_settings().clone();

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -17,6 +17,7 @@ use crate::core::weak::Weak;
 use crate::storage::block_manager::block_index::BlockIndex;
 use crate::storage::block_manager::{BlockManager, BLOCK_INDEX_FILE};
 use crate::storage::entry::entry_loader::EntryLoader;
+use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::proto::ts_to_us;
 use crate::storage::query::base::QueryOptions;
 use crate::storage::query::{build_query, next_query_id, spawn_query_task, QueryRx};
@@ -35,6 +36,7 @@ pub(crate) use system::{
     is_system_meta_entry, meta_entry_name, meta_entry_parent, strategy_for_entry,
     validate_remove_entry, validate_remove_records, SystemEntryBehavior, META_ENTRY_MAX_BLOCK_SIZE,
 };
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::JoinHandle;
 
 struct QueryHandle {
@@ -60,6 +62,7 @@ pub(crate) struct Entry {
     status: AsyncRwLock<ResourceStatus>,
     path: PathBuf,
     cfg: Arc<Cfg>,
+    io_limiter: InFlightIoLimiter,
 }
 
 #[derive(PartialEq)]
@@ -77,11 +80,23 @@ pub struct EntrySettings {
 }
 
 impl Entry {
+    #[allow(dead_code)]
     pub async fn try_build(
         name: &str,
         path: PathBuf,
         settings: EntrySettings,
         cfg: Arc<Cfg>,
+    ) -> Result<Self, ReductError> {
+        let io_limiter = InFlightIoLimiter::from_cfg(cfg.as_ref());
+        Self::try_build_with_limiter(name, path, settings, cfg, io_limiter).await
+    }
+
+    pub(crate) async fn try_build_with_limiter(
+        name: &str,
+        path: PathBuf,
+        settings: EntrySettings,
+        cfg: Arc<Cfg>,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Self, ReductError> {
         let bucket_name = path.file_name().unwrap().to_str().unwrap().to_string();
         let path = path.join(name);
@@ -113,9 +128,11 @@ impl Entry {
             status: AsyncRwLock::new(ResourceStatus::Ready),
             path,
             cfg,
+            io_limiter,
         })
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn restore(
         path: PathBuf,
         entry_name: String,
@@ -123,10 +140,40 @@ impl Entry {
         options: EntrySettings,
         cfg: Arc<Cfg>,
     ) -> Result<Option<Entry>, ReductError> {
-        let entry =
-            EntryLoader::restore_entry_with_names(path, entry_name, bucket_name, options, cfg)
-                .await?;
+        let io_limiter = InFlightIoLimiter::from_cfg(cfg.as_ref());
+        Self::restore_with_limiter(path, entry_name, bucket_name, options, cfg, io_limiter).await
+    }
+
+    pub(crate) async fn restore_with_limiter(
+        path: PathBuf,
+        entry_name: String,
+        bucket_name: String,
+        options: EntrySettings,
+        cfg: Arc<Cfg>,
+        io_limiter: InFlightIoLimiter,
+    ) -> Result<Option<Entry>, ReductError> {
+        let entry = EntryLoader::restore_entry_with_names(
+            path,
+            entry_name,
+            bucket_name,
+            options,
+            cfg,
+            io_limiter,
+        )
+        .await?;
         Ok(entry)
+    }
+
+    pub(crate) async fn acquire_writer_slot(
+        &self,
+    ) -> Result<Option<OwnedSemaphorePermit>, ReductError> {
+        self.io_limiter.acquire_writer_slot().await
+    }
+
+    pub(crate) async fn acquire_reader_slot(
+        &self,
+    ) -> Result<Option<OwnedSemaphorePermit>, ReductError> {
+        self.io_limiter.acquire_reader_slot().await
     }
 
     /// Query records for a time range.

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -23,6 +23,7 @@ use crate::storage::block_manager::{
 };
 use crate::storage::entry::strategy_for_entry;
 use crate::storage::entry::{Entry, EntrySettings};
+use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::proto::{ts_to_us, Block, MinimalBlock};
 use reduct_base::error::ReductError;
 use reduct_base::internal_server_error;
@@ -38,6 +39,7 @@ impl EntryLoader {
         options: EntrySettings,
         cfg: Arc<Cfg>,
     ) -> Result<Option<Entry>, ReductError> {
+        let io_limiter = InFlightIoLimiter::from_cfg(cfg.as_ref());
         let entry_name = path.file_name().unwrap().to_str().unwrap().to_string();
         let bucket_name = path
             .parent()
@@ -47,7 +49,8 @@ impl EntryLoader {
             .to_str()
             .unwrap()
             .to_string();
-        Self::restore_entry_with_names(path, entry_name, bucket_name, options, cfg).await
+        Self::restore_entry_with_names(path, entry_name, bucket_name, options, cfg, io_limiter)
+            .await
     }
 
     pub async fn restore_entry_with_names(
@@ -56,6 +59,7 @@ impl EntryLoader {
         bucket_name: String,
         options: EntrySettings,
         cfg: Arc<Cfg>,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Option<Entry>, ReductError> {
         let start_time = Instant::now();
 
@@ -65,6 +69,7 @@ impl EntryLoader {
             bucket_name.clone(),
             options.clone(),
             cfg.clone(),
+            io_limiter.clone(),
         )
         .await
         {
@@ -85,6 +90,7 @@ impl EntryLoader {
                     bucket_name.clone(),
                     options.clone(),
                     cfg.clone(),
+                    io_limiter.clone(),
                 )
                 .await?
             }
@@ -115,6 +121,7 @@ impl EntryLoader {
                     bucket_name,
                     options,
                     cfg.clone(),
+                    io_limiter.clone(),
                 )
                 .await?;
             }
@@ -142,6 +149,7 @@ impl EntryLoader {
         bucket_name: String,
         options: EntrySettings,
         cfg: Arc<Cfg>,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Entry, ReductError> {
         async fn remove_block_files(path: &PathBuf) -> Result<(), ReductError> {
             warn!("Removing meta block {:?}", path);
@@ -244,6 +252,7 @@ impl EntryLoader {
             status: AsyncRwLock::new(ResourceStatus::Ready),
             path,
             cfg,
+            io_limiter,
         })
     }
 
@@ -254,6 +263,7 @@ impl EntryLoader {
         bucket_name: String,
         options: EntrySettings,
         cfg: Arc<Cfg>,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Entry, ReductError> {
         let block_index = BlockIndex::try_load(path.join(BLOCK_INDEX_FILE)).await?;
 
@@ -276,6 +286,7 @@ impl EntryLoader {
             status: AsyncRwLock::new(ResourceStatus::Ready),
             path,
             cfg,
+            io_limiter,
         })
     }
 

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -17,6 +17,7 @@ use std::io::Read;
 use std::io::{Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::OwnedSemaphorePermit;
 
 /// RecordReader is responsible for reading the content of a record from the storage.
 pub(crate) struct RecordReader {
@@ -25,6 +26,7 @@ pub(crate) struct RecordReader {
     offset: u64,
     content_size: u64,
     pos: u64,
+    _permit: Option<OwnedSemaphorePermit>,
 }
 
 impl RecordReader {
@@ -47,6 +49,7 @@ impl RecordReader {
         block_ref: BlockRef,
         record_timestamp: u64,
         processed_record: Option<Record>,
+        permit: Option<OwnedSemaphorePermit>,
     ) -> Result<Self, ReductError> {
         let bm = block_manager.read().await?;
         let block = block_ref.read().await?;
@@ -83,6 +86,7 @@ impl RecordReader {
             offset,
             content_size,
             pos: 0,
+            _permit: permit,
         })
     }
 
@@ -108,6 +112,7 @@ impl RecordReader {
             offset: 0,
             content_size: 0,
             pos: 0,
+            _permit: None,
         }
     }
 

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -88,7 +88,8 @@ impl Entry {
             ));
         }
 
-        RecordReader::try_new(self.block_manager.clone(), block_ref, time, None).await
+        let permit = self.acquire_reader_slot().await?;
+        RecordReader::try_new(self.block_manager.clone(), block_ref, time, None, permit).await
     }
 }
 

--- a/reductstore/src/storage/entry/write_record.rs
+++ b/reductstore/src/storage/entry/write_record.rs
@@ -4,11 +4,45 @@
 use crate::storage::block_manager::BlockRef;
 use crate::storage::entry::{Entry, RecordType, RecordWriter};
 use crate::storage::proto::{record, us_to_ts, Record};
+use async_trait::async_trait;
 use log::debug;
 use reduct_base::error::ReductError;
-use reduct_base::io::WriteRecord;
+use reduct_base::io::{WriteChunk, WriteRecord};
 use reduct_base::Labels;
 use std::sync::Arc;
+use tokio::sync::OwnedSemaphorePermit;
+
+struct InFlightWriteRecord {
+    inner: Box<dyn WriteRecord + Sync + Send>,
+    _permit: Option<OwnedSemaphorePermit>,
+}
+
+impl InFlightWriteRecord {
+    fn new(
+        inner: Box<dyn WriteRecord + Sync + Send>,
+        permit: Option<OwnedSemaphorePermit>,
+    ) -> Self {
+        Self {
+            inner,
+            _permit: permit,
+        }
+    }
+}
+
+#[async_trait]
+impl WriteRecord for InFlightWriteRecord {
+    async fn send(&mut self, chunk: WriteChunk) -> Result<(), ReductError> {
+        self.inner.send(chunk).await
+    }
+
+    async fn send_timeout(
+        &mut self,
+        chunk: WriteChunk,
+        timeout: std::time::Duration,
+    ) -> Result<(), ReductError> {
+        self.inner.send_timeout(chunk, timeout).await
+    }
+}
 
 impl Entry {
     /// Starts a new record write.
@@ -31,6 +65,7 @@ impl Entry {
         content_type: String,
         labels: Labels,
     ) -> Result<Box<dyn WriteRecord + Sync + Send>, ReductError> {
+        let permit = self.acquire_writer_slot().await?;
         // Strategy validates labels and can perform pre-write maintenance.
         self.system_behavior.prepare_write(self, &labels).await?;
 
@@ -108,7 +143,10 @@ impl Entry {
                             )
                             .await?;
 
-                            return Ok(Box::new(writer));
+                            return Ok(Box::new(InFlightWriteRecord::new(
+                                Box::new(writer),
+                                permit,
+                            )));
                         };
                     }
                     RecordType::Belated
@@ -147,7 +185,7 @@ impl Entry {
 
         let writer =
             RecordWriter::try_new(Arc::clone(&self.block_manager), block_ref, time).await?;
-        Ok(Box::new(writer))
+        Ok(Box::new(InFlightWriteRecord::new(Box::new(writer), permit)))
     }
 
     async fn prepare_block_for_writing(

--- a/reductstore/src/storage/in_flight.rs
+++ b/reductstore/src/storage/in_flight.rs
@@ -68,3 +68,83 @@ impl InFlightIoLimiter {
             .map_err(|_| ReductError::new(ErrorCode::TooManyRequests, message))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cfg::io::IoConfig;
+
+    fn cfg_with_limits(
+        max_writers_in_flight: Option<usize>,
+        max_readers_in_flight: Option<usize>,
+    ) -> Cfg {
+        Cfg {
+            io_conf: IoConfig {
+                max_writers_in_flight,
+                max_readers_in_flight,
+                operation_timeout: Duration::from_millis(1),
+                ..IoConfig::default()
+            },
+            ..Cfg::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_limits_do_not_require_permits() {
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(None, None));
+
+        assert!(limiter.acquire_writer_slot().await.unwrap().is_none());
+        assert!(limiter.acquire_reader_slot().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn writer_limit_rejects_when_all_slots_are_held() {
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1), None));
+        let permit = limiter.acquire_writer_slot().await.unwrap();
+
+        let err = limiter.acquire_writer_slot().await.err().unwrap();
+        assert_eq!(err.status, ErrorCode::TooManyRequests);
+        assert_eq!(
+            err.message,
+            "in-flight writers limit exceeded: try again later"
+        );
+
+        drop(permit);
+        assert!(limiter.acquire_writer_slot().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn reader_limit_rejects_when_all_slots_are_held() {
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(None, Some(1)));
+        let permit = limiter.acquire_reader_slot().await.unwrap();
+
+        let err = limiter.acquire_reader_slot().await.err().unwrap();
+        assert_eq!(err.status, ErrorCode::TooManyRequests);
+        assert_eq!(
+            err.message,
+            "in-flight readers limit exceeded: try again later"
+        );
+
+        drop(permit);
+        assert!(limiter.acquire_reader_slot().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn cloned_limiter_shares_slots() {
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1), None));
+        let clone = limiter.clone();
+        let _permit = limiter.acquire_writer_slot().await.unwrap();
+
+        let err = clone.acquire_writer_slot().await.err().unwrap();
+
+        assert_eq!(err.status, ErrorCode::TooManyRequests);
+    }
+
+    #[tokio::test]
+    async fn reader_and_writer_limits_are_independent() {
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1), Some(1)));
+        let _writer_permit = limiter.acquire_writer_slot().await.unwrap();
+
+        assert!(limiter.acquire_reader_slot().await.unwrap().is_some());
+    }
+}

--- a/reductstore/src/storage/in_flight.rs
+++ b/reductstore/src/storage/in_flight.rs
@@ -1,0 +1,70 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::cfg::Cfg;
+use reduct_base::error::{ErrorCode, ReductError};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::time::timeout;
+
+#[derive(Clone, Default)]
+pub(crate) struct InFlightIoLimiter {
+    writer_slots: Option<Arc<Semaphore>>,
+    reader_slots: Option<Arc<Semaphore>>,
+    acquire_timeout: Duration,
+}
+
+impl InFlightIoLimiter {
+    pub(crate) fn from_cfg(cfg: &Cfg) -> Self {
+        Self {
+            writer_slots: cfg
+                .io_conf
+                .max_writers_in_flight
+                .map(Semaphore::new)
+                .map(Arc::new),
+            reader_slots: cfg
+                .io_conf
+                .max_readers_in_flight
+                .map(Semaphore::new)
+                .map(Arc::new),
+            acquire_timeout: cfg.io_conf.operation_timeout,
+        }
+    }
+
+    pub(crate) async fn acquire_writer_slot(
+        &self,
+    ) -> Result<Option<OwnedSemaphorePermit>, ReductError> {
+        self.try_acquire_slot(
+            &self.writer_slots,
+            "in-flight writers limit exceeded: try again later",
+        )
+        .await
+    }
+
+    pub(crate) async fn acquire_reader_slot(
+        &self,
+    ) -> Result<Option<OwnedSemaphorePermit>, ReductError> {
+        self.try_acquire_slot(
+            &self.reader_slots,
+            "in-flight readers limit exceeded: try again later",
+        )
+        .await
+    }
+
+    async fn try_acquire_slot(
+        &self,
+        semaphore: &Option<Arc<Semaphore>>,
+        message: &str,
+    ) -> Result<Option<OwnedSemaphorePermit>, ReductError> {
+        let Some(semaphore) = semaphore else {
+            return Ok(None);
+        };
+
+        timeout(self.acquire_timeout, semaphore.clone().acquire_owned())
+            .await
+            .map_err(|_| ReductError::new(ErrorCode::TooManyRequests, message))?
+            .map(Some)
+            .map_err(|_| ReductError::new(ErrorCode::TooManyRequests, message))
+    }
+}

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -12,6 +12,7 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::BlockManager;
 use crate::storage::entry::RecordReader;
+use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::query::base::{Query, QueryOptions};
 use log::{debug, trace};
 use reduct_base::error::ErrorCode::NoContent;
@@ -43,6 +44,7 @@ pub(in crate::storage) fn build_query(
     stop: u64,
     options: QueryOptions,
     io_defaults: IoConfig,
+    io_limiter: InFlightIoLimiter,
 ) -> Result<Box<dyn Query + Send + Sync>, ReductError> {
     if start > stop && !options.continuous {
         return Err(unprocessable_entity!("Start time must be before stop time",));
@@ -55,6 +57,7 @@ pub(in crate::storage) fn build_query(
             stop,
             options,
             io_defaults,
+            io_limiter,
         )?)
     } else if options.continuous {
         Box::new(continuous::ContinuousQuery::try_new(
@@ -62,6 +65,7 @@ pub(in crate::storage) fn build_query(
             start,
             options,
             io_defaults,
+            io_limiter,
         )?)
     } else {
         Box::new(historical::HistoricalQuery::try_new(
@@ -70,6 +74,7 @@ pub(in crate::storage) fn build_query(
             stop,
             options,
             io_defaults,
+            io_limiter,
         )?)
     })
 }
@@ -207,7 +212,8 @@ mod tests {
                 10,
                 5,
                 options.clone(),
-                IoConfig::default()
+                IoConfig::default(),
+                InFlightIoLimiter::default(),
             )
             .err()
             .unwrap(),
@@ -219,7 +225,8 @@ mod tests {
             10,
             10,
             options.clone(),
-            IoConfig::default()
+            IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .is_ok());
         assert!(build_query(
@@ -227,7 +234,8 @@ mod tests {
             10,
             11,
             options.clone(),
-            IoConfig::default()
+            IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .is_ok());
     }
@@ -243,7 +251,8 @@ mod tests {
             10,
             5,
             options.clone(),
-            IoConfig::default()
+            IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .is_ok());
     }
@@ -263,6 +272,7 @@ mod tests {
             5,
             options.clone(),
             IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -292,6 +302,7 @@ mod tests {
             5,
             options.clone(),
             IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .unwrap();
 
@@ -328,6 +339,7 @@ mod tests {
             5,
             options.clone(),
             IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .unwrap();
         let (mut rx, handle) = spawn_query_task(
@@ -382,6 +394,7 @@ mod tests {
             10,
             options.clone(),
             IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .unwrap();
 

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -5,6 +5,7 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::BlockManager;
 use crate::storage::entry::RecordReader;
+use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::historical::HistoricalQuery;
 use async_trait::async_trait;
@@ -19,6 +20,7 @@ pub struct ContinuousQuery {
     count: usize,
     options: QueryOptions,
     io_defaults: IoConfig,
+    io_limiter: InFlightIoLimiter,
 }
 
 impl ContinuousQuery {
@@ -27,6 +29,7 @@ impl ContinuousQuery {
         start: u64,
         options: QueryOptions,
         io_defaults: IoConfig,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Self, ReductError> {
         if !options.continuous {
             panic!("Continuous query must be continuous");
@@ -40,11 +43,13 @@ impl ContinuousQuery {
                 u64::MAX,
                 options.clone(),
                 io_defaults.clone(),
+                io_limiter.clone(),
             )?,
             next_start: start,
             count: 0,
             options,
             io_defaults,
+            io_limiter,
         })
     }
 }
@@ -71,6 +76,7 @@ impl Query for ContinuousQuery {
                     u64::MAX,
                     self.options.clone(),
                     self.io_defaults.clone(),
+                    self.io_limiter.clone(),
                 )?;
                 Err(ReductError {
                     status: ErrorCode::NoContent,
@@ -108,6 +114,7 @@ mod tests {
                 ..QueryOptions::default()
             },
             IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .unwrap();
         {

--- a/reductstore/src/storage/query/filters/when/io_cfg.rs
+++ b/reductstore/src/storage/query/filters/when/io_cfg.rs
@@ -161,6 +161,7 @@ mod tests {
                 batch_timeout: Duration::from_secs(5),
                 batch_records_timeout: Duration::from_secs(2),
                 operation_timeout: Duration::from_secs(10),
+                ..IoConfig::default()
             };
 
             let merged_cfg = merge_io_config_from_directives(&mut directives, default_cfg).unwrap();
@@ -192,6 +193,7 @@ mod tests {
                 batch_timeout: Duration::from_secs(5),
                 batch_records_timeout: Duration::from_secs(2),
                 operation_timeout: Duration::from_secs(10),
+                ..IoConfig::default()
             };
             let merged_cfg = merge_io_config_from_directives(&mut directives, default_cfg).unwrap();
             assert_eq!(merged_cfg.batch_max_size, 2048);

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -5,6 +5,7 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::{BlockManager, BlockRef};
 use crate::storage::entry::RecordReader;
+use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::proto::record;
 use crate::storage::proto::{record::State as RecordState, ts_to_us, Record};
 use crate::storage::query::base::{Query, QueryOptions};
@@ -66,6 +67,8 @@ pub struct HistoricalQuery {
     is_interrupted: bool,
     /// Io Config
     io_config: IoConfig,
+    /// Limits in-flight storage readers.
+    io_limiter: InFlightIoLimiter,
 }
 
 impl HistoricalQuery {
@@ -75,6 +78,7 @@ impl HistoricalQuery {
         stop_time: u64,
         options: QueryOptions,
         io_defaults: IoConfig,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Self, ReductError> {
         let mut filters: Vec<Filter> = vec![
             Box::new(TimeRangeFilter::new(start_time, stop_time)),
@@ -129,6 +133,7 @@ impl HistoricalQuery {
             only_metadata,
             is_interrupted: false,
             io_config,
+            io_limiter,
         })
     }
 }
@@ -231,12 +236,13 @@ impl Query for HistoricalQuery {
         if self.only_metadata {
             Ok(RecordReader::form_record(&self.entry_name, record))
         } else {
+            let permit = self.io_limiter.acquire_reader_slot().await?;
             RecordReader::try_new(
                 Arc::clone(&block_manager),
                 block.clone(),
                 ts_to_us(&record.timestamp.unwrap()),
                 Some(record),
-                None,
+                permit,
             )
             .await
         }
@@ -271,6 +277,7 @@ impl HistoricalQuery {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::time::Duration;
 
     use rstest::rstest;
 
@@ -281,6 +288,7 @@ mod tests {
     use crate::core::file_cache::FILE_CACHE;
     use crate::storage::block_manager::block::Block;
     use crate::storage::block_manager::block_index::BlockIndex;
+    use crate::storage::in_flight::InFlightIoLimiter;
     use crate::storage::proto::record;
     use crate::storage::proto::{us_to_ts, Record};
     use crate::storage::query::base::tests::block_manager;
@@ -300,6 +308,7 @@ mod tests {
             stop_time,
             options,
             IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
     }
 
@@ -393,6 +402,38 @@ mod tests {
             "entry",
             "entry_name should be returned for HEAD request (only_metadata=true)"
         );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_reader_limit_applies_to_content_readers(
+        #[future] block_manager: Arc<AsyncRwLock<BlockManager>>,
+    ) {
+        let block_manager = block_manager.await;
+        let cfg = Cfg {
+            io_conf: IoConfig {
+                max_readers_in_flight: Some(1),
+                operation_timeout: Duration::from_millis(1),
+                ..IoConfig::default()
+            },
+            ..Cfg::default()
+        };
+        let limiter = InFlightIoLimiter::from_cfg(&cfg);
+        let mut query = HistoricalQuery::try_new(
+            "entry".to_string(),
+            0,
+            1000,
+            QueryOptions::default(),
+            cfg.io_conf.clone(),
+            limiter,
+        )
+        .unwrap();
+
+        let _reader = query.next(block_manager.clone()).await.unwrap();
+        let err = query.next(block_manager).await.err().unwrap();
+
+        assert_eq!(err.status, ErrorCode::TooManyRequests);
+        assert!(err.message.contains("in-flight readers limit exceeded"));
     }
 
     #[rstest]

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -236,6 +236,7 @@ impl Query for HistoricalQuery {
                 block.clone(),
                 ts_to_us(&record.timestamp.unwrap()),
                 Some(record),
+                None,
             )
             .await
         }

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -5,6 +5,7 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::BlockManager;
 use crate::storage::entry::RecordReader;
+use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::historical::HistoricalQuery;
 use async_trait::async_trait;
@@ -25,9 +26,17 @@ impl LimitedQuery {
         stop: u64,
         options: QueryOptions,
         io_config: IoConfig,
+        io_limiter: InFlightIoLimiter,
     ) -> Result<Self, ReductError> {
         Ok(LimitedQuery {
-            query: HistoricalQuery::try_new(entry_name, start, stop, options.clone(), io_config)?,
+            query: HistoricalQuery::try_new(
+                entry_name,
+                start,
+                stop,
+                options.clone(),
+                io_config,
+                io_limiter,
+            )?,
             limit_count: options.limit.unwrap(),
         })
     }
@@ -73,6 +82,7 @@ mod tests {
                 ..Default::default()
             },
             IoConfig::default(),
+            InFlightIoLimiter::default(),
         )
         .unwrap();
 

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -64,10 +64,12 @@ impl Query for LimitedQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cfg::Cfg;
     use crate::storage::query::base::tests::block_manager;
     use reduct_base::error::ErrorCode;
     use reduct_base::io::ReadRecord;
     use rstest::rstest;
+    use std::time::Duration;
 
     #[rstest]
     #[tokio::test]
@@ -96,5 +98,39 @@ mod tests {
                 message: "No content".to_string(),
             })
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn applies_reader_limiter_to_wrapped_query(
+        #[future] block_manager: Arc<AsyncRwLock<BlockManager>>,
+    ) {
+        let block_manager = block_manager.await;
+        let cfg = Cfg {
+            io_conf: IoConfig {
+                max_readers_in_flight: Some(1),
+                operation_timeout: Duration::from_millis(1),
+                ..IoConfig::default()
+            },
+            ..Cfg::default()
+        };
+        let mut query = LimitedQuery::try_new(
+            "entry".to_string(),
+            0,
+            u64::MAX,
+            QueryOptions {
+                limit: Some(2),
+                ..Default::default()
+            },
+            cfg.io_conf.clone(),
+            InFlightIoLimiter::from_cfg(&cfg),
+        )
+        .unwrap();
+
+        let _reader = query.next(block_manager.clone()).await.unwrap();
+        let err = query.next(block_manager).await.err().unwrap();
+
+        assert_eq!(err.status, ErrorCode::TooManyRequests);
+        assert!(err.message.contains("in-flight readers limit exceeded"));
     }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature + performance improvement

### What was changed?

- Added optional in-flight IO limits for storage operations:
  - `RS_IO_MAX_WRITERS_IN_FLIGHT`
  - `RS_IO_MAX_READERS_IN_FLIGHT`
- Introduced `InFlightIoLimiter` and threaded it through `StorageEngine`, `Bucket`, and `Entry` restore/build paths.
- Applied limiter permits to record write/read flows and return `429 Too Many Requests` on acquire timeout.
- Reduced file-cache lock contention during sync by collecting candidates under a read lock and syncing outside the cache-wide write lock.
- Made block sync after write completion lazy (background task) to avoid blocking entry operations.
- Updated tests and config assertions for new IO config fields.

### Related issues

N/A

### Does this PR introduce a breaking change?

No. New behavior is opt-in via environment variables.

### Other information:

Target branch: `stable`
