### PR TITLE
remove in-flight reader limit from storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Suppress non-actionable file-cache sync warnings when a file disappears during background sync (`NotFound`), [PR-1360](https://github.com/reductstore/reductstore/pull/1360)
+- Reduce reader-permit hoarding under configured in-flight reader limits by applying limiter-aware query/aggregator buffering and backpressure, [PR-1361](https://github.com/reductstore/reductstore/pull/1361)
 
 ## 1.19.6 - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Suppress non-actionable file-cache sync warnings when a file disappears during background sync (`NotFound`), [PR-1360](https://github.com/reductstore/reductstore/pull/1360)
-- Reduce reader-permit hoarding under configured in-flight reader limits by applying limiter-aware query/aggregator buffering and backpressure, [PR-1361](https://github.com/reductstore/reductstore/pull/1361)
+- Remove in-flight reader limiting from storage read/query paths (`RS_IO_MAX_READERS_IN_FLIGHT`) while keeping writer in-flight limiting enabled, [PR-1361](https://github.com/reductstore/reductstore/pull/1361)
 
 ## 1.19.6 - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.19.7 - 2026-04-27
+
 ### Fixed
 
 - Suppress non-actionable file-cache sync warnings when a file disappears during background sync (`NotFound`), [PR-1360](https://github.com/reductstore/reductstore/pull/1360)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.19.6"
+version = "1.19.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.19.6"
+version = "1.19.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.19.6"
+version = "1.19.7"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.19.6"
+version = "1.19.7"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.89.0"

--- a/reductstore/src/cfg/io.rs
+++ b/reductstore/src/cfg/io.rs
@@ -30,8 +30,6 @@ pub struct IoConfig {
     pub operation_timeout: Duration,
     /// Maximum number of in-flight writers for storage engine.
     pub max_writers_in_flight: Option<usize>,
-    /// Maximum number of in-flight readers for storage engine.
-    pub max_readers_in_flight: Option<usize>,
 }
 
 impl Default for IoConfig {
@@ -44,7 +42,6 @@ impl Default for IoConfig {
             batch_records_timeout: Duration::from_secs(DEFAULT_BATCH_RECORDS_TIMEOUT_S),
             operation_timeout: Duration::from_secs(DEFAULT_OPERATION_TIMEOUT_S),
             max_writers_in_flight: None,
-            max_readers_in_flight: None,
         }
     }
 }
@@ -77,9 +74,6 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             ),
             max_writers_in_flight: env
                 .get_optional::<usize>("RS_IO_MAX_WRITERS_IN_FLIGHT")
-                .filter(|value| *value > 0),
-            max_readers_in_flight: env
-                .get_optional::<usize>("RS_IO_MAX_READERS_IN_FLIGHT")
                 .filter(|value| *value > 0),
         }
     }
@@ -125,10 +119,6 @@ mod tests {
             .expect_get()
             .with(eq("RS_IO_MAX_WRITERS_IN_FLIGHT"))
             .return_const(Ok("2".to_string()));
-        env_getter
-            .expect_get()
-            .with(eq("RS_IO_MAX_READERS_IN_FLIGHT"))
-            .return_const(Ok("3".to_string()));
 
         let io_settings = IoConfig {
             batch_max_size: 1000000,
@@ -138,7 +128,6 @@ mod tests {
             batch_records_timeout: Duration::from_secs(5),
             operation_timeout: Duration::from_secs(60),
             max_writers_in_flight: Some(2),
-            max_readers_in_flight: Some(3),
         };
 
         assert_eq!(

--- a/reductstore/src/storage/bucket/query.rs
+++ b/reductstore/src/storage/bucket/query.rs
@@ -18,11 +18,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
-const DEFAULT_AGGREGATOR_BUFFER_SIZE: usize = 64;
-const LIMITED_AGGREGATOR_BUFFER_SIZE: usize = 1;
-const LIMITED_PENDING_READERS: usize = 1;
+const AGGREGATOR_BUFFER_SIZE: usize = 64;
 
-#[allow(dead_code)]
 pub(super) struct MultiEntryQuery {
     entry_queries: HashMap<String, u64>,
     aggregated_rx: Arc<AsyncRwLock<QueryRx>>,
@@ -158,15 +155,16 @@ impl Bucket {
             entry_receivers.insert(entry_name.clone(), rx);
         }
 
-        let io_settings = io_settings.unwrap_or_default();
-        let (tx, rx_out) = mpsc::channel(aggregator_channel_size(&io_settings));
-        let max_pending_readers = aggregator_pending_readers(&io_settings);
+        let (tx, rx_out) = mpsc::channel(AGGREGATOR_BUFFER_SIZE);
 
         tokio::spawn(async move {
-            Self::aggregate(entry_receivers, tx, max_pending_readers).await;
+            Self::aggregate(entry_receivers, tx).await;
         });
 
-        Ok((Arc::new(AsyncRwLock::new(rx_out)), io_settings))
+        Ok((
+            Arc::new(AsyncRwLock::new(rx_out)),
+            io_settings.unwrap_or_default(),
+        ))
     }
 
     async fn remove_expired_query(
@@ -187,7 +185,6 @@ impl Bucket {
     async fn aggregate(
         entry_receivers: HashMap<String, Arc<AsyncRwLock<QueryRx>>>,
         tx: mpsc::Sender<Result<RecordReader, ReductError>>,
-        max_pending_readers: usize,
     ) {
         let mut pending_readers: HashMap<String, Option<RecordReader>> = HashMap::new();
         let mut completed: HashSet<String> = HashSet::new();
@@ -197,20 +194,10 @@ impl Bucket {
                 break;
             }
 
-            if tx.capacity() == 0 {
-                tokio::time::sleep(Duration::from_millis(1)).await;
-                continue;
-            }
-
             let mut last_error: Option<ReductError> = None;
             let mut made_progress = false;
-            let mut pending_count = pending_readers.values().flatten().count();
 
             for (entry_name, rx) in &entry_receivers {
-                if pending_count >= max_pending_readers {
-                    break;
-                }
-
                 if matches!(
                     pending_readers.get(entry_name).and_then(|opt| opt.as_ref()),
                     Some(_)
@@ -233,7 +220,6 @@ impl Bucket {
                 match recv_result {
                     Ok(Ok(reader)) => {
                         pending_readers.insert(entry_name.clone(), Some(reader));
-                        pending_count += 1;
                         made_progress = true;
                     }
                     Ok(Err(err)) => {
@@ -297,22 +283,6 @@ impl Bucket {
     }
 }
 
-fn aggregator_channel_size(io_settings: &IoConfig) -> usize {
-    if io_settings.max_readers_in_flight.is_some() {
-        LIMITED_AGGREGATOR_BUFFER_SIZE
-    } else {
-        DEFAULT_AGGREGATOR_BUFFER_SIZE
-    }
-}
-
-fn aggregator_pending_readers(io_settings: &IoConfig) -> usize {
-    if io_settings.max_readers_in_flight.is_some() {
-        LIMITED_PENDING_READERS
-    } else {
-        usize::MAX
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -327,27 +297,6 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::time::timeout;
-
-    #[test]
-    fn aggregator_limits_are_reduced_when_reader_limit_enabled() {
-        assert_eq!(
-            aggregator_channel_size(&IoConfig::default()),
-            DEFAULT_AGGREGATOR_BUFFER_SIZE
-        );
-        assert_eq!(aggregator_pending_readers(&IoConfig::default()), usize::MAX);
-
-        let mut limited = IoConfig::default();
-        limited.max_readers_in_flight = Some(256);
-
-        assert_eq!(
-            aggregator_channel_size(&limited),
-            LIMITED_AGGREGATOR_BUFFER_SIZE
-        );
-        assert_eq!(
-            aggregator_pending_readers(&limited),
-            LIMITED_PENDING_READERS
-        );
-    }
 
     async fn collect_records(rx: Weak<AsyncRwLock<QueryRx>>) -> Vec<(String, u64)> {
         let rx = rx.upgrade().unwrap();
@@ -617,7 +566,7 @@ mod tests {
         // Should exit immediately because the receiver is gone.
         assert!(timeout(
             Duration::from_millis(100),
-            Bucket::aggregate(HashMap::new(), tx, usize::MAX)
+            Bucket::aggregate(HashMap::new(), tx)
         )
         .await
         .is_ok());

--- a/reductstore/src/storage/bucket/query.rs
+++ b/reductstore/src/storage/bucket/query.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
-const AGGREGATOR_BUFFER_SIZE: usize = 64;
+const DEFAULT_AGGREGATOR_BUFFER_SIZE: usize = 64;
+const LIMITED_AGGREGATOR_BUFFER_SIZE: usize = 1;
+const LIMITED_PENDING_READERS: usize = 1;
 
 #[allow(dead_code)]
 pub(super) struct MultiEntryQuery {
@@ -156,16 +158,15 @@ impl Bucket {
             entry_receivers.insert(entry_name.clone(), rx);
         }
 
-        let (tx, rx_out) = mpsc::channel(AGGREGATOR_BUFFER_SIZE);
+        let io_settings = io_settings.unwrap_or_default();
+        let (tx, rx_out) = mpsc::channel(aggregator_channel_size(&io_settings));
+        let max_pending_readers = aggregator_pending_readers(&io_settings);
 
         tokio::spawn(async move {
-            Self::aggregate(entry_receivers, tx).await;
+            Self::aggregate(entry_receivers, tx, max_pending_readers).await;
         });
 
-        Ok((
-            Arc::new(AsyncRwLock::new(rx_out)),
-            io_settings.unwrap_or_default(),
-        ))
+        Ok((Arc::new(AsyncRwLock::new(rx_out)), io_settings))
     }
 
     async fn remove_expired_query(
@@ -186,6 +187,7 @@ impl Bucket {
     async fn aggregate(
         entry_receivers: HashMap<String, Arc<AsyncRwLock<QueryRx>>>,
         tx: mpsc::Sender<Result<RecordReader, ReductError>>,
+        max_pending_readers: usize,
     ) {
         let mut pending_readers: HashMap<String, Option<RecordReader>> = HashMap::new();
         let mut completed: HashSet<String> = HashSet::new();
@@ -195,10 +197,20 @@ impl Bucket {
                 break;
             }
 
+            if tx.capacity() == 0 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                continue;
+            }
+
             let mut last_error: Option<ReductError> = None;
             let mut made_progress = false;
+            let mut pending_count = pending_readers.values().flatten().count();
 
             for (entry_name, rx) in &entry_receivers {
+                if pending_count >= max_pending_readers {
+                    break;
+                }
+
                 if matches!(
                     pending_readers.get(entry_name).and_then(|opt| opt.as_ref()),
                     Some(_)
@@ -221,6 +233,7 @@ impl Bucket {
                 match recv_result {
                     Ok(Ok(reader)) => {
                         pending_readers.insert(entry_name.clone(), Some(reader));
+                        pending_count += 1;
                         made_progress = true;
                     }
                     Ok(Err(err)) => {
@@ -284,6 +297,22 @@ impl Bucket {
     }
 }
 
+fn aggregator_channel_size(io_settings: &IoConfig) -> usize {
+    if io_settings.max_readers_in_flight.is_some() {
+        LIMITED_AGGREGATOR_BUFFER_SIZE
+    } else {
+        DEFAULT_AGGREGATOR_BUFFER_SIZE
+    }
+}
+
+fn aggregator_pending_readers(io_settings: &IoConfig) -> usize {
+    if io_settings.max_readers_in_flight.is_some() {
+        LIMITED_PENDING_READERS
+    } else {
+        usize::MAX
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,6 +327,27 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::time::timeout;
+
+    #[test]
+    fn aggregator_limits_are_reduced_when_reader_limit_enabled() {
+        assert_eq!(
+            aggregator_channel_size(&IoConfig::default()),
+            DEFAULT_AGGREGATOR_BUFFER_SIZE
+        );
+        assert_eq!(aggregator_pending_readers(&IoConfig::default()), usize::MAX);
+
+        let mut limited = IoConfig::default();
+        limited.max_readers_in_flight = Some(256);
+
+        assert_eq!(
+            aggregator_channel_size(&limited),
+            LIMITED_AGGREGATOR_BUFFER_SIZE
+        );
+        assert_eq!(
+            aggregator_pending_readers(&limited),
+            LIMITED_PENDING_READERS
+        );
+    }
 
     async fn collect_records(rx: Weak<AsyncRwLock<QueryRx>>) -> Vec<(String, u64)> {
         let rx = rx.upgrade().unwrap();
@@ -567,7 +617,7 @@ mod tests {
         // Should exit immediately because the receiver is gone.
         assert!(timeout(
             Duration::from_millis(100),
-            Bucket::aggregate(HashMap::new(), tx)
+            Bucket::aggregate(HashMap::new(), tx, usize::MAX)
         )
         .await
         .is_ok());

--- a/reductstore/src/storage/bucket/query.rs
+++ b/reductstore/src/storage/bucket/query.rs
@@ -21,7 +21,6 @@ use tokio::sync::mpsc;
 const AGGREGATOR_BUFFER_SIZE: usize = 64;
 
 pub(super) struct MultiEntryQuery {
-    entry_queries: HashMap<String, u64>,
     aggregated_rx: Arc<AsyncRwLock<QueryRx>>,
     io_settings: IoConfig,
     options: QueryOptions,
@@ -52,7 +51,6 @@ impl Bucket {
         let (aggregated_rx, io_settings) = self.init_aggregator(&entry_queries).await?;
 
         let multi_query = MultiEntryQuery {
-            entry_queries,
             aggregated_rx,
             io_settings,
             options,

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -170,12 +170,6 @@ impl Entry {
         self.io_limiter.acquire_writer_slot().await
     }
 
-    pub(crate) async fn acquire_reader_slot(
-        &self,
-    ) -> Result<Option<OwnedSemaphorePermit>, ReductError> {
-        self.io_limiter.acquire_reader_slot().await
-    }
-
     /// Query records for a time range.
     ///
     /// # Arguments
@@ -200,7 +194,6 @@ impl Entry {
             stop,
             options.clone(),
             self.cfg.io_conf.clone(),
-            self.io_limiter.clone(),
         )?;
 
         let io_settings = query.as_ref().io_settings().clone();

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -88,8 +88,7 @@ impl Entry {
             ));
         }
 
-        let permit = self.acquire_reader_slot().await?;
-        RecordReader::try_new(self.block_manager.clone(), block_ref, time, None, permit).await
+        RecordReader::try_new(self.block_manager.clone(), block_ref, time, None, None).await
     }
 }
 

--- a/reductstore/src/storage/in_flight.rs
+++ b/reductstore/src/storage/in_flight.rs
@@ -11,7 +11,6 @@ use tokio::time::timeout;
 #[derive(Clone, Default)]
 pub(crate) struct InFlightIoLimiter {
     writer_slots: Option<Arc<Semaphore>>,
-    reader_slots: Option<Arc<Semaphore>>,
     acquire_timeout: Duration,
 }
 
@@ -21,11 +20,6 @@ impl InFlightIoLimiter {
             writer_slots: cfg
                 .io_conf
                 .max_writers_in_flight
-                .map(Semaphore::new)
-                .map(Arc::new),
-            reader_slots: cfg
-                .io_conf
-                .max_readers_in_flight
                 .map(Semaphore::new)
                 .map(Arc::new),
             acquire_timeout: cfg.io_conf.operation_timeout,
@@ -38,16 +32,6 @@ impl InFlightIoLimiter {
         self.try_acquire_slot(
             &self.writer_slots,
             "in-flight writers limit exceeded: try again later",
-        )
-        .await
-    }
-
-    pub(crate) async fn acquire_reader_slot(
-        &self,
-    ) -> Result<Option<OwnedSemaphorePermit>, ReductError> {
-        self.try_acquire_slot(
-            &self.reader_slots,
-            "in-flight readers limit exceeded: try again later",
         )
         .await
     }
@@ -74,14 +58,10 @@ mod tests {
     use super::*;
     use crate::cfg::io::IoConfig;
 
-    fn cfg_with_limits(
-        max_writers_in_flight: Option<usize>,
-        max_readers_in_flight: Option<usize>,
-    ) -> Cfg {
+    fn cfg_with_limits(max_writers_in_flight: Option<usize>) -> Cfg {
         Cfg {
             io_conf: IoConfig {
                 max_writers_in_flight,
-                max_readers_in_flight,
                 operation_timeout: Duration::from_millis(1),
                 ..IoConfig::default()
             },
@@ -91,15 +71,14 @@ mod tests {
 
     #[tokio::test]
     async fn disabled_limits_do_not_require_permits() {
-        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(None, None));
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(None));
 
         assert!(limiter.acquire_writer_slot().await.unwrap().is_none());
-        assert!(limiter.acquire_reader_slot().await.unwrap().is_none());
     }
 
     #[tokio::test]
     async fn writer_limit_rejects_when_all_slots_are_held() {
-        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1), None));
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1)));
         let permit = limiter.acquire_writer_slot().await.unwrap();
 
         let err = limiter.acquire_writer_slot().await.err().unwrap();
@@ -114,37 +93,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reader_limit_rejects_when_all_slots_are_held() {
-        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(None, Some(1)));
-        let permit = limiter.acquire_reader_slot().await.unwrap();
-
-        let err = limiter.acquire_reader_slot().await.err().unwrap();
-        assert_eq!(err.status, ErrorCode::TooManyRequests);
-        assert_eq!(
-            err.message,
-            "in-flight readers limit exceeded: try again later"
-        );
-
-        drop(permit);
-        assert!(limiter.acquire_reader_slot().await.unwrap().is_some());
-    }
-
-    #[tokio::test]
     async fn cloned_limiter_shares_slots() {
-        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1), None));
+        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1)));
         let clone = limiter.clone();
         let _permit = limiter.acquire_writer_slot().await.unwrap();
 
         let err = clone.acquire_writer_slot().await.err().unwrap();
 
         assert_eq!(err.status, ErrorCode::TooManyRequests);
-    }
-
-    #[tokio::test]
-    async fn reader_and_writer_limits_are_independent() {
-        let limiter = InFlightIoLimiter::from_cfg(&cfg_with_limits(Some(1), Some(1)));
-        let _writer_permit = limiter.acquire_writer_slot().await.unwrap();
-
-        assert!(limiter.acquire_reader_slot().await.unwrap().is_some());
     }
 }

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -28,7 +28,8 @@ use tokio::time::sleep;
 
 pub(crate) type QueryRx = Receiver<Result<RecordReader, ReductError>>;
 
-const QUERY_BUFFER_SIZE: usize = 64;
+const DEFAULT_QUERY_BUFFER_SIZE: usize = 64;
+const LIMITED_QUERY_BUFFER_SIZE: usize = 1;
 const MIN_FULL_CHANNEL_SLEEP: Duration = Duration::from_micros(10);
 const MAX_FULL_CHANNEL_SLEEP: Duration = Duration::from_millis(10);
 
@@ -95,7 +96,8 @@ pub(super) fn spawn_query_task(
     options: QueryOptions,
     block_manager: Arc<AsyncRwLock<BlockManager>>,
 ) -> (QueryRx, JoinHandle<()>) {
-    let (tx, rx) = tokio::sync::mpsc::channel(QUERY_BUFFER_SIZE);
+    let query_buffer_size = query_channel_size(query.io_settings());
+    let (tx, rx) = tokio::sync::mpsc::channel(query_buffer_size);
 
     // we spawn a new task to run the query outside hierarchical task group to avoid deadlocks
     let handle = tokio::spawn(async move {
@@ -121,6 +123,7 @@ pub(super) fn spawn_query_task(
                 // to avoid flooding the channel but still be responsive
                 let timeout = watcher.full_channel();
                 sleep(timeout).await;
+                continue;
             }
 
             let next_result = query.next(block_manager.clone()).await;
@@ -150,6 +153,14 @@ pub(super) fn spawn_query_task(
         }
     });
     (rx, handle)
+}
+
+fn query_channel_size(io_settings: &IoConfig) -> usize {
+    if io_settings.max_readers_in_flight.is_some() {
+        LIMITED_QUERY_BUFFER_SIZE
+    } else {
+        DEFAULT_QUERY_BUFFER_SIZE
+    }
 }
 
 /// A wrapper for timeout and expiry time logic
@@ -202,6 +213,18 @@ mod tests {
     use rstest::*;
     use test_log::test as log_test;
     use tokio::time::timeout;
+
+    #[test]
+    fn query_channel_size_respects_reader_limits() {
+        assert_eq!(
+            query_channel_size(&IoConfig::default()),
+            DEFAULT_QUERY_BUFFER_SIZE
+        );
+
+        let mut limited = IoConfig::default();
+        limited.max_readers_in_flight = Some(256);
+        assert_eq!(query_channel_size(&limited), LIMITED_QUERY_BUFFER_SIZE);
+    }
 
     #[log_test(rstest)]
     fn test_bad_start_stop() {

--- a/reductstore/src/storage/query.rs
+++ b/reductstore/src/storage/query.rs
@@ -12,7 +12,6 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::BlockManager;
 use crate::storage::entry::RecordReader;
-use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::query::base::{Query, QueryOptions};
 use log::{debug, trace};
 use reduct_base::error::ErrorCode::NoContent;
@@ -28,8 +27,7 @@ use tokio::time::sleep;
 
 pub(crate) type QueryRx = Receiver<Result<RecordReader, ReductError>>;
 
-const DEFAULT_QUERY_BUFFER_SIZE: usize = 64;
-const LIMITED_QUERY_BUFFER_SIZE: usize = 1;
+const QUERY_BUFFER_SIZE: usize = 64;
 const MIN_FULL_CHANNEL_SLEEP: Duration = Duration::from_micros(10);
 const MAX_FULL_CHANNEL_SLEEP: Duration = Duration::from_millis(10);
 
@@ -45,7 +43,6 @@ pub(in crate::storage) fn build_query(
     stop: u64,
     options: QueryOptions,
     io_defaults: IoConfig,
-    io_limiter: InFlightIoLimiter,
 ) -> Result<Box<dyn Query + Send + Sync>, ReductError> {
     if start > stop && !options.continuous {
         return Err(unprocessable_entity!("Start time must be before stop time",));
@@ -58,7 +55,6 @@ pub(in crate::storage) fn build_query(
             stop,
             options,
             io_defaults,
-            io_limiter,
         )?)
     } else if options.continuous {
         Box::new(continuous::ContinuousQuery::try_new(
@@ -66,7 +62,6 @@ pub(in crate::storage) fn build_query(
             start,
             options,
             io_defaults,
-            io_limiter,
         )?)
     } else {
         Box::new(historical::HistoricalQuery::try_new(
@@ -75,7 +70,6 @@ pub(in crate::storage) fn build_query(
             stop,
             options,
             io_defaults,
-            io_limiter,
         )?)
     })
 }
@@ -96,8 +90,7 @@ pub(super) fn spawn_query_task(
     options: QueryOptions,
     block_manager: Arc<AsyncRwLock<BlockManager>>,
 ) -> (QueryRx, JoinHandle<()>) {
-    let query_buffer_size = query_channel_size(query.io_settings());
-    let (tx, rx) = tokio::sync::mpsc::channel(query_buffer_size);
+    let (tx, rx) = tokio::sync::mpsc::channel(QUERY_BUFFER_SIZE);
 
     // we spawn a new task to run the query outside hierarchical task group to avoid deadlocks
     let handle = tokio::spawn(async move {
@@ -123,7 +116,6 @@ pub(super) fn spawn_query_task(
                 // to avoid flooding the channel but still be responsive
                 let timeout = watcher.full_channel();
                 sleep(timeout).await;
-                continue;
             }
 
             let next_result = query.next(block_manager.clone()).await;
@@ -153,14 +145,6 @@ pub(super) fn spawn_query_task(
         }
     });
     (rx, handle)
-}
-
-fn query_channel_size(io_settings: &IoConfig) -> usize {
-    if io_settings.max_readers_in_flight.is_some() {
-        LIMITED_QUERY_BUFFER_SIZE
-    } else {
-        DEFAULT_QUERY_BUFFER_SIZE
-    }
 }
 
 /// A wrapper for timeout and expiry time logic
@@ -214,18 +198,6 @@ mod tests {
     use test_log::test as log_test;
     use tokio::time::timeout;
 
-    #[test]
-    fn query_channel_size_respects_reader_limits() {
-        assert_eq!(
-            query_channel_size(&IoConfig::default()),
-            DEFAULT_QUERY_BUFFER_SIZE
-        );
-
-        let mut limited = IoConfig::default();
-        limited.max_readers_in_flight = Some(256);
-        assert_eq!(query_channel_size(&limited), LIMITED_QUERY_BUFFER_SIZE);
-    }
-
     #[log_test(rstest)]
     fn test_bad_start_stop() {
         let options = QueryOptions::default();
@@ -236,7 +208,6 @@ mod tests {
                 5,
                 options.clone(),
                 IoConfig::default(),
-                InFlightIoLimiter::default(),
             )
             .err()
             .unwrap(),
@@ -249,7 +220,6 @@ mod tests {
             10,
             options.clone(),
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .is_ok());
         assert!(build_query(
@@ -258,7 +228,6 @@ mod tests {
             11,
             options.clone(),
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .is_ok());
     }
@@ -275,7 +244,6 @@ mod tests {
             5,
             options.clone(),
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .is_ok());
     }
@@ -295,7 +263,6 @@ mod tests {
             5,
             options.clone(),
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -325,7 +292,6 @@ mod tests {
             5,
             options.clone(),
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .unwrap();
 
@@ -362,7 +328,6 @@ mod tests {
             5,
             options.clone(),
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .unwrap();
         let (mut rx, handle) = spawn_query_task(
@@ -417,7 +382,6 @@ mod tests {
             10,
             options.clone(),
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .unwrap();
 

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -5,7 +5,6 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::BlockManager;
 use crate::storage::entry::RecordReader;
-use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::historical::HistoricalQuery;
 use async_trait::async_trait;
@@ -20,7 +19,6 @@ pub struct ContinuousQuery {
     count: usize,
     options: QueryOptions,
     io_defaults: IoConfig,
-    io_limiter: InFlightIoLimiter,
 }
 
 impl ContinuousQuery {
@@ -29,7 +27,6 @@ impl ContinuousQuery {
         start: u64,
         options: QueryOptions,
         io_defaults: IoConfig,
-        io_limiter: InFlightIoLimiter,
     ) -> Result<Self, ReductError> {
         if !options.continuous {
             panic!("Continuous query must be continuous");
@@ -43,13 +40,11 @@ impl ContinuousQuery {
                 u64::MAX,
                 options.clone(),
                 io_defaults.clone(),
-                io_limiter.clone(),
             )?,
             next_start: start,
             count: 0,
             options,
             io_defaults,
-            io_limiter,
         })
     }
 }
@@ -76,7 +71,6 @@ impl Query for ContinuousQuery {
                     u64::MAX,
                     self.options.clone(),
                     self.io_defaults.clone(),
-                    self.io_limiter.clone(),
                 )?;
                 Err(ReductError {
                     status: ErrorCode::NoContent,
@@ -114,7 +108,6 @@ mod tests {
                 ..QueryOptions::default()
             },
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .unwrap();
         {

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -5,7 +5,6 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::{BlockManager, BlockRef};
 use crate::storage::entry::RecordReader;
-use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::proto::record;
 use crate::storage::proto::{record::State as RecordState, ts_to_us, Record};
 use crate::storage::query::base::{Query, QueryOptions};
@@ -67,8 +66,6 @@ pub struct HistoricalQuery {
     is_interrupted: bool,
     /// Io Config
     io_config: IoConfig,
-    /// Limits in-flight storage readers.
-    io_limiter: InFlightIoLimiter,
 }
 
 impl HistoricalQuery {
@@ -78,7 +75,6 @@ impl HistoricalQuery {
         stop_time: u64,
         options: QueryOptions,
         io_defaults: IoConfig,
-        io_limiter: InFlightIoLimiter,
     ) -> Result<Self, ReductError> {
         let mut filters: Vec<Filter> = vec![
             Box::new(TimeRangeFilter::new(start_time, stop_time)),
@@ -133,7 +129,6 @@ impl HistoricalQuery {
             only_metadata,
             is_interrupted: false,
             io_config,
-            io_limiter,
         })
     }
 }
@@ -236,13 +231,12 @@ impl Query for HistoricalQuery {
         if self.only_metadata {
             Ok(RecordReader::form_record(&self.entry_name, record))
         } else {
-            let permit = self.io_limiter.acquire_reader_slot().await?;
             RecordReader::try_new(
                 Arc::clone(&block_manager),
                 block.clone(),
                 ts_to_us(&record.timestamp.unwrap()),
                 Some(record),
-                permit,
+                None,
             )
             .await
         }
@@ -276,10 +270,8 @@ impl HistoricalQuery {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::time::Duration;
-
     use rstest::rstest;
+    use std::collections::HashMap;
 
     use super::*;
 
@@ -288,7 +280,6 @@ mod tests {
     use crate::core::file_cache::FILE_CACHE;
     use crate::storage::block_manager::block::Block;
     use crate::storage::block_manager::block_index::BlockIndex;
-    use crate::storage::in_flight::InFlightIoLimiter;
     use crate::storage::proto::record;
     use crate::storage::proto::{us_to_ts, Record};
     use crate::storage::query::base::tests::block_manager;
@@ -308,7 +299,6 @@ mod tests {
             stop_time,
             options,
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
     }
 
@@ -402,38 +392,6 @@ mod tests {
             "entry",
             "entry_name should be returned for HEAD request (only_metadata=true)"
         );
-    }
-
-    #[rstest]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_query_reader_limit_applies_to_content_readers(
-        #[future] block_manager: Arc<AsyncRwLock<BlockManager>>,
-    ) {
-        let block_manager = block_manager.await;
-        let cfg = Cfg {
-            io_conf: IoConfig {
-                max_readers_in_flight: Some(1),
-                operation_timeout: Duration::from_millis(1),
-                ..IoConfig::default()
-            },
-            ..Cfg::default()
-        };
-        let limiter = InFlightIoLimiter::from_cfg(&cfg);
-        let mut query = HistoricalQuery::try_new(
-            "entry".to_string(),
-            0,
-            1000,
-            QueryOptions::default(),
-            cfg.io_conf.clone(),
-            limiter,
-        )
-        .unwrap();
-
-        let _reader = query.next(block_manager.clone()).await.unwrap();
-        let err = query.next(block_manager).await.err().unwrap();
-
-        assert_eq!(err.status, ErrorCode::TooManyRequests);
-        assert!(err.message.contains("in-flight readers limit exceeded"));
     }
 
     #[rstest]

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -5,7 +5,6 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::BlockManager;
 use crate::storage::entry::RecordReader;
-use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::query::base::{Query, QueryOptions};
 use crate::storage::query::historical::HistoricalQuery;
 use async_trait::async_trait;
@@ -26,17 +25,9 @@ impl LimitedQuery {
         stop: u64,
         options: QueryOptions,
         io_config: IoConfig,
-        io_limiter: InFlightIoLimiter,
     ) -> Result<Self, ReductError> {
         Ok(LimitedQuery {
-            query: HistoricalQuery::try_new(
-                entry_name,
-                start,
-                stop,
-                options.clone(),
-                io_config,
-                io_limiter,
-            )?,
+            query: HistoricalQuery::try_new(entry_name, start, stop, options.clone(), io_config)?,
             limit_count: options.limit.unwrap(),
         })
     }
@@ -64,12 +55,10 @@ impl Query for LimitedQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cfg::Cfg;
     use crate::storage::query::base::tests::block_manager;
     use reduct_base::error::ErrorCode;
     use reduct_base::io::ReadRecord;
     use rstest::rstest;
-    use std::time::Duration;
 
     #[rstest]
     #[tokio::test]
@@ -84,7 +73,6 @@ mod tests {
                 ..Default::default()
             },
             IoConfig::default(),
-            InFlightIoLimiter::default(),
         )
         .unwrap();
 
@@ -98,39 +86,5 @@ mod tests {
                 message: "No content".to_string(),
             })
         );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn applies_reader_limiter_to_wrapped_query(
-        #[future] block_manager: Arc<AsyncRwLock<BlockManager>>,
-    ) {
-        let block_manager = block_manager.await;
-        let cfg = Cfg {
-            io_conf: IoConfig {
-                max_readers_in_flight: Some(1),
-                operation_timeout: Duration::from_millis(1),
-                ..IoConfig::default()
-            },
-            ..Cfg::default()
-        };
-        let mut query = LimitedQuery::try_new(
-            "entry".to_string(),
-            0,
-            u64::MAX,
-            QueryOptions {
-                limit: Some(2),
-                ..Default::default()
-            },
-            cfg.io_conf.clone(),
-            InFlightIoLimiter::from_cfg(&cfg),
-        )
-        .unwrap();
-
-        let _reader = query.next(block_manager.clone()).await.unwrap();
-        let err = query.next(block_manager).await.err().unwrap();
-
-        assert_eq!(err.status, ErrorCode::TooManyRequests);
-        assert!(err.message.contains("in-flight readers limit exceeded"));
     }
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / behavior change

### What was changed?

- Removed in-flight reader limiting from storage:
  - removed `RS_IO_MAX_READERS_IN_FLIGHT` config parsing and corresponding `IoConfig` field
  - removed reader permit acquisition from record read/query paths
  - removed reader-slot semaphore handling in `InFlightIoLimiter`
- Kept in-flight writer limiting unchanged (`RS_IO_MAX_WRITERS_IN_FLIGHT`).
- Removed reader-limit-specific tests and constructor plumbing that became obsolete.
- Updated changelog entry for `PR-1361` to reflect reader-limit removal.

### Related issues

User-reported hanging/degradation under in-flight reader limiting; decision is to remove this limit for now and re-introduce later if needed.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run:
- `cargo fmt --all`
- `cargo check -p reductstore`
- `cargo test -p reductstore storage::in_flight::tests::`
- `cargo test -p reductstore cfg::io::tests::`
- `cargo test -p reductstore storage::query::tests::`
- `cargo test -p reductstore storage::query::historical::tests::`
- `cargo test -p reductstore storage::query::limited::tests::`
- `cargo test -p reductstore storage::bucket::query::tests::`