### PR TITLE
ci: remove Node 20 deprecation warnings in Actions

### DIFF
--- a/.github/actions/api/http-tests/action.yml
+++ b/.github/actions/api/http-tests/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/

--- a/.github/actions/api/http-tests/action.yml
+++ b/.github/actions/api/http-tests/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/

--- a/.github/actions/api/zenoh-tests/action.yml
+++ b/.github/actions/api/zenoh-tests/action.yml
@@ -25,7 +25,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/

--- a/.github/actions/api/zenoh-tests/action.yml
+++ b/.github/actions/api/zenoh-tests/action.yml
@@ -25,7 +25,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/

--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download image artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/
@@ -95,7 +95,7 @@ runs:
       shell: bash
       run: docker logs reductstore | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       if: always()
       with:
         name: docker-log-benchmark-${{ inputs.branch }}

--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download image artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/
@@ -95,7 +95,7 @@ runs:
       shell: bash
       run: docker logs reductstore | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: always()
       with:
         name: docker-log-benchmark-${{ inputs.branch }}

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -4,6 +4,9 @@ inputs:
   minimal_rust_version:
     description: 'Minimal Rust version.'
     required: true
+  action_github_token:
+    description: 'GitHub token for setup-protoc.'
+    required: true
   target:
     description: 'Target triple.'
     required: true
@@ -23,57 +26,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install protoc
-      shell: bash
-      env:
-        PROTOC_VERSION: '26.1'
-      run: |
-        set -euo pipefail
-
-        case "${RUNNER_OS}-${RUNNER_ARCH}" in
-          Linux-X64)
-            asset="protoc-${PROTOC_VERSION}-linux-x86_64.zip"
-            ;;
-          Linux-ARM64)
-            asset="protoc-${PROTOC_VERSION}-linux-aarch_64.zip"
-            ;;
-          macOS-X64)
-            asset="protoc-${PROTOC_VERSION}-osx-x86_64.zip"
-            ;;
-          macOS-ARM64)
-            asset="protoc-${PROTOC_VERSION}-osx-aarch_64.zip"
-            ;;
-          Windows-X64)
-            asset="protoc-${PROTOC_VERSION}-win64.zip"
-            ;;
-          *)
-            echo "Unsupported runner platform for protoc: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-            exit 1
-            ;;
-        esac
-
-        archive_path="${RUNNER_TEMP}/${asset}"
-        install_dir="${RUNNER_TEMP}/protoc-${PROTOC_VERSION}-${RUNNER_OS}-${RUNNER_ARCH}"
-
-        rm -rf "${install_dir}"
-        mkdir -p "${install_dir}"
-
-        curl -fsSL --retry 5 --retry-all-errors \
-          "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${asset}" \
-          -o "${archive_path}"
-
-        python_bin="python3"
-        if ! command -v "${python_bin}" >/dev/null 2>&1; then
-          python_bin="python"
-        fi
-
-        "${python_bin}" -c 'import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])' "${archive_path}" "${install_dir}"
-
-        chmod +x "${install_dir}/bin/protoc"
-        echo "${install_dir}/bin" >> "${GITHUB_PATH}"
-        echo "PROTOC=${install_dir}/bin/protoc" >> "${GITHUB_ENV}"
-        echo "PROTOC_INCLUDE=${install_dir}/include" >> "${GITHUB_ENV}"
-        "${install_dir}/bin/protoc" --version
+    - uses: reductstore/setup-protoc@ac76da16b8e70736e159368a4bc962934d1f825a # master
+      with:
+        version: '26.x'
+        repo-token: ${{ inputs.action_github_token }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -4,9 +4,6 @@ inputs:
   minimal_rust_version:
     description: 'Minimal Rust version.'
     required: true
-  action_github_token:
-    description: 'GitHub token for setup-protoc.'
-    required: true
   target:
     description: 'Target triple.'
     required: true
@@ -26,10 +23,57 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: arduino/setup-protoc@v3
-      with:
-        version: '26.x'
-        repo-token: ${{ inputs.action_github_token }}
+    - name: Install protoc
+      shell: bash
+      env:
+        PROTOC_VERSION: '26.1'
+      run: |
+        set -euo pipefail
+
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)
+            asset="protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+            ;;
+          Linux-ARM64)
+            asset="protoc-${PROTOC_VERSION}-linux-aarch_64.zip"
+            ;;
+          macOS-X64)
+            asset="protoc-${PROTOC_VERSION}-osx-x86_64.zip"
+            ;;
+          macOS-ARM64)
+            asset="protoc-${PROTOC_VERSION}-osx-aarch_64.zip"
+            ;;
+          Windows-X64)
+            asset="protoc-${PROTOC_VERSION}-win64.zip"
+            ;;
+          *)
+            echo "Unsupported runner platform for protoc: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
+
+        archive_path="${RUNNER_TEMP}/${asset}"
+        install_dir="${RUNNER_TEMP}/protoc-${PROTOC_VERSION}-${RUNNER_OS}-${RUNNER_ARCH}"
+
+        rm -rf "${install_dir}"
+        mkdir -p "${install_dir}"
+
+        curl -fsSL --retry 5 --retry-all-errors \
+          "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${asset}" \
+          -o "${archive_path}"
+
+        python_bin="python3"
+        if ! command -v "${python_bin}" >/dev/null 2>&1; then
+          python_bin="python"
+        fi
+
+        "${python_bin}" -c 'import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])' "${archive_path}" "${install_dir}"
+
+        chmod +x "${install_dir}/bin/protoc"
+        echo "${install_dir}/bin" >> "${GITHUB_PATH}"
+        echo "PROTOC=${install_dir}/bin/protoc" >> "${GITHUB_ENV}"
+        echo "PROTOC_INCLUDE=${install_dir}/include" >> "${GITHUB_ENV}"
+        "${install_dir}/bin/protoc" --version
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -83,7 +83,7 @@ runs:
       shell: bash
 
     - name: Upload binary (PR)
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       # Only upload Linux binary for PRs for sanity test
       if: github.event_name == 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
       with:
