### PR TITLE
fix lifecycle cleanup semantics for attachments (#1393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserve attachment metadata (`entry/$meta`) during lifecycle delete cleanup by enforcing and documenting exclusion of system metadata entries from lifecycle matching, [PR-1395](https://github.com/reductstore/reductstore/pull/1395)
 - Fix lifecycle delete worker first-run failure (`422 Start time must be before stop time`) by ensuring delete queries use a valid initial time range even when all records are newer than `max_age`, [PR-1394](https://github.com/reductstore/reductstore/pull/1394)
 - Fix runtime default for lifecycle interval by implementing manual Default for LifecycleSettings, [PR-1385](https://github.com/reductstore/reductstore/pull/1385)
 - Downgrade `write_batched` log severity for closed writer-channel handoff from error to warning to reduce noisy false-positive error bursts under expected stream abort/backpressure scenarios, [PR-1356](https://github.com/reductstore/reductstore/pull/1356)

--- a/reduct_base/src/msg/lifecycle_api.rs
+++ b/reduct_base/src/msg/lifecycle_api.rs
@@ -42,6 +42,7 @@ pub struct LifecycleSettings {
     /// Bucket to apply the lifecycle policy to.
     pub bucket: String,
     /// Entries to clean. If empty, all removable entries are matched. Prefix wildcards are supported.
+    /// System metadata entries (e.g. `entry/$meta`) are always excluded.
     #[serde(default)]
     pub entries: Vec<String>,
     /// Maximum record age, e.g. "30d", "24h", or "3600s".

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -72,7 +72,7 @@ impl LifecycleAction for DeleteLifecycleAction {
 mod tests {
     use super::*;
     use crate::lifecycle::lifecycle_task::tests::{settings, storage};
-    use crate::storage::bucket::tests::write;
+    use crate::storage::bucket::tests::{write, write_meta};
     use crate::storage::bucket::Bucket;
     use crate::storage::engine::StorageEngine;
     use rstest::{fixture, rstest};
@@ -143,5 +143,33 @@ mod tests {
 
         assert_eq!(result.affected_records, 0);
         assert!(test_bucket.begin_read("entry-1", now_us).await.is_ok());
+    }
+
+    #[tokio::test]
+    #[rstest]
+    async fn delete_lifecycle_keeps_meta_attachments(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+
+        write_meta(&test_bucket, "entry-1/$meta", 1, br#"{"k":"v"}"#)
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 1, b"data").await.unwrap();
+
+        settings.mode = LifecycleMode::Enabled;
+        settings.max_age = "0s".to_string();
+        settings.entries = vec!["entry-1*".to_string()];
+
+        let result = action
+            .run("test", &settings, LifecycleContext::new(test_storage))
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 1);
+        assert!(test_bucket.begin_read("entry-1", 1).await.is_err());
+        assert!(test_bucket.begin_read("entry-1/$meta", 1).await.is_ok());
     }
 }


### PR DESCRIPTION
Closes #1393

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix (lifecycle safety regression coverage) + docs clarification.

### What was changed?

- Added a lifecycle delete regression test to ensure lifecycle cleanup preserves attachment metadata in `entry/$meta` while deleting matching records in the parent entry.
- Clarified `LifecycleSettings.entries` semantics to explicitly document that system metadata entries (`entry/$meta`) are excluded from lifecycle matching.

### Related issues

- Issue: https://github.com/reductstore/reductstore/issues/1393
- Approved implementation plan comment: https://github.com/reductstore/reductstore/issues/1393#issuecomment-4551840162

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with targeted tests:

- `cargo test -p reductstore delete_lifecycle_keeps_meta_attachments -- --nocapture`
- `cargo test -p reductstore query_remove_records_wildcard_excludes_meta_entries -- --nocapture`
