### PR TITLE
1011 http api bucket scoped lifecycle policies crud

### DIFF
--- a/.github/actions/aws-cargo-cache/action.yml
+++ b/.github/actions/aws-cargo-cache/action.yml
@@ -39,7 +39,6 @@ runs:
       uses: runs-on/cache@v4
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add HTTP CRUD endpoints for bucket-scoped lifecycle policies (`GET/POST/PUT/DELETE /api/v1/b/{bucket}/lifecycle-policies/{id}`), [PR-1382](https://github.com/reductstore/reductstore/pull/1382)
+- Add HTTP CRUD endpoints for lifecycle policies, [PR-1382](https://github.com/reductstore/reductstore/pull/1382)
 - Add lifecycle policy environment provisioning and background delete workers with structured lifecycle audit events, [PR-1376](https://github.com/reductstore/reductstore/pull/1376)
 - Support object shorthand for unconditional `#ext` pipelines by expanding multi-extension objects into ordered execution steps, while keeping array-based pipeline syntax unchanged, [PR-1367](https://github.com/reductstore/reductstore/pull/1367)
 - Support strict extension pipelines in `#ext` directives with ordered step execution and backward compatibility for legacy `"#ext": { ... }` object format, [PR-1351](https://github.com/reductstore/reductstore/pull/1351)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add HTTP CRUD endpoints for bucket-scoped lifecycle policies (`GET/POST/PUT/DELETE /api/v1/b/{bucket}/lifecycle-policies/{id}`), [PR-1382](https://github.com/reductstore/reductstore/pull/1382)
 - Add lifecycle policy environment provisioning and background delete workers with structured lifecycle audit events, [PR-1376](https://github.com/reductstore/reductstore/pull/1376)
 - Support object shorthand for unconditional `#ext` pipelines by expanding multi-extension objects into ordered execution steps, while keeping array-based pipeline syntax unchanged, [PR-1367](https://github.com/reductstore/reductstore/pull/1367)
 - Support strict extension pipelines in `#ext` directives with ordered step execution and backward compatibility for legacy `"#ext": { ... }` object format, [PR-1351](https://github.com/reductstore/reductstore/pull/1351)

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -28,8 +28,8 @@ use axum::{
 };
 use bucket::create_bucket_api_routes;
 use entry::create_entry_api_routes;
-use lifecycle::create_lifecycle_policy_api_routes;
 use hyper::http::HeaderValue;
+use lifecycle::create_lifecycle_policy_api_routes;
 use log::{error, warn};
 use middleware::{
     attach_client_ip, audit_requests, check_api_rate_limit, default_headers, print_statuses,

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -4,6 +4,7 @@
 mod bucket;
 mod entry;
 mod io;
+mod lifecycle;
 mod links;
 mod middleware;
 mod replication;
@@ -27,6 +28,7 @@ use axum::{
 };
 use bucket::create_bucket_api_routes;
 use entry::create_entry_api_routes;
+use lifecycle::create_lifecycle_policy_api_routes;
 use hyper::http::HeaderValue;
 use log::{error, warn};
 use middleware::{
@@ -212,7 +214,9 @@ impl AxumAppBuilder {
         }
 
         let cfg = self.cfg.unwrap();
-        let b_route = create_bucket_api_routes().merge(create_entry_api_routes());
+        let b_route = create_bucket_api_routes()
+            .merge(create_entry_api_routes())
+            .merge(create_lifecycle_policy_api_routes());
         let cors = Self::configure_cors(&cfg.cors_allow_origin);
         let state_keeper = Arc::new(StateKeeper::new(
             self.lc

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -214,9 +214,7 @@ impl AxumAppBuilder {
         }
 
         let cfg = self.cfg.unwrap();
-        let b_route = create_bucket_api_routes()
-            .merge(create_entry_api_routes())
-            .merge(create_lifecycle_policy_api_routes());
+        let b_route = create_bucket_api_routes().merge(create_entry_api_routes());
         let cors = Self::configure_cors(&cfg.cors_allow_origin);
         let state_keeper = Arc::new(StateKeeper::new(
             self.lc
@@ -243,6 +241,11 @@ impl AxumAppBuilder {
                 .nest(
                     &format!("{}api/v1/replications", cfg.api_base_path),
                     create_replication_api_routes(),
+                )
+                // Lifecycle API
+                .nest(
+                    &format!("{}api/v1/lifecycles", cfg.api_base_path),
+                    create_lifecycle_policy_api_routes(),
                 )
                 .nest(
                     &format!("{}api/v1/io", cfg.api_base_path),

--- a/reductstore/src/api/http/lifecycle.rs
+++ b/reductstore/src/api/http/lifecycle.rs
@@ -96,8 +96,10 @@ pub(super) fn create_lifecycle_policy_api_routes() -> axum::Router<Arc<StateKeep
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::http::tests::keeper;
     use reduct_base::msg::lifecycle_api::{LifecycleMode, LifecycleSettings};
     use rstest::fixture;
+    use std::sync::Arc;
 
     #[fixture]
     pub(super) fn settings() -> LifecycleSettings {
@@ -110,6 +112,21 @@ mod tests {
             mode: LifecycleMode::Enabled,
             ..LifecycleSettings::default()
         }
+    }
+
+    #[fixture]
+    pub(super) async fn keeper_with_policy(#[future] keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+        components
+            .lifecycle_repo
+            .write()
+            .await
+            .unwrap()
+            .create_lifecycle("test-policy", settings())
+            .await
+            .unwrap();
+        keeper
     }
 
     mod from_request {

--- a/reductstore/src/api/http/lifecycle.rs
+++ b/reductstore/src/api/http/lifecycle.rs
@@ -5,38 +5,35 @@ mod create;
 mod get;
 mod list;
 mod remove;
+mod set_mode;
 mod update;
 
 use crate::api::http::lifecycle::create::create_lifecycle_policy;
 use crate::api::http::lifecycle::get::get_lifecycle_policy;
 use crate::api::http::lifecycle::list::list_lifecycle_policies;
 use crate::api::http::lifecycle::remove::remove_lifecycle_policy;
+use crate::api::http::lifecycle::set_mode::set_mode;
 use crate::api::http::lifecycle::update::update_lifecycle_policy;
 use crate::api::http::{HttpError, StateKeeper};
 use axum::body::Body;
 use axum::extract::FromRequest;
 use axum::http::Request;
-use axum::routing::{delete, get, post, put};
+use axum::routing::{delete, get, patch, post, put};
 use axum_extra::headers::HeaderMapExt;
 use bytes::Bytes;
-use reduct_base::msg::lifecycle_api::{FullLifecycleInfo, LifecycleList};
+use reduct_base::msg::lifecycle_api::{
+    FullLifecycleInfo, LifecycleList, LifecycleModePayload, LifecycleSettings,
+};
 use reduct_macros::{IntoResponse, Twin};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(super) struct BucketLifecyclePolicyBody {
-    #[serde(default)]
-    pub entries: Vec<String>,
-    pub max_age: String,
-    #[serde(default)]
-    pub when: Option<serde_json::Value>,
-}
+#[derive(IntoResponse, Twin, Debug)]
+pub(super) struct LifecycleSettingsAxum(LifecycleSettings);
 
 #[derive(IntoResponse, Twin, Debug)]
-pub(super) struct BucketLifecyclePolicyBodyAxum(BucketLifecyclePolicyBody);
+pub(super) struct LifecycleModePayloadAxum(LifecycleModePayload);
 
-impl<S> FromRequest<S> for BucketLifecyclePolicyBodyAxum
+impl<S> FromRequest<S> for LifecycleModePayloadAxum
 where
     Bytes: FromRequest<S>,
     S: Send + Sync,
@@ -50,10 +47,33 @@ where
                 "Invalid body",
             )
         })?;
-        match serde_json::from_slice::<BucketLifecyclePolicyBody>(&*bytes) {
-            Ok(x) => Ok(BucketLifecyclePolicyBodyAxum::from(x)),
-            Err(e) => Err(e.into()),
-        }
+        let response = match serde_json::from_slice::<LifecycleModePayload>(&*bytes) {
+            Ok(x) => Ok(LifecycleModePayloadAxum::from(x)),
+            Err(e) => Err(crate::api::http::HttpError::from(e)),
+        };
+        response
+    }
+}
+
+impl<S> FromRequest<S> for LifecycleSettingsAxum
+where
+    Bytes: FromRequest<S>,
+    S: Send + Sync,
+{
+    type Rejection = HttpError;
+
+    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
+        let bytes = Bytes::from_request(req, state).await.map_err(|_| {
+            HttpError::new(
+                reduct_base::error::ErrorCode::UnprocessableEntity,
+                "Invalid body",
+            )
+        })?;
+        let response = match serde_json::from_slice::<LifecycleSettings>(&*bytes) {
+            Ok(x) => Ok(LifecycleSettingsAxum::from(x)),
+            Err(e) => Err(crate::api::http::HttpError::from(e)),
+        };
+        response
     }
 }
 
@@ -63,47 +83,32 @@ pub(super) struct LifecyclePolicyListAxum(LifecycleList);
 #[derive(IntoResponse, Twin, Debug)]
 pub(super) struct FullLifecyclePolicyInfoAxum(FullLifecycleInfo);
 
-#[derive(Deserialize)]
-pub(super) struct PolicyPath {
-    pub bucket_name: String,
-    pub policy_id: String,
-}
-
 pub(super) fn create_lifecycle_policy_api_routes() -> axum::Router<Arc<StateKeeper>> {
     axum::Router::new()
-        .route(
-            "/{bucket_name}/lifecycle-policies",
-            get(list_lifecycle_policies),
-        )
-        .route(
-            "/{bucket_name}/lifecycle-policies/{policy_id}",
-            post(create_lifecycle_policy),
-        )
-        .route(
-            "/{bucket_name}/lifecycle-policies/{policy_id}",
-            get(get_lifecycle_policy),
-        )
-        .route(
-            "/{bucket_name}/lifecycle-policies/{policy_id}",
-            put(update_lifecycle_policy),
-        )
-        .route(
-            "/{bucket_name}/lifecycle-policies/{policy_id}",
-            delete(remove_lifecycle_policy),
-        )
+        .route("/", get(list_lifecycle_policies))
+        .route("/{policy_name}", get(get_lifecycle_policy))
+        .route("/{policy_name}", post(create_lifecycle_policy))
+        .route("/{policy_name}", put(update_lifecycle_policy))
+        .route("/{policy_name}/mode", patch(set_mode))
+        .route("/{policy_name}", delete(remove_lifecycle_policy))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reduct_base::msg::lifecycle_api::{LifecycleMode, LifecycleSettings};
     use rstest::fixture;
 
     #[fixture]
-    pub(super) fn policy_body() -> BucketLifecyclePolicyBody {
-        BucketLifecyclePolicyBody {
+    pub(super) fn settings() -> LifecycleSettings {
+        LifecycleSettings {
+            bucket: "bucket-1".to_string(),
             entries: vec![],
             max_age: "1d".to_string(),
+            interval: "1h".to_string(),
             when: None,
+            mode: LifecycleMode::Enabled,
+            ..LifecycleSettings::default()
         }
     }
 
@@ -119,20 +124,19 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_body_ok() {
-            let json = r#"{"entries":["sensors/*"],"max_age":"P30D"}"#;
+        async fn test_settings_ok() {
+            let json = r#"{"bucket":"bucket-1","entries":["sensors/*"],"max_age":"P30D"}"#;
             let req = Request::builder().body(Body::from(json)).unwrap();
-            let body = BucketLifecyclePolicyBodyAxum::from_request(req, &())
-                .await
-                .unwrap();
+            let body = LifecycleSettingsAxum::from_request(req, &()).await.unwrap();
             assert_eq!(body.0.max_age, "P30D");
+            assert_eq!(body.0.interval, "3600s");
         }
 
         #[rstest]
         #[tokio::test]
-        async fn test_body_invalid_json() {
+        async fn test_settings_invalid_json() {
             let req = Request::builder().body(Body::from("{bad")).unwrap();
-            let err = BucketLifecyclePolicyBodyAxum::from_request(req, &())
+            let err = LifecycleSettingsAxum::from_request(req, &())
                 .await
                 .unwrap_err();
             assert_eq!(err.status(), UnprocessableEntity);
@@ -140,14 +144,53 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_body_stream_error() {
+        async fn test_settings_stream_error() {
             let stream = stream::once(async {
                 Err::<Bytes, _>(io::Error::new(io::ErrorKind::Other, "boom"))
             });
             let req = Request::builder().body(Body::from_stream(stream)).unwrap();
-            let err = BucketLifecyclePolicyBodyAxum::from_request(req, &())
+            let err = LifecycleSettingsAxum::from_request(req, &())
                 .await
                 .unwrap_err();
+            assert_eq!(err.status(), UnprocessableEntity);
+            assert_eq!(err.message(), "Invalid body");
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_mode_payload_ok() {
+            let req = Request::builder()
+                .body(Body::from(r#"{"mode":"disabled"}"#))
+                .unwrap();
+
+            let payload = LifecycleModePayloadAxum::from_request(req, &())
+                .await
+                .expect("parse payload");
+            assert_eq!(payload.0.mode, LifecycleMode::Disabled);
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_mode_payload_invalid_json() {
+            let req = Request::builder().body(Body::from("{bad json")).unwrap();
+
+            let err = LifecycleModePayloadAxum::from_request(req, &())
+                .await
+                .expect_err("should fail");
+            assert_eq!(err.status(), UnprocessableEntity);
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_mode_payload_body_error() {
+            let stream = stream::once(async {
+                Err::<Bytes, _>(io::Error::new(io::ErrorKind::Other, "boom"))
+            });
+            let req = Request::builder().body(Body::from_stream(stream)).unwrap();
+
+            let err = LifecycleModePayloadAxum::from_request(req, &())
+                .await
+                .expect_err("should fail");
             assert_eq!(err.status(), UnprocessableEntity);
             assert_eq!(err.message(), "Invalid body");
         }

--- a/reductstore/src/api/http/lifecycle.rs
+++ b/reductstore/src/api/http/lifecycle.rs
@@ -1,0 +1,155 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+mod create;
+mod get;
+mod list;
+mod remove;
+mod update;
+
+use crate::api::http::lifecycle::create::create_lifecycle_policy;
+use crate::api::http::lifecycle::get::get_lifecycle_policy;
+use crate::api::http::lifecycle::list::list_lifecycle_policies;
+use crate::api::http::lifecycle::remove::remove_lifecycle_policy;
+use crate::api::http::lifecycle::update::update_lifecycle_policy;
+use crate::api::http::{HttpError, StateKeeper};
+use axum::body::Body;
+use axum::extract::FromRequest;
+use axum::http::Request;
+use axum::routing::{delete, get, post, put};
+use axum_extra::headers::HeaderMapExt;
+use bytes::Bytes;
+use reduct_base::msg::lifecycle_api::{FullLifecycleInfo, LifecycleList};
+use reduct_macros::{IntoResponse, Twin};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(super) struct BucketLifecyclePolicyBody {
+    #[serde(default)]
+    pub entries: Vec<String>,
+    pub max_age: String,
+    #[serde(default)]
+    pub when: Option<serde_json::Value>,
+}
+
+#[derive(IntoResponse, Twin, Debug)]
+pub(super) struct BucketLifecyclePolicyBodyAxum(BucketLifecyclePolicyBody);
+
+impl<S> FromRequest<S> for BucketLifecyclePolicyBodyAxum
+where
+    Bytes: FromRequest<S>,
+    S: Send + Sync,
+{
+    type Rejection = HttpError;
+
+    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
+        let bytes = Bytes::from_request(req, state).await.map_err(|_| {
+            HttpError::new(
+                reduct_base::error::ErrorCode::UnprocessableEntity,
+                "Invalid body",
+            )
+        })?;
+        match serde_json::from_slice::<BucketLifecyclePolicyBody>(&*bytes) {
+            Ok(x) => Ok(BucketLifecyclePolicyBodyAxum::from(x)),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[derive(IntoResponse, Twin, Default)]
+pub(super) struct LifecyclePolicyListAxum(LifecycleList);
+
+#[derive(IntoResponse, Twin, Debug)]
+pub(super) struct FullLifecyclePolicyInfoAxum(FullLifecycleInfo);
+
+#[derive(Deserialize)]
+pub(super) struct PolicyPath {
+    pub bucket_name: String,
+    pub policy_id: String,
+}
+
+pub(super) fn create_lifecycle_policy_api_routes() -> axum::Router<Arc<StateKeeper>> {
+    axum::Router::new()
+        .route(
+            "/{bucket_name}/lifecycle-policies",
+            get(list_lifecycle_policies),
+        )
+        .route(
+            "/{bucket_name}/lifecycle-policies/{policy_id}",
+            post(create_lifecycle_policy),
+        )
+        .route(
+            "/{bucket_name}/lifecycle-policies/{policy_id}",
+            get(get_lifecycle_policy),
+        )
+        .route(
+            "/{bucket_name}/lifecycle-policies/{policy_id}",
+            put(update_lifecycle_policy),
+        )
+        .route(
+            "/{bucket_name}/lifecycle-policies/{policy_id}",
+            delete(remove_lifecycle_policy),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::fixture;
+
+    #[fixture]
+    pub(super) fn policy_body() -> BucketLifecyclePolicyBody {
+        BucketLifecyclePolicyBody {
+            entries: vec![],
+            max_age: "1d".to_string(),
+            when: None,
+        }
+    }
+
+    mod from_request {
+        use super::*;
+        use axum::body::Body;
+        use axum::extract::FromRequest;
+        use axum::http::Request;
+        use futures_util::stream;
+        use reduct_base::error::ErrorCode::UnprocessableEntity;
+        use rstest::rstest;
+        use std::io;
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_body_ok() {
+            let json = r#"{"entries":["sensors/*"],"max_age":"P30D"}"#;
+            let req = Request::builder().body(Body::from(json)).unwrap();
+            let body = BucketLifecyclePolicyBodyAxum::from_request(req, &())
+                .await
+                .unwrap();
+            assert_eq!(body.0.max_age, "P30D");
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_body_invalid_json() {
+            let req = Request::builder().body(Body::from("{bad")).unwrap();
+            let err = BucketLifecyclePolicyBodyAxum::from_request(req, &())
+                .await
+                .unwrap_err();
+            assert_eq!(err.status(), UnprocessableEntity);
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_body_stream_error() {
+            let stream = stream::once(async {
+                Err::<Bytes, _>(io::Error::new(io::ErrorKind::Other, "boom"))
+            });
+            let req = Request::builder().body(Body::from_stream(stream)).unwrap();
+            let err = BucketLifecyclePolicyBodyAxum::from_request(req, &())
+                .await
+                .unwrap_err();
+            assert_eq!(err.status(), UnprocessableEntity);
+            assert_eq!(err.message(), "Invalid body");
+        }
+    }
+}

--- a/reductstore/src/api/http/lifecycle/create.rs
+++ b/reductstore/src/api/http/lifecycle/create.rs
@@ -30,7 +30,7 @@ pub(super) async fn create_lifecycle_policy(
         "max_age": body.max_age,
         "when": body.when,
     }))
-    .map_err(HttpError::from)?;
+    ?;
     components
         .lifecycle_repo
         .write()

--- a/reductstore/src/api/http/lifecycle/create.rs
+++ b/reductstore/src/api/http/lifecycle/create.rs
@@ -29,8 +29,7 @@ pub(super) async fn create_lifecycle_policy(
         "entries": body.entries,
         "max_age": body.max_age,
         "when": body.when,
-    }))
-    ?;
+    }))?;
     components
         .lifecycle_repo
         .write()
@@ -144,5 +143,4 @@ mod tests {
             .unwrap();
         assert_eq!(settings.interval, "3600s");
     }
-
 }

--- a/reductstore/src/api/http/lifecycle/create.rs
+++ b/reductstore/src/api/http/lifecycle/create.rs
@@ -1,0 +1,148 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::api::http::lifecycle::{BucketLifecyclePolicyBodyAxum, PolicyPath};
+use crate::api::http::{HttpError, StateKeeper};
+use crate::auth::policy::FullAccessPolicy;
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use reduct_base::msg::lifecycle_api::LifecycleSettings;
+use serde_json::json;
+use std::sync::Arc;
+
+// POST /b/:bucket_name/lifecycle-policies/:policy_id
+pub(super) async fn create_lifecycle_policy(
+    State(keeper): State<Arc<StateKeeper>>,
+    Path(PolicyPath {
+        bucket_name,
+        policy_id,
+    }): Path<PolicyPath>,
+    headers: HeaderMap,
+    body: BucketLifecyclePolicyBodyAxum,
+) -> Result<(), HttpError> {
+    let components = keeper
+        .get_with_permissions(&headers, FullAccessPolicy {})
+        .await?;
+    let body = body.0;
+    let settings: LifecycleSettings = serde_json::from_value(json!({
+        "bucket": bucket_name,
+        "entries": body.entries,
+        "max_age": body.max_age,
+        "when": body.when,
+    }))
+    .map_err(HttpError::from)?;
+    components
+        .lifecycle_repo
+        .write()
+        .await?
+        .create_lifecycle(&policy_id, settings)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::http::lifecycle::tests::policy_body;
+    use crate::api::http::lifecycle::BucketLifecyclePolicyBody;
+    use crate::api::http::tests::{headers, keeper};
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
+        Path(PolicyPath {
+            bucket_name: bucket.to_string(),
+            policy_id: policy.to_string(),
+        })
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_create_ok(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+        policy_body: BucketLifecyclePolicyBody,
+    ) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        create_lifecycle_policy(
+            State(Arc::clone(&keeper)),
+            policy_path("bucket-1", "test-policy"),
+            headers,
+            BucketLifecyclePolicyBodyAxum::from(policy_body),
+        )
+        .await
+        .unwrap();
+
+        assert!(components
+            .lifecycle_repo
+            .read()
+            .await
+            .unwrap()
+            .get_info("test-policy")
+            .await
+            .is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_create_sets_bucket(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+        policy_body: BucketLifecyclePolicyBody,
+    ) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        create_lifecycle_policy(
+            State(Arc::clone(&keeper)),
+            policy_path("bucket-1", "test-policy"),
+            headers,
+            BucketLifecyclePolicyBodyAxum::from(policy_body),
+        )
+        .await
+        .unwrap();
+
+        let settings = components
+            .lifecycle_repo
+            .read()
+            .await
+            .unwrap()
+            .get_lifecycle_settings("test-policy")
+            .await
+            .unwrap();
+        assert_eq!(settings.bucket, "bucket-1");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_create_default_interval(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+        policy_body: BucketLifecyclePolicyBody,
+    ) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        create_lifecycle_policy(
+            State(Arc::clone(&keeper)),
+            policy_path("bucket-1", "test-policy"),
+            headers,
+            BucketLifecyclePolicyBodyAxum::from(policy_body),
+        )
+        .await
+        .unwrap();
+
+        let settings = components
+            .lifecycle_repo
+            .read()
+            .await
+            .unwrap()
+            .get_lifecycle_settings("test-policy")
+            .await
+            .unwrap();
+        assert_eq!(settings.interval, "3600s");
+    }
+
+}

--- a/reductstore/src/api/http/lifecycle/create.rs
+++ b/reductstore/src/api/http/lifecycle/create.rs
@@ -1,40 +1,28 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use crate::api::http::lifecycle::{BucketLifecyclePolicyBodyAxum, PolicyPath};
+use crate::api::http::lifecycle::LifecycleSettingsAxum;
 use crate::api::http::{HttpError, StateKeeper};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::http::HeaderMap;
-use reduct_base::msg::lifecycle_api::LifecycleSettings;
-use serde_json::json;
 use std::sync::Arc;
 
-// POST /b/:bucket_name/lifecycle-policies/:policy_id
+// POST /api/v1/lifecycles/:policy_name
 pub(super) async fn create_lifecycle_policy(
     State(keeper): State<Arc<StateKeeper>>,
-    Path(PolicyPath {
-        bucket_name,
-        policy_id,
-    }): Path<PolicyPath>,
+    Path(policy_name): Path<String>,
     headers: HeaderMap,
-    body: BucketLifecyclePolicyBodyAxum,
+    settings: LifecycleSettingsAxum,
 ) -> Result<(), HttpError> {
     let components = keeper
         .get_with_permissions(&headers, FullAccessPolicy {})
         .await?;
-    let body = body.0;
-    let settings: LifecycleSettings = serde_json::from_value(json!({
-        "bucket": bucket_name,
-        "entries": body.entries,
-        "max_age": body.max_age,
-        "when": body.when,
-    }))?;
     components
         .lifecycle_repo
         .write()
         .await?
-        .create_lifecycle(&policy_id, settings)
+        .create_lifecycle(&policy_name, settings.into())
         .await?;
     Ok(())
 }
@@ -42,34 +30,27 @@ pub(super) async fn create_lifecycle_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::http::lifecycle::tests::policy_body;
-    use crate::api::http::lifecycle::BucketLifecyclePolicyBody;
+    use crate::api::http::lifecycle::tests::settings;
     use crate::api::http::tests::{headers, keeper};
+    use reduct_base::msg::lifecycle_api::LifecycleSettings;
     use rstest::rstest;
     use std::sync::Arc;
-
-    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
-        Path(PolicyPath {
-            bucket_name: bucket.to_string(),
-            policy_id: policy.to_string(),
-        })
-    }
 
     #[rstest]
     #[tokio::test]
     async fn test_create_ok(
         #[future] keeper: Arc<StateKeeper>,
         headers: HeaderMap,
-        policy_body: BucketLifecyclePolicyBody,
+        settings: LifecycleSettings,
     ) {
         let keeper = keeper.await;
         let components = keeper.get_anonymous().await.unwrap();
 
         create_lifecycle_policy(
             State(Arc::clone(&keeper)),
-            policy_path("bucket-1", "test-policy"),
+            Path("test-policy".to_string()),
             headers,
-            BucketLifecyclePolicyBodyAxum::from(policy_body),
+            LifecycleSettingsAxum::from(settings),
         )
         .await
         .unwrap();
@@ -89,16 +70,17 @@ mod tests {
     async fn test_create_sets_bucket(
         #[future] keeper: Arc<StateKeeper>,
         headers: HeaderMap,
-        policy_body: BucketLifecyclePolicyBody,
+        mut settings: LifecycleSettings,
     ) {
         let keeper = keeper.await;
         let components = keeper.get_anonymous().await.unwrap();
+        settings.bucket = "bucket-2".to_string();
 
         create_lifecycle_policy(
             State(Arc::clone(&keeper)),
-            policy_path("bucket-1", "test-policy"),
+            Path("test-policy".to_string()),
             headers,
-            BucketLifecyclePolicyBodyAxum::from(policy_body),
+            LifecycleSettingsAxum::from(settings),
         )
         .await
         .unwrap();
@@ -111,36 +93,26 @@ mod tests {
             .get_lifecycle_settings("test-policy")
             .await
             .unwrap();
-        assert_eq!(settings.bucket, "bucket-1");
+        assert_eq!(settings.bucket, "bucket-2");
     }
 
     #[rstest]
     #[tokio::test]
-    async fn test_create_default_interval(
+    async fn test_create_invalid_bucket(
         #[future] keeper: Arc<StateKeeper>,
         headers: HeaderMap,
-        policy_body: BucketLifecyclePolicyBody,
+        mut settings: LifecycleSettings,
     ) {
-        let keeper = keeper.await;
-        let components = keeper.get_anonymous().await.unwrap();
+        settings.bucket = "no-such-bucket".to_string();
 
-        create_lifecycle_policy(
-            State(Arc::clone(&keeper)),
-            policy_path("bucket-1", "test-policy"),
+        let result = create_lifecycle_policy(
+            State(keeper.await),
+            Path("test-policy".to_string()),
             headers,
-            BucketLifecyclePolicyBodyAxum::from(policy_body),
+            LifecycleSettingsAxum::from(settings),
         )
-        .await
-        .unwrap();
+        .await;
 
-        let settings = components
-            .lifecycle_repo
-            .read()
-            .await
-            .unwrap()
-            .get_lifecycle_settings("test-policy")
-            .await
-            .unwrap();
-        assert_eq!(settings.interval, "3600s");
+        assert!(result.is_err());
     }
 }

--- a/reductstore/src/api/http/lifecycle/get.rs
+++ b/reductstore/src/api/http/lifecycle/get.rs
@@ -30,37 +30,16 @@ pub(super) async fn get_lifecycle_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::http::lifecycle::tests::keeper_with_policy;
     use crate::api::http::tests::{headers, keeper};
     use reduct_base::error::ErrorCode::NotFound;
-    use reduct_base::msg::lifecycle_api::LifecycleSettings;
     use rstest::rstest;
     use std::sync::Arc;
 
-    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
-        let components = keeper.get_anonymous().await.unwrap();
-        components
-            .lifecycle_repo
-            .write()
-            .await
-            .unwrap()
-            .create_lifecycle(
-                "test-policy",
-                LifecycleSettings {
-                    bucket: "bucket-1".to_string(),
-                    max_age: "1d".to_string(),
-                    interval: "1h".to_string(),
-                    ..LifecycleSettings::default()
-                },
-            )
-            .await
-            .unwrap();
-        keeper
-    }
-
     #[rstest]
     #[tokio::test]
-    async fn test_get_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
-        let keeper = make_keeper_with_policy(keeper.await).await;
+    async fn test_get_ok(#[future] keeper_with_policy: Arc<StateKeeper>, headers: HeaderMap) {
+        let keeper = keeper_with_policy.await;
         let info = get_lifecycle_policy(State(keeper), Path("test-policy".to_string()), headers)
             .await
             .unwrap()

--- a/reductstore/src/api/http/lifecycle/get.rs
+++ b/reductstore/src/api/http/lifecycle/get.rs
@@ -95,5 +95,4 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.status(), NotFound);
     }
-
 }

--- a/reductstore/src/api/http/lifecycle/get.rs
+++ b/reductstore/src/api/http/lifecycle/get.rs
@@ -1,20 +1,17 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use crate::api::http::lifecycle::{FullLifecyclePolicyInfoAxum, PolicyPath};
+use crate::api::http::lifecycle::FullLifecyclePolicyInfoAxum;
 use crate::api::http::{HttpError, StateKeeper};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::http::HeaderMap;
 use std::sync::Arc;
 
-// GET /b/:bucket_name/lifecycle-policies/:policy_id
+// GET /api/v1/lifecycles/:policy_name
 pub(super) async fn get_lifecycle_policy(
     State(keeper): State<Arc<StateKeeper>>,
-    Path(PolicyPath {
-        bucket_name: _,
-        policy_id,
-    }): Path<PolicyPath>,
+    Path(policy_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<FullLifecyclePolicyInfoAxum, HttpError> {
     let components = keeper
@@ -25,7 +22,7 @@ pub(super) async fn get_lifecycle_policy(
         .lifecycle_repo
         .read()
         .await?
-        .get_info(&policy_id)
+        .get_info(&policy_name)
         .await?;
     Ok(info.into())
 }
@@ -60,25 +57,14 @@ mod tests {
         keeper
     }
 
-    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
-        Path(PolicyPath {
-            bucket_name: bucket.to_string(),
-            policy_id: policy.to_string(),
-        })
-    }
-
     #[rstest]
     #[tokio::test]
     async fn test_get_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
         let keeper = make_keeper_with_policy(keeper.await).await;
-        let info = get_lifecycle_policy(
-            State(keeper),
-            policy_path("bucket-1", "test-policy"),
-            headers,
-        )
-        .await
-        .unwrap()
-        .0;
+        let info = get_lifecycle_policy(State(keeper), Path("test-policy".to_string()), headers)
+            .await
+            .unwrap()
+            .0;
         assert_eq!(info.info.name, "test-policy");
         assert_eq!(info.settings.bucket, "bucket-1");
     }
@@ -88,7 +74,7 @@ mod tests {
     async fn test_get_not_found(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
         let err = get_lifecycle_policy(
             State(keeper.await),
-            policy_path("bucket-1", "no-such-policy"),
+            Path("no-such-policy".to_string()),
             headers,
         )
         .await

--- a/reductstore/src/api/http/lifecycle/get.rs
+++ b/reductstore/src/api/http/lifecycle/get.rs
@@ -1,0 +1,99 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::api::http::lifecycle::{FullLifecyclePolicyInfoAxum, PolicyPath};
+use crate::api::http::{HttpError, StateKeeper};
+use crate::auth::policy::FullAccessPolicy;
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use std::sync::Arc;
+
+// GET /b/:bucket_name/lifecycle-policies/:policy_id
+pub(super) async fn get_lifecycle_policy(
+    State(keeper): State<Arc<StateKeeper>>,
+    Path(PolicyPath {
+        bucket_name: _,
+        policy_id,
+    }): Path<PolicyPath>,
+    headers: HeaderMap,
+) -> Result<FullLifecyclePolicyInfoAxum, HttpError> {
+    let components = keeper
+        .get_with_permissions(&headers, FullAccessPolicy {})
+        .await?;
+
+    let info = components
+        .lifecycle_repo
+        .read()
+        .await?
+        .get_info(&policy_id)
+        .await?;
+    Ok(info.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::http::tests::{headers, keeper};
+    use reduct_base::error::ErrorCode::NotFound;
+    use reduct_base::msg::lifecycle_api::LifecycleSettings;
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
+        let components = keeper.get_anonymous().await.unwrap();
+        components
+            .lifecycle_repo
+            .write()
+            .await
+            .unwrap()
+            .create_lifecycle(
+                "test-policy",
+                LifecycleSettings {
+                    bucket: "bucket-1".to_string(),
+                    max_age: "1d".to_string(),
+                    interval: "1h".to_string(),
+                    ..LifecycleSettings::default()
+                },
+            )
+            .await
+            .unwrap();
+        keeper
+    }
+
+    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
+        Path(PolicyPath {
+            bucket_name: bucket.to_string(),
+            policy_id: policy.to_string(),
+        })
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let keeper = make_keeper_with_policy(keeper.await).await;
+        let info = get_lifecycle_policy(
+            State(keeper),
+            policy_path("bucket-1", "test-policy"),
+            headers,
+        )
+        .await
+        .unwrap()
+        .0;
+        assert_eq!(info.info.name, "test-policy");
+        assert_eq!(info.settings.bucket, "bucket-1");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_not_found(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let err = get_lifecycle_policy(
+            State(keeper.await),
+            policy_path("bucket-1", "no-such-policy"),
+            headers,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status(), NotFound);
+    }
+
+}

--- a/reductstore/src/api/http/lifecycle/list.rs
+++ b/reductstore/src/api/http/lifecycle/list.rs
@@ -1,0 +1,106 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::api::http::lifecycle::LifecyclePolicyListAxum;
+use crate::api::http::{HttpError, StateKeeper};
+use crate::auth::policy::FullAccessPolicy;
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use std::sync::Arc;
+
+// GET /b/:bucket_name/lifecycle-policies
+pub(super) async fn list_lifecycle_policies(
+    State(keeper): State<Arc<StateKeeper>>,
+    Path(bucket_name): Path<String>,
+    headers: HeaderMap,
+) -> Result<LifecyclePolicyListAxum, HttpError> {
+    let components = keeper
+        .get_with_permissions(&headers, FullAccessPolicy {})
+        .await?;
+
+    let mut list = LifecyclePolicyListAxum::default();
+    for policy_info in components
+        .lifecycle_repo
+        .read()
+        .await?
+        .lifecycles()
+        .await?
+    {
+        if components
+            .lifecycle_repo
+            .read()
+            .await?
+            .get_lifecycle_settings(&policy_info.name)
+            .await?
+            .bucket
+            == bucket_name
+        {
+            list.0.lifecycles.push(policy_info);
+        }
+    }
+
+    Ok(list)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::http::tests::{headers, keeper};
+    use reduct_base::msg::lifecycle_api::LifecycleSettings;
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
+        let components = keeper.get_anonymous().await.unwrap();
+        components
+            .lifecycle_repo
+            .write()
+            .await
+            .unwrap()
+            .create_lifecycle(
+                "test-policy",
+                LifecycleSettings {
+                    bucket: "bucket-1".to_string(),
+                    max_age: "1d".to_string(),
+                    interval: "1h".to_string(),
+                    ..LifecycleSettings::default()
+                },
+            )
+            .await
+            .unwrap();
+        keeper
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_list_empty(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let list = list_lifecycle_policies(State(keeper.await), Path("bucket-1".to_string()), headers)
+            .await
+            .unwrap()
+            .0;
+        assert_eq!(list.lifecycles.len(), 0);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_list_with_policy(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let keeper = make_keeper_with_policy(keeper.await).await;
+        let list = list_lifecycle_policies(State(keeper), Path("bucket-1".to_string()), headers)
+            .await
+            .unwrap()
+            .0;
+        assert_eq!(list.lifecycles.len(), 1);
+        assert_eq!(list.lifecycles[0].name, "test-policy");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_list_filters_by_bucket(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let keeper = make_keeper_with_policy(keeper.await).await;
+        let list = list_lifecycle_policies(State(keeper), Path("bucket-2".to_string()), headers)
+            .await
+            .unwrap()
+            .0;
+        assert_eq!(list.lifecycles.len(), 0);
+    }
+}

--- a/reductstore/src/api/http/lifecycle/list.rs
+++ b/reductstore/src/api/http/lifecycle/list.rs
@@ -19,13 +19,7 @@ pub(super) async fn list_lifecycle_policies(
         .await?;
 
     let mut list = LifecyclePolicyListAxum::default();
-    for policy_info in components
-        .lifecycle_repo
-        .read()
-        .await?
-        .lifecycles()
-        .await?
-    {
+    for policy_info in components.lifecycle_repo.read().await?.lifecycles().await? {
         if components
             .lifecycle_repo
             .read()
@@ -74,10 +68,11 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_list_empty(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
-        let list = list_lifecycle_policies(State(keeper.await), Path("bucket-1".to_string()), headers)
-            .await
-            .unwrap()
-            .0;
+        let list =
+            list_lifecycle_policies(State(keeper.await), Path("bucket-1".to_string()), headers)
+                .await
+                .unwrap()
+                .0;
         assert_eq!(list.lifecycles.len(), 0);
     }
 

--- a/reductstore/src/api/http/lifecycle/list.rs
+++ b/reductstore/src/api/http/lifecycle/list.rs
@@ -28,31 +28,10 @@ pub(super) async fn list_lifecycle_policies(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::http::lifecycle::tests::keeper_with_policy;
     use crate::api::http::tests::{headers, keeper};
-    use reduct_base::msg::lifecycle_api::LifecycleSettings;
     use rstest::rstest;
     use std::sync::Arc;
-
-    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
-        let components = keeper.get_anonymous().await.unwrap();
-        components
-            .lifecycle_repo
-            .write()
-            .await
-            .unwrap()
-            .create_lifecycle(
-                "test-policy",
-                LifecycleSettings {
-                    bucket: "bucket-1".to_string(),
-                    max_age: "1d".to_string(),
-                    interval: "1h".to_string(),
-                    ..LifecycleSettings::default()
-                },
-            )
-            .await
-            .unwrap();
-        keeper
-    }
 
     #[rstest]
     #[tokio::test]
@@ -66,8 +45,11 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_list_with_policy(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
-        let keeper = make_keeper_with_policy(keeper.await).await;
+    async fn test_list_with_policy(
+        #[future] keeper_with_policy: Arc<StateKeeper>,
+        headers: HeaderMap,
+    ) {
+        let keeper = keeper_with_policy.await;
         let list = list_lifecycle_policies(State(keeper), headers)
             .await
             .unwrap()

--- a/reductstore/src/api/http/lifecycle/list.rs
+++ b/reductstore/src/api/http/lifecycle/list.rs
@@ -4,14 +4,13 @@
 use crate::api::http::lifecycle::LifecyclePolicyListAxum;
 use crate::api::http::{HttpError, StateKeeper};
 use crate::auth::policy::FullAccessPolicy;
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::HeaderMap;
 use std::sync::Arc;
 
-// GET /b/:bucket_name/lifecycle-policies
+// GET /api/v1/lifecycles
 pub(super) async fn list_lifecycle_policies(
     State(keeper): State<Arc<StateKeeper>>,
-    Path(bucket_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<LifecyclePolicyListAxum, HttpError> {
     let components = keeper
@@ -20,17 +19,7 @@ pub(super) async fn list_lifecycle_policies(
 
     let mut list = LifecyclePolicyListAxum::default();
     for policy_info in components.lifecycle_repo.read().await?.lifecycles().await? {
-        if components
-            .lifecycle_repo
-            .read()
-            .await?
-            .get_lifecycle_settings(&policy_info.name)
-            .await?
-            .bucket
-            == bucket_name
-        {
-            list.0.lifecycles.push(policy_info);
-        }
+        list.0.lifecycles.push(policy_info);
     }
 
     Ok(list)
@@ -68,11 +57,10 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_list_empty(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
-        let list =
-            list_lifecycle_policies(State(keeper.await), Path("bucket-1".to_string()), headers)
-                .await
-                .unwrap()
-                .0;
+        let list = list_lifecycle_policies(State(keeper.await), headers)
+            .await
+            .unwrap()
+            .0;
         assert_eq!(list.lifecycles.len(), 0);
     }
 
@@ -80,22 +68,11 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_policy(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
         let keeper = make_keeper_with_policy(keeper.await).await;
-        let list = list_lifecycle_policies(State(keeper), Path("bucket-1".to_string()), headers)
+        let list = list_lifecycle_policies(State(keeper), headers)
             .await
             .unwrap()
             .0;
         assert_eq!(list.lifecycles.len(), 1);
         assert_eq!(list.lifecycles[0].name, "test-policy");
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_list_filters_by_bucket(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
-        let keeper = make_keeper_with_policy(keeper.await).await;
-        let list = list_lifecycle_policies(State(keeper), Path("bucket-2".to_string()), headers)
-            .await
-            .unwrap()
-            .0;
-        assert_eq!(list.lifecycles.len(), 0);
     }
 }

--- a/reductstore/src/api/http/lifecycle/remove.rs
+++ b/reductstore/src/api/http/lifecycle/remove.rs
@@ -29,37 +29,16 @@ pub(super) async fn remove_lifecycle_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::http::lifecycle::tests::keeper_with_policy;
     use crate::api::http::tests::{headers, keeper};
     use reduct_base::error::ErrorCode::NotFound;
-    use reduct_base::msg::lifecycle_api::LifecycleSettings;
     use rstest::rstest;
     use std::sync::Arc;
 
-    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
-        let components = keeper.get_anonymous().await.unwrap();
-        components
-            .lifecycle_repo
-            .write()
-            .await
-            .unwrap()
-            .create_lifecycle(
-                "test-policy",
-                LifecycleSettings {
-                    bucket: "bucket-1".to_string(),
-                    max_age: "1d".to_string(),
-                    interval: "1h".to_string(),
-                    ..LifecycleSettings::default()
-                },
-            )
-            .await
-            .unwrap();
-        keeper
-    }
-
     #[rstest]
     #[tokio::test]
-    async fn test_remove_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
-        let keeper = make_keeper_with_policy(keeper.await).await;
+    async fn test_remove_ok(#[future] keeper_with_policy: Arc<StateKeeper>, headers: HeaderMap) {
+        let keeper = keeper_with_policy.await;
         let components = keeper.get_anonymous().await.unwrap();
 
         remove_lifecycle_policy(

--- a/reductstore/src/api/http/lifecycle/remove.rs
+++ b/reductstore/src/api/http/lifecycle/remove.rs
@@ -1,20 +1,16 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use crate::api::http::lifecycle::PolicyPath;
 use crate::api::http::{HttpError, StateKeeper};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::http::HeaderMap;
 use std::sync::Arc;
 
-// DELETE /b/:bucket_name/lifecycle-policies/:policy_id
+// DELETE /api/v1/lifecycles/:policy_name
 pub(super) async fn remove_lifecycle_policy(
     State(keeper): State<Arc<StateKeeper>>,
-    Path(PolicyPath {
-        bucket_name: _,
-        policy_id,
-    }): Path<PolicyPath>,
+    Path(policy_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<(), HttpError> {
     let components = keeper
@@ -25,7 +21,7 @@ pub(super) async fn remove_lifecycle_policy(
         .lifecycle_repo
         .write()
         .await?
-        .remove_lifecycle(&policy_id)
+        .remove_lifecycle(&policy_name)
         .await?;
     Ok(())
 }
@@ -60,13 +56,6 @@ mod tests {
         keeper
     }
 
-    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
-        Path(PolicyPath {
-            bucket_name: bucket.to_string(),
-            policy_id: policy.to_string(),
-        })
-    }
-
     #[rstest]
     #[tokio::test]
     async fn test_remove_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
@@ -75,7 +64,7 @@ mod tests {
 
         remove_lifecycle_policy(
             State(Arc::clone(&keeper)),
-            policy_path("bucket-1", "test-policy"),
+            Path("test-policy".to_string()),
             headers,
         )
         .await
@@ -101,11 +90,15 @@ mod tests {
     async fn test_remove_not_found(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
         let err = remove_lifecycle_policy(
             State(keeper.await),
-            policy_path("bucket-1", "no-such-policy"),
+            Path("no-such-policy".to_string()),
             headers,
         )
         .await
         .unwrap_err();
-        assert_eq!(err.status(), NotFound);
+        assert_eq!(
+            err.status(),
+            NotFound,
+            "Expected NotFound error when removing non-existent policy"
+        );
     }
 }

--- a/reductstore/src/api/http/lifecycle/remove.rs
+++ b/reductstore/src/api/http/lifecycle/remove.rs
@@ -1,0 +1,112 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::api::http::lifecycle::PolicyPath;
+use crate::api::http::{HttpError, StateKeeper};
+use crate::auth::policy::FullAccessPolicy;
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use std::sync::Arc;
+
+// DELETE /b/:bucket_name/lifecycle-policies/:policy_id
+pub(super) async fn remove_lifecycle_policy(
+    State(keeper): State<Arc<StateKeeper>>,
+    Path(PolicyPath {
+        bucket_name: _,
+        policy_id,
+    }): Path<PolicyPath>,
+    headers: HeaderMap,
+) -> Result<(), HttpError> {
+    let components = keeper
+        .get_with_permissions(&headers, FullAccessPolicy {})
+        .await?;
+
+    components
+        .lifecycle_repo
+        .write()
+        .await?
+        .remove_lifecycle(&policy_id)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::http::tests::{headers, keeper};
+    use reduct_base::error::ErrorCode::NotFound;
+    use reduct_base::msg::lifecycle_api::LifecycleSettings;
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
+        let components = keeper.get_anonymous().await.unwrap();
+        components
+            .lifecycle_repo
+            .write()
+            .await
+            .unwrap()
+            .create_lifecycle(
+                "test-policy",
+                LifecycleSettings {
+                    bucket: "bucket-1".to_string(),
+                    max_age: "1d".to_string(),
+                    interval: "1h".to_string(),
+                    ..LifecycleSettings::default()
+                },
+            )
+            .await
+            .unwrap();
+        keeper
+    }
+
+    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
+        Path(PolicyPath {
+            bucket_name: bucket.to_string(),
+            policy_id: policy.to_string(),
+        })
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let keeper = make_keeper_with_policy(keeper.await).await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        remove_lifecycle_policy(
+            State(Arc::clone(&keeper)),
+            policy_path("bucket-1", "test-policy"),
+            headers,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            components
+                .lifecycle_repo
+                .read()
+                .await
+                .unwrap()
+                .get_info("test-policy")
+                .await
+                .err()
+                .unwrap()
+                .status,
+            NotFound
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_not_found(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let err = remove_lifecycle_policy(
+            State(keeper.await),
+            policy_path("bucket-1", "no-such-policy"),
+            headers,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status(), NotFound);
+    }
+
+}

--- a/reductstore/src/api/http/lifecycle/remove.rs
+++ b/reductstore/src/api/http/lifecycle/remove.rs
@@ -108,5 +108,4 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.status(), NotFound);
     }
-
 }

--- a/reductstore/src/api/http/lifecycle/set_mode.rs
+++ b/reductstore/src/api/http/lifecycle/set_mode.rs
@@ -1,0 +1,80 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::api::http::lifecycle::LifecycleModePayloadAxum;
+use crate::api::http::{HttpError, StateKeeper};
+use crate::auth::policy::FullAccessPolicy;
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use std::sync::Arc;
+
+// PATCH /api/v1/lifecycles/:policy_name/mode
+pub(super) async fn set_mode(
+    State(keeper): State<Arc<StateKeeper>>,
+    Path(policy_name): Path<String>,
+    headers: HeaderMap,
+    payload: LifecycleModePayloadAxum,
+) -> Result<(), HttpError> {
+    let components = keeper
+        .get_with_permissions(&headers, FullAccessPolicy {})
+        .await?;
+
+    components
+        .lifecycle_repo
+        .write()
+        .await?
+        .set_mode(&policy_name, payload.0.mode)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::http::lifecycle::tests::settings;
+    use crate::api::http::tests::{headers, keeper};
+    use reduct_base::msg::lifecycle_api::{LifecycleMode, LifecycleModePayload, LifecycleSettings};
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_set_mode(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+        settings: LifecycleSettings,
+    ) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+        components
+            .lifecycle_repo
+            .write()
+            .await
+            .unwrap()
+            .create_lifecycle("test", settings)
+            .await
+            .unwrap();
+
+        set_mode(
+            State(Arc::clone(&keeper)),
+            Path("test".to_string()),
+            headers,
+            LifecycleModePayload {
+                mode: LifecycleMode::Disabled,
+            }
+            .into(),
+        )
+        .await
+        .unwrap();
+
+        let info = components
+            .lifecycle_repo
+            .read()
+            .await
+            .unwrap()
+            .get_info("test")
+            .await
+            .unwrap();
+        assert_eq!(info.info.mode, LifecycleMode::Disabled);
+    }
+}

--- a/reductstore/src/api/http/lifecycle/update.rs
+++ b/reductstore/src/api/http/lifecycle/update.rs
@@ -39,8 +39,7 @@ pub(super) async fn update_lifecycle_policy(
         "interval": existing.interval,
         "type": existing.lifecycle_type,
         "mode": existing.mode,
-    }))
-    ?;
+    }))?;
     components
         .lifecycle_repo
         .write()
@@ -164,5 +163,4 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.status(), NotFound);
     }
-
 }

--- a/reductstore/src/api/http/lifecycle/update.rs
+++ b/reductstore/src/api/http/lifecycle/update.rs
@@ -1,0 +1,168 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::api::http::lifecycle::{BucketLifecyclePolicyBodyAxum, PolicyPath};
+use crate::api::http::{HttpError, StateKeeper};
+use crate::auth::policy::FullAccessPolicy;
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use reduct_base::msg::lifecycle_api::LifecycleSettings;
+use serde_json::json;
+use std::sync::Arc;
+
+// PUT /b/:bucket_name/lifecycle-policies/:policy_id
+pub(super) async fn update_lifecycle_policy(
+    State(keeper): State<Arc<StateKeeper>>,
+    Path(PolicyPath {
+        bucket_name,
+        policy_id,
+    }): Path<PolicyPath>,
+    headers: HeaderMap,
+    body: BucketLifecyclePolicyBodyAxum,
+) -> Result<(), HttpError> {
+    let components = keeper
+        .get_with_permissions(&headers, FullAccessPolicy {})
+        .await?;
+
+    let existing = components
+        .lifecycle_repo
+        .read()
+        .await?
+        .get_lifecycle_settings(&policy_id)
+        .await?;
+    let body = body.0;
+    let settings: LifecycleSettings = serde_json::from_value(json!({
+        "bucket": bucket_name,
+        "entries": body.entries,
+        "max_age": body.max_age,
+        "when": body.when,
+        "interval": existing.interval,
+        "type": existing.lifecycle_type,
+        "mode": existing.mode,
+    }))
+    ?;
+    components
+        .lifecycle_repo
+        .write()
+        .await?
+        .update_lifecycle(&policy_id, settings)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::http::lifecycle::{BucketLifecyclePolicyBody, BucketLifecyclePolicyBodyAxum};
+    use crate::api::http::tests::{headers, keeper};
+    use reduct_base::error::ErrorCode::NotFound;
+    use reduct_base::msg::lifecycle_api::LifecycleSettings;
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
+        let components = keeper.get_anonymous().await.unwrap();
+        components
+            .lifecycle_repo
+            .write()
+            .await
+            .unwrap()
+            .create_lifecycle(
+                "test-policy",
+                LifecycleSettings {
+                    bucket: "bucket-1".to_string(),
+                    max_age: "1d".to_string(),
+                    interval: "1h".to_string(),
+                    ..LifecycleSettings::default()
+                },
+            )
+            .await
+            .unwrap();
+        keeper
+    }
+
+    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
+        Path(PolicyPath {
+            bucket_name: bucket.to_string(),
+            policy_id: policy.to_string(),
+        })
+    }
+
+    fn update_body(max_age: &str) -> BucketLifecyclePolicyBodyAxum {
+        BucketLifecyclePolicyBodyAxum::from(BucketLifecyclePolicyBody {
+            entries: vec![],
+            max_age: max_age.to_string(),
+            when: None,
+        })
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let keeper = make_keeper_with_policy(keeper.await).await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        update_lifecycle_policy(
+            State(Arc::clone(&keeper)),
+            policy_path("bucket-1", "test-policy"),
+            headers,
+            update_body("7d"),
+        )
+        .await
+        .unwrap();
+
+        let settings = components
+            .lifecycle_repo
+            .read()
+            .await
+            .unwrap()
+            .get_lifecycle_settings("test-policy")
+            .await
+            .unwrap();
+        assert_eq!(settings.max_age, "7d");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_preserves_interval_when_omitted(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+    ) {
+        let keeper = make_keeper_with_policy(keeper.await).await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        update_lifecycle_policy(
+            State(Arc::clone(&keeper)),
+            policy_path("bucket-1", "test-policy"),
+            headers,
+            update_body("7d"),
+        )
+        .await
+        .unwrap();
+
+        let settings = components
+            .lifecycle_repo
+            .read()
+            .await
+            .unwrap()
+            .get_lifecycle_settings("test-policy")
+            .await
+            .unwrap();
+        assert_eq!(settings.interval, "1h");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_not_found(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+        let err = update_lifecycle_policy(
+            State(keeper.await),
+            policy_path("bucket-1", "no-such-policy"),
+            headers,
+            update_body("1d"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status(), NotFound);
+    }
+
+}

--- a/reductstore/src/api/http/lifecycle/update.rs
+++ b/reductstore/src/api/http/lifecycle/update.rs
@@ -31,42 +31,21 @@ pub(super) async fn update_lifecycle_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::http::lifecycle::tests::settings;
+    use crate::api::http::lifecycle::tests::{keeper_with_policy, settings};
     use crate::api::http::tests::{headers, keeper};
     use reduct_base::error::ErrorCode::NotFound;
     use reduct_base::msg::lifecycle_api::LifecycleSettings;
     use rstest::rstest;
     use std::sync::Arc;
 
-    async fn make_keeper_with_policy(keeper: Arc<StateKeeper>) -> Arc<StateKeeper> {
-        let components = keeper.get_anonymous().await.unwrap();
-        components
-            .lifecycle_repo
-            .write()
-            .await
-            .unwrap()
-            .create_lifecycle(
-                "test-policy",
-                LifecycleSettings {
-                    bucket: "bucket-1".to_string(),
-                    max_age: "1d".to_string(),
-                    interval: "1h".to_string(),
-                    ..LifecycleSettings::default()
-                },
-            )
-            .await
-            .unwrap();
-        keeper
-    }
-
     #[rstest]
     #[tokio::test]
     async fn test_update_ok(
-        #[future] keeper: Arc<StateKeeper>,
+        #[future] keeper_with_policy: Arc<StateKeeper>,
         headers: HeaderMap,
         mut settings: LifecycleSettings,
     ) {
-        let keeper = make_keeper_with_policy(keeper.await).await;
+        let keeper = keeper_with_policy.await;
         let components = keeper.get_anonymous().await.unwrap();
         settings.max_age = "7d".to_string();
         settings.interval = "2h".to_string();

--- a/reductstore/src/api/http/lifecycle/update.rs
+++ b/reductstore/src/api/http/lifecycle/update.rs
@@ -1,50 +1,29 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use crate::api::http::lifecycle::{BucketLifecyclePolicyBodyAxum, PolicyPath};
+use crate::api::http::lifecycle::LifecycleSettingsAxum;
 use crate::api::http::{HttpError, StateKeeper};
 use crate::auth::policy::FullAccessPolicy;
 use axum::extract::{Path, State};
 use axum::http::HeaderMap;
-use reduct_base::msg::lifecycle_api::LifecycleSettings;
-use serde_json::json;
 use std::sync::Arc;
 
-// PUT /b/:bucket_name/lifecycle-policies/:policy_id
+// PUT /api/v1/lifecycles/:policy_name
 pub(super) async fn update_lifecycle_policy(
     State(keeper): State<Arc<StateKeeper>>,
-    Path(PolicyPath {
-        bucket_name,
-        policy_id,
-    }): Path<PolicyPath>,
+    Path(policy_name): Path<String>,
     headers: HeaderMap,
-    body: BucketLifecyclePolicyBodyAxum,
+    settings: LifecycleSettingsAxum,
 ) -> Result<(), HttpError> {
     let components = keeper
         .get_with_permissions(&headers, FullAccessPolicy {})
         .await?;
 
-    let existing = components
-        .lifecycle_repo
-        .read()
-        .await?
-        .get_lifecycle_settings(&policy_id)
-        .await?;
-    let body = body.0;
-    let settings: LifecycleSettings = serde_json::from_value(json!({
-        "bucket": bucket_name,
-        "entries": body.entries,
-        "max_age": body.max_age,
-        "when": body.when,
-        "interval": existing.interval,
-        "type": existing.lifecycle_type,
-        "mode": existing.mode,
-    }))?;
     components
         .lifecycle_repo
         .write()
         .await?
-        .update_lifecycle(&policy_id, settings)
+        .update_lifecycle(&policy_name, settings.into())
         .await?;
     Ok(())
 }
@@ -52,7 +31,7 @@ pub(super) async fn update_lifecycle_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::http::lifecycle::{BucketLifecyclePolicyBody, BucketLifecyclePolicyBodyAxum};
+    use crate::api::http::lifecycle::tests::settings;
     use crate::api::http::tests::{headers, keeper};
     use reduct_base::error::ErrorCode::NotFound;
     use reduct_base::msg::lifecycle_api::LifecycleSettings;
@@ -80,32 +59,23 @@ mod tests {
         keeper
     }
 
-    fn policy_path(bucket: &str, policy: &str) -> Path<PolicyPath> {
-        Path(PolicyPath {
-            bucket_name: bucket.to_string(),
-            policy_id: policy.to_string(),
-        })
-    }
-
-    fn update_body(max_age: &str) -> BucketLifecyclePolicyBodyAxum {
-        BucketLifecyclePolicyBodyAxum::from(BucketLifecyclePolicyBody {
-            entries: vec![],
-            max_age: max_age.to_string(),
-            when: None,
-        })
-    }
-
     #[rstest]
     #[tokio::test]
-    async fn test_update_ok(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
+    async fn test_update_ok(
+        #[future] keeper: Arc<StateKeeper>,
+        headers: HeaderMap,
+        mut settings: LifecycleSettings,
+    ) {
         let keeper = make_keeper_with_policy(keeper.await).await;
         let components = keeper.get_anonymous().await.unwrap();
+        settings.max_age = "7d".to_string();
+        settings.interval = "2h".to_string();
 
         update_lifecycle_policy(
             State(Arc::clone(&keeper)),
-            policy_path("bucket-1", "test-policy"),
+            Path("test-policy".to_string()),
             headers,
-            update_body("7d"),
+            LifecycleSettingsAxum::from(settings),
         )
         .await
         .unwrap();
@@ -119,45 +89,21 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(settings.max_age, "7d");
+        assert_eq!(settings.interval, "2h");
     }
 
     #[rstest]
     #[tokio::test]
-    async fn test_update_preserves_interval_when_omitted(
+    async fn test_update_not_found(
         #[future] keeper: Arc<StateKeeper>,
         headers: HeaderMap,
+        settings: LifecycleSettings,
     ) {
-        let keeper = make_keeper_with_policy(keeper.await).await;
-        let components = keeper.get_anonymous().await.unwrap();
-
-        update_lifecycle_policy(
-            State(Arc::clone(&keeper)),
-            policy_path("bucket-1", "test-policy"),
-            headers,
-            update_body("7d"),
-        )
-        .await
-        .unwrap();
-
-        let settings = components
-            .lifecycle_repo
-            .read()
-            .await
-            .unwrap()
-            .get_lifecycle_settings("test-policy")
-            .await
-            .unwrap();
-        assert_eq!(settings.interval, "1h");
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_update_not_found(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
         let err = update_lifecycle_policy(
             State(keeper.await),
-            policy_path("bucket-1", "no-such-policy"),
+            Path("no-such-policy".to_string()),
             headers,
-            update_body("1d"),
+            LifecycleSettingsAxum::from(settings),
         )
         .await
         .unwrap_err();

--- a/reductstore/src/api/http/replication/list.rs
+++ b/reductstore/src/api/http/replication/list.rs
@@ -10,7 +10,7 @@ use crate::api::http::replication::ReplicationListAxum;
 use crate::api::http::{HttpError, StateKeeper};
 use crate::auth::policy::FullAccessPolicy;
 
-// GET /api/v1/replications/
+// GET /api/v1/replications
 pub(super) async fn list_replications(
     State(keeper): State<Arc<StateKeeper>>,
     headers: HeaderMap,
@@ -18,16 +18,16 @@ pub(super) async fn list_replications(
     let components = keeper
         .get_with_permissions(&headers, FullAccessPolicy {})
         .await?;
-    let mut list = ReplicationListAxum::default();
 
-    for x in components
+    let mut list = ReplicationListAxum::default();
+    for replication_info in components
         .replication_repo
         .read()
         .await?
         .replications()
         .await?
     {
-        list.0.replications.push((x).clone());
+        list.0.replications.push(replication_info);
     }
 
     Ok(list)


### PR DESCRIPTION
Closes #1011

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Task

### What was changed?

Add HTTP CRUD endpoints for bucket-scoped lifecycle policies (`GET/POST/PUT/DELETE /api/v1/b/{bucket}/lifecycle-policies/{id}`

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