@@ -92,7 +92,7 @@ runs:
         if-no-files-found: 'error'
 
     - name: Upload binary (Release)
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: github.event_name != 'pull_request'
       with:
         name: reductstore-${{ inputs.target }}
@@ -111,7 +111,7 @@ runs:
         syft "file:Cargo.lock" -o spdx-json="$sbom_path"
 
     - name: Upload SBOM
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: reductstore-sbom-${{ inputs.target }}
         path: /tmp/sbom/reductstore.${{ inputs.target }}.sbom.spdx.json
@@ -122,7 +122,7 @@ runs:
       shell: bash
 
     - name: Upload tests
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: reductstore-tests-${{ inputs.target }}
         path: target/${{ inputs.target }}/tests

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -83,7 +83,7 @@ runs:
       shell: bash
 
     - name: Upload binary (PR)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       # Only upload Linux binary for PRs for sanity test
       if: github.event_name == 'pull_request' && inputs.target == 'x86_64-unknown-linux-gnu'
       with:
@@ -92,7 +92,7 @@ runs:
         if-no-files-found: 'error'
 
     - name: Upload binary (Release)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: github.event_name != 'pull_request'
       with:
         name: reductstore-${{ inputs.target }}
@@ -111,7 +111,7 @@ runs:
         syft "file:Cargo.lock" -o spdx-json="$sbom_path"
 
     - name: Upload SBOM
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: reductstore-sbom-${{ inputs.target }}
         path: /tmp/sbom/reductstore.${{ inputs.target }}.sbom.spdx.json
@@ -122,7 +122,7 @@ runs:
       shell: bash
 
     - name: Upload tests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: reductstore-tests-${{ inputs.target }}
         path: target/${{ inputs.target }}/tests

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -41,7 +41,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: reductstore-${{ inputs.target }}
         path: /tmp/reductstore/
