### PR TITLE
suppress warning for removed files during file sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Suppress non-actionable file-cache sync warnings when a file disappears during background sync (`NotFound`), [PR-1360](https://github.com/reductstore/reductstore/pull/1360)
+
 ## 1.19.6 - 2026-04-27
 
 ### Changed

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -187,7 +187,11 @@ impl FileCache {
             };
 
             if let Err(err) = file_lock.sync_all().await {
-                warn!("Failed to sync file {}: {}", path.display(), err);
+                // ignore not found errors, since file can be removed while we are syncing,
+                // it's better than holding the file lock for too long and preventing other operations on the file
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    warn!("Failed to sync file {}: {}", path.display(), err);
+                }
                 continue;
             }
         }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Suppress warning logs during background file sync when a file has already been removed from storage cache/backend and `sync_all` returns `NotFound`.

This keeps warning logs focused on actionable sync failures while preserving warning level for other I/O errors.

### Related issues

Regression observed after v1.19.6 storage/file-cache sync refactor where WAL files can be removed while sync candidates are processed.

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with:
- `cargo fmt --all`
- `cargo test -p reductstore core::file_cache`
