### PR TITLE
Revert "1371 feature support schema attachments in formats beyond json (#1372)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support format-agnostic schema attachments in `$meta` entries by encoding non-JSON payloads as base64 strings during extension attachment resolution, while preserving native JSON parsing for JSON content types, [PR-1372](https://github.com/reductstore/reductstore/pull/1372)
 - Support object shorthand for unconditional `#ext` pipelines by expanding multi-extension objects into ordered execution steps, while keeping array-based pipeline syntax unchanged, [PR-1367](https://github.com/reductstore/reductstore/pull/1367)
 - Support strict extension pipelines in `#ext` directives with ordered step execution and backward compatibility for legacy `"#ext": { ... }` object format, [PR-1351](https://github.com/reductstore/reductstore/pull/1351)
 - Add `--version` (`-V`) CLI option to the `reductstore` server binary to print the version and exit successfully from shared launcher code, [PR-1343](https://github.com/reductstore/reductstore/pull/1343)

--- a/reductstore/src/ext/ext_repository.rs
+++ b/reductstore/src/ext/ext_repository.rs
@@ -11,8 +11,6 @@ use crate::storage::query::base::QueryOptions;
 use crate::storage::query::condition::{Parser, Value};
 use crate::storage::query::QueryRx;
 use async_trait::async_trait;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use base64::Engine;
 use dlopen2::wrapper::{Container, WrapperApi};
 use futures_util::StreamExt;
 use log::warn;
@@ -618,19 +616,15 @@ impl ExtRepository {
                 data.extend_from_slice(chunk.as_ref());
             }
 
-            let parsed = if Self::is_json_content_type(record.meta().content_type()) {
-                serde_json::from_slice::<serde_json::Value>(&data).map_err(|err| {
-                    unprocessable_entity!(
-                        "Meta attachment '${}' in '{}/{}' must be valid JSON: {}",
-                        ext_name,
-                        bucket_name,
-                        meta_name,
-                        err
-                    )
-                })?
-            } else {
-                serde_json::Value::String(BASE64_STANDARD.encode(&data))
-            };
+            let parsed = serde_json::from_slice::<serde_json::Value>(&data).map_err(|err| {
+                unprocessable_entity!(
+                    "Meta attachment '${}' in '{}/{}' must be valid JSON: {}",
+                    ext_name,
+                    bucket_name,
+                    meta_name,
+                    err
+                )
+            })?;
 
             attachments.insert(entry, parsed);
         }
@@ -659,13 +653,6 @@ impl ExtRepository {
                 .entry("attachments".to_string())
                 .or_insert(attachments);
         }
-    }
-
-    fn is_json_content_type(content_type: &str) -> bool {
-        let ct = content_type.split(';').next().unwrap_or("").trim();
-        ct.eq_ignore_ascii_case("application/json")
-            || ct.eq_ignore_ascii_case("text/json")
-            || ct.to_ascii_lowercase().ends_with("+json")
     }
 }
 
