### PR TITLE
fix version flag handling during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Downgrade `write_batched` log severity for closed writer-channel handoff from error to warning to reduce noisy false-positive error bursts under expected stream abort/backpressure scenarios, [PR-1356](https://github.com/reductstore/reductstore/pull/1356)
+- Handle `--version` (`-V`) in `main` before server startup so version output remains clean and exits without initialization side effects, [PR-1365](https://github.com/reductstore/reductstore/pull/1365)
 
 ## 1.19.7 - 2026-04-27
 

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -12,7 +12,6 @@ use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use log::{error, info};
 use reduct_base::logger::Logger;
-use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::process::exit;
 use std::str::FromStr;
@@ -234,42 +233,6 @@ mod tests {
     use tokio::time::sleep;
 
     static STOP_SERVER: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
-
-    #[test]
-    fn test_has_version_flag() {
-        assert!(has_version_flag(vec!["reductstore", "--version"]));
-        assert!(has_version_flag(vec!["reductstore", "-V"]));
-        assert!(has_version_flag(vec![
-            "reductstore",
-            "--config",
-            "cfg.yml",
-            "--version"
-        ]));
-
-        assert!(!has_version_flag(vec!["reductstore"]));
-        assert!(!has_version_flag(vec!["reductstore", "--verbose"]));
-        assert!(!has_version_flag(vec!["--version"])); // first arg is binary name and must be ignored
-        assert!(!has_version_flag(Vec::<&str>::new()));
-    }
-
-    #[test]
-    fn test_maybe_print_version() {
-        let mut output = Vec::new();
-        assert!(maybe_print_version(
-            vec!["reductstore", "--version"],
-            "1.2.3",
-            &mut output
-        ));
-        assert_eq!(String::from_utf8(output).unwrap(), "1.2.3\n");
-
-        let mut output = Vec::new();
-        assert!(!maybe_print_version(
-            vec!["reductstore"],
-            "1.2.3",
-            &mut output
-        ));
-        assert!(output.is_empty());
-    }
 
     pub(super) async fn shutdown_server(handle: Handle<SocketAddr>) {
         while !*STOP_SERVER.lock().await {

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -14,6 +14,7 @@ use log::{error, info};
 use reduct_base::logger::Logger;
 use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
+use std::process::exit;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -21,27 +22,14 @@ use tokio::sync::mpsc;
 
 static SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
-fn has_version_flag<I, S>(args: I) -> bool
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<str>,
-{
-    args.into_iter()
+pub fn maybe_print_version_and_exit() {
+    if std::env::args()
+        .into_iter()
         .skip(1)
         .any(|arg| matches!(arg.as_ref(), "--version" | "-V"))
-}
-
-fn maybe_print_version<I, S, W>(args: I, version: &str, mut writer: W) -> bool
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<str>,
-    W: Write,
-{
-    if has_version_flag(args) {
-        let _ = writeln!(writer, "{version}");
-        true
-    } else {
-        false
+    {
+        println!(env!("CARGO_PKG_VERSION"));
+        exit(0)
     }
 }
 
@@ -49,19 +37,7 @@ pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_pares
 where
     Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
 {
-    launch_server_with_version(ext_cfg_pareser, env!("CARGO_PKG_VERSION")).await;
-}
-
-pub async fn launch_server_with_version<Parser, ExtCfg: ExtCfgBounds + 'static>(
-    ext_cfg_pareser: Parser,
-    version: &str,
-) where
-    Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
-{
-    if maybe_print_version(std::env::args(), version, std::io::stdout()) {
-        return;
-    }
-
+    let version = env!("CARGO_PKG_VERSION");
     Logger::init("INFO");
     info!(
         "ReductStore Core {} [{} at {}]",

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -1,10 +1,12 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
+use reductstore::launcher::maybe_print_version_and_exit;
 use reductstore::{cfg::CoreExtCfgParser, launcher::launch_server};
 
 #[tokio::main]
 async fn main() {
+    maybe_print_version_and_exit();
     let ext_cfg_parser = CoreExtCfgParser;
     launch_server(ext_cfg_parser).await;
 }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- moved `--version` / `-V` handling to `main` before launching the server
- print only the package version and exit immediately when version flags are present
- removed generic version-print helpers from `launcher` and simplified startup flow

This avoids logger/server initialization side effects for version checks and makes CLI output deterministic.

### Related issues

- Related to https://github.com/reductstore/reductstore/pull/1343

### Does this PR introduce a breaking change?

No.

### Other information:

- No behavior changes for normal server startup.
