### PR TITLE
Feat/replication audit events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Periodically write aggregated replication diagnostics as system events to the `$system` bucket under `replications/<instance>/<replication-name>`, aggregated per status code and flushed on status change, idle window, or time cap, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN)
+- Periodically write aggregated replication diagnostics as system events to the `$system` bucket under `replications/<instance>/<replication-name>`, aggregated per status code and flushed on status change, idle window, or time cap, [PR-1417](https://github.com/reductstore/reductstore/pull/1417) by @DibbayajyotiRoy
 - Accept `x-reduct-content-length` as an alternative to `Content-Length` for browser streaming via the Fetch API, [PR-1411](https://github.com/reductstore/reductstore/pull/1411)
 - Pass attachment key-value maps to extensions instead of selecting a single attachment key, [PR-1383](https://github.com/reductstore/reductstore/pull/1383)
 - Add HTTP CRUD endpoints for lifecycle policies, [PR-1382](https://github.com/reductstore/reductstore/pull/1382)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Periodically write aggregated replication diagnostics as system events to the `$system` bucket under `replications/<instance>/<replication-name>`, aggregated per status code and flushed on status change, idle window, or time cap, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN)
 - Accept `x-reduct-content-length` as an alternative to `Content-Length` for browser streaming via the Fetch API, [PR-1411](https://github.com/reductstore/reductstore/pull/1411)
 - Pass attachment key-value maps to extensions instead of selecting a single attachment key, [PR-1383](https://github.com/reductstore/reductstore/pull/1383)
 - Add HTTP CRUD endpoints for lifecycle policies, [PR-1382](https://github.com/reductstore/reductstore/pull/1382)

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -33,6 +33,7 @@ use crate::ext::ext_repository::create_ext_repository;
 use crate::lifecycle::SystemEventSink;
 use crate::lock_file::{BoxedLockFile, LockFileBuilder};
 use crate::syslog::build_audit_logger;
+use crate::syslog::build_replication_system_logger;
 use crate::syslog::build_system_logger;
 use async_trait::async_trait;
 use log::{info, warn};
@@ -399,8 +400,17 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         let storage = Arc::new(self.provision_buckets(&data_path).await);
         let token_repo = self.provision_tokens(&data_path, Arc::clone(&storage));
         let console = create_asset_manager(load_console());
+        let replication_system_logger =
+            build_replication_system_logger(&self.cfg, Arc::clone(&storage)).await;
+        let replication_system_logger = Arc::new(AsyncRwLock::new(replication_system_logger));
         let replication_engine = self
-            .provision_replication_repo(Arc::clone(&storage))
+            .provision_replication_repo(
+                Arc::clone(&storage),
+                SystemEventSink {
+                    system_logger: Arc::clone(&replication_system_logger),
+                    instance_name: self.cfg.instance_name.clone(),
+                },
+            )
             .await?;
         let ext_path = if let Some(ext_path) = &self.cfg.ext_path {
             Some(PathBuf::try_from(ext_path).map_err(|e| {

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -3,6 +3,7 @@
 
 use crate::cfg::{CfgParser, ExtCfgBounds, ProvisionedReplication};
 use crate::core::env::{Env, GetEnv};
+use crate::lifecycle::SystemEventSink;
 use crate::replication::{ManageReplications, ReplicationRepoBuilder};
 use crate::storage::engine::StorageEngine;
 use log::{error, info, warn};
@@ -16,32 +17,34 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
     pub(in crate::cfg) async fn provision_replication_repo(
         &self,
         storage: Arc<StorageEngine>,
+        system_event_sink: SystemEventSink,
     ) -> Result<Box<dyn ManageReplications + Send + Sync>, ReductError> {
         let mut repo = ReplicationRepoBuilder::new(self.cfg.clone())
+            .with_system_event_sink(system_event_sink)
             .build(Arc::clone(&storage))
             .await;
         for (name, replication) in &self.cfg.replications {
             if let Err(e) = repo
-                .create_replication(&name, replication.settings.clone())
+                .create_replication(name, replication.settings.clone())
                 .await
             {
                 if e.status() == ErrorCode::Conflict {
                     let mut settings = replication.settings.clone();
                     if replication.mode_override.is_none() {
-                        if let Ok(info) = repo.get_info(&name).await {
+                        if let Ok(info) = repo.get_info(name).await {
                             settings.mode = info.info.mode;
                         }
                     }
-                    repo.update_replication(&name, settings).await?;
+                    repo.update_replication(name, settings).await?;
                 } else {
                     error!("Failed to provision replication '{}': {}", name, e);
                     continue;
                 }
             }
 
-            repo.set_replication_provisioned(&name, true).await?;
+            repo.set_replication_provisioned(name, true).await?;
 
-            let info_data = repo.get_info(&name).await?;
+            let info_data = repo.get_info(name).await?;
             info!(
                 "Provisioned replication '{}' with {:?}",
                 name, info_data.settings
@@ -175,13 +178,13 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             }
         }
 
-        let replications = replications
+        
+
+        replications
             .into_iter()
             .filter(|(id, _)| !unfinished_replications.contains(id))
             .map(|(_, (name, replication))| (name, replication))
-            .collect();
-
-        replications
+            .collect()
     }
 }
 

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -178,8 +178,6 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             }
         }
 
-        
-
         replications
             .into_iter()
             .filter(|(id, _)| !unfinished_replications.contains(id))

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -11,6 +11,8 @@ use reduct_base::msg::replication_api::{
 mod diagnostics;
 pub mod proto;
 mod remote_bucket;
+mod replication_aggregator;
+mod replication_event_payload;
 mod replication_repository;
 mod replication_sender;
 mod replication_task;
@@ -27,9 +29,9 @@ pub enum Transaction {
     UpdateRecord(u64),
 }
 
-impl Into<u8> for Transaction {
-    fn into(self) -> u8 {
-        match self {
+impl From<Transaction> for u8 {
+    fn from(val: Transaction) -> Self {
+        match val {
             Transaction::WriteRecord(_) => 0,
             Transaction::UpdateRecord(_) => 1,
         }

--- a/reductstore/src/replication/replication_aggregator.rs
+++ b/reductstore/src/replication/replication_aggregator.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-//! Aggregates replication diagnostics into periodic system events.
+//! Aggregates replication diagnostics into periodic `$system` events.
 //!
 //! One active "bucket" (running tally) is kept per replication task, keyed by
 //! the status code. The bucket is flushed and a new one opened when ANY of:
@@ -9,66 +9,38 @@
 //!   2. no records were replicated for [`AGGREGATION_WINDOW_SECS`] (idle),
 //!   3. the bucket accumulated [`FORCE_FLUSH_TIMEOUT_SECS`] of data (cap).
 //!
-//! The window/force-flush timing (conditions 2 and 3) reuses the model of
-//! [`crate::api::audit::aggregator::ApiAuditEventAggregator`]; the status-change
-//! trigger (condition 1) is added on top.
+//! Replication only runs on the primary node, so — unlike the API audit
+//! aggregator, which forwards events off read-only replicas through a channel
+//! and a background worker — this aggregator is owned and driven directly by
+//! the single-threaded replication worker loop. It emits straight through the
+//! [`SystemEventSink`], the same way the lifecycle module does.
 
 use crate::api::audit::aggregator::{AGGREGATION_WINDOW_SECS, FORCE_FLUSH_TIMEOUT_SECS};
-use crate::core::sync::AsyncRwLock;
 use crate::lifecycle::SystemEventSink;
 use crate::replication::replication_event_payload::ReplicationSystemEventPayload;
-use crate::syslog::{SystemEvent, SystemEventHandler};
+use crate::syslog::SystemEvent;
 use log::error;
 use reduct_base::error::ReductError;
-use reduct_base::internal_server_error;
-use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::mpsc;
-use tokio::time::{Duration, Instant};
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-const REPLICATION_CHANNEL_SIZE: usize = 1024;
 const REPLICATION_EVENT_TYPE: &str = "replication_sync";
 
-/// A single observation reported by a replication pass for one status code.
+/// The active aggregation bucket for a replication task, keyed by status code.
 #[derive(Debug, Clone)]
-pub(crate) struct ReplicationObservation {
-    pub instance: String,
-    pub replication_name: String,
-    pub timestamp: u64,
-    pub status: u16,
-    pub pending_records: u64,
-    pub records: u64,
-    pub data_size: u64,
-    pub duration: f64,
-    pub message: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct ReplicationAggregateKey {
-    pub instance: String,
-    pub replication_name: String,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ReplicationAggregate {
-    pub status: u16,
-    pub first_timestamp: u64,
-    pub last_timestamp: u64,
-    pub pending_records: u64,
-    pub written_records: u64,
-    pub failed_records: u64,
-    pub replicated_data_size: u64,
-    pub duration: f64,
-    pub message: String,
-    pub flush_at: Instant,
-    pub force_flush_at: Instant,
-}
-
-#[derive(Default)]
-pub(crate) struct ReplicationAggregatorState {
-    pub aggregates: HashMap<ReplicationAggregateKey, ReplicationAggregate>,
+struct ReplicationAggregate {
+    status: u16,
+    first_timestamp: u64,
+    pending_records: u64,
+    written_records: u64,
+    failed_records: u64,
+    replicated_data_size: u64,
+    duration: f64,
+    message: String,
+    /// Sliding idle deadline (condition 2).
+    flush_at: Instant,
+    /// Hard time-cap deadline (condition 3).
+    force_flush_at: Instant,
 }
 
 fn is_success(status: u16) -> bool {
@@ -82,25 +54,9 @@ fn now_micros() -> u64 {
         .as_micros() as u64
 }
 
-fn new_aggregate(obs: &ReplicationObservation, now: Instant) -> ReplicationAggregate {
-    let success = is_success(obs.status);
-    ReplicationAggregate {
-        status: obs.status,
-        first_timestamp: obs.timestamp,
-        last_timestamp: obs.timestamp,
-        pending_records: obs.pending_records,
-        written_records: if success { obs.records } else { 0 },
-        failed_records: if success { 0 } else { obs.records },
-        replicated_data_size: obs.data_size,
-        duration: obs.duration,
-        message: obs.message.clone(),
-        flush_at: now + Duration::from_secs(AGGREGATION_WINDOW_SECS),
-        force_flush_at: now + Duration::from_secs(FORCE_FLUSH_TIMEOUT_SECS),
-    }
-}
-
-pub(crate) fn make_event(
-    key: ReplicationAggregateKey,
+fn make_event(
+    instance: &str,
+    replication_name: &str,
     aggregate: ReplicationAggregate,
 ) -> SystemEvent {
     let payload = ReplicationSystemEventPayload {
@@ -115,56 +71,38 @@ pub(crate) fn make_event(
     SystemEvent {
         event_type: REPLICATION_EVENT_TYPE.to_string(),
         timestamp: aggregate.first_timestamp,
-        instance: key.instance,
-        entry_name: key.replication_name,
+        instance: instance.to_string(),
+        entry_name: replication_name.to_string(),
         status: aggregate.status,
         message: aggregate.message,
         payload: payload.to_value(),
     }
 }
 
-pub(crate) struct ReplicationEventAggregator {
-    instance_name: String,
+/// Per-task replication diagnostics aggregator.
+pub(super) struct ReplicationEventAggregator {
+    sink: SystemEventSink,
     replication_name: String,
-    tx: mpsc::Sender<ReplicationObservation>,
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
+    active: Option<ReplicationAggregate>,
 }
 
 impl ReplicationEventAggregator {
-    pub(crate) fn new(sink: SystemEventSink, replication_name: String) -> Self {
-        let instance_name = sink.instance_name.clone();
-        let logger = Arc::clone(&sink.system_logger);
-        let handler: SystemEventHandler = Arc::new(move |event| {
-            let logger = Arc::clone(&logger);
-            Box::pin(async move {
-                let mut guard = logger.write().await?;
-                guard.log_event(event).await
-            })
-        });
-
-        let state = Arc::new(AsyncRwLock::new(ReplicationAggregatorState::default()));
-        let (tx, rx) = mpsc::channel(REPLICATION_CHANNEL_SIZE);
-        tokio::spawn(Self::run_worker(rx, Arc::clone(&state), handler));
-
+    pub(super) fn new(sink: SystemEventSink, replication_name: String) -> Self {
         Self {
-            instance_name,
+            sink,
             replication_name,
-            tx,
-            #[cfg(test)]
-            state,
+            active: None,
         }
     }
 
-    /// Record a replication pass.
+    /// Record one replication pass as a list of `(result, records, data_size)`.
     ///
-    /// Telemetry must never break replication, so enqueue failures are
-    /// swallowed and logged rather than propagated. The pass `duration` is
-    /// attributed to the lowest-status observation only, so it is never
-    /// double-counted when a single pass produces several status codes.
-    pub(crate) async fn record_pass(
-        &self,
+    /// Telemetry must never break replication, so emission failures are
+    /// swallowed and logged. The pass `duration` is attributed once, to the
+    /// lowest-status observation, so it is never double-counted when a single
+    /// pass produces several status codes.
+    pub(super) async fn record_pass(
+        &mut self,
         pending_records: u64,
         duration: f64,
         counter: &[(Result<(), ReductError>, u64, u64)],
@@ -190,190 +128,90 @@ impl ReplicationEventAggregator {
         let timestamp = now_micros();
         let mut first = true;
         for (status, (records, data_size, message)) in per_status {
-            let observation = ReplicationObservation {
-                instance: self.instance_name.clone(),
-                replication_name: self.replication_name.clone(),
-                timestamp,
-                status,
-                pending_records,
-                records,
-                data_size,
-                duration: if first { duration } else { 0.0 },
-                message,
-            };
+            let pass_duration = if first { duration } else { 0.0 };
             first = false;
-            if let Err(err) = self.enqueue(observation).await {
-                error!(
-                    "Failed to enqueue replication diagnostics for '{}': {}",
-                    self.replication_name, err
-                );
+
+            // Condition 1: a status change flushes the current bucket.
+            if self
+                .active
+                .as_ref()
+                .is_some_and(|aggregate| aggregate.status != status)
+            {
+                self.flush().await;
             }
-        }
-    }
 
-    async fn enqueue(&self, observation: ReplicationObservation) -> Result<(), ReductError> {
-        self.tx
-            .send(observation)
-            .await
-            .map_err(|_| internal_server_error!("Replication diagnostics worker is not available"))
-    }
-
-    async fn run_worker(
-        mut rx: mpsc::Receiver<ReplicationObservation>,
-        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
-        handler: SystemEventHandler,
-    ) {
-        loop {
-            if let Some(deadline) = Self::next_deadline(&state).await {
-                tokio::select! {
-                    maybe_observation = rx.recv() => {
-                        match maybe_observation {
-                            Some(observation) => {
-                                Self::handle_observation(&state, &handler, observation).await;
-                            }
-                            None => {
-                                let _ = Self::flush_all(&state, &handler).await;
-                                break;
-                            }
-                        }
-                    }
-                    _ = tokio::time::sleep_until(deadline) => {
-                        let _ = Self::flush_expired(&state, &handler).await;
-                    }
-                }
-            } else {
-                match rx.recv().await {
-                    Some(observation) => {
-                        Self::handle_observation(&state, &handler, observation).await;
-                    }
-                    None => break,
-                }
-            }
-        }
-    }
-
-    async fn handle_observation(
-        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
-        handler: &SystemEventHandler,
-        observation: ReplicationObservation,
-    ) {
-        match Self::aggregate_event(state, observation).await {
-            Ok(events) => Self::emit_all(handler, events).await,
-            Err(err) => error!("Failed to aggregate replication diagnostics: {}", err),
-        }
-    }
-
-    /// Apply an observation to the active bucket, returning any event displaced
-    /// by a status change (condition 1).
-    async fn aggregate_event(
-        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
-        observation: ReplicationObservation,
-    ) -> Result<Vec<SystemEvent>, ReductError> {
-        let now = Instant::now();
-        let key = ReplicationAggregateKey {
-            instance: observation.instance.clone(),
-            replication_name: observation.replication_name.clone(),
-        };
-
-        let mut state = state.write().await?;
-        let mut displaced = Vec::new();
-        match state.aggregates.entry(key.clone()) {
-            Entry::Occupied(mut entry) => {
-                if entry.get().status != observation.status {
-                    let previous = entry.insert(new_aggregate(&observation, now));
-                    displaced.push(make_event(key, previous));
-                } else {
-                    let aggregate = entry.get_mut();
-                    if is_success(observation.status) {
-                        aggregate.written_records += observation.records;
-                        aggregate.replicated_data_size += observation.data_size;
+            let now = Instant::now();
+            match &mut self.active {
+                Some(aggregate) => {
+                    if is_success(status) {
+                        aggregate.written_records += records;
+                        aggregate.replicated_data_size += data_size;
                     } else {
-                        aggregate.failed_records += observation.records;
+                        aggregate.failed_records += records;
                     }
-                    aggregate.pending_records = observation.pending_records;
-                    aggregate.duration += observation.duration;
-                    aggregate.last_timestamp = observation.timestamp;
-                    if observation.timestamp < aggregate.first_timestamp {
-                        aggregate.first_timestamp = observation.timestamp;
-                    }
-                    if !observation.message.is_empty() {
-                        aggregate.message = observation.message;
+                    aggregate.pending_records = pending_records;
+                    aggregate.duration += pass_duration;
+                    if !message.is_empty() {
+                        aggregate.message = message;
                     }
                     aggregate.flush_at = now + Duration::from_secs(AGGREGATION_WINDOW_SECS);
                 }
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(new_aggregate(&observation, now));
+                None => {
+                    let success = is_success(status);
+                    self.active = Some(ReplicationAggregate {
+                        status,
+                        first_timestamp: timestamp,
+                        pending_records,
+                        written_records: if success { records } else { 0 },
+                        failed_records: if success { 0 } else { records },
+                        replicated_data_size: data_size,
+                        duration: pass_duration,
+                        message,
+                        flush_at: now + Duration::from_secs(AGGREGATION_WINDOW_SECS),
+                        force_flush_at: now + Duration::from_secs(FORCE_FLUSH_TIMEOUT_SECS),
+                    });
+                }
             }
         }
 
-        Ok(displaced)
+        // Condition 3: the bucket may have hit its time cap.
+        self.flush_if_due().await;
     }
 
-    async fn next_deadline(
-        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
-    ) -> Option<Instant> {
-        let state = state.read().await.ok()?;
-        state
-            .aggregates
-            .values()
-            .map(|aggregate| aggregate.flush_at.min(aggregate.force_flush_at))
-            .min()
-    }
-
-    async fn flush_expired(
-        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
-        handler: &SystemEventHandler,
-    ) -> Result<(), ReductError> {
+    /// Flush the open bucket if its idle window elapsed (condition 2) or it hit
+    /// the time cap (condition 3). Called every worker iteration so an idle
+    /// bucket is flushed even when no new records arrive.
+    pub(super) async fn flush_if_due(&mut self) {
         let now = Instant::now();
-        let events = {
-            let mut state = state.write().await?;
-            let expired_keys: Vec<_> = state
-                .aggregates
-                .iter()
-                .filter(|(_, aggregate)| {
-                    aggregate.flush_at <= now || aggregate.force_flush_at <= now
-                })
-                .map(|(key, _)| key.clone())
-                .collect();
-
-            expired_keys
-                .into_iter()
-                .filter_map(|key| {
-                    state
-                        .aggregates
-                        .remove(&key)
-                        .map(|aggregate| make_event(key, aggregate))
-                })
-                .collect::<Vec<_>>()
-        };
-
-        Self::emit_all(handler, events).await;
-        Ok(())
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|aggregate| now >= aggregate.flush_at || now >= aggregate.force_flush_at)
+        {
+            self.flush().await;
+        }
     }
 
-    async fn flush_all(
-        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
-        handler: &SystemEventHandler,
-    ) -> Result<(), ReductError> {
-        let events = {
-            let mut state = state.write().await?;
-            state
-                .aggregates
-                .drain()
-                .map(|(key, aggregate)| make_event(key, aggregate))
-                .collect::<Vec<_>>()
+    /// Emit the open bucket (if any) as a `$system` event and clear it.
+    pub(super) async fn flush(&mut self) {
+        let Some(aggregate) = self.active.take() else {
+            return;
         };
+        let event = make_event(&self.sink.instance_name, &self.replication_name, aggregate);
 
-        Self::emit_all(handler, events).await;
-        Ok(())
-    }
-
-    async fn emit_all(handler: &SystemEventHandler, events: Vec<SystemEvent>) {
-        for event in events {
-            if let Err(err) = handler(event).await {
-                error!("Failed to persist replication system event: {}", err);
+        match self.sink.system_logger.write().await {
+            Ok(mut logger) => {
+                if let Err(err) = logger.log_event(event).await {
+                    error!(
+                        "Failed to persist replication diagnostics for '{}': {}",
+                        self.replication_name, err
+                    );
+                }
             }
+            Err(err) => error!(
+                "Failed to lock system logger for replication '{}': {}",
+                self.replication_name, err
+            ),
         }
     }
 }
@@ -381,89 +219,108 @@ impl ReplicationEventAggregator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::sync::AsyncRwLock;
+    use crate::syslog::LogSystemEvent;
     use reduct_base::{not_found, timeout};
     use rstest::{fixture, rstest};
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
-    fn observation(status: u16, records: u64, data_size: u64) -> ReplicationObservation {
-        ReplicationObservation {
-            instance: "instance-a".to_string(),
-            replication_name: "repl-1".to_string(),
-            timestamp: 10,
-            status,
-            pending_records: 3,
-            records,
-            data_size,
-            duration: 0.5,
-            message: if is_success(status) {
-                String::new()
-            } else {
-                "boom".to_string()
-            },
+    #[derive(Clone)]
+    struct CapturingLogger {
+        events: Arc<Mutex<Vec<SystemEvent>>>,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl LogSystemEvent for CapturingLogger {
+        async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError> {
+            if self.fail {
+                return Err(timeout!("sink is down"));
+            }
+            self.events.lock().unwrap().push(event);
+            Ok(())
         }
     }
 
-    fn make_test_handler(events: Arc<Mutex<Vec<SystemEvent>>>) -> SystemEventHandler {
-        Arc::new(move |event| {
-            let events = Arc::clone(&events);
-            Box::pin(async move {
-                events.lock().unwrap().push(event);
-                Ok(())
-            })
-        })
+    fn aggregator(events: Arc<Mutex<Vec<SystemEvent>>>, fail: bool) -> ReplicationEventAggregator {
+        let sink = SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(
+                Box::new(CapturingLogger { events, fail }) as Box<dyn LogSystemEvent + Send + Sync>
+            )),
+            instance_name: "instance-1".to_string(),
+        };
+        ReplicationEventAggregator::new(sink, "repl-1".to_string())
     }
 
     #[fixture]
-    fn state() -> Arc<AsyncRwLock<ReplicationAggregatorState>> {
-        Arc::new(AsyncRwLock::new(ReplicationAggregatorState::default()))
-    }
-
-    #[fixture]
-    fn flushed_events() -> Arc<Mutex<Vec<SystemEvent>>> {
+    fn events() -> Arc<Mutex<Vec<SystemEvent>>> {
         Arc::new(Mutex::new(Vec::new()))
     }
 
     #[rstest]
-    fn make_event_carries_unified_payload() {
-        let event = make_event(
-            ReplicationAggregateKey {
-                instance: "instance-a".to_string(),
-                replication_name: "repl-1".to_string(),
-            },
-            new_aggregate(&observation(200, 5, 1234), Instant::now()),
-        );
+    #[tokio::test]
+    async fn records_and_flushes_success(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+        agg.record_pass(3, 0.5, &[(Ok(()), 5, 1234)]).await;
+        agg.flush().await;
 
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let event = &captured[0];
         assert_eq!(event.event_type, "replication_sync");
-        assert_eq!(event.instance, "instance-a");
+        assert_eq!(event.instance, "instance-1");
         assert_eq!(event.entry_name, "repl-1");
         assert_eq!(event.status, 200);
-        assert_eq!(event.timestamp, 10);
-        assert_eq!(event.payload["status"], 200);
         assert_eq!(event.payload["pending_records"], 3);
         assert_eq!(event.payload["written_records"], 5);
         assert_eq!(event.payload["failed_records"], 0);
         assert_eq!(event.payload["replicated_data_size"], 1234);
     }
 
-    /// Schema invariant: a success and a failure event carry the identical
-    /// field set (status, pending, written, failed, size, duration).
+    /// Status-change flush (condition 1): accumulate at 200, then a 404 record
+    /// flushes one 200 event with the accumulated written_records and opens a
+    /// fresh 404 bucket whose flush carries failed_records=X.
     #[rstest]
-    fn success_and_failure_events_share_schema() {
-        let success = make_event(
-            ReplicationAggregateKey {
-                instance: "instance-a".to_string(),
-                replication_name: "repl-1".to_string(),
-            },
-            new_aggregate(&observation(200, 5, 100), Instant::now()),
-        );
-        let failure = make_event(
-            ReplicationAggregateKey {
-                instance: "instance-a".to_string(),
-                replication_name: "repl-1".to_string(),
-            },
-            new_aggregate(&observation(404, 7, 0), Instant::now()),
-        );
+    #[tokio::test]
+    async fn status_change_flushes_previous_bucket(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+        agg.record_pass(0, 0.1, &[(Ok(()), 2, 20)]).await;
+        agg.record_pass(0, 0.1, &[(Ok(()), 3, 30)]).await;
+        assert!(events.lock().unwrap().is_empty(), "same status accumulates");
 
+        agg.record_pass(7, 0.1, &[(Err(not_found!("missing")), 4, 0)])
+            .await;
+
+        {
+            let captured = events.lock().unwrap();
+            assert_eq!(captured.len(), 1, "status change flushed the 200 bucket");
+            assert_eq!(captured[0].status, 200);
+            assert_eq!(captured[0].payload["written_records"], 5);
+            assert_eq!(captured[0].payload["replicated_data_size"], 50);
+        }
+
+        agg.flush().await;
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[1].status, 404);
+        assert_eq!(captured[1].payload["failed_records"], 4);
+        assert_eq!(captured[1].payload["written_records"], 0);
+        assert_eq!(captured[1].message, "missing");
+    }
+
+    /// Schema invariant (#4): success and failure events carry the identical
+    /// field set.
+    #[rstest]
+    #[tokio::test]
+    async fn success_and_failure_events_share_schema(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+        agg.record_pass(0, 0.1, &[(Ok(()), 5, 100)]).await;
+        agg.flush().await;
+        agg.record_pass(0, 0.1, &[(Err(not_found!("x")), 7, 0)])
+            .await;
+        agg.flush().await;
+
+        let captured = events.lock().unwrap();
         let keys_of = |event: &SystemEvent| {
             let mut keys = event
                 .payload
@@ -475,281 +332,85 @@ mod tests {
             keys.sort();
             keys
         };
-        assert_eq!(keys_of(&success), keys_of(&failure));
-
-        // success: written=N, failed=0; failure: failed=X, written=0
-        assert_eq!(success.payload["written_records"], 5);
-        assert_eq!(success.payload["failed_records"], 0);
-        assert_eq!(failure.payload["written_records"], 0);
-        assert_eq!(failure.payload["failed_records"], 7);
+        assert_eq!(keys_of(&captured[0]), keys_of(&captured[1]));
+        assert_eq!(captured[0].payload["written_records"], 5);
+        assert_eq!(captured[0].payload["failed_records"], 0);
+        assert_eq!(captured[1].payload["written_records"], 0);
+        assert_eq!(captured[1].payload["failed_records"], 7);
     }
 
-    /// Status-change flush (condition 1): a 200 observation then a 404 one
-    /// flushes exactly one 200 event with the accumulated written_records and
-    /// opens a fresh 404 bucket.
+    /// Idle flush (condition 2): once the sliding window elapses, flush_if_due
+    /// emits the bucket without any new activity.
     #[rstest]
     #[tokio::test]
-    async fn status_change_flushes_previous_bucket(
-        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
-    ) {
-        ReplicationEventAggregator::aggregate_event(&state, observation(200, 2, 20))
-            .await
-            .unwrap();
-        let displaced =
-            ReplicationEventAggregator::aggregate_event(&state, observation(200, 3, 30))
-                .await
-                .unwrap();
-        assert!(displaced.is_empty(), "same status keeps accumulating");
+    async fn idle_window_flushes(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+        agg.record_pass(0, 0.1, &[(Ok(()), 1, 10)]).await;
+        // age the idle deadline into the past
+        agg.active.as_mut().unwrap().flush_at = Instant::now() - Duration::from_millis(1);
 
-        let displaced = ReplicationEventAggregator::aggregate_event(&state, observation(404, 4, 0))
-            .await
-            .unwrap();
-
-        assert_eq!(displaced.len(), 1, "status change flushes the 200 bucket");
-        let event = &displaced[0];
-        assert_eq!(event.status, 200);
-        assert_eq!(event.payload["written_records"], 5);
-        assert_eq!(event.payload["failed_records"], 0);
-        assert_eq!(event.payload["replicated_data_size"], 50);
-
-        let guard = state.read().await.unwrap();
-        assert_eq!(guard.aggregates.len(), 1);
-        let aggregate = guard.aggregates.values().next().unwrap();
-        assert_eq!(aggregate.status, 404);
-        assert_eq!(aggregate.failed_records, 4);
-        assert_eq!(aggregate.written_records, 0);
+        agg.flush_if_due().await;
+        assert_eq!(events.lock().unwrap().len(), 1);
+        assert!(agg.active.is_none());
     }
 
-    /// End-to-end 200 -> 404 example: the 404 event carries failed_records=X.
+    /// Cap flush (condition 3): once the force-flush deadline passes, the bucket
+    /// is flushed even though the idle window has not elapsed.
     #[rstest]
     #[tokio::test]
-    async fn flush_all_emits_open_bucket(
-        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
-        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
-    ) {
-        let handler = make_test_handler(Arc::clone(&flushed_events));
-
-        ReplicationEventAggregator::aggregate_event(&state, observation(404, 6, 0))
-            .await
-            .unwrap();
-        ReplicationEventAggregator::flush_all(&state, &handler)
-            .await
-            .unwrap();
-
-        let events = flushed_events.lock().unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].status, 404);
-        assert_eq!(events[0].payload["failed_records"], 6);
-        assert_eq!(events[0].message, "boom");
-        assert!(state.read().await.unwrap().aggregates.is_empty());
-    }
-
-    /// Counts: written/failed map correctly and pending is pulled from the
-    /// latest observation; record_pass groups a mixed pass by status.
-    #[rstest]
-    #[tokio::test]
-    async fn record_pass_groups_counter_by_status(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
-        let sink = SystemEventSink {
-            system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingLogger {
-                events: Arc::clone(&flushed_events),
-                fail: false,
-            })
-                as Box<dyn crate::syslog::LogSystemEvent + Send + Sync>)),
-            instance_name: "instance-a".to_string(),
-        };
-        let aggregator = ReplicationEventAggregator::new(sink, "repl-1".to_string());
-
-        let counter = vec![
-            (Ok(()), 2u64, 40u64),
-            (Err(not_found!("missing")), 1u64, 0u64),
-        ];
-        aggregator.record_pass(7, 0.25, &counter).await;
-
-        // allow the worker to drain the channel
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        let guard = aggregator.state.read().await.unwrap();
-        // 200 grouped, then 404 grouped -> status change flushed the 200 bucket
-        assert_eq!(guard.aggregates.len(), 1);
-        let aggregate = guard.aggregates.values().next().unwrap();
-        assert_eq!(aggregate.status, 404);
-        assert_eq!(aggregate.failed_records, 1);
-        assert_eq!(aggregate.pending_records, 7);
-        drop(guard);
-
-        let events = flushed_events.lock().unwrap();
-        assert_eq!(
-            events.len(),
-            1,
-            "the 200 bucket was flushed on status change"
-        );
-        assert_eq!(events[0].status, 200);
-        assert_eq!(events[0].payload["written_records"], 2);
-        assert_eq!(events[0].payload["replicated_data_size"], 40);
-    }
-
-    /// Safety: a logger whose log_event returns Err must not break the
-    /// aggregator; the error is swallowed and logged, never propagated.
-    #[rstest]
-    #[tokio::test]
-    async fn emission_errors_are_swallowed(
-        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
-        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
-    ) {
-        let handler: SystemEventHandler = Arc::new(move |_event| {
-            Box::pin(async move { Err(internal_server_error!("disk is on fire")) })
-        });
-
-        ReplicationEventAggregator::aggregate_event(&state, observation(200, 1, 10))
-            .await
-            .unwrap();
-
-        // must not panic / propagate despite the failing handler
-        ReplicationEventAggregator::flush_all(&state, &handler)
-            .await
-            .unwrap();
-
-        assert!(flushed_events.lock().unwrap().is_empty());
-        assert!(state.read().await.unwrap().aggregates.is_empty());
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn next_deadline_returns_none_when_empty(
-        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
-    ) {
-        assert!(ReplicationEventAggregator::next_deadline(&state)
-            .await
-            .is_none());
-    }
-
-    fn insert_aggregate(
-        state: &ReplicationAggregatorState,
-        flush_at: Instant,
-        force_flush_at: Instant,
-    ) -> ReplicationAggregatorState {
-        let mut state = ReplicationAggregatorState {
-            aggregates: state.aggregates.clone(),
-        };
-        state.aggregates.insert(
-            ReplicationAggregateKey {
-                instance: "instance-a".to_string(),
-                replication_name: "repl-1".to_string(),
-            },
-            ReplicationAggregate {
-                status: 200,
-                first_timestamp: 1,
-                last_timestamp: 1,
-                pending_records: 0,
-                written_records: 1,
-                failed_records: 0,
-                replicated_data_size: 10,
-                duration: 0.1,
-                message: String::new(),
-                flush_at,
-                force_flush_at,
-            },
-        );
-        state
-    }
-
-    /// Idle flush (condition 2): a bucket whose sliding window expired is
-    /// flushed even though the cap has not been reached.
-    #[rstest]
-    #[tokio::test]
-    async fn flush_expired_flushes_idle_bucket(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
+    async fn time_cap_flushes(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+        agg.record_pass(0, 0.1, &[(Ok(()), 1, 10)]).await;
         let now = Instant::now();
-        let state = Arc::new(AsyncRwLock::new(insert_aggregate(
-            &ReplicationAggregatorState::default(),
-            now - Duration::from_millis(1),
-            now + Duration::from_secs(60),
-        )));
-        let handler = make_test_handler(Arc::clone(&flushed_events));
+        let aggregate = agg.active.as_mut().unwrap();
+        aggregate.flush_at = now + Duration::from_secs(5); // not idle
+        aggregate.force_flush_at = now - Duration::from_millis(1); // capped
 
-        ReplicationEventAggregator::flush_expired(&state, &handler)
-            .await
-            .unwrap();
-
-        assert_eq!(flushed_events.lock().unwrap().len(), 1);
-        assert!(state.read().await.unwrap().aggregates.is_empty());
-    }
-
-    /// Cap flush (condition 3): a bucket whose force-flush deadline expired is
-    /// flushed even though it is still receiving activity (window not idle).
-    #[rstest]
-    #[tokio::test]
-    async fn flush_expired_flushes_capped_bucket(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
-        let now = Instant::now();
-        let state = Arc::new(AsyncRwLock::new(insert_aggregate(
-            &ReplicationAggregatorState::default(),
-            now + Duration::from_secs(5),
-            now - Duration::from_millis(1),
-        )));
-        let handler = make_test_handler(Arc::clone(&flushed_events));
-
-        ReplicationEventAggregator::flush_expired(&state, &handler)
-            .await
-            .unwrap();
-
-        assert_eq!(flushed_events.lock().unwrap().len(), 1);
-        assert!(state.read().await.unwrap().aggregates.is_empty());
+        agg.flush_if_due().await;
+        assert_eq!(events.lock().unwrap().len(), 1);
+        assert!(agg.active.is_none());
     }
 
     #[rstest]
     #[tokio::test]
-    async fn flush_expired_keeps_active_bucket(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
-        let now = Instant::now();
-        let state = Arc::new(AsyncRwLock::new(insert_aggregate(
-            &ReplicationAggregatorState::default(),
-            now + Duration::from_secs(5),
-            now + Duration::from_secs(60),
-        )));
-        let handler = make_test_handler(Arc::clone(&flushed_events));
+    async fn flush_if_due_keeps_fresh_bucket(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+        agg.record_pass(0, 0.1, &[(Ok(()), 1, 10)]).await;
 
-        ReplicationEventAggregator::flush_expired(&state, &handler)
-            .await
-            .unwrap();
-
-        assert!(flushed_events.lock().unwrap().is_empty());
-        assert_eq!(state.read().await.unwrap().aggregates.len(), 1);
+        agg.flush_if_due().await;
+        assert!(events.lock().unwrap().is_empty());
+        assert!(agg.active.is_some());
     }
 
-    /// Idle flush through the real worker (condition 2): after the aggregation
-    /// window elapses with no further activity, the bucket is flushed.
-    #[cfg(target_os = "linux")] // we need precise timing
+    /// Safety (#6): a logger that always errors must not break the aggregator;
+    /// the error is swallowed, the bucket is still cleared.
+    #[rstest]
+    #[tokio::test]
+    async fn emission_errors_are_swallowed(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), true);
+        agg.record_pass(0, 0.1, &[(Ok(()), 1, 10)]).await;
+        agg.flush().await; // must not panic / propagate
+
+        assert!(events.lock().unwrap().is_empty());
+        assert!(agg.active.is_none());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn empty_pass_is_ignored(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+        agg.record_pass(0, 0.1, &[]).await;
+        assert!(agg.active.is_none());
+        agg.flush().await;
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    /// Entry path (#7): events land at replications/<instance>/<name>. With the
+    /// inline aggregator, flush() persists synchronously, so the entry is
+    /// readable immediately after — no polling needed.
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn worker_flushes_after_idle_window(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
-        let sink = SystemEventSink {
-            system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingLogger {
-                events: Arc::clone(&flushed_events),
-                fail: false,
-            })
-                as Box<dyn crate::syslog::LogSystemEvent + Send + Sync>)),
-            instance_name: "instance-a".to_string(),
-        };
-        let aggregator = ReplicationEventAggregator::new(sink, "repl-1".to_string());
-
-        aggregator
-            .record_pass(0, 0.1, &[(Ok(()), 1u64, 10u64)])
-            .await;
-
-        // AGGREGATION_WINDOW_SECS is 1 in test builds; wait past it
-        tokio::time::sleep(
-            Duration::from_secs(AGGREGATION_WINDOW_SECS) + Duration::from_millis(500),
-        )
-        .await;
-
-        let events = flushed_events.lock().unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].status, 200);
-        assert_eq!(events[0].payload["written_records"], 1);
-    }
-
-    /// Entry path (#7): events land at replications/<instance>/<replication-name>.
-    #[rstest]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn writes_replication_event_to_system_bucket() {
+    async fn writes_event_to_replications_entry_path() {
         use crate::cfg::Cfg;
         use crate::storage::engine::StorageEngine;
         use crate::syslog::{build_replication_system_logger, SYSTEM_BUCKET_NAME};
@@ -776,38 +437,26 @@ mod tests {
             system_logger: Arc::new(AsyncRwLock::new(logger)),
             instance_name: "instance-1".to_string(),
         };
-        let aggregator = ReplicationEventAggregator::new(sink, "repl-1".to_string());
+        let mut agg = ReplicationEventAggregator::new(sink, "repl-1".to_string());
 
-        aggregator
-            .record_pass(2, 0.5, &[(Ok(()), 3u64, 120u64)])
-            .await;
+        agg.record_pass(2, 0.5, &[(Ok(()), 3, 120)]).await;
+        agg.flush().await;
 
-        // drop the aggregator to close the channel and flush the open bucket
-        drop(aggregator);
-
-        // The worker creates the bucket, flushes and persists asynchronously, so
-        // poll for the entry to appear rather than relying on a single fixed sleep
-        // (disk I/O can be slow on some platforms, e.g. Windows CI).
+        let bucket = storage
+            .get_bucket(SYSTEM_BUCKET_NAME)
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
         let entry_path = "replications/instance-1/repl-1";
-        let mut found = None;
-        for _ in 0..100 {
-            if let Ok(weak_bucket) = storage.get_bucket(SYSTEM_BUCKET_NAME).await {
-                let bucket = weak_bucket.upgrade_and_unwrap();
-                if let Some(entry) = Arc::clone(&bucket)
-                    .info()
-                    .await
-                    .unwrap()
-                    .entries
-                    .into_iter()
-                    .find(|entry| entry.name == entry_path)
-                {
-                    found = Some((bucket, entry.latest_record));
-                    break;
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        let (bucket, latest_record) = found.expect("replication diagnostics entry must exist");
+        let latest_record = Arc::clone(&bucket)
+            .info()
+            .await
+            .unwrap()
+            .entries
+            .into_iter()
+            .find(|entry| entry.name == entry_path)
+            .expect("replication diagnostics entry must exist")
+            .latest_record;
         let mut reader = bucket.begin_read(entry_path, latest_record).await.unwrap();
         let record = reader.read_chunk().unwrap().unwrap();
         let event: serde_json::Value = serde_json::from_slice(&record).unwrap();
@@ -817,22 +466,5 @@ mod tests {
         assert_eq!(event["written_records"], 3);
         assert_eq!(event["replicated_data_size"], 120);
         assert_eq!(event["pending_records"], 2);
-    }
-
-    #[derive(Clone)]
-    struct CapturingLogger {
-        events: Arc<Mutex<Vec<SystemEvent>>>,
-        fail: bool,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::syslog::LogSystemEvent for CapturingLogger {
-        async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError> {
-            if self.fail {
-                return Err(timeout!("nope"));
-            }
-            self.events.lock().unwrap().push(event);
-            Ok(())
-        }
     }
 }

--- a/reductstore/src/replication/replication_aggregator.rs
+++ b/reductstore/src/replication/replication_aggregator.rs
@@ -784,23 +784,30 @@ mod tests {
 
         // drop the aggregator to close the channel and flush the open bucket
         drop(aggregator);
-        tokio::time::sleep(Duration::from_millis(200)).await;
 
-        let bucket = storage
-            .get_bucket(SYSTEM_BUCKET_NAME)
-            .await
-            .unwrap()
-            .upgrade_and_unwrap();
+        // The worker creates the bucket, flushes and persists asynchronously, so
+        // poll for the entry to appear rather than relying on a single fixed sleep
+        // (disk I/O can be slow on some platforms, e.g. Windows CI).
         let entry_path = "replications/instance-1/repl-1";
-        let latest_record = Arc::clone(&bucket)
-            .info()
-            .await
-            .unwrap()
-            .entries
-            .into_iter()
-            .find(|entry| entry.name == entry_path)
-            .expect("replication diagnostics entry must exist")
-            .latest_record;
+        let mut found = None;
+        for _ in 0..100 {
+            if let Ok(weak_bucket) = storage.get_bucket(SYSTEM_BUCKET_NAME).await {
+                let bucket = weak_bucket.upgrade_and_unwrap();
+                if let Some(entry) = Arc::clone(&bucket)
+                    .info()
+                    .await
+                    .unwrap()
+                    .entries
+                    .into_iter()
+                    .find(|entry| entry.name == entry_path)
+                {
+                    found = Some((bucket, entry.latest_record));
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let (bucket, latest_record) = found.expect("replication diagnostics entry must exist");
         let mut reader = bucket.begin_read(entry_path, latest_record).await.unwrap();
         let record = reader.read_chunk().unwrap().unwrap();
         let event: serde_json::Value = serde_json::from_slice(&record).unwrap();

--- a/reductstore/src/replication/replication_aggregator.rs
+++ b/reductstore/src/replication/replication_aggregator.rs
@@ -99,7 +99,10 @@ fn new_aggregate(obs: &ReplicationObservation, now: Instant) -> ReplicationAggre
     }
 }
 
-pub(crate) fn make_event(key: ReplicationAggregateKey, aggregate: ReplicationAggregate) -> SystemEvent {
+pub(crate) fn make_event(
+    key: ReplicationAggregateKey,
+    aggregate: ReplicationAggregate,
+) -> SystemEvent {
     let payload = ReplicationSystemEventPayload {
         status: aggregate.status,
         pending_records: aggregate.pending_records,
@@ -307,7 +310,9 @@ impl ReplicationEventAggregator {
         Ok(displaced)
     }
 
-    async fn next_deadline(state: &Arc<AsyncRwLock<ReplicationAggregatorState>>) -> Option<Instant> {
+    async fn next_deadline(
+        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
+    ) -> Option<Instant> {
         let state = state.read().await.ok()?;
         state
             .aggregates
@@ -490,15 +495,15 @@ mod tests {
         ReplicationEventAggregator::aggregate_event(&state, observation(200, 2, 20))
             .await
             .unwrap();
-        let displaced = ReplicationEventAggregator::aggregate_event(&state, observation(200, 3, 30))
-            .await
-            .unwrap();
-        assert!(displaced.is_empty(), "same status keeps accumulating");
-
         let displaced =
-            ReplicationEventAggregator::aggregate_event(&state, observation(404, 4, 0))
+            ReplicationEventAggregator::aggregate_event(&state, observation(200, 3, 30))
                 .await
                 .unwrap();
+        assert!(displaced.is_empty(), "same status keeps accumulating");
+
+        let displaced = ReplicationEventAggregator::aggregate_event(&state, observation(404, 4, 0))
+            .await
+            .unwrap();
 
         assert_eq!(displaced.len(), 1, "status change flushes the 200 bucket");
         let event = &displaced[0];
@@ -543,9 +548,7 @@ mod tests {
     /// latest observation; record_pass groups a mixed pass by status.
     #[rstest]
     #[tokio::test]
-    async fn record_pass_groups_counter_by_status(
-        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
-    ) {
+    async fn record_pass_groups_counter_by_status(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
         let sink = SystemEventSink {
             system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingLogger {
                 events: Arc::clone(&flushed_events),
@@ -575,7 +578,11 @@ mod tests {
         drop(guard);
 
         let events = flushed_events.lock().unwrap();
-        assert_eq!(events.len(), 1, "the 200 bucket was flushed on status change");
+        assert_eq!(
+            events.len(),
+            1,
+            "the 200 bucket was flushed on status change"
+        );
         assert_eq!(events[0].status, 200);
         assert_eq!(events[0].payload["written_records"], 2);
         assert_eq!(events[0].payload["replicated_data_size"], 40);
@@ -650,9 +657,7 @@ mod tests {
     /// flushed even though the cap has not been reached.
     #[rstest]
     #[tokio::test]
-    async fn flush_expired_flushes_idle_bucket(
-        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
-    ) {
+    async fn flush_expired_flushes_idle_bucket(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
         let now = Instant::now();
         let state = Arc::new(AsyncRwLock::new(insert_aggregate(
             &ReplicationAggregatorState::default(),
@@ -673,9 +678,7 @@ mod tests {
     /// flushed even though it is still receiving activity (window not idle).
     #[rstest]
     #[tokio::test]
-    async fn flush_expired_flushes_capped_bucket(
-        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
-    ) {
+    async fn flush_expired_flushes_capped_bucket(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
         let now = Instant::now();
         let state = Arc::new(AsyncRwLock::new(insert_aggregate(
             &ReplicationAggregatorState::default(),
@@ -694,9 +697,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn flush_expired_keeps_active_bucket(
-        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
-    ) {
+    async fn flush_expired_keeps_active_bucket(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
         let now = Instant::now();
         let state = Arc::new(AsyncRwLock::new(insert_aggregate(
             &ReplicationAggregatorState::default(),
@@ -734,8 +735,10 @@ mod tests {
             .await;
 
         // AGGREGATION_WINDOW_SECS is 1 in test builds; wait past it
-        tokio::time::sleep(Duration::from_secs(AGGREGATION_WINDOW_SECS) + Duration::from_millis(500))
-            .await;
+        tokio::time::sleep(
+            Duration::from_secs(AGGREGATION_WINDOW_SECS) + Duration::from_millis(500),
+        )
+        .await;
 
         let events = flushed_events.lock().unwrap();
         assert_eq!(events.len(), 1);

--- a/reductstore/src/replication/replication_aggregator.rs
+++ b/reductstore/src/replication/replication_aggregator.rs
@@ -1,0 +1,828 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+//! Aggregates replication diagnostics into periodic system events.
+//!
+//! One active "bucket" (running tally) is kept per replication task, keyed by
+//! the status code. The bucket is flushed and a new one opened when ANY of:
+//!   1. the status (the key) changes (e.g. 200 -> 404),
+//!   2. no records were replicated for [`AGGREGATION_WINDOW_SECS`] (idle),
+//!   3. the bucket accumulated [`FORCE_FLUSH_TIMEOUT_SECS`] of data (cap).
+//!
+//! The window/force-flush timing (conditions 2 and 3) reuses the model of
+//! [`crate::api::audit::aggregator::ApiAuditEventAggregator`]; the status-change
+//! trigger (condition 1) is added on top.
+
+use crate::api::audit::aggregator::{AGGREGATION_WINDOW_SECS, FORCE_FLUSH_TIMEOUT_SECS};
+use crate::core::sync::AsyncRwLock;
+use crate::lifecycle::SystemEventSink;
+use crate::replication::replication_event_payload::ReplicationSystemEventPayload;
+use crate::syslog::{SystemEvent, SystemEventHandler};
+use log::error;
+use reduct_base::error::ReductError;
+use reduct_base::internal_server_error;
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::mpsc;
+use tokio::time::{Duration, Instant};
+
+const REPLICATION_CHANNEL_SIZE: usize = 1024;
+const REPLICATION_EVENT_TYPE: &str = "replication_sync";
+
+/// A single observation reported by a replication pass for one status code.
+#[derive(Debug, Clone)]
+pub(crate) struct ReplicationObservation {
+    pub instance: String,
+    pub replication_name: String,
+    pub timestamp: u64,
+    pub status: u16,
+    pub pending_records: u64,
+    pub records: u64,
+    pub data_size: u64,
+    pub duration: f64,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ReplicationAggregateKey {
+    pub instance: String,
+    pub replication_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReplicationAggregate {
+    pub status: u16,
+    pub first_timestamp: u64,
+    pub last_timestamp: u64,
+    pub pending_records: u64,
+    pub written_records: u64,
+    pub failed_records: u64,
+    pub replicated_data_size: u64,
+    pub duration: f64,
+    pub message: String,
+    pub flush_at: Instant,
+    pub force_flush_at: Instant,
+}
+
+#[derive(Default)]
+pub(crate) struct ReplicationAggregatorState {
+    pub aggregates: HashMap<ReplicationAggregateKey, ReplicationAggregate>,
+}
+
+fn is_success(status: u16) -> bool {
+    (200..300).contains(&status)
+}
+
+fn now_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
+}
+
+fn new_aggregate(obs: &ReplicationObservation, now: Instant) -> ReplicationAggregate {
+    let success = is_success(obs.status);
+    ReplicationAggregate {
+        status: obs.status,
+        first_timestamp: obs.timestamp,
+        last_timestamp: obs.timestamp,
+        pending_records: obs.pending_records,
+        written_records: if success { obs.records } else { 0 },
+        failed_records: if success { 0 } else { obs.records },
+        replicated_data_size: obs.data_size,
+        duration: obs.duration,
+        message: obs.message.clone(),
+        flush_at: now + Duration::from_secs(AGGREGATION_WINDOW_SECS),
+        force_flush_at: now + Duration::from_secs(FORCE_FLUSH_TIMEOUT_SECS),
+    }
+}
+
+pub(crate) fn make_event(key: ReplicationAggregateKey, aggregate: ReplicationAggregate) -> SystemEvent {
+    let payload = ReplicationSystemEventPayload {
+        status: aggregate.status,
+        pending_records: aggregate.pending_records,
+        written_records: aggregate.written_records,
+        failed_records: aggregate.failed_records,
+        replicated_data_size: aggregate.replicated_data_size,
+        duration: aggregate.duration,
+    };
+
+    SystemEvent {
+        event_type: REPLICATION_EVENT_TYPE.to_string(),
+        timestamp: aggregate.first_timestamp,
+        instance: key.instance,
+        entry_name: key.replication_name,
+        status: aggregate.status,
+        message: aggregate.message,
+        payload: payload.to_value(),
+    }
+}
+
+pub(crate) struct ReplicationEventAggregator {
+    instance_name: String,
+    replication_name: String,
+    tx: mpsc::Sender<ReplicationObservation>,
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
+}
+
+impl ReplicationEventAggregator {
+    pub(crate) fn new(sink: SystemEventSink, replication_name: String) -> Self {
+        let instance_name = sink.instance_name.clone();
+        let logger = Arc::clone(&sink.system_logger);
+        let handler: SystemEventHandler = Arc::new(move |event| {
+            let logger = Arc::clone(&logger);
+            Box::pin(async move {
+                let mut guard = logger.write().await?;
+                guard.log_event(event).await
+            })
+        });
+
+        let state = Arc::new(AsyncRwLock::new(ReplicationAggregatorState::default()));
+        let (tx, rx) = mpsc::channel(REPLICATION_CHANNEL_SIZE);
+        tokio::spawn(Self::run_worker(rx, Arc::clone(&state), handler));
+
+        Self {
+            instance_name,
+            replication_name,
+            tx,
+            #[cfg(test)]
+            state,
+        }
+    }
+
+    /// Record a replication pass.
+    ///
+    /// Telemetry must never break replication, so enqueue failures are
+    /// swallowed and logged rather than propagated. The pass `duration` is
+    /// attributed to the lowest-status observation only, so it is never
+    /// double-counted when a single pass produces several status codes.
+    pub(crate) async fn record_pass(
+        &self,
+        pending_records: u64,
+        duration: f64,
+        counter: &[(Result<(), ReductError>, u64, u64)],
+    ) {
+        let mut per_status: BTreeMap<u16, (u64, u64, String)> = BTreeMap::new();
+        for (result, records, data_size) in counter {
+            let (status, message) = match result {
+                Ok(_) => (200u16, String::new()),
+                Err(err) => (err.status as u16, err.message.clone()),
+            };
+            let entry = per_status.entry(status).or_default();
+            entry.0 += *records;
+            entry.1 += *data_size;
+            if !message.is_empty() {
+                entry.2 = message;
+            }
+        }
+
+        if per_status.is_empty() {
+            return;
+        }
+
+        let timestamp = now_micros();
+        let mut first = true;
+        for (status, (records, data_size, message)) in per_status {
+            let observation = ReplicationObservation {
+                instance: self.instance_name.clone(),
+                replication_name: self.replication_name.clone(),
+                timestamp,
+                status,
+                pending_records,
+                records,
+                data_size,
+                duration: if first { duration } else { 0.0 },
+                message,
+            };
+            first = false;
+            if let Err(err) = self.enqueue(observation).await {
+                error!(
+                    "Failed to enqueue replication diagnostics for '{}': {}",
+                    self.replication_name, err
+                );
+            }
+        }
+    }
+
+    async fn enqueue(&self, observation: ReplicationObservation) -> Result<(), ReductError> {
+        self.tx
+            .send(observation)
+            .await
+            .map_err(|_| internal_server_error!("Replication diagnostics worker is not available"))
+    }
+
+    async fn run_worker(
+        mut rx: mpsc::Receiver<ReplicationObservation>,
+        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
+        handler: SystemEventHandler,
+    ) {
+        loop {
+            if let Some(deadline) = Self::next_deadline(&state).await {
+                tokio::select! {
+                    maybe_observation = rx.recv() => {
+                        match maybe_observation {
+                            Some(observation) => {
+                                Self::handle_observation(&state, &handler, observation).await;
+                            }
+                            None => {
+                                let _ = Self::flush_all(&state, &handler).await;
+                                break;
+                            }
+                        }
+                    }
+                    _ = tokio::time::sleep_until(deadline) => {
+                        let _ = Self::flush_expired(&state, &handler).await;
+                    }
+                }
+            } else {
+                match rx.recv().await {
+                    Some(observation) => {
+                        Self::handle_observation(&state, &handler, observation).await;
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+
+    async fn handle_observation(
+        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
+        handler: &SystemEventHandler,
+        observation: ReplicationObservation,
+    ) {
+        match Self::aggregate_event(state, observation).await {
+            Ok(events) => Self::emit_all(handler, events).await,
+            Err(err) => error!("Failed to aggregate replication diagnostics: {}", err),
+        }
+    }
+
+    /// Apply an observation to the active bucket, returning any event displaced
+    /// by a status change (condition 1).
+    async fn aggregate_event(
+        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
+        observation: ReplicationObservation,
+    ) -> Result<Vec<SystemEvent>, ReductError> {
+        let now = Instant::now();
+        let key = ReplicationAggregateKey {
+            instance: observation.instance.clone(),
+            replication_name: observation.replication_name.clone(),
+        };
+
+        let mut state = state.write().await?;
+        let mut displaced = Vec::new();
+        match state.aggregates.entry(key.clone()) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().status != observation.status {
+                    let previous = entry.insert(new_aggregate(&observation, now));
+                    displaced.push(make_event(key, previous));
+                } else {
+                    let aggregate = entry.get_mut();
+                    if is_success(observation.status) {
+                        aggregate.written_records += observation.records;
+                        aggregate.replicated_data_size += observation.data_size;
+                    } else {
+                        aggregate.failed_records += observation.records;
+                    }
+                    aggregate.pending_records = observation.pending_records;
+                    aggregate.duration += observation.duration;
+                    aggregate.last_timestamp = observation.timestamp;
+                    if observation.timestamp < aggregate.first_timestamp {
+                        aggregate.first_timestamp = observation.timestamp;
+                    }
+                    if !observation.message.is_empty() {
+                        aggregate.message = observation.message;
+                    }
+                    aggregate.flush_at = now + Duration::from_secs(AGGREGATION_WINDOW_SECS);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(new_aggregate(&observation, now));
+            }
+        }
+
+        Ok(displaced)
+    }
+
+    async fn next_deadline(state: &Arc<AsyncRwLock<ReplicationAggregatorState>>) -> Option<Instant> {
+        let state = state.read().await.ok()?;
+        state
+            .aggregates
+            .values()
+            .map(|aggregate| aggregate.flush_at.min(aggregate.force_flush_at))
+            .min()
+    }
+
+    async fn flush_expired(
+        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
+        handler: &SystemEventHandler,
+    ) -> Result<(), ReductError> {
+        let now = Instant::now();
+        let events = {
+            let mut state = state.write().await?;
+            let expired_keys: Vec<_> = state
+                .aggregates
+                .iter()
+                .filter(|(_, aggregate)| {
+                    aggregate.flush_at <= now || aggregate.force_flush_at <= now
+                })
+                .map(|(key, _)| key.clone())
+                .collect();
+
+            expired_keys
+                .into_iter()
+                .filter_map(|key| {
+                    state
+                        .aggregates
+                        .remove(&key)
+                        .map(|aggregate| make_event(key, aggregate))
+                })
+                .collect::<Vec<_>>()
+        };
+
+        Self::emit_all(handler, events).await;
+        Ok(())
+    }
+
+    async fn flush_all(
+        state: &Arc<AsyncRwLock<ReplicationAggregatorState>>,
+        handler: &SystemEventHandler,
+    ) -> Result<(), ReductError> {
+        let events = {
+            let mut state = state.write().await?;
+            state
+                .aggregates
+                .drain()
+                .map(|(key, aggregate)| make_event(key, aggregate))
+                .collect::<Vec<_>>()
+        };
+
+        Self::emit_all(handler, events).await;
+        Ok(())
+    }
+
+    async fn emit_all(handler: &SystemEventHandler, events: Vec<SystemEvent>) {
+        for event in events {
+            if let Err(err) = handler(event).await {
+                error!("Failed to persist replication system event: {}", err);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reduct_base::{not_found, timeout};
+    use rstest::{fixture, rstest};
+    use std::sync::Mutex;
+
+    fn observation(status: u16, records: u64, data_size: u64) -> ReplicationObservation {
+        ReplicationObservation {
+            instance: "instance-a".to_string(),
+            replication_name: "repl-1".to_string(),
+            timestamp: 10,
+            status,
+            pending_records: 3,
+            records,
+            data_size,
+            duration: 0.5,
+            message: if is_success(status) {
+                String::new()
+            } else {
+                "boom".to_string()
+            },
+        }
+    }
+
+    fn make_test_handler(events: Arc<Mutex<Vec<SystemEvent>>>) -> SystemEventHandler {
+        Arc::new(move |event| {
+            let events = Arc::clone(&events);
+            Box::pin(async move {
+                events.lock().unwrap().push(event);
+                Ok(())
+            })
+        })
+    }
+
+    #[fixture]
+    fn state() -> Arc<AsyncRwLock<ReplicationAggregatorState>> {
+        Arc::new(AsyncRwLock::new(ReplicationAggregatorState::default()))
+    }
+
+    #[fixture]
+    fn flushed_events() -> Arc<Mutex<Vec<SystemEvent>>> {
+        Arc::new(Mutex::new(Vec::new()))
+    }
+
+    #[rstest]
+    fn make_event_carries_unified_payload() {
+        let event = make_event(
+            ReplicationAggregateKey {
+                instance: "instance-a".to_string(),
+                replication_name: "repl-1".to_string(),
+            },
+            new_aggregate(&observation(200, 5, 1234), Instant::now()),
+        );
+
+        assert_eq!(event.event_type, "replication_sync");
+        assert_eq!(event.instance, "instance-a");
+        assert_eq!(event.entry_name, "repl-1");
+        assert_eq!(event.status, 200);
+        assert_eq!(event.timestamp, 10);
+        assert_eq!(event.payload["status"], 200);
+        assert_eq!(event.payload["pending_records"], 3);
+        assert_eq!(event.payload["written_records"], 5);
+        assert_eq!(event.payload["failed_records"], 0);
+        assert_eq!(event.payload["replicated_data_size"], 1234);
+    }
+
+    /// Schema invariant: a success and a failure event carry the identical
+    /// field set (status, pending, written, failed, size, duration).
+    #[rstest]
+    fn success_and_failure_events_share_schema() {
+        let success = make_event(
+            ReplicationAggregateKey {
+                instance: "instance-a".to_string(),
+                replication_name: "repl-1".to_string(),
+            },
+            new_aggregate(&observation(200, 5, 100), Instant::now()),
+        );
+        let failure = make_event(
+            ReplicationAggregateKey {
+                instance: "instance-a".to_string(),
+                replication_name: "repl-1".to_string(),
+            },
+            new_aggregate(&observation(404, 7, 0), Instant::now()),
+        );
+
+        let keys_of = |event: &SystemEvent| {
+            let mut keys = event
+                .payload
+                .as_object()
+                .unwrap()
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>();
+            keys.sort();
+            keys
+        };
+        assert_eq!(keys_of(&success), keys_of(&failure));
+
+        // success: written=N, failed=0; failure: failed=X, written=0
+        assert_eq!(success.payload["written_records"], 5);
+        assert_eq!(success.payload["failed_records"], 0);
+        assert_eq!(failure.payload["written_records"], 0);
+        assert_eq!(failure.payload["failed_records"], 7);
+    }
+
+    /// Status-change flush (condition 1): a 200 observation then a 404 one
+    /// flushes exactly one 200 event with the accumulated written_records and
+    /// opens a fresh 404 bucket.
+    #[rstest]
+    #[tokio::test]
+    async fn status_change_flushes_previous_bucket(
+        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
+    ) {
+        ReplicationEventAggregator::aggregate_event(&state, observation(200, 2, 20))
+            .await
+            .unwrap();
+        let displaced = ReplicationEventAggregator::aggregate_event(&state, observation(200, 3, 30))
+            .await
+            .unwrap();
+        assert!(displaced.is_empty(), "same status keeps accumulating");
+
+        let displaced =
+            ReplicationEventAggregator::aggregate_event(&state, observation(404, 4, 0))
+                .await
+                .unwrap();
+
+        assert_eq!(displaced.len(), 1, "status change flushes the 200 bucket");
+        let event = &displaced[0];
+        assert_eq!(event.status, 200);
+        assert_eq!(event.payload["written_records"], 5);
+        assert_eq!(event.payload["failed_records"], 0);
+        assert_eq!(event.payload["replicated_data_size"], 50);
+
+        let guard = state.read().await.unwrap();
+        assert_eq!(guard.aggregates.len(), 1);
+        let aggregate = guard.aggregates.values().next().unwrap();
+        assert_eq!(aggregate.status, 404);
+        assert_eq!(aggregate.failed_records, 4);
+        assert_eq!(aggregate.written_records, 0);
+    }
+
+    /// End-to-end 200 -> 404 example: the 404 event carries failed_records=X.
+    #[rstest]
+    #[tokio::test]
+    async fn flush_all_emits_open_bucket(
+        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
+        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
+    ) {
+        let handler = make_test_handler(Arc::clone(&flushed_events));
+
+        ReplicationEventAggregator::aggregate_event(&state, observation(404, 6, 0))
+            .await
+            .unwrap();
+        ReplicationEventAggregator::flush_all(&state, &handler)
+            .await
+            .unwrap();
+
+        let events = flushed_events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, 404);
+        assert_eq!(events[0].payload["failed_records"], 6);
+        assert_eq!(events[0].message, "boom");
+        assert!(state.read().await.unwrap().aggregates.is_empty());
+    }
+
+    /// Counts: written/failed map correctly and pending is pulled from the
+    /// latest observation; record_pass groups a mixed pass by status.
+    #[rstest]
+    #[tokio::test]
+    async fn record_pass_groups_counter_by_status(
+        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
+    ) {
+        let sink = SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingLogger {
+                events: Arc::clone(&flushed_events),
+                fail: false,
+            })
+                as Box<dyn crate::syslog::LogSystemEvent + Send + Sync>)),
+            instance_name: "instance-a".to_string(),
+        };
+        let aggregator = ReplicationEventAggregator::new(sink, "repl-1".to_string());
+
+        let counter = vec![
+            (Ok(()), 2u64, 40u64),
+            (Err(not_found!("missing")), 1u64, 0u64),
+        ];
+        aggregator.record_pass(7, 0.25, &counter).await;
+
+        // allow the worker to drain the channel
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let guard = aggregator.state.read().await.unwrap();
+        // 200 grouped, then 404 grouped -> status change flushed the 200 bucket
+        assert_eq!(guard.aggregates.len(), 1);
+        let aggregate = guard.aggregates.values().next().unwrap();
+        assert_eq!(aggregate.status, 404);
+        assert_eq!(aggregate.failed_records, 1);
+        assert_eq!(aggregate.pending_records, 7);
+        drop(guard);
+
+        let events = flushed_events.lock().unwrap();
+        assert_eq!(events.len(), 1, "the 200 bucket was flushed on status change");
+        assert_eq!(events[0].status, 200);
+        assert_eq!(events[0].payload["written_records"], 2);
+        assert_eq!(events[0].payload["replicated_data_size"], 40);
+    }
+
+    /// Safety: a logger whose log_event returns Err must not break the
+    /// aggregator; the error is swallowed and logged, never propagated.
+    #[rstest]
+    #[tokio::test]
+    async fn emission_errors_are_swallowed(
+        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
+        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
+    ) {
+        let handler: SystemEventHandler = Arc::new(move |_event| {
+            Box::pin(async move { Err(internal_server_error!("disk is on fire")) })
+        });
+
+        ReplicationEventAggregator::aggregate_event(&state, observation(200, 1, 10))
+            .await
+            .unwrap();
+
+        // must not panic / propagate despite the failing handler
+        ReplicationEventAggregator::flush_all(&state, &handler)
+            .await
+            .unwrap();
+
+        assert!(flushed_events.lock().unwrap().is_empty());
+        assert!(state.read().await.unwrap().aggregates.is_empty());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn next_deadline_returns_none_when_empty(
+        state: Arc<AsyncRwLock<ReplicationAggregatorState>>,
+    ) {
+        assert!(ReplicationEventAggregator::next_deadline(&state)
+            .await
+            .is_none());
+    }
+
+    fn insert_aggregate(
+        state: &ReplicationAggregatorState,
+        flush_at: Instant,
+        force_flush_at: Instant,
+    ) -> ReplicationAggregatorState {
+        let mut state = ReplicationAggregatorState {
+            aggregates: state.aggregates.clone(),
+        };
+        state.aggregates.insert(
+            ReplicationAggregateKey {
+                instance: "instance-a".to_string(),
+                replication_name: "repl-1".to_string(),
+            },
+            ReplicationAggregate {
+                status: 200,
+                first_timestamp: 1,
+                last_timestamp: 1,
+                pending_records: 0,
+                written_records: 1,
+                failed_records: 0,
+                replicated_data_size: 10,
+                duration: 0.1,
+                message: String::new(),
+                flush_at,
+                force_flush_at,
+            },
+        );
+        state
+    }
+
+    /// Idle flush (condition 2): a bucket whose sliding window expired is
+    /// flushed even though the cap has not been reached.
+    #[rstest]
+    #[tokio::test]
+    async fn flush_expired_flushes_idle_bucket(
+        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
+    ) {
+        let now = Instant::now();
+        let state = Arc::new(AsyncRwLock::new(insert_aggregate(
+            &ReplicationAggregatorState::default(),
+            now - Duration::from_millis(1),
+            now + Duration::from_secs(60),
+        )));
+        let handler = make_test_handler(Arc::clone(&flushed_events));
+
+        ReplicationEventAggregator::flush_expired(&state, &handler)
+            .await
+            .unwrap();
+
+        assert_eq!(flushed_events.lock().unwrap().len(), 1);
+        assert!(state.read().await.unwrap().aggregates.is_empty());
+    }
+
+    /// Cap flush (condition 3): a bucket whose force-flush deadline expired is
+    /// flushed even though it is still receiving activity (window not idle).
+    #[rstest]
+    #[tokio::test]
+    async fn flush_expired_flushes_capped_bucket(
+        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
+    ) {
+        let now = Instant::now();
+        let state = Arc::new(AsyncRwLock::new(insert_aggregate(
+            &ReplicationAggregatorState::default(),
+            now + Duration::from_secs(5),
+            now - Duration::from_millis(1),
+        )));
+        let handler = make_test_handler(Arc::clone(&flushed_events));
+
+        ReplicationEventAggregator::flush_expired(&state, &handler)
+            .await
+            .unwrap();
+
+        assert_eq!(flushed_events.lock().unwrap().len(), 1);
+        assert!(state.read().await.unwrap().aggregates.is_empty());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn flush_expired_keeps_active_bucket(
+        flushed_events: Arc<Mutex<Vec<SystemEvent>>>,
+    ) {
+        let now = Instant::now();
+        let state = Arc::new(AsyncRwLock::new(insert_aggregate(
+            &ReplicationAggregatorState::default(),
+            now + Duration::from_secs(5),
+            now + Duration::from_secs(60),
+        )));
+        let handler = make_test_handler(Arc::clone(&flushed_events));
+
+        ReplicationEventAggregator::flush_expired(&state, &handler)
+            .await
+            .unwrap();
+
+        assert!(flushed_events.lock().unwrap().is_empty());
+        assert_eq!(state.read().await.unwrap().aggregates.len(), 1);
+    }
+
+    /// Idle flush through the real worker (condition 2): after the aggregation
+    /// window elapses with no further activity, the bucket is flushed.
+    #[cfg(target_os = "linux")] // we need precise timing
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn worker_flushes_after_idle_window(flushed_events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let sink = SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingLogger {
+                events: Arc::clone(&flushed_events),
+                fail: false,
+            })
+                as Box<dyn crate::syslog::LogSystemEvent + Send + Sync>)),
+            instance_name: "instance-a".to_string(),
+        };
+        let aggregator = ReplicationEventAggregator::new(sink, "repl-1".to_string());
+
+        aggregator
+            .record_pass(0, 0.1, &[(Ok(()), 1u64, 10u64)])
+            .await;
+
+        // AGGREGATION_WINDOW_SECS is 1 in test builds; wait past it
+        tokio::time::sleep(Duration::from_secs(AGGREGATION_WINDOW_SECS) + Duration::from_millis(500))
+            .await;
+
+        let events = flushed_events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, 200);
+        assert_eq!(events[0].payload["written_records"], 1);
+    }
+
+    /// Entry path (#7): events land at replications/<instance>/<replication-name>.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn writes_replication_event_to_system_bucket() {
+        use crate::cfg::Cfg;
+        use crate::storage::engine::StorageEngine;
+        use crate::syslog::{build_replication_system_logger, SYSTEM_BUCKET_NAME};
+        use reduct_base::io::ReadRecord;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let mut cfg = Cfg {
+            data_path: tmp_dir.keep(),
+            ..Cfg::default()
+        };
+        cfg.system_events_conf.enabled = true;
+        cfg.instance_name = "instance-1".to_string();
+
+        let storage = Arc::new(
+            StorageEngine::builder()
+                .with_data_path(cfg.data_path.clone())
+                .with_cfg(cfg.clone())
+                .build()
+                .await,
+        );
+
+        let logger = build_replication_system_logger(&cfg, Arc::clone(&storage)).await;
+        let sink = SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(logger)),
+            instance_name: "instance-1".to_string(),
+        };
+        let aggregator = ReplicationEventAggregator::new(sink, "repl-1".to_string());
+
+        aggregator
+            .record_pass(2, 0.5, &[(Ok(()), 3u64, 120u64)])
+            .await;
+
+        // drop the aggregator to close the channel and flush the open bucket
+        drop(aggregator);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let bucket = storage
+            .get_bucket(SYSTEM_BUCKET_NAME)
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+        let entry_path = "replications/instance-1/repl-1";
+        let latest_record = Arc::clone(&bucket)
+            .info()
+            .await
+            .unwrap()
+            .entries
+            .into_iter()
+            .find(|entry| entry.name == entry_path)
+            .expect("replication diagnostics entry must exist")
+            .latest_record;
+        let mut reader = bucket.begin_read(entry_path, latest_record).await.unwrap();
+        let record = reader.read_chunk().unwrap().unwrap();
+        let event: serde_json::Value = serde_json::from_slice(&record).unwrap();
+
+        assert_eq!(event["instance"], "instance-1");
+        assert_eq!(event["status"], 200);
+        assert_eq!(event["written_records"], 3);
+        assert_eq!(event["replicated_data_size"], 120);
+        assert_eq!(event["pending_records"], 2);
+    }
+
+    #[derive(Clone)]
+    struct CapturingLogger {
+        events: Arc<Mutex<Vec<SystemEvent>>>,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::syslog::LogSystemEvent for CapturingLogger {
+        async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError> {
+            if self.fail {
+                return Err(timeout!("nope"));
+            }
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+}

--- a/reductstore/src/replication/replication_event_payload.rs
+++ b/reductstore/src/replication/replication_event_payload.rs
@@ -1,0 +1,34 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Aggregated replication diagnostics carried by a replication system event.
+///
+/// The schema is identical for success and failure events so downstream
+/// parsing is uniform: a success event has `written_records = N` and
+/// `failed_records = 0`, a failure event has `failed_records = X` and
+/// `written_records = 0`, but both carry every field.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ReplicationSystemEventPayload {
+    pub status: u16,
+    pub pending_records: u64,
+    pub written_records: u64,
+    pub failed_records: u64,
+    pub replicated_data_size: u64,
+    pub duration: f64,
+}
+
+impl ReplicationSystemEventPayload {
+    pub(crate) fn to_value(&self) -> Value {
+        json!({
+            "status": self.status,
+            "pending_records": self.pending_records,
+            "written_records": self.written_records,
+            "failed_records": self.failed_records,
+            "replicated_data_size": self.replicated_data_size,
+            "duration": self.duration,
+        })
+    }
+}

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -6,6 +6,7 @@ mod repo;
 
 use crate::cfg::Cfg;
 use crate::cfg::InstanceRole::Replica;
+use crate::lifecycle::SystemEventSink;
 use crate::replication::ManageReplications;
 use crate::storage::engine::StorageEngine;
 use read_only::ReadOnlyReplicationRepository;
@@ -14,20 +15,32 @@ use std::sync::Arc;
 
 pub(crate) struct ReplicationRepoBuilder {
     cfg: Cfg,
+    system_event_sink: Option<SystemEventSink>,
 }
 
 type BoxedReplicationRepository = Box<dyn ManageReplications + Send + Sync>;
 
 impl ReplicationRepoBuilder {
     pub fn new(cfg: Cfg) -> Self {
-        ReplicationRepoBuilder { cfg }
+        ReplicationRepoBuilder {
+            cfg,
+            system_event_sink: None,
+        }
+    }
+
+    pub fn with_system_event_sink(mut self, system_event_sink: SystemEventSink) -> Self {
+        self.system_event_sink = Some(system_event_sink);
+        self
     }
 
     pub async fn build(self, storage: Arc<StorageEngine>) -> BoxedReplicationRepository {
         if self.cfg.role == Replica {
             Box::new(ReadOnlyReplicationRepository::new())
         } else {
-            Box::new(ReplicationRepository::load_or_create(storage, self.cfg).await)
+            Box::new(
+                ReplicationRepository::load_or_create(storage, self.cfg, self.system_event_sink)
+                    .await,
+            )
         }
     }
 }

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -168,8 +168,7 @@ impl ManageReplications for ReplicationRepository {
             )));
         }
 
-        self.create_or_update_replication_task(name, settings)
-            .await
+        self.create_or_update_replication_task(name, settings).await
     }
 
     async fn update_replication(
@@ -195,8 +194,7 @@ impl ManageReplications for ReplicationRepository {
             ))),
         }?;
 
-        self.create_or_update_replication_task(name, settings)
-            .await
+        self.create_or_update_replication_task(name, settings).await
     }
 
     async fn replications(&self) -> Result<Vec<ReplicationInfo>, ReductError> {
@@ -693,13 +691,15 @@ mod tests {
         ) {
             let storage = storage.await;
             let mut repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None).await;
+                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
+                    .await;
             repo.create_replication("test", settings.clone())
                 .await
                 .unwrap();
 
             let repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None).await;
+                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
+                    .await;
             assert_eq!(repo.replications().await.unwrap().len(), 1);
             assert_eq!(
                 repo.get_replication_settings("test").await.unwrap(),
@@ -906,7 +906,8 @@ mod tests {
 
             // check if replication is removed from file
             let repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None).await;
+                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
+                    .await;
             assert_eq!(
                 repo.replications().await.unwrap().len(),
                 0,

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -4,6 +4,7 @@
 use crate::cfg::{Cfg, DEFAULT_PORT};
 use crate::core::file_cache::FILE_CACHE;
 use crate::core::sync::AsyncRwLock;
+use crate::lifecycle::SystemEventSink;
 use crate::replication::proto::replication_repo::Item;
 use crate::replication::proto::{
     Label as ProtoLabel, ReplicationMode as ProtoReplicationMode,
@@ -146,6 +147,7 @@ pub(crate) struct ReplicationRepository {
     storage: Arc<StorageEngine>,
     repo_path: PathBuf,
     config: Cfg,
+    system_event_sink: Option<SystemEventSink>,
     started: bool,
     notification_tx: UnboundedSender<NotificationCommand>,
     notification_worker: Option<JoinHandle<()>>,
@@ -166,7 +168,7 @@ impl ManageReplications for ReplicationRepository {
             )));
         }
 
-        self.create_or_update_replication_task(&name, settings)
+        self.create_or_update_replication_task(name, settings)
             .await
     }
 
@@ -193,7 +195,7 @@ impl ManageReplications for ReplicationRepository {
             ))),
         }?;
 
-        self.create_or_update_replication_task(&name, settings)
+        self.create_or_update_replication_task(name, settings)
             .await
     }
 
@@ -321,7 +323,11 @@ impl ManageReplications for ReplicationRepository {
 }
 
 impl ReplicationRepository {
-    pub(crate) async fn load_or_create(storage: Arc<StorageEngine>, config: Cfg) -> Self {
+    pub(crate) async fn load_or_create(
+        storage: Arc<StorageEngine>,
+        config: Cfg,
+        system_event_sink: Option<SystemEventSink>,
+    ) -> Self {
         let repo_path = storage.data_path().join(REPLICATION_REPO_FILE_NAME);
         let replications = Arc::new(AsyncRwLock::new(HashMap::<String, ReplicationTask>::new()));
         let (notification_tx, mut notification_rx) = unbounded_channel::<NotificationCommand>();
@@ -358,6 +364,7 @@ impl ReplicationRepository {
             storage,
             repo_path,
             config,
+            system_event_sink,
             started: false,
             notification_tx,
             notification_worker: Some(notification_worker),
@@ -504,8 +511,13 @@ impl ReplicationRepository {
         let mut settings = settings;
         settings.dst_token = init_token;
 
-        let replication =
-            ReplicationTask::new(name.to_string(), settings, conf, Arc::clone(&self.storage))?;
+        let replication = ReplicationTask::new(
+            name.to_string(),
+            settings,
+            conf,
+            Arc::clone(&self.storage),
+            self.system_event_sink.clone(),
+        )?;
         let mut replication = replication;
         if self.started {
             replication.start();
@@ -681,13 +693,13 @@ mod tests {
         ) {
             let storage = storage.await;
             let mut repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default()).await;
+                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None).await;
             repo.create_replication("test", settings.clone())
                 .await
                 .unwrap();
 
             let repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default()).await;
+                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None).await;
             assert_eq!(repo.replications().await.unwrap().len(), 1);
             assert_eq!(
                 repo.get_replication_settings("test").await.unwrap(),
@@ -894,7 +906,7 @@ mod tests {
 
             // check if replication is removed from file
             let repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default()).await;
+                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None).await;
             assert_eq!(
                 repo.replications().await.unwrap().len(),
                 0,
@@ -1330,6 +1342,6 @@ mod tests {
     #[fixture]
     async fn repo(#[future] storage: Arc<StorageEngine>) -> ReplicationRepository {
         let storage = storage.await;
-        ReplicationRepository::load_or_create(storage, Cfg::default()).await
+        ReplicationRepository::load_or_create(storage, Cfg::default(), None).await
     }
 }

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -11,6 +11,7 @@ use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::BoxedReadRecord;
 use reduct_base::msg::replication_api::ReplicationSettings;
 use std::cmp::PartialEq;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
@@ -23,7 +24,10 @@ pub(super) struct ReplicationSender {
     bucket: Box<dyn RemoteBucket + Send + Sync>,
 }
 
-type ResultResult = (Result<(), ReductError>, u64);
+/// Outcome of replicating a group of records: the result, the number of
+/// records it covers, and the number of bytes successfully replicated
+/// (non-zero only for successful writes).
+type ResultResult = (Result<(), ReductError>, u64, u64);
 
 #[derive(Debug, PartialEq)]
 pub(super) enum SyncState {
@@ -86,6 +90,7 @@ impl ReplicationSender {
                         continue;
                     }
                     let mut batch = Vec::new();
+                    let mut batch_sizes: BTreeMap<u64, u64> = BTreeMap::new();
                     let mut total_size = 0;
                     let mut processed_transactions = 0;
                     for transaction in vec {
@@ -101,6 +106,7 @@ impl ReplicationSender {
                             Ok(record_to_sync) => {
                                 let record_size = record_to_sync.meta().content_length();
                                 total_size += record_size;
+                                batch_sizes.insert(*transaction.timestamp(), record_size);
                                 batch.push((record_to_sync, transaction));
 
                                 if total_size >= self.io_config.batch_max_size {
@@ -115,7 +121,7 @@ impl ReplicationSender {
                                     transaction.timestamp(),
                                     err
                                 );
-                                counter.push((Err(err), 1));
+                                counter.push((Err(err), 1, 0));
                             }
                         }
                     }
@@ -123,13 +129,20 @@ impl ReplicationSender {
                     let batch_size = batch.len() as u64;
                     match self.bucket.write_batch(entry_name, batch).await {
                         Ok(map) => {
-                            counter.push((Ok(()), batch_size - map.len() as u64));
+                            // Bytes successfully replicated are those whose
+                            // timestamp is not reported as failed.
+                            let written_size: u64 = batch_sizes
+                                .iter()
+                                .filter(|(timestamp, _)| !map.contains_key(*timestamp))
+                                .map(|(_, size)| *size)
+                                .sum();
+                            counter.push((Ok(()), batch_size - map.len() as u64, written_size));
                             for (timestamp, err) in map.into_iter() {
                                 debug!(
                                     "Failed to replicate record {}/{}/{}: {:?}",
                                     self.settings.src_bucket, entry_name, timestamp, err
                                 );
-                                counter.push((Err(err), 1));
+                                counter.push((Err(err), 1, 0));
                             }
                         }
                         Err(err) => {
@@ -138,7 +151,7 @@ impl ReplicationSender {
                                 self.settings.src_bucket, entry_name, err
                             );
 
-                            counter.push((Err(err), batch_size));
+                            counter.push((Err(err), batch_size, 0));
                         }
                     }
 
@@ -183,7 +196,7 @@ impl ReplicationSender {
                         .get_bucket(&self.settings.src_bucket)
                         .await?
                         .upgrade()?
-                        .get_entry(&entry_name)
+                        .get_entry(entry_name)
                         .await?
                         .upgrade()?
                         .begin_read(*transaction.timestamp())
@@ -276,7 +289,7 @@ mod tests {
 
         assert_eq!(
             sender.run().await.unwrap(),
-            SyncState::SyncedOrRemoved(vec![(Ok(()), 1)])
+            SyncState::SyncedOrRemoved(vec![(Ok(()), 1, 5)])
         );
         assert_eq!(
             sender
@@ -309,7 +322,7 @@ mod tests {
 
         assert_eq!(
             sender.run().await.unwrap(),
-            SyncState::NotAvailable(vec![(Err(timeout!("Timeout")), 1)])
+            SyncState::NotAvailable(vec![(Err(timeout!("Timeout")), 1, 0)])
         );
 
         assert_eq!(
@@ -346,6 +359,7 @@ mod tests {
             SyncState::NotAvailable(vec![(
                 Err(ReductError::new(ErrorCode::TooManyRequests, "slow down")),
                 1,
+                0,
             )])
         );
 
@@ -395,8 +409,12 @@ mod tests {
         assert_eq!(
             sender.run().await.unwrap(),
             SyncState::SyncedOrRemoved(vec![
-                (Err(not_found!("Entry 'test' not found in bucket 'src'")), 1),
-                (Ok(()), 0)
+                (
+                    Err(not_found!("Entry 'test' not found in bucket 'src'")),
+                    1,
+                    0
+                ),
+                (Ok(()), 0, 0)
             ]),
         );
         assert!(
@@ -456,7 +474,7 @@ mod tests {
         writer.send(Ok(None)).await.unwrap();
         assert_eq!(
             handle.await.unwrap().unwrap(),
-            SyncState::SyncedOrRemoved(vec![(Ok(()), 1)])
+            SyncState::SyncedOrRemoved(vec![(Ok(()), 1, 4)])
         );
     }
 
@@ -506,9 +524,10 @@ mod tests {
                     Err(too_early!(
                         "Record with timestamp 20 in src/test is still being written"
                     )),
-                    1
+                    1,
+                    0
                 ),
-                (Ok(()), 0)
+                (Ok(()), 0, 0)
             ])
         );
     }
@@ -536,7 +555,10 @@ mod tests {
 
         assert_eq!(
             sender.run().await.unwrap(),
-            SyncState::SyncedOrRemoved(vec![(Ok(()), 1), (Err(conflict!("AlreadyExists")), 1)])
+            SyncState::SyncedOrRemoved(vec![
+                (Ok(()), 1, 5),
+                (Err(conflict!("AlreadyExists")), 1, 0)
+            ])
         );
         assert!(
             sender
@@ -576,7 +598,11 @@ mod tests {
 
         assert_eq!(
             sender.run().await.unwrap(),
-            SyncState::SyncedOrRemoved(vec![(Ok(()), 1)])
+            SyncState::SyncedOrRemoved(vec![(
+                Ok(()),
+                1,
+                IoConfig::default().batch_max_size + 1
+            )])
         );
         assert!(
             sender

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -598,11 +598,7 @@ mod tests {
 
         assert_eq!(
             sender.run().await.unwrap(),
-            SyncState::SyncedOrRemoved(vec![(
-                Ok(()),
-                1,
-                IoConfig::default().batch_max_size + 1
-            )])
+            SyncState::SyncedOrRemoved(vec![(Ok(()), 1, IoConfig::default().batch_max_size + 1)])
         );
         assert!(
             sender

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -165,9 +165,10 @@ impl ReplicationTask {
         let thr_mode = Arc::clone(&self.mode);
 
         let handle = tokio::spawn(async move {
-            // Aggregates replication diagnostics into periodic $system events.
-            // Dropped on loop exit, which flushes the last open bucket.
-            let diagnostics_aggregator = thr_system_event_sink
+            // Aggregates replication diagnostics into periodic $system events,
+            // driven inline by this worker loop (flushed on idle/cap each
+            // iteration and on loop exit).
+            let mut diagnostics_aggregator = thr_system_event_sink
                 .map(|sink| ReplicationEventAggregator::new(sink, replication_name.clone()));
             let init_transaction_logs = async || {
                 let mut logs = thr_log_map.write().await?;
@@ -226,6 +227,11 @@ impl ReplicationTask {
             );
 
             while !thr_stop_flag.load(Ordering::Relaxed) {
+                // Flush an idle/capped diagnostics bucket regardless of mode.
+                if let Some(aggregator) = &mut diagnostics_aggregator {
+                    aggregator.flush_if_due().await;
+                }
+
                 match ReplicationTask::load_mode_from(&thr_mode) {
                     ReplicationMode::Disabled => {
                         thr_is_active.store(false, Ordering::Relaxed);
@@ -336,13 +342,18 @@ impl ReplicationTask {
                         Err(err) => error!("Failed to acquire hourly diagnostics lock: {:?}", err),
                     }
 
-                    if let Some(aggregator) = &diagnostics_aggregator {
+                    if let Some(aggregator) = &mut diagnostics_aggregator {
                         let pending_records = Self::count_pending_records(&thr_log_map).await;
                         aggregator
                             .record_pass(pending_records, pass_duration, &c)
                             .await;
                     }
                 }
+            }
+
+            // Flush the last open bucket before the worker exits.
+            if let Some(mut aggregator) = diagnostics_aggregator {
+                aggregator.flush().await;
             }
         });
 

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -338,7 +338,9 @@ impl ReplicationTask {
 
                     if let Some(aggregator) = &diagnostics_aggregator {
                         let pending_records = Self::count_pending_records(&thr_log_map).await;
-                        aggregator.record_pass(pending_records, pass_duration, &c).await;
+                        aggregator
+                            .record_pass(pending_records, pass_duration, &c)
+                            .await;
                     }
                 }
             }

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -5,8 +5,10 @@ use crate::cfg::io::IoConfig;
 use crate::cfg::Cfg;
 use crate::core::file_cache::FILE_CACHE;
 use crate::core::sync::AsyncRwLock;
+use crate::lifecycle::SystemEventSink;
 use crate::replication::diagnostics::DiagnosticsCounter;
 use crate::replication::remote_bucket::{RemoteBucket, RemoteBucketBuilder};
+use crate::replication::replication_aggregator::ReplicationEventAggregator;
 use crate::replication::replication_sender::{ReplicationSender, SyncState};
 use crate::replication::transaction_filter::TransactionFilter;
 use crate::replication::transaction_log::{TransactionLog, TransactionLogMap, TransactionLogRef};
@@ -20,7 +22,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 
 #[derive(Clone)]
@@ -41,6 +43,7 @@ pub struct ReplicationTask {
     log_map: TransactionLogMap,
     storage: Arc<StorageEngine>,
     hourly_diagnostics: Arc<AsyncRwLock<DiagnosticsCounter>>,
+    system_event_sink: Option<SystemEventSink>,
     stop_flag: Arc<AtomicBool>,
     is_active: Arc<AtomicBool>,
     mode: Arc<AtomicU8>,
@@ -66,6 +69,7 @@ impl ReplicationTask {
         settings: ReplicationSettings,
         config: Cfg,
         storage: Arc<StorageEngine>,
+        system_event_sink: Option<SystemEventSink>,
     ) -> Result<Self, ReductError> {
         let ReplicationSettings {
             dst_bucket: remote_bucket,
@@ -88,7 +92,7 @@ impl ReplicationTask {
 
         let system_options = ReplicationSystemOptions {
             transaction_log_size: config.replication_conf.replication_log_size,
-            remote_bucket_unavailable_timeout: config.replication_conf.connection_timeout.clone(),
+            remote_bucket_unavailable_timeout: config.replication_conf.connection_timeout,
             ..Default::default()
         };
 
@@ -99,6 +103,7 @@ impl ReplicationTask {
             config.io_conf,
             remote_bucket,
             storage,
+            system_event_sink,
         ))
     }
 
@@ -109,6 +114,7 @@ impl ReplicationTask {
         io_config: IoConfig,
         remote_bucket: Box<dyn RemoteBucket + Send + Sync>,
         storage: Arc<StorageEngine>,
+        system_event_sink: Option<SystemEventSink>,
     ) -> Self {
         let log_map: TransactionLogMap =
             Arc::new(AsyncRwLock::new(HashMap::<String, TransactionLogRef>::new()));
@@ -131,6 +137,7 @@ impl ReplicationTask {
             filter_map: HashMap::new(),
             log_map,
             hourly_diagnostics,
+            system_event_sink,
             stop_flag,
             is_active,
             mode,
@@ -152,11 +159,16 @@ impl ReplicationTask {
         let thr_storage = Arc::clone(&self.storage);
         let thr_hourly_diagnostics = Arc::clone(&self.hourly_diagnostics);
         let thr_system_options = self.system_options.clone();
+        let thr_system_event_sink = self.system_event_sink.clone();
         let thr_stop_flag = Arc::clone(&self.stop_flag);
         let thr_is_active = Arc::clone(&self.is_active);
         let thr_mode = Arc::clone(&self.mode);
 
         let handle = tokio::spawn(async move {
+            // Aggregates replication diagnostics into periodic $system events.
+            // Dropped on loop exit, which flushes the last open bucket.
+            let diagnostics_aggregator = thr_system_event_sink
+                .map(|sink| ReplicationEventAggregator::new(sink, replication_name.clone()));
             let init_transaction_logs = async || {
                 let mut logs = thr_log_map.write().await?;
                 for entry in thr_storage
@@ -238,7 +250,10 @@ impl ReplicationTask {
                 }
 
                 let mut counter = None;
-                match sender.run().await {
+                let pass_started = Instant::now();
+                let sync_result = sender.run().await;
+                let pass_duration = pass_started.elapsed().as_secs_f64();
+                match sync_result {
                     Ok(SyncState::SyncedOrRemoved(c)) => {
                         thr_is_active.store(true, Ordering::Relaxed);
                         counter = Some(c);
@@ -314,11 +329,16 @@ impl ReplicationTask {
                 if let Some(c) = counter {
                     match thr_hourly_diagnostics.write().await {
                         Ok(mut diagnostics) => {
-                            for (result, count) in c.into_iter() {
-                                diagnostics.count(result, count);
+                            for (result, count, _size) in c.iter() {
+                                diagnostics.count(result.clone(), *count);
                             }
                         }
                         Err(err) => error!("Failed to acquire hourly diagnostics lock: {:?}", err),
+                    }
+
+                    if let Some(aggregator) = &diagnostics_aggregator {
+                        let pending_records = Self::count_pending_records(&thr_log_map).await;
+                        aggregator.record_pass(pending_records, pass_duration, &c).await;
                     }
                 }
             }
@@ -421,7 +441,7 @@ impl ReplicationTask {
     }
 
     pub fn set_mode(&mut self, mode: ReplicationMode) {
-        self.settings.mode = mode.clone();
+        self.settings.mode = mode;
         self.mode.store(mode as u8, Ordering::Relaxed);
     }
 
@@ -438,7 +458,7 @@ impl ReplicationTask {
         let mode = self.load_mode();
         Ok(ReplicationInfo {
             name: self.name.clone(),
-            mode: mode.clone(),
+            mode,
             is_active: matches!(mode, ReplicationMode::Enabled | ReplicationMode::Paused)
                 && self.is_active.load(Ordering::Relaxed),
             is_provisioned: self.is_provisioned,
@@ -450,6 +470,19 @@ impl ReplicationTask {
         Ok(Diagnostics {
             hourly: self.hourly_diagnostics.read().await?.diagnostics(),
         })
+    }
+
+    /// Sum pending (not-yet-replicated) records across all transaction logs.
+    async fn count_pending_records(log_map: &TransactionLogMap) -> u64 {
+        let mut pending_records = 0;
+        if let Ok(logs) = log_map.read().await {
+            for (_, log) in logs.iter() {
+                if let Ok(log) = log.read().await {
+                    pending_records += log.len() as u64;
+                }
+            }
+        }
+        pending_records
     }
 
     async fn sleep_with_stop(stop_flag: &Arc<AtomicBool>, duration: Duration) {
@@ -1037,6 +1070,7 @@ mod tests {
             IoConfig::default(),
             Box::new(remote_bucket),
             storage,
+            None,
         );
 
         repl.start();

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -1019,10 +1019,129 @@ mod tests {
         );
     }
 
+    #[derive(Clone)]
+    struct CapturingSystemLogger {
+        events: Arc<std::sync::Mutex<Vec<crate::syslog::SystemEvent>>>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl crate::syslog::LogSystemEvent for CapturingSystemLogger {
+        async fn log_event(
+            &mut self,
+            event: crate::syslog::SystemEvent,
+        ) -> Result<(), ReductError> {
+            if self.fail {
+                return Err(ReductError::internal_server_error(
+                    "diagnostics sink is down",
+                ));
+            }
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    fn capturing_sink(
+        events: Arc<std::sync::Mutex<Vec<crate::syslog::SystemEvent>>>,
+        fail: bool,
+    ) -> SystemEventSink {
+        SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingSystemLogger {
+                events,
+                fail,
+            })
+                as Box<dyn crate::syslog::LogSystemEvent + Send + Sync>)),
+            instance_name: "instance-1".to_string(),
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_emits_replication_diagnostics(
+        mut remote_bucket: MockRmBucket,
+        notification: TransactionNotification,
+        settings: ReplicationSettings,
+        path: PathBuf,
+    ) {
+        remote_bucket
+            .expect_write_batch()
+            .returning(|_, _| Ok(ErrorRecordMap::new()));
+        remote_bucket.expect_is_active().return_const(true);
+
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut replication = build_replication_with_sink(
+            path,
+            remote_bucket,
+            settings,
+            Some(capturing_sink(Arc::clone(&captured), false)),
+        )
+        .await;
+
+        replication.notify(notification).await.unwrap();
+        tokio_sleep(Duration::from_millis(200)).await; // let a sync pass run and feed the aggregator
+        replication.stop().await; // dropping the aggregator flushes the open bucket
+        tokio_sleep(Duration::from_millis(100)).await; // let the aggregator worker emit
+
+        let events = captured.lock().unwrap();
+        let event = events
+            .iter()
+            .find(|event| event.event_type == "replication_sync")
+            .expect("a replication_sync diagnostics event must be emitted");
+        assert_eq!(event.instance, "instance-1");
+        assert_eq!(event.entry_name, "test");
+        assert_eq!(event.status, 200);
+        assert!(
+            event.payload["written_records"].as_u64().unwrap() >= 1,
+            "successful pass should report written_records"
+        );
+    }
+
+    // Safety: a diagnostics sink that always errors must not break replication.
+    #[rstest]
+    #[tokio::test]
+    async fn test_replication_continues_when_diagnostics_logger_errors(
+        mut remote_bucket: MockRmBucket,
+        notification: TransactionNotification,
+        settings: ReplicationSettings,
+        path: PathBuf,
+    ) {
+        remote_bucket
+            .expect_write_batch()
+            .returning(|_, _| Ok(ErrorRecordMap::new()));
+        remote_bucket.expect_is_active().return_const(true);
+
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut replication = build_replication_with_sink(
+            path,
+            remote_bucket,
+            settings,
+            Some(capturing_sink(Arc::clone(&captured), true)),
+        )
+        .await;
+
+        replication.notify(notification).await.unwrap();
+        tokio_sleep(Duration::from_millis(200)).await;
+
+        // Replication keeps draining the log despite the failing diagnostics sink.
+        assert!(transaction_log_is_empty(&replication).await);
+        let info = replication.info().await.unwrap();
+        assert_eq!(info.pending_records, 0);
+        assert!(captured.lock().unwrap().is_empty());
+    }
+
     async fn build_replication(
         path: PathBuf,
         remote_bucket: MockRmBucket,
         settings: ReplicationSettings,
+    ) -> ReplicationTask {
+        build_replication_with_sink(path, remote_bucket, settings, None).await
+    }
+
+    async fn build_replication_with_sink(
+        path: PathBuf,
+        remote_bucket: MockRmBucket,
+        settings: ReplicationSettings,
+        system_event_sink: Option<SystemEventSink>,
     ) -> ReplicationTask {
         let cfg = Cfg {
             data_path: path.clone(),
@@ -1072,7 +1191,7 @@ mod tests {
             IoConfig::default(),
             Box::new(remote_bucket),
             storage,
-            None,
+            system_event_sink,
         );
 
         repl.start();

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -23,6 +23,7 @@ pub(crate) const AUDIT_BUCKET_NAME: &str = "$audit";
 pub(crate) const SYSTEM_BUCKET_NAME: &str = "$system";
 pub(crate) const SYSTEM_AUDIT_ENTRY_PREFIX: &str = "audit";
 pub(crate) const SYSTEM_LIFECYCLE_ENTRY_PREFIX: &str = "lifecycle";
+pub(crate) const SYSTEM_REPLICATION_ENTRY_PREFIX: &str = "replications";
 
 pub(crate) type SystemEventFlushFuture =
     Pin<Box<dyn Future<Output = Result<(), ReductError>> + Send>>;
@@ -172,6 +173,20 @@ pub(crate) async fn build_system_logger(
         .with_entry_prefix(SYSTEM_LIFECYCLE_ENTRY_PREFIX)
         .build(cfg, storage)
         .expect("system logger must build")
+}
+
+pub(crate) async fn build_replication_system_logger(
+    cfg: &Cfg,
+    storage: Arc<StorageEngine>,
+) -> BoxedSystemLogger {
+    if !cfg.system_events_conf.enabled {
+        return Box::new(DisabledSystemLogger);
+    }
+
+    SystemLoggerBuilder::new(SYSTEM_BUCKET_NAME, system_bucket_settings(cfg))
+        .with_entry_prefix(SYSTEM_REPLICATION_ENTRY_PREFIX)
+        .build(cfg, storage)
+        .expect("replication system logger must build")
 }
 
 fn system_bucket_settings(cfg: &Cfg) -> BucketSettings {


### PR DESCRIPTION
Closes #1374

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

Replication tasks now emit periodic, aggregated diagnostics as `$system` events,
mirroring the lifecycle system-event wiring (#1399) and reusing the audit aggregator's
timing model.

- New `$system` entry path: `replications/<instance-name>/<replication-name>`
- One active bucket per replication task, keyed by status code. Flushed on (1) status
  change, (2) 5s idle, (3) 60s cap — reusing AGGREGATION_WINDOW_SECS / FORCE_FLUSH_TIMEOUT_SECS.
- Unified payload schema for success and failure events:
  `{ status, pending_records, written_records, failed_records, replicated_data_size, duration }`
  A 200→404 transition flushes the 200 bucket (written_records=N) and opens a 404 bucket
  (failed_records=X), same shape.
- `replicated_data_size` and `duration` were not tracked before; threaded byte size through
  the sender result and added per-pass timing in the worker loop.
- Emission failures are swallowed-and-logged, never propagated into the replication path.

### Related issues

Closes #1374

### Points to confirm

- **Duration attribution on mixed-status passes:** a pass's measured duration is attributed
  once, to the lowest status code seen that pass (others get 0.0), to avoid double-counting.
  Exact for single-status passes and the 200→404 example. Is this the semantics you want, or
  would you prefer attribution by record share?
- **`status` cast:** kept as `u16` to match lifecycle (`lifecycle_task.rs`); note
  `forward_system_logger.rs` uses `i16` — pre-existing inconsistency, flagged not fixed here.
- **`replicated_data_size`** = bytes of successfully written records (0 for failure buckets).
- **`event_type`** = `"replication_sync"` (matches the `lifecycle_run` style) — rename if you'd prefer.
- Clippy 1.91 surfaces pre-existing repo-wide lints; CI doesn't gate on clippy, so left untouched.