### PR TITLE
snap: use Cargo.toml version for published snap

### DIFF
--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -44,6 +44,35 @@ runs:
         set -euo pipefail
         chmod +x .snap-build/bin/reductstore
 
+    - name: Set snap version from Cargo.toml and GITHUB_SHA
+      shell: bash
+      run: |
+        set -euo pipefail
+        python3 - <<'PY'
+        import os, re
+        from pathlib import Path
+
+        cargo = Path('Cargo.toml').read_text(encoding='utf-8')
+        m = re.search(r'(?ms)^\[package\]\n(.*?)(?:^\[|\Z)', cargo)
+        if not m:
+            raise SystemExit('Could not find [package] section in Cargo.toml')
+        v = re.search(r'^version\s*=\s*"([^"]+)"\s*$', m.group(1), re.M)
+        if not v:
+            raise SystemExit('Could not find package.version in Cargo.toml')
+        sha = os.environ.get('GITHUB_SHA', '')[:7]
+        if not sha:
+            raise SystemExit('GITHUB_SHA is required for snap version')
+        version = f"{v.group(1)}-git{sha}"
+
+        p = Path('snap/snapcraft.yaml')
+        text = p.read_text(encoding='utf-8')
+        text, n = re.subn(r'^version:\s*"[^"]*"\s*$', f'version: "{version}"', text, count=1, flags=re.M)
+        if n != 1:
+            raise SystemExit('Could not update version in snap/snapcraft.yaml')
+        p.write_text(text, encoding='utf-8')
+        print(f'set snap version to {version}')
+        PY
+
     - uses: snapcore/action-build@v1
       id: build-snap
       with:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: ReductStore
 name: reductstore # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: git
+adopt-info: reductstore
 summary: High Performance Data Storage and Streaming for Robotics and Industrial IoT # 79 char long summary
 description: |
   ReductStore is a high-performance, time-series object storage and streaming solution for ELT-based data acquisition (DAQ) systems in robotics and industrial IoT (IIoT).
@@ -26,6 +26,10 @@ parts:
   reductstore:
     plugin: dump
     source: .snap-build/bin
+    override-pull: |
+      craftctl default
+      VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
+      craftctl set version="$VERSION"
     organize:
       reductstore: bin/reductstore
   hooks:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,18 +26,29 @@ parts:
   reductstore:
     plugin: dump
     source: .snap-build/bin
-    override-pull: |
-      craftctl default
-      VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      SHA=${GITHUB_SHA:0:7}
-      if [ -z "$SHA" ]; then
-        echo "ERROR: GITHUB_SHA is required for snap version" >&2
-        exit 1
-      fi
-      craftctl set version="${VERSION}-git${SHA}"
     organize:
       reductstore: bin/reductstore
   hooks:
+    plugin: dump
+    source: snap/local/hooks
+    organize:
+      bin/: snap/hooks/
+  scripts:
+    plugin: dump
+    source: snap/local/scripts
+
+
+apps:
+  reductstore:
+    command: bin/wrapper
+    daemon: simple
+    restart-condition: on-failure
+    plugs:
+      - network
+      - network-bind
+      - removable-media
+      - home
+
     plugin: dump
     source: snap/local/hooks
     organize:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,13 +29,9 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      SHA=${GITHUB_SHA:-${CRAFT_PART_SRC_COMMIT:-}}
+      SHA=${GITHUB_SHA:0:7}
       if [ -z "$SHA" ]; then
-        SHA=$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || true)
-      fi
-      SHA=${SHA:0:7}
-      if [ -z "$SHA" ]; then
-        echo "ERROR: Unable to determine git commit SHA for snap version (GITHUB_SHA/CRAFT_PART_SRC_COMMIT/git unavailable)" >&2
+        echo "ERROR: GITHUB_SHA is required for snap version" >&2
         exit 1
       fi
       craftctl set version="${VERSION}-git${SHA}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,10 +29,13 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || true)}
+      SHA=${GITHUB_SHA:-${CRAFT_PART_SRC_COMMIT:-}}
+      if [ -z "$SHA" ]; then
+        SHA=$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || true)
+      fi
       SHA=${SHA:0:7}
       if [ -z "$SHA" ]; then
-        echo "ERROR: Unable to determine git commit SHA for snap version" >&2
+        echo "ERROR: Unable to determine git commit SHA for snap version (GITHUB_SHA/CRAFT_PART_SRC_COMMIT/git unavailable)" >&2
         exit 1
       fi
       craftctl set version="${VERSION}-git${SHA}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,9 +29,13 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || echo local)}
+      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || true)}
       SHA=${SHA:0:7}
-      craftctl set version="${VERSION}-git.${SHA}"
+      if [ -z "$SHA" ]; then
+        echo "ERROR: Unable to determine git commit SHA for snap version" >&2
+        exit 1
+      fi
+      craftctl set version="${VERSION}-git${SHA}"
     organize:
       reductstore: bin/reductstore
   hooks:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,9 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$CRAFT_PROJECT_DIR/Cargo.toml" | head -n1)
-      craftctl set version="$VERSION"
+      SHA=${GITHUB_SHA:-$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=7 HEAD 2>/dev/null || echo local)}
+      SHA=${SHA:0:7}
+      craftctl set version="${VERSION}-git.${SHA}"
     organize:
       reductstore: bin/reductstore
   hooks:


### PR DESCRIPTION
## Summary
- replace `version: git` in `snap/snapcraft.yaml` with `adopt-info: reductstore`
- set snap version during pull via `craftctl set version` from `Cargo.toml`
- keep snap version aligned with crate semantic version instead of opaque `0+git.<sha>`

## Testing
- verified `snap/snapcraft.yaml` diff
- version extraction command reads `Cargo.toml` package version

## Why
Snap Store currently shows git-hash versions in stable channel for `reductstore`. This change makes published version numbers user-facing and semver-based.

Closes #