@@ -122,7 +122,7 @@ runs:
 
     - name: Upload artifact
       if: ${{ inputs.upload_artifact == 'true' }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: ${{ inputs.image_artifact_name }}
         path: /tmp/image.tar

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -41,7 +41,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: reductstore-${{ inputs.target }}
         path: /tmp/reductstore/
@@ -122,7 +122,7 @@ runs:
 
     - name: Upload artifact
       if: ${{ inputs.upload_artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.image_artifact_name }}
         path: /tmp/image.tar

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -43,7 +43,7 @@ runs:
         cargo llvm-cov --features fs-backend,ci --workspace --lcov --output-path lcov.info
 
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: lcov.info
         path: lcov.info

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -43,7 +43,7 @@ runs:
         cargo llvm-cov --features fs-backend,ci --workspace --lcov --output-path lcov.info
 
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: lcov.info
         path: lcov.info

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
-    - uses: arduino/setup-protoc@v3
+    - uses: reductstore/setup-protoc@ac76da16b8e70736e159368a4bc962934d1f825a # master
       with:
         version: '26.x'
         repo-token: ${{ inputs.action_github_token }}

--- a/.github/actions/migration-test/action.yml
+++ b/.github/actions/migration-test/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: 3.12
 
@@ -56,7 +56,7 @@ runs:
           "chown -R 10001:10001 /data && chmod -R 770 /data"
 
     - name: Download artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/
@@ -98,7 +98,7 @@ runs:
       shell: bash
       run: docker logs current | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: always()
       with:
         name: docker-log-migration-${{ inputs.version }}

--- a/.github/actions/migration-test/action.yml
+++ b/.github/actions/migration-test/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.12
 
@@ -56,7 +56,7 @@ runs:
           "chown -R 10001:10001 /data && chmod -R 770 /data"
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/
@@ -98,7 +98,7 @@ runs:
       shell: bash
       run: docker logs current | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       if: always()
       with:
         name: docker-log-migration-${{ inputs.version }}

--- a/.github/actions/primary-secondary-test/action.yml
+++ b/.github/actions/primary-secondary-test/action.yml
@@ -14,12 +14,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: 3.12
 
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/

--- a/.github/actions/primary-secondary-test/action.yml
+++ b/.github/actions/primary-secondary-test/action.yml
@@ -14,12 +14,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.12
 
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/

--- a/.github/actions/read-only-replica-test/action.yml
+++ b/.github/actions/read-only-replica-test/action.yml
@@ -10,12 +10,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.12
 
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/

--- a/.github/actions/read-only-replica-test/action.yml
+++ b/.github/actions/read-only-replica-test/action.yml
@@ -10,12 +10,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: 3.12
 
     - name: Download Docker image artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/

--- a/.github/actions/recovery-test/action.yml
+++ b/.github/actions/recovery-test/action.yml
@@ -10,12 +10,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.12
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/
@@ -68,7 +68,7 @@ runs:
       shell: bash
       run: docker logs reductstore | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       if: always()
       with:
         name: docker-log-recovery-${{ inputs.cmd }}

--- a/.github/actions/recovery-test/action.yml
+++ b/.github/actions/recovery-test/action.yml
@@ -13,12 +13,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: 3.12
 
     - name: Download artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/
@@ -71,7 +71,7 @@ runs:
       shell: bash
       run: docker logs reductstore | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: always()
       with:
         name: docker-log-recovery-${{ inputs.cmd }}

--- a/.github/actions/replication-test/action.yml
+++ b/.github/actions/replication-test/action.yml
@@ -19,11 +19,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.12
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: image
         path: /tmp/
@@ -91,7 +91,7 @@ runs:
       shell: bash
       run: docker logs current | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       if: always()
       with:
         name: docker-log-repl-${{ inputs.max_blob_size }}

--- a/.github/actions/replication-test/action.yml
+++ b/.github/actions/replication-test/action.yml
@@ -19,11 +19,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: 3.12
     - name: Download artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: image
         path: /tmp/
@@ -91,7 +91,7 @@ runs:
       shell: bash
       run: docker logs current | zip > /tmp/docker-log.zip
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: always()
       with:
         name: docker-log-repl-${{ inputs.max_blob_size }}

--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -33,7 +33,7 @@ runs:
         echo "BINARY_ARTIFACT=reductstore-${target_triple}" >> "$GITHUB_ENV"
 
     - name: Download binary artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: ${{ env.BINARY_ARTIFACT }}
         path: .snap-build/bin

--- a/.github/actions/snap-release/action.yml
+++ b/.github/actions/snap-release/action.yml
@@ -33,7 +33,7 @@ runs:
         echo "BINARY_ARTIFACT=reductstore-${target_triple}" >> "$GITHUB_ENV"
 
     - name: Download binary artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: ${{ env.BINARY_ARTIFACT }}
         path: .snap-build/bin

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: reductstore-tests-${{ inputs.target }}
         path: ./tmp/tests

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: reductstore-tests-${{ inputs.target }}
         path: ./tmp/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: ./.github/actions/build-binaries
         with:
           minimal_rust_version: ${{ vars.MINIMAL_RUST_VERSION }}
+          action_github_token: ${{ secrets.ACTION_GITHUB_TOKEN }}
           target: ${{ matrix.target }}
           os: ${{ matrix.os }}
           compiler: ${{ matrix.compiler }}
@@ -654,7 +655,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: ${{ vars.MINIMAL_RUST_VERSION }}
-      - uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
+      - uses: reductstore/setup-protoc@ac76da16b8e70736e159368a4bc962934d1f825a # master
         with:
           version: "3.x"
           repo-token: ${{ secrets.ACTION_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           image_tag: ${{ github.repository }}
 
       - name: Upload default image artifact (amd64)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: image
           path: /tmp/image.tar
@@ -431,12 +431,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download ${{ matrix.target }} artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: reductstore-${{ matrix.target }}
           path: /tmp/
       - name: Download ${{ matrix.target }} SBOM artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: reductstore-sbom-${{ matrix.target }}
           path: /tmp/
@@ -570,7 +570,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: digests-${{ matrix.digest }}
           path: /tmp/digests/
@@ -584,7 +584,7 @@ jobs:
       - push_image_dockerhub
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: digests-*
           path: /tmp/digests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           image_tag: ${{ github.repository }}
 
       - name: Upload default image artifact (amd64)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: image
           path: /tmp/image.tar
@@ -431,12 +431,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download ${{ matrix.target }} artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: reductstore-${{ matrix.target }}
           path: /tmp/
       - name: Download ${{ matrix.target }} SBOM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: reductstore-sbom-${{ matrix.target }}
           path: /tmp/
@@ -570,7 +570,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digests-${{ matrix.digest }}
           path: /tmp/digests/
@@ -584,7 +584,7 @@ jobs:
       - push_image_dockerhub
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: digests-*
           path: /tmp/digests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
       - uses: ./.github/actions/build-binaries
         with:
           minimal_rust_version: ${{ vars.MINIMAL_RUST_VERSION }}
-          action_github_token: ${{ secrets.ACTION_GITHUB_TOKEN }}
           target: ${{ matrix.target }}
           os: ${{ matrix.os }}
           compiler: ${{ matrix.compiler }}


### PR DESCRIPTION
## Summary
- bump `actions/download-artifact` from `v4` to `v5`
- bump `actions/upload-artifact` from `v4` to `v5`
- bump `actions/setup-python` from `v5` to `v6`

These action major versions are Node 24-compatible and address the warnings seen in run #25484337131.

## Scope
- `.github/workflows/ci.yml`
- reusable composite actions under `.github/actions/**`