### PR TITLE
Accept  as an alternative to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Accept `x-reduct-content-length` as an alternative to `Content-Length` for browser streaming via the Fetch API, [PR-1411](https://github.com/reductstore/reductstore/pull/1411)
 - Pass attachment key-value maps to extensions instead of selecting a single attachment key, [PR-1383](https://github.com/reductstore/reductstore/pull/1383)
 - Add HTTP CRUD endpoints for lifecycle policies, [PR-1382](https://github.com/reductstore/reductstore/pull/1382)
 - Add lifecycle policy environment provisioning and background delete workers with structured lifecycle audit events, [PR-1376](https://github.com/reductstore/reductstore/pull/1376)

--- a/reductstore/src/api/http/entry/common.rs
+++ b/reductstore/src/api/http/entry/common.rs
@@ -10,13 +10,19 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 pub(crate) fn parse_content_length_from_header(headers: &HeaderMap) -> Result<u64, HttpError> {
-    let content_size = headers
-        .get("content-length")
-        .ok_or(unprocessable_entity!("content-length header is required"))?
+    let (name, value) = if let Some(v) = headers.get("content-length") {
+        ("content-length", v)
+    } else if let Some(v) = headers.get("x-reduct-content-length") {
+        ("x-reduct-content-length", v)
+    } else {
+        return Err(unprocessable_entity!("content-length header is required").into());
+    };
+
+    let content_size = value
         .to_str()
-        .map_err(|_| unprocessable_entity!("content-length header must be a string",))?
+        .map_err(|_| unprocessable_entity!("{} header must be a string", name))?
         .parse::<u64>()
-        .map_err(|_| unprocessable_entity!("content-length header must be a number"))?;
+        .map_err(|_| unprocessable_entity!("{} header must be a number", name))?;
     Ok(content_size)
 }
 
@@ -223,8 +229,55 @@ pub(super) fn check_and_extract_ts_or_query_id(
 mod tests {
     use super::*;
 
+    use axum::http::HeaderMap;
     use rstest::rstest;
     use std::collections::HashMap;
+
+    mod parse_content_length_from_header {
+        use super::*;
+
+        #[rstest]
+        fn test_content_length() {
+            let mut headers = HeaderMap::new();
+            headers.insert("content-length", "42".parse().unwrap());
+            assert_eq!(parse_content_length_from_header(&headers).unwrap(), 42);
+        }
+
+        #[rstest]
+        fn test_x_reduct_content_length() {
+            let mut headers = HeaderMap::new();
+            headers.insert("x-reduct-content-length", "42".parse().unwrap());
+            assert_eq!(parse_content_length_from_header(&headers).unwrap(), 42);
+        }
+
+        #[rstest]
+        fn test_content_length_takes_priority_when_both_present() {
+            let mut headers = HeaderMap::new();
+            headers.insert("content-length", "99".parse().unwrap());
+            headers.insert("x-reduct-content-length", "10".parse().unwrap());
+            assert_eq!(parse_content_length_from_header(&headers).unwrap(), 99);
+        }
+
+        #[rstest]
+        fn test_missing() {
+            let headers = HeaderMap::new();
+            assert_eq!(
+                parse_content_length_from_header(&headers)
+                    .err()
+                    .unwrap()
+                    .into_inner()
+                    .to_string(),
+                "[UnprocessableEntity] content-length header is required"
+            );
+        }
+
+        #[rstest]
+        fn test_invalid_value() {
+            let mut headers = HeaderMap::new();
+            headers.insert("x-reduct-content-length", "abc".parse().unwrap());
+            assert!(parse_content_length_from_header(&headers).is_err());
+        }
+    }
 
     mod parse_ttl {
         use super::*;

--- a/reductstore/src/api/http/entry/write_batched.rs
+++ b/reductstore/src/api/http/entry/write_batched.rs
@@ -11,7 +11,7 @@ use axum_extra::headers::{Expect, Header, HeaderMap};
 use bytes::Bytes;
 use futures_util::StreamExt;
 
-use crate::api::http::entry::common::err_to_batched_header;
+use crate::api::http::entry::common::{err_to_batched_header, parse_content_length_from_header};
 use crate::api::http::StateKeeper;
 use crate::api::limits::limit_scope_from_client_ip;
 use crate::replication::{Transaction, TransactionNotification};
@@ -278,15 +278,8 @@ fn check_and_get_content_length(
         .map(|(_, header)| header.content_length)
         .sum();
 
-    if total_content_length
-        != headers
-            .get("content-length")
-            .ok_or(unprocessable_entity!("content-length header is required",))?
-            .to_str()
-            .unwrap()
-            .parse::<u64>()
-            .map_err(|_| unprocessable_entity!("Invalid content-length header"))?
-    {
+    let header_content_length = parse_content_length_from_header(headers)?;
+    if total_content_length != header_content_length {
         return Err(unprocessable_entity!(
             "content-length header does not match the sum of the content-lengths in the headers",
         )


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Support

### What was changed?

Accept `x-reduct-content-length` as an alternative to `Content-Length` for browser streaming via the Fetch API

### Related issues

https://github.com/reductstore/reduct-js/pull/179

### Does this PR introduce a breaking change?

No

### Other information:
