### PR TITLE
fix lifecycle first-run invalid query window (#1392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix lifecycle delete worker first-run failure (`422 Start time must be before stop time`) by ensuring delete queries use a valid initial time range even when all records are newer than `max_age`, [PR-1394](https://github.com/reductstore/reductstore/pull/1394)
 - Fix runtime default for lifecycle interval by implementing manual Default for LifecycleSettings, [PR-1385](https://github.com/reductstore/reductstore/pull/1385)
 - Downgrade `write_batched` log severity for closed writer-channel handoff from error to warning to reduce noisy false-positive error bursts under expected stream abort/backpressure scenarios, [PR-1356](https://github.com/reductstore/reductstore/pull/1356)
 - Handle `--version` (`-V`) in `main` before server startup so version output remains clean and exits without initialization side effects, [PR-1365](https://github.com/reductstore/reductstore/pull/1365)

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -50,7 +50,9 @@ impl LifecycleAction for DeleteLifecycleAction {
                 QueryType::Remove
             },
             entries,
-            start: None,
+            // Use absolute range start to avoid invalid (start > stop) when
+            // an entry contains only fresh records newer than `cutoff`.
+            start: Some(0),
             stop,
             when: settings.when.clone(),
             ..Default::default()
@@ -114,6 +116,46 @@ mod tests {
         assert_eq!(result.affected_records, 2);
         assert!(bucket.begin_read("entry-1", 1).await.is_ok());
         assert!(bucket.begin_read("entry-1", 2).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn dry_run_delete_with_only_fresh_records_returns_zero() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+
+        let now_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        write(&bucket, "entry-1", now_us, b"fresh").await.unwrap();
+
+        let settings = LifecycleSettings {
+            lifecycle_type: LifecycleType::Delete,
+            bucket: "bucket-1".to_string(),
+            entries: vec!["entry-1".to_string()],
+            max_age: "1h".to_string(),
+            interval: "1h".to_string(),
+            when: None,
+            mode: LifecycleMode::DryRun,
+        };
+
+        let action = DeleteLifecycleAction;
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(Arc::clone(&storage)),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 0);
+        assert!(bucket.begin_read("entry-1", now_us).await.is_ok());
     }
 
     async fn storage() -> Arc<StorageEngine> {

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -71,18 +71,15 @@ impl LifecycleAction for DeleteLifecycleAction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cfg::Cfg;
+    use crate::lifecycle::lifecycle_task::tests::{settings, storage};
+    use crate::storage::bucket::tests::write;
     use crate::storage::bucket::Bucket;
     use crate::storage::engine::StorageEngine;
-    use bytes::Bytes;
-    use reduct_base::error::ReductError;
-    use reduct_base::internal_server_error;
-    use reduct_base::msg::bucket_api::BucketSettings;
-    use reduct_base::Labels;
+    use rstest::{fixture, rstest};
     use std::sync::Arc;
 
-    #[tokio::test]
-    async fn dry_run_delete_counts_without_removing() {
+    #[fixture]
+    async fn test_context() -> (Arc<StorageEngine>, Arc<Bucket>) {
         let storage = storage().await;
         let bucket = storage
             .get_bucket("bucket-1")
@@ -90,116 +87,61 @@ mod tests {
             .unwrap()
             .upgrade()
             .unwrap();
-        write(&bucket, "entry-1", 1, b"r1").await.unwrap();
-        write(&bucket, "entry-1", 2, b"r2").await.unwrap();
+        (storage, bucket)
+    }
 
-        let settings = LifecycleSettings {
-            lifecycle_type: LifecycleType::Delete,
-            bucket: "bucket-1".to_string(),
-            entries: vec!["entry-1".to_string()],
-            max_age: "0s".to_string(),
-            interval: "1h".to_string(),
-            when: None,
-            mode: LifecycleMode::DryRun,
-        };
+    #[fixture]
+    fn action() -> DeleteLifecycleAction {
+        DeleteLifecycleAction
+    }
 
-        let action = DeleteLifecycleAction;
+    #[rstest]
+    #[tokio::test]
+    async fn dry_run_delete_counts_without_removing(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        write(&test_bucket, "entry-1", 2, b"r2").await.unwrap();
+        settings.mode = LifecycleMode::DryRun;
+        settings.max_age = "0s".to_string();
+
         let result = action
-            .run(
-                "test",
-                &settings,
-                LifecycleContext::new(Arc::clone(&storage)),
-            )
+            .run("test", &settings, LifecycleContext::new(test_storage))
             .await
             .unwrap();
 
         assert_eq!(result.affected_records, 2);
-        assert!(bucket.begin_read("entry-1", 1).await.is_ok());
-        assert!(bucket.begin_read("entry-1", 2).await.is_ok());
+        assert!(test_bucket.begin_read("entry-1", 1).await.is_ok());
+        assert!(test_bucket.begin_read("entry-1", 2).await.is_ok());
     }
 
     #[tokio::test]
-    async fn dry_run_delete_with_only_fresh_records_returns_zero() {
-        let storage = storage().await;
-        let bucket = storage
-            .get_bucket("bucket-1")
-            .await
-            .unwrap()
-            .upgrade()
-            .unwrap();
+    #[rstest]
+    async fn dry_run_delete_with_only_fresh_records_returns_zero(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        settings.mode = LifecycleMode::DryRun;
 
         let now_us = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_micros() as u64;
-        write(&bucket, "entry-1", now_us, b"fresh").await.unwrap();
+        write(&test_bucket, "entry-1", now_us, b"fresh")
+            .await
+            .unwrap();
 
-        let settings = LifecycleSettings {
-            lifecycle_type: LifecycleType::Delete,
-            bucket: "bucket-1".to_string(),
-            entries: vec!["entry-1".to_string()],
-            max_age: "1h".to_string(),
-            interval: "1h".to_string(),
-            when: None,
-            mode: LifecycleMode::DryRun,
-        };
-
-        let action = DeleteLifecycleAction;
         let result = action
-            .run(
-                "test",
-                &settings,
-                LifecycleContext::new(Arc::clone(&storage)),
-            )
+            .run("test", &settings, LifecycleContext::new(test_storage))
             .await
             .unwrap();
 
         assert_eq!(result.affected_records, 0);
-        assert!(bucket.begin_read("entry-1", now_us).await.is_ok());
-    }
-
-    async fn storage() -> Arc<StorageEngine> {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let cfg = Cfg {
-            data_path: tmp_dir.keep(),
-            ..Cfg::default()
-        };
-
-        let storage = StorageEngine::builder()
-            .with_data_path(cfg.data_path.clone())
-            .with_cfg(cfg)
-            .build()
-            .await;
-        storage
-            .create_bucket("bucket-1", BucketSettings::default())
-            .await
-            .unwrap();
-        Arc::new(storage)
-    }
-
-    async fn write(
-        bucket: &Arc<Bucket>,
-        entry_name: &str,
-        time: u64,
-        content: &'static [u8],
-    ) -> Result<(), ReductError> {
-        let mut sender = bucket
-            .begin_write(
-                entry_name,
-                time,
-                content.len() as u64,
-                "".to_string(),
-                Labels::new(),
-            )
-            .await?;
-        sender
-            .send(Ok(Some(Bytes::from(content))))
-            .await
-            .map_err(|e| internal_server_error!("Failed to send data: {}", e))?;
-        sender
-            .send(Ok(None))
-            .await
-            .map_err(|e| internal_server_error!("Failed to sync channel: {}", e))?;
-        Ok(())
+        assert!(test_bucket.begin_read("entry-1", now_us).await.is_ok());
     }
 }

--- a/reductstore/src/lifecycle/lifecycle_repository/repo.rs
+++ b/reductstore/src/lifecycle/lifecycle_repository/repo.rs
@@ -367,6 +367,8 @@ impl LifecycleRepository {
 mod tests {
     use super::*;
     use crate::lifecycle::action::{LifecycleAction, LifecycleRunResult};
+    use crate::lifecycle::lifecycle_task::tests::settings;
+    use crate::lifecycle::lifecycle_task::tests::settings_fixture;
     use reduct_base::msg::bucket_api::BucketSettings;
     use reduct_base::msg::lifecycle_api::{LifecycleMode, LifecycleType};
     use reduct_base::{conflict, not_found, unprocessable_entity};
@@ -806,23 +808,6 @@ mod tests {
 
         let info = repo.get_info("test").await.unwrap();
         assert_eq!(info.info.mode, LifecycleMode::Disabled);
-    }
-
-    #[fixture]
-    fn settings() -> LifecycleSettings {
-        settings_fixture()
-    }
-
-    fn settings_fixture() -> LifecycleSettings {
-        LifecycleSettings {
-            lifecycle_type: LifecycleType::Delete,
-            bucket: "bucket-1".to_string(),
-            entries: vec!["entry-1".to_string()],
-            max_age: "1h".to_string(),
-            interval: "1h".to_string(),
-            when: None,
-            mode: LifecycleMode::Enabled,
-        }
     }
 
     #[cfg(any(debug_assertions, test))]

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -277,7 +277,7 @@ impl Drop for LifecycleTask {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use super::*;
     use crate::audit::{AuditEvent, LogAuditEvent};
     use crate::cfg::Cfg;
@@ -287,6 +287,7 @@ mod tests {
     use async_trait::async_trait;
     use reduct_base::msg::bucket_api::BucketSettings;
     use reduct_base::unprocessable_entity;
+    use rstest::fixture;
     use std::sync::Mutex;
     use tokio::sync::mpsc;
     use tokio::time::{timeout, Duration};
@@ -574,7 +575,7 @@ mod tests {
         )
     }
 
-    async fn storage() -> Arc<StorageEngine> {
+    pub async fn storage() -> Arc<StorageEngine> {
         let tmp_dir = tempfile::tempdir().unwrap();
         let cfg = Cfg {
             data_path: tmp_dir.keep(),
@@ -591,5 +592,22 @@ mod tests {
             .await
             .unwrap();
         Arc::new(storage)
+    }
+
+    #[fixture]
+    pub fn settings() -> LifecycleSettings {
+        settings_fixture()
+    }
+
+    pub fn settings_fixture() -> LifecycleSettings {
+        LifecycleSettings {
+            lifecycle_type: LifecycleType::Delete,
+            bucket: "bucket-1".to_string(),
+            entries: vec!["entry-1".to_string()],
+            max_age: "1h".to_string(),
+            interval: "1h".to_string(),
+            when: None,
+            mode: LifecycleMode::Enabled,
+        }
     }
 }

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -489,7 +489,7 @@ impl Bucket {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use reduct_base::conflict;
     use reduct_base::io::ReadRecord;


### PR DESCRIPTION
Closes #1392

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Fixed lifecycle delete action to always query with `start: Some(0)`, which prevents `start > stop` on first run when all records are newer than the configured `max_age` cutoff.
- Added regression coverage for the first-run scenario with only fresh records.
- Refactored delete lifecycle tests to use `rstest` fixtures and removed duplicated write helper by reusing shared bucket test helper.

### Related issues

- https://github.com/reductstore/reductstore/issues/1392

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with:

- `cargo test -p reductstore lifecycle::action::delete::tests`