### PR TITLE
Fix snap release version update when snapcraft.yaml has no version key

### DIFF
--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -68,23 +68,14 @@ runs:
         p = Path('snap/snapcraft.yaml')
         text = p.read_text(encoding='utf-8')
 
-        # Replace existing top-level version if present (quoted or unquoted),
-        # otherwise insert one right after `name:`.
         text, n = re.subn(
             r'(?m)^version:\s*(?:"[^"]*"|[^#\n]+)\s*(?:#.*)?$',
             f'version: "{version}"',
             text,
             count=1,
         )
-        if n == 0:
-            text, n = re.subn(
-                r'(?m)^(name:\s*[^\n]+\n)',
-                rf'\1version: "{version}"\n',
-                text,
-                count=1,
-            )
         if n != 1:
-            raise SystemExit('Could not set version in snap/snapcraft.yaml')
+            raise SystemExit('Could not update version in snap/snapcraft.yaml')
 
         p.write_text(text, encoding='utf-8')
         print(f'set snap version to {version}')

--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -67,9 +67,25 @@ runs:
 
         p = Path('snap/snapcraft.yaml')
         text = p.read_text(encoding='utf-8')
-        text, n = re.subn(r'^version:\s*"[^"]*"\s*$', f'version: "{version}"', text, count=1, flags=re.M)
+
+        # Replace existing top-level version if present (quoted or unquoted),
+        # otherwise insert one right after `name:`.
+        text, n = re.subn(
+            r'(?m)^version:\s*(?:"[^"]*"|[^#\n]+)\s*(?:#.*)?$',
+            f'version: "{version}"',
+            text,
+            count=1,
+        )
+        if n == 0:
+            text, n = re.subn(
+                r'(?m)^(name:\s*[^\n]+\n)',
+                rf'\1version: "{version}"\n',
+                text,
+                count=1,
+            )
         if n != 1:
-            raise SystemExit('Could not update version in snap/snapcraft.yaml')
+            raise SystemExit('Could not set version in snap/snapcraft.yaml')
+
         p.write_text(text, encoding='utf-8')
         print(f'set snap version to {version}')
         PY


### PR DESCRIPTION
## Summary
- fix snap release composite action so version injection works even when `snap/snapcraft.yaml` does not already contain a `version:` key
- support both quoted and unquoted existing `version:` values
- if no `version:` exists, insert `version: "<workspace-version>-git<sha>"` right after `name:`

## Why
The snap jobs failed in CI for both amd64 and arm64 with:
`Could not update version in snap/snapcraft.yaml`
because the script expected a pre-existing quoted `version:` line, but current `snap/snapcraft.yaml` uses `adopt-info` and has no `version:` key.

## Testing
- local dry-run of the Python transformation with `GITHUB_SHA=abcdef1234567`
- verified it inserts `version: "1.20.0-gitabcdef1"` into `snap/snapcraft.yaml` when missing
- restored file after test to avoid payload changes

## Checklist
- [x] Tests added/updated where applicable
- [x] Documentation updated where applicable
- [x] Backward compatibility considered

Closes #
