### PR TITLE
snap: fix version resolution for workspace Cargo.toml

### DIFF
--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -49,27 +49,35 @@ runs:
       run: |
         set -euo pipefail
         python3 - <<'PY'
-        import os, re
+        import os
         from pathlib import Path
+        import tomllib
 
-        candidates = [Path('Cargo.toml'), Path('reductstore/Cargo.toml')]
-        v = None
-        for cargo_path in candidates:
-            if not cargo_path.exists():
+        root_manifest = Path('Cargo.toml')
+        root = tomllib.loads(root_manifest.read_text(encoding='utf-8'))
+        ws = root.get('workspace')
+        if not ws:
+            raise SystemExit('Expected workspace Cargo.toml at repository root')
+
+        members = ws.get('members', [])
+        package_version = None
+        for member in members:
+            member_manifest = Path(member) / 'Cargo.toml'
+            if not member_manifest.exists():
                 continue
-            cargo = cargo_path.read_text(encoding='utf-8')
-            m = re.search(r'(?ms)^\[package\]\n(.*?)(?:^\[|\Z)', cargo)
-            if not m:
-                continue
-            v = re.search(r'^version\s*=\s*"([^"]+)"\s*$', m.group(1), re.M)
-            if v:
+            data = tomllib.loads(member_manifest.read_text(encoding='utf-8'))
+            pkg = data.get('package') or {}
+            if pkg.get('name') == 'reductstore':
+                package_version = pkg.get('version')
                 break
-        if not v:
-            raise SystemExit('Could not find package.version in Cargo.toml (checked root and reductstore/Cargo.toml)')
+
+        if not package_version:
+            raise SystemExit('Could not find reductstore package version from workspace members')
+
         sha = os.environ.get('GITHUB_SHA', '')[:7]
         if not sha:
             raise SystemExit('GITHUB_SHA is required for snap version')
-        version = f"{v.group(1)}-git{sha}"
+        version = f"{package_version}-git{sha}"
 
         p = Path('snap/snapcraft.yaml')
         text = p.read_text(encoding='utf-8')

--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -49,35 +49,21 @@ runs:
       run: |
         set -euo pipefail
         python3 - <<'PY'
-        import os
+        import os, re
         from pathlib import Path
-        import tomllib
 
-        root_manifest = Path('Cargo.toml')
-        root = tomllib.loads(root_manifest.read_text(encoding='utf-8'))
-        ws = root.get('workspace')
-        if not ws:
-            raise SystemExit('Expected workspace Cargo.toml at repository root')
-
-        members = ws.get('members', [])
-        package_version = None
-        for member in members:
-            member_manifest = Path(member) / 'Cargo.toml'
-            if not member_manifest.exists():
-                continue
-            data = tomllib.loads(member_manifest.read_text(encoding='utf-8'))
-            pkg = data.get('package') or {}
-            if pkg.get('name') == 'reductstore':
-                package_version = pkg.get('version')
-                break
-
-        if not package_version:
-            raise SystemExit('Could not find reductstore package version from workspace members')
+        cargo = Path('reductstore/Cargo.toml').read_text(encoding='utf-8')
+        m = re.search(r'(?ms)^\[package\]\n(.*?)(?:^\[|\Z)', cargo)
+        if not m:
+            raise SystemExit('Could not find [package] section in reductstore/Cargo.toml')
+        v = re.search(r'^version\s*=\s*"([^"]+)"\s*$', m.group(1), re.M)
+        if not v:
+            raise SystemExit('Could not find package.version in reductstore/Cargo.toml')
 
         sha = os.environ.get('GITHUB_SHA', '')[:7]
         if not sha:
             raise SystemExit('GITHUB_SHA is required for snap version')
-        version = f"{package_version}-git{sha}"
+        version = f"{v.group(1)}-git{sha}"
 
         p = Path('snap/snapcraft.yaml')
         text = p.read_text(encoding='utf-8')

--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -52,13 +52,20 @@ runs:
         import os, re
         from pathlib import Path
 
-        cargo = Path('Cargo.toml').read_text(encoding='utf-8')
-        m = re.search(r'(?ms)^\[package\]\n(.*?)(?:^\[|\Z)', cargo)
-        if not m:
-            raise SystemExit('Could not find [package] section in Cargo.toml')
-        v = re.search(r'^version\s*=\s*"([^"]+)"\s*$', m.group(1), re.M)
+        candidates = [Path('Cargo.toml'), Path('reductstore/Cargo.toml')]
+        v = None
+        for cargo_path in candidates:
+            if not cargo_path.exists():
+                continue
+            cargo = cargo_path.read_text(encoding='utf-8')
+            m = re.search(r'(?ms)^\[package\]\n(.*?)(?:^\[|\Z)', cargo)
+            if not m:
+                continue
+            v = re.search(r'^version\s*=\s*"([^"]+)"\s*$', m.group(1), re.M)
+            if v:
+                break
         if not v:
-            raise SystemExit('Could not find package.version in Cargo.toml')
+            raise SystemExit('Could not find package.version in Cargo.toml (checked root and reductstore/Cargo.toml)')
         sha = os.environ.get('GITHUB_SHA', '')[:7]
         if not sha:
             raise SystemExit('GITHUB_SHA is required for snap version')

--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -52,13 +52,13 @@ runs:
         import os, re
         from pathlib import Path
 
-        cargo = Path('reductstore/Cargo.toml').read_text(encoding='utf-8')
-        m = re.search(r'(?ms)^\[package\]\n(.*?)(?:^\[|\Z)', cargo)
+        cargo = Path('Cargo.toml').read_text(encoding='utf-8')
+        m = re.search(r'(?ms)^\[workspace\.package\]\n(.*?)(?:^\[|\Z)', cargo)
         if not m:
-            raise SystemExit('Could not find [package] section in reductstore/Cargo.toml')
+            raise SystemExit('Could not find [workspace.package] section in Cargo.toml')
         v = re.search(r'^version\s*=\s*"([^"]+)"\s*$', m.group(1), re.M)
         if not v:
-            raise SystemExit('Could not find package.version in reductstore/Cargo.toml')
+            raise SystemExit('Could not find workspace.package.version in Cargo.toml')
 
         sha = os.environ.get('GITHUB_SHA', '')[:7]
         if not sha:


### PR DESCRIPTION
Fix snap version resolver to handle workspace root Cargo.toml.

- checks both  and 
- keeps -based  suffix
- avoids CI failure when root manifest has only 