@@ -1208,7 +1195,6 @@ pub(super) mod tests {
             entry_name: &str,
             key: &str,
             payload: &'static [u8],
-            content_type: Option<&str>,
         ) {
             let bucket = storage
                 .get_bucket(bucket_name)
@@ -1221,7 +1207,7 @@ pub(super) mod tests {
                     entry_name,
                     1,
                     payload.len() as u64,
-                    content_type.unwrap_or("application/json").to_string(),
+                    "application/json".to_string(),
                     Labels::from_iter([("key".to_string(), key.to_string())]),
                 )
                 .await
@@ -1346,7 +1332,6 @@ pub(super) mod tests {
                 "entry/$meta",
                 "$another-ext",
                 br#"{"scale":100}"#,
-                None,
             )
             .await;
 
@@ -1368,15 +1353,7 @@ pub(super) mod tests {
                 .await
                 .unwrap();
 
-            write_meta_record(
-                &storage,
-                "bucket",
-                "entry/$meta",
-                "$test-ext",
-                b"not-json",
-                None,
-            )
-            .await;
+            write_meta_record(&storage, "bucket", "entry/$meta", "$test-ext", b"not-json").await;
 
             let repo = mocked_ext_repo_with_storage("test-ext", mock_ext, Some(storage));
             let err = repo
@@ -1404,7 +1381,6 @@ pub(super) mod tests {
                 "entry-a/$meta",
                 "$test-ext",
                 br#"{"topic":"/a"}"#,
-                None,
             )
             .await;
             write_meta_record(
@@ -1413,7 +1389,6 @@ pub(super) mod tests {
                 "entry-b/$meta",
                 "$test-ext",
                 br#"{"topic":"/b"}"#,
-                None,
             )
             .await;
 
@@ -1448,7 +1423,6 @@ pub(super) mod tests {
                 "entry-matched/$meta",
                 "$test-ext",
                 br#"{"topic":"/matched"}"#,
-                None,
             )
             .await;
             write_meta_record(
@@ -1457,7 +1431,6 @@ pub(super) mod tests {
                 "other/$meta",
                 "$test-ext",
                 br#"{"topic":"/other"}"#,
-                None,
             )
             .await;
             write_record(&storage, "bucket", "entry-no-meta").await;
@@ -1492,7 +1465,6 @@ pub(super) mod tests {
                 "entry-a/$meta",
                 "$test-ext",
                 br#"{"topic":"/a"}"#,
-                None,
             )
             .await;
             write_meta_record(
@@ -1501,7 +1473,6 @@ pub(super) mod tests {
                 "entry-b/$meta",
                 "$test-ext",
                 br#"{"topic":"/b"}"#,
-                None,
             )
             .await;
 
@@ -1519,70 +1490,6 @@ pub(super) mod tests {
                     "entry-b": {"topic": "/b"}
                 }))
             );
-        }
-
-        #[rstest]
-        #[case::protobuf(b"\x00\x01\x02\x03", "application/protobuf")]
-        #[case::yaml(b"schema:\n  version: 1\n  fields:\n    - name", "application/yaml")]
-        #[case::octet_stream(b"\xCA\xFE\xBA\xBE", "application/octet-stream")]
-        #[tokio::test(flavor = "multi_thread")]
-        async fn returns_base64_string_for_non_json_content_type(
-            mock_ext: MockIoExtension,
-            #[case] payload: &'static [u8],
-            #[case] content_type: &'static str,
-        ) {
-            let storage = create_storage().await;
-            storage
-                .create_bucket("bucket", BucketSettings::default())
-                .await
-                .unwrap();
-
-            write_meta_record(
-                &storage,
-                "bucket",
-                "entry/$meta",
-                "$test-ext",
-                payload,
-                Some(content_type),
-            )
-            .await;
-
-            let repo = mocked_ext_repo_with_storage("test-ext", mock_ext, Some(storage));
-            let result = repo
-                .get_ext_attachments("bucket", "entry", &QueryEntry::default(), "test-ext")
-                .await
-                .unwrap();
-
-            let expected = BASE64_STANDARD.encode(payload);
-            assert_eq!(result, Some(json!({"entry": expected})));
-        }
-
-        #[rstest]
-        #[tokio::test(flavor = "multi_thread")]
-        async fn parses_json_for_json_content_type_variants(mock_ext: MockIoExtension) {
-            let storage = create_storage().await;
-            storage
-                .create_bucket("bucket", BucketSettings::default())
-                .await
-                .unwrap();
-
-            write_meta_record(
-                &storage,
-                "bucket",
-                "entry/$meta",
-                "$test-ext",
-                br#"{"schema":"v1"}"#,
-                Some("application/schema+json"),
-            )
-            .await;
-
-            let repo = mocked_ext_repo_with_storage("test-ext", mock_ext, Some(storage));
-            let result = repo
-                .get_ext_attachments("bucket", "entry", &QueryEntry::default(), "test-ext")
-                .await
-                .unwrap();
-
-            assert_eq!(result, Some(json!({"entry": {"schema": "v1"}})));
         }
     }
 


### PR DESCRIPTION
Reverts reductstore/reductstore#1372 as requested.

This removes format-agnostic schema attachment handling for non-JSON payloads from the core server.

Related SDK/web-console follow-up reverts are being handled separately.