### PR TITLE
fix: develop `ReplicationSender`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,6 +3022,7 @@ dependencies = [
  "crc64fast",
  "crossbeam-channel",
  "dlopen2",
+ "either",
  "flate2",
  "futures",
  "futures-util",
@@ -3049,6 +3050,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "tokio",
+ "tokio-retry",
  "tower",
  "tower-http",
  "url",
@@ -4132,6 +4134,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.1"
+source = "git+https://github.com/skaunov/tokio-retry#9a37100ec56a689351a8d5d2c9be13523964e7fc"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,6 @@ dependencies = [
  "crc64fast",
  "crossbeam-channel",
  "dlopen2",
- "either",
  "flate2",
  "futures",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,8 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.3.1"
-source = "git+https://github.com/skaunov/tokio-retry#9a37100ec56a689351a8d5d2c9be13523964e7fc"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
  "rand 0.10.1",

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -49,7 +49,6 @@ axum-extra = { version = "0.12.1", features = ["default", "typed-header"] }
 tokio = { version = "1.51.1", features = ["full"] }
 hyper = { version = "1.10.1", features = ["full"] }
 futures-util = "0.3.31"
-futures = "0.3"
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 mime_guess = "2.0.5"
 bytesize = "2.3.1"
@@ -74,7 +73,8 @@ aes-siv = "0.8.0-rc.1"
 uuid = { version = "1.21.0", features = ["v4"] }
 parking_lot="0.12.5"
 zenoh = { version = "1.9.0", optional = true }
-
+tokio-retry = {git = "https://github.com/skaunov/tokio-retry"} # switch to <Crates.io> when <https://github.com/djc/tokio-retry/pull/41>, `0.3.1` did not had it yet
+either = "*"
 
 [build-dependencies]
 prost-build = "0.14.1"
@@ -89,6 +89,7 @@ serial_test = "3.2.0"
 test-log = "0.2.19"
 tower = "0.5.2"
 reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls", "blocking"] }
+futures = "0.3"
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -74,7 +74,6 @@ uuid = { version = "1.21.0", features = ["v4"] }
 parking_lot="0.12.5"
 zenoh = { version = "1.9.0", optional = true }
 tokio-retry = "0.3.2"
-either = "*"
 
 [build-dependencies]
 prost-build = "0.14.1"

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -73,7 +73,7 @@ aes-siv = "0.8.0-rc.1"
 uuid = { version = "1.21.0", features = ["v4"] }
 parking_lot="0.12.5"
 zenoh = { version = "1.9.0", optional = true }
-tokio-retry = {git = "https://github.com/skaunov/tokio-retry"} # switch to <Crates.io> when <https://github.com/djc/tokio-retry/pull/41>, `0.3.1` did not had it yet
+tokio-retry = "0.3.2"
 either = "*"
 
 [build-dependencies]

--- a/reductstore/src/api/http/replication.rs
+++ b/reductstore/src/api/http/replication.rs
@@ -47,11 +47,11 @@ where
                 "Invalid body",
             )
         })?;
-        let response = match serde_json::from_slice::<ReplicationModePayload>(&*bytes) {
+
+        match serde_json::from_slice::<ReplicationModePayload>(&bytes) {
             Ok(x) => Ok(ReplicationModePayloadAxum::from(x)),
             Err(e) => Err(crate::api::http::HttpError::from(e)),
-        };
-        response
+        }
     }
 }
 
@@ -69,11 +69,11 @@ where
                 "Invalid body",
             )
         })?;
-        let response = match serde_json::from_slice::<ReplicationSettings>(&*bytes) {
+
+        match serde_json::from_slice::<ReplicationSettings>(&bytes) {
             Ok(x) => Ok(ReplicationSettingsAxum::from(x)),
             Err(e) => Err(crate::api::http::HttpError::from(e)),
-        };
-        response
+        }
     }
 }
 

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -188,7 +188,7 @@ impl ExtCfgBounds for CoreExtCfg {
     }
 }
 
-/// Database configuration
+/// Database configuration.
 pub struct CfgParser<EnvGetter: GetEnv = StdEnvGetter, ExtCfg: ExtCfgBounds = CoreExtCfg> {
     pub cfg: Cfg,
     pub license: Option<License>,
@@ -199,7 +199,7 @@ pub struct CfgParser<EnvGetter: GetEnv = StdEnvGetter, ExtCfg: ExtCfgBounds = Co
 #[async_trait]
 pub trait ExtCfgParser<EnvGetter: GetEnv> {
     type Cfg: ExtCfgBounds;
-    async fn from_env(&self, env: &mut Env<EnvGetter>, version: &str) -> Self::Cfg;
+    async fn from_env(env: &mut Env<EnvGetter>, version: &str) -> Self::Cfg;
 }
 
 #[derive(Default)]
@@ -209,7 +209,7 @@ pub struct CoreExtCfgParser;
 impl<EnvGetter: GetEnv + Send> ExtCfgParser<EnvGetter> for CoreExtCfgParser {
     type Cfg = CoreExtCfg;
 
-    async fn from_env(&self, env: &mut Env<EnvGetter>, _version: &str) -> Self::Cfg {
+    async fn from_env(env: &mut Env<EnvGetter>, _version: &str) -> Self::Cfg {
         let role = match env
             .get::<String>("RS_INSTANCE_ROLE", "STANDALONE".to_string())
             .to_lowercase()
@@ -233,16 +233,12 @@ impl<EnvGetter: GetEnv + Send> ExtCfgParser<EnvGetter> for CoreExtCfgParser {
 
 impl<EnvGetter: GetEnv + Send> CfgParser<EnvGetter, CoreExtCfg> {
     pub async fn from_env(env_getter: EnvGetter, version: &str) -> Self {
-        Self::from_env_with_ext(env_getter, &CoreExtCfgParser, version).await
+        Self::from_env_with_ext::<CoreExtCfgParser>(env_getter, version).await
     }
 }
 
 impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
-    pub async fn from_env_with_ext<ExtParser>(
-        env_getter: EnvGetter,
-        ext_parser: &ExtParser,
-        version: &str,
-    ) -> Self
+    pub async fn from_env_with_ext<ExtParser>(env_getter: EnvGetter, version: &str) -> Self
     where
         ExtParser: ExtCfgParser<EnvGetter, Cfg = ExtCfg>,
     {
@@ -255,11 +251,11 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         let port = env.get("RS_PORT", DEFAULT_PORT);
         let cert_path = env
             .get_optional::<String>("RS_CERT_PATH")
-            .and_then(|p| if p.is_empty() { None } else { Some(p) })
+            .filter(|p| !p.is_empty())
             .map(PathBuf::from);
         let cert_key_path = env
             .get_optional::<String>("RS_CERT_KEY_PATH")
-            .and_then(|p| if p.is_empty() { None } else { Some(p) })
+            .filter(|p| !p.is_empty())
             .map(PathBuf::from);
 
         let protocol = if cert_path.is_none() { "http" } else { "https" };
@@ -275,7 +271,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             public_url.push('/');
         }
 
-        let ext_cfg = ext_parser.from_env(&mut env, version).await;
+        let ext_cfg = ExtParser::from_env(&mut env, version).await;
 
         let replications = Self::parse_replications(&mut env);
         let lifecycles = Self::parse_lifecycles(&mut env);
@@ -296,10 +292,10 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             role: ext_cfg.role(),
             primary_url: env
                 .get_optional::<String>("RS_PRIMARY_URL")
-                .and_then(|url| if url.is_empty() { None } else { Some(url) }),
+                .filter(|url| !url.is_empty()),
             secondary_url: env
                 .get_optional::<String>("RS_SECONDARY_URL")
-                .and_then(|url| if url.is_empty() { None } else { Some(url) }),
+                .filter(|url| !url.is_empty()),
             instance_name: resolve_instance_name(env.get_optional::<String>("RS_INSTANCE_NAME")),
             ext_path: env.get_optional::<String>("RS_EXT_PATH").map(PathBuf::from),
             cors_allow_origin: Self::parse_cors_allow_origin(&mut env),
@@ -394,17 +390,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         let replication_engine = self
             .provision_replication_repo(Arc::clone(&storage))
             .await?;
-        let ext_path = if let Some(ext_path) = &self.cfg.ext_path {
-            Some(PathBuf::try_from(ext_path).map_err(|e| {
-                internal_server_error!(
-                    "Failed to resolve extension path {}: {}",
-                    ext_path.to_str().unwrap(),
-                    e
-                )
-            })?)
-        } else {
-            None
-        };
+        let ext_path = self.cfg.ext_path.as_ref().map(PathBuf::from);
 
         let server_info = storage.info().await?;
         let ext_settings = ExtSettings::builder()

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -538,7 +538,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> Display for CfgParser<EnvGetter, E
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::FutureExt;
+    use futures_util::FutureExt;
 
     use mockall::mock;
     use mockall::predicate::eq;

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -22,26 +22,26 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             .await;
         for (name, replication) in &self.cfg.replications {
             if let Err(e) = repo
-                .create_replication(&name, replication.settings.clone())
+                .create_replication(name, replication.settings.clone())
                 .await
             {
                 if e.status() == ErrorCode::Conflict {
                     let mut settings = replication.settings.clone();
                     if replication.mode_override.is_none() {
-                        if let Ok(info) = repo.get_info(&name).await {
+                        if let Ok(info) = repo.get_info(name).await {
                             settings.mode = info.info.mode;
                         }
                     }
-                    repo.update_replication(&name, settings).await?;
+                    repo.update_replication(name, settings).await?;
                 } else {
                     error!("Failed to provision replication '{}': {}", name, e);
                     continue;
                 }
             }
 
-            repo.set_replication_provisioned(&name, true).await?;
+            repo.set_replication_provisioned(name, true).await?;
 
-            let info_data = repo.get_info(&name).await?;
+            let info_data = repo.get_info(name).await?;
             info!(
                 "Provisioned replication '{}' with {:?}",
                 name, info_data.settings
@@ -175,13 +175,11 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             }
         }
 
-        let replications = replications
+        replications
             .into_iter()
             .filter(|(id, _)| !unfinished_replications.contains(id))
             .map(|(_, (name, replication))| (name, replication))
-            .collect();
-
-        replications
+            .collect()
     }
 }
 

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -33,14 +33,11 @@ pub(crate) static FILE_CACHE: LazyLock<FileCache> = LazyLock::new(|| {
 
     #[cfg(test)]
     {
-        use futures::executor;
-
-        // Use an isolated filesystem backend for tests to avoid relying on
-        // other tests to initialise the global cache.
+        // Use an isolated filesystem backend for tests to avoid relying on other tests to initialise the global cache.
         let temp_dir = tempfile::tempdir()
             .expect("Failed to create temporary directory for FILE_CACHE")
             .keep();
-        executor::block_on(async {
+        futures::executor::block_on(async {
             let mut backend = cache.backend.write().await.unwrap();
             *backend = (Backend::builder().local_data_path(temp_dir).try_build())
                 .await

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -176,7 +176,7 @@ impl FileCache {
 
         // For scheduled synchronization we syn only a batch of files that are the most overdue for synchronization
         if !force {
-            files_to_sync.sort_by(|a, b| a.2.cmp(&b.2));
+            files_to_sync.sort_by_key(|a| a.2);
             files_to_sync.truncate(FILE_CACHE_SYNC_BATCH_SIZE);
         }
 

--- a/reductstore/src/core/file_cache.rs
+++ b/reductstore/src/core/file_cache.rs
@@ -51,7 +51,7 @@ pub(crate) static FILE_CACHE: LazyLock<FileCache> = LazyLock::new(|| {
 pub(crate) type FileLock = Arc<AsyncRwLock<File>>;
 pub(crate) type FileGuard = OwnedRwLockWriteGuard<File>;
 
-/// A cache to keep file descriptors open
+/// A cache to keep file descriptors open.
 ///
 /// This optimization is needed for network file systems because opening
 /// and closing files for writing causes synchronization overhead.
@@ -269,18 +269,18 @@ impl FileCache {
         Ok((discarded_count, synced_count))
     }
 
-    /// Set the storage backend
+    /// Set the storage backend.
     pub async fn set_storage_backend(&self, backpack: Backend) {
         let mut backend = self.backend.write().await.unwrap();
         *backend = backpack;
     }
 
-    /// Set sync interval
+    /// Set sync interval.
     pub fn set_sync_interval(&self, interval: Duration) {
         *self.sync_interval.write_blocking() = interval;
     }
 
-    /// Set read-only mode
+    /// Set read-only mode.
     pub fn set_read_only(&self, read_only: bool) {
         self.read_only.store(read_only, Ordering::Relaxed);
     }
@@ -296,7 +296,7 @@ impl FileCache {
     ///
     /// # Returns
     ///
-    /// A file reference
+    /// A file reference.
     pub async fn read(&self, path: &PathBuf, pos: SeekFrom) -> Result<FileGuard, ReductError> {
         let file = {
             let file = self.cache.read().await?.get(path).cloned();
@@ -318,19 +318,16 @@ impl FileCache {
         Ok(lock)
     }
 
-    /// Get a file descriptor for writing
+    /// Get a file descriptor for writing.
     ///
     /// If the file is not in the cache, it will be opened or created and added to the cache.
     ///
-    /// # Arguments
+    /// # Arguments.
+    /// * `path` - The path to the file.
+    /// * `pos` - The position to write to.
     ///
-    /// * `path` - The path to the file
-    /// * `pos` - The position to write to
-    ///
-    ///
-    /// # Returns
-    ///
-    /// A file reference
+    /// # Returns.
+    /// A file reference.
     pub async fn write_or_create(
         &self,
         path: &PathBuf,

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -29,7 +29,6 @@ static RW_LOCK_SHUTDOWN_TIMEOUT: Duration = Duration::from_hours(1);
 
 pub fn maybe_print_version_and_exit() {
     if std::env::args()
-        .into_iter()
         .skip(1)
         .any(|arg| matches!(arg.as_ref(), "--version" | "-V"))
     {
@@ -38,7 +37,7 @@ pub fn maybe_print_version_and_exit() {
     }
 }
 
-pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_pareser: Parser)
+pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>()
 where
     Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
 {
@@ -51,8 +50,7 @@ where
         env!("BUILD_TIME")
     );
 
-    let parser =
-        CfgParser::from_env_with_ext(StdEnvGetter::default(), &ext_cfg_pareser, version).await;
+    let parser = CfgParser::from_env_with_ext::<Parser>(StdEnvGetter::default(), version).await;
     let handle = Handle::new();
     let lock_file = Arc::new(parser.build_lock_file().unwrap());
 
@@ -155,17 +153,12 @@ where
         }};
     }
 
-    if cfg.cert_path.is_none() {
-        apply_http_settings!(axum_server::bind(addr))
-            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
-            .await
-            .unwrap_or_else(|e| error!("Server error: {}", e));
-    } else {
+    if let Some(cert_path) = cfg.cert_path {
         rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .expect("Failed to install rustls crypto provider");
         let config = RustlsConfig::from_pem_file(
-            cfg.cert_path.expect("Cert path must be set"),
+            cert_path,
             cfg.cert_key_path.expect("Cert key path must be set"),
         )
         .await
@@ -174,7 +167,12 @@ where
             .serve(app.into_make_service_with_connect_info::<SocketAddr>())
             .await
             .unwrap_or_else(|e| error!("Server error: {}", e));
-    };
+    } else {
+        apply_http_settings!(axum_server::bind(addr))
+            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+            .await
+            .unwrap_or_else(|e| error!("Server error: {}", e));
+    }
 
     // shutdown procedure
     #[cfg(feature = "zenoh-api")]
@@ -499,7 +497,7 @@ mod tests {
         let task = spawn(|| {
             tokio::runtime::Runtime::new().unwrap().block_on(async {
                 *STOP_SERVER.lock().await = false;
-                launch_server(CoreExtCfgParser).await;
+                launch_server::<CoreExtCfgParser, _>().await;
             });
         });
 

--- a/reductstore/src/main.rs
+++ b/reductstore/src/main.rs
@@ -7,6 +7,5 @@ use reductstore::{cfg::CoreExtCfgParser, launcher::launch_server};
 #[tokio::main]
 async fn main() {
     maybe_print_version_and_exit();
-    let ext_cfg_parser = CoreExtCfgParser;
-    launch_server(ext_cfg_parser).await;
+    launch_server::<CoreExtCfgParser, _>().await;
 }

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -37,17 +37,10 @@ impl Into<u8> for Transaction {
 }
 
 impl Transaction {
-    pub fn timestamp(&self) -> &u64 {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Transaction::WriteRecord(ts) => ts,
-            Transaction::UpdateRecord(ts) => ts,
-        }
-    }
-
-    pub fn into_timestamp(self) -> u64 {
-        match self {
-            Transaction::WriteRecord(ts) => ts,
-            Transaction::UpdateRecord(ts) => ts,
+            Transaction::WriteRecord(ts) => *ts,
+            Transaction::UpdateRecord(ts) => *ts,
         }
     }
 }

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -27,9 +27,9 @@ pub enum Transaction {
     UpdateRecord(u64),
 }
 
-impl Into<u8> for Transaction {
-    fn into(self) -> u8 {
-        match self {
+impl From<Transaction> for u8 {
+    fn from(val: Transaction) -> Self {
+        match val {
             Transaction::WriteRecord(_) => 0,
             Transaction::UpdateRecord(_) => 1,
         }

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -147,9 +147,12 @@ impl BucketWrapper {
 
     fn prepare_batch_to_write(
         mut records: Vec<BoxedReadRecord>,
-    ) -> (HeaderMap, impl futures_util::Stream<Item = Result<Bytes, ReductError>>) {
+    ) -> (
+        HeaderMap,
+        impl futures_util::Stream<Item = Result<Bytes, ReductError>>,
+    ) {
         Self::sort_by_timestamp(&mut records);
-        let headers = Self::build_headers(&mut records, false);
+        let headers = Self::build_headers(&records, false);
 
         let stream = async_stream::stream! {
             while let Some(mut record) = records.pop() {
@@ -163,8 +166,7 @@ impl BucketWrapper {
     }
 
     fn prepare_batch_to_update(records: &Vec<BoxedReadRecord>) -> HeaderMap {
-        let headers = Self::build_headers(&records, true);
-        headers
+        Self::build_headers(records, true)
     }
 
     fn parse_record_errors(
@@ -216,7 +218,7 @@ impl ReductClientApi for ReductClient {
     async fn get_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError> {
         let request = self.client_api.client().request(
             Method::GET,
-            &format!("{}{}/b/{}", self.server_url, API_PATH, bucket_name),
+            format!("{}{}/b/{}", self.server_url, API_PATH, bucket_name),
         );
 
         let resp = request.send().await;
@@ -244,7 +246,7 @@ impl ReductBucketApi for BucketWrapper {
         let (headers, stream) = Self::prepare_batch_to_write(records);
         let request = self.client.request(
             Method::POST,
-            &format!(
+            format!(
                 "{}{}/b/{}/{}/batch",
                 self.server_url, API_PATH, self.bucket_name, entry
             ),
@@ -267,7 +269,7 @@ impl ReductBucketApi for BucketWrapper {
         let headers = Self::prepare_batch_to_update(records);
         let request = self.client.request(
             Method::PATCH,
-            &format!(
+            format!(
                 "{}{}/b/{}/{}/batch",
                 self.server_url, API_PATH, self.bucket_name, entry
             ),

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -5,11 +5,9 @@ use crate::core::internal_client::{
     ClientBuildErrorContext, ClientBuildErrorKind, InternalClientApi, InternalClientBuilder,
 };
 use crate::replication::remote_bucket::{ErrorRecordMap, RemoteBucketConfig};
-use async_stream::stream;
 use async_trait::async_trait;
 use axum::http::HeaderName;
 use bytes::Bytes;
-use futures_util::Stream;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::BoxedReadRecord;
 use reduct_base::unprocessable_entity;
@@ -149,11 +147,11 @@ impl BucketWrapper {
 
     fn prepare_batch_to_write(
         mut records: Vec<BoxedReadRecord>,
-    ) -> (HeaderMap, impl Stream<Item = Result<Bytes, ReductError>>) {
+    ) -> (HeaderMap, impl futures_util::Stream<Item = Result<Bytes, ReductError>>) {
         Self::sort_by_timestamp(&mut records);
         let headers = Self::build_headers(&mut records, false);
 
-        let stream = stream! {
+        let stream = async_stream::stream! {
             while let Some(mut record) = records.pop() {
                 while let Some(chunk) = record.read_chunk() {
                      yield chunk;

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -166,8 +166,7 @@ impl ManageReplications for ReplicationRepository {
             )));
         }
 
-        self.create_or_update_replication_task(&name, settings)
-            .await
+        self.create_or_update_replication_task(name, settings).await
     }
 
     async fn update_replication(
@@ -193,14 +192,13 @@ impl ManageReplications for ReplicationRepository {
             ))),
         }?;
 
-        self.create_or_update_replication_task(&name, settings)
-            .await
+        self.create_or_update_replication_task(name, settings).await
     }
 
     async fn replications(&self) -> Result<Vec<ReplicationInfo>, ReductError> {
         let mut replications = Vec::new();
         let guard = self.replications.read().await?;
-        for (_, replication) in guard.iter() {
+        for replication in guard.values() {
             replications.push(replication.info().await?);
         }
         Ok(replications)
@@ -314,7 +312,7 @@ impl ManageReplications for ReplicationRepository {
         }
 
         let mut guard = self.replications.write().await.unwrap();
-        for (_, task) in guard.iter_mut() {
+        for task in guard.values_mut() {
             task.stop().await;
         }
     }
@@ -338,7 +336,7 @@ impl ReplicationRepository {
                             }
                         };
 
-                        for (_, replication) in replications.iter_mut() {
+                        for replication in replications.values_mut() {
                             if replication.settings().src_bucket != notification.bucket {
                                 continue;
                             }
@@ -487,7 +485,7 @@ impl ReplicationRepository {
             conf.io_conf = filer.io_config().clone();
         }
 
-        // remove old replication because before creating new one
+        // remove old replication before creating new one
         let mut removed = self.replications.write().await?.remove(name);
 
         // we keep the old token if the new one is empty (meaning not updated)
@@ -525,7 +523,7 @@ impl ReplicationRepository {
         }
 
         if let Some(mut replications) = self.replications.try_write() {
-            for (_, task) in replications.iter_mut() {
+            for task in replications.values_mut() {
                 task.start();
             }
         } else {
@@ -538,7 +536,7 @@ impl ReplicationRepository {
                         return;
                     }
                 };
-                for (_, task) in replications.iter_mut() {
+                for task in replications.values_mut() {
                     task.start();
                 }
             });

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -109,7 +109,7 @@ impl ReplicationSender {
                                 Err(err) => {
                                     error!("Failed to get the entry {src_bucket}/{entry_name_ref}. {err:?}");
                                     let transactions_len = transactions.len();
-                                    
+
                                     write_batches_send.send((
                                         entry_name,
                                         vec![],
@@ -145,16 +145,17 @@ impl ReplicationSender {
                                             transaction
                                         )
                                     }).buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
-                                    .scan(0u64, |total_size, record_and_transaction| {
-                                        if let (Ok(record_to_sync), _) = &record_and_transaction {
-                                            if *total_size >= batch_max_size {
-                                                return future::ready(None)
-                                            }
+                                    .scan(0u64, |total_size, record_and_transaction| {future::ready(
+                                        if *total_size >= batch_max_size { None }
+                                        else {
                                             // This backwards order is intentional. https://github.com/reductstore/reductstore/issues/1433#issuecomment-4700929658
-                                            *total_size += record_to_sync.meta().content_length();
+                                            if let (Ok(record_to_sync), _) = &record_and_transaction {
+                                                *total_size += record_to_sync.meta().content_length();
+                                            }
+
+                                            Some(record_and_transaction)
                                         }
-                                        future::ready(Some(record_and_transaction))
-                                    });
+                                    )});
 
                                     while let Some((record_to_sync, transaction)) = transactions.next().await {
                                         match record_to_sync {
@@ -172,7 +173,7 @@ impl ReplicationSender {
                                     }
                                     drop(transactions);
                                     let batch_len = batch.len();
-                                    
+
                                     write_batches_send.send((
                                         entry_name,
                                         batch,
@@ -184,7 +185,7 @@ impl ReplicationSender {
                             }
                         ))
                     }).try_buffer_unordered(DEFAULT_CONCURRENCY_LIMIT);
-                    
+
                     while let Some((log, processed_transactions)) = reading.try_next().await? {
                         let guard = self_mutex.lock().await;
                         if guard.bucket.is_active() {
@@ -196,7 +197,7 @@ impl ReplicationSender {
                         };
                     }
                     drop(reading);
-                    
+
                     log::trace!["concurrent part finished: communicating this to sequential"];
                     Ok(drop(write_batches_send))
                 },

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -5,16 +5,16 @@ use crate::cfg::io::IoConfig;
 use crate::replication::remote_bucket::RemoteBucket;
 use crate::replication::transaction_log::TransactionLogMap;
 use crate::storage::engine::StorageEngine;
-use futures_util::{TryStreamExt, StreamExt, future, stream};
+use either::Either;
+use futures_util::{future, stream, StreamExt, TryStreamExt};
 use log::{debug, error};
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::{BoxedReadRecord, ReadRecord};
 use reduct_base::msg::replication_api::ReplicationSettings;
-use tokio_retry::RetryIf;
-use tokio_retry::strategy::ExponentialBackoff;
-use either::Either;
 use std::cmp::PartialEq;
 use std::sync::Arc;
+use tokio_retry::strategy::FibonacciBackoff;
+use tokio_retry::RetryIf;
 
 /// TODO just a guess, someone knowing the context should tune this, also foreshadowing this with global parameter would be nice
 pub const DEFAULT_CONCURRENCY_LIMIT: usize = 300;
@@ -63,100 +63,109 @@ impl ReplicationSender {
     pub async fn run(&mut self) -> Result<SyncState, ReductError> {
         let batch_max_size = self.io_config.batch_max_size;
         let batch_max_records = self.io_config.batch_max_records;
-        
-        let log_map_lock = self
-        .log_map
-        .read()
-        .await?;
+
+        let log_map_lock = self.log_map.read().await?;
         let log_map = log_map_lock.clone();
         drop(log_map_lock);
 
         let mut counter_aggregated = Vec::with_capacity(log_map.len()); // can be estimated slightly better
-        
+
         let mut buffered = stream::iter(log_map)
-        .map(|(entry_name, log)| async move {
-            let transactions = log.read().await.map_err(either::Either::Left)?.front(batch_max_records).await.map_err(|err| {
-                error!("Failed to read transaction: {err:?}");
-                either::Either::Right(SyncState::BrokenLog(entry_name.clone()))
-            });
-            transactions.map(|transactions| (entry_name, log, transactions))
-        }).buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
-        .try_filter(|item| future::ready(!item.2.is_empty()))
-        .map_ok(|(entry_name, log, transactions)| {
-            let src_bucket = self.settings.src_bucket.clone();
-            let storage = self.storage.clone();
-            async move {
-                let mut counter = Vec::with_capacity(1); // it will have at least `Ok()`
-                let entry_name_ref = entry_name.as_str();
-                    
-                let mut batch = Vec::new();
-                let mut total_size = 0;
-                let mut processed_transactions = 0;
-                for transaction in transactions {
-                    debug!(
-                        "Replicating transaction {}/{}/{:?}",
-                        src_bucket, entry_name_ref, transaction
-                    );
+            .map(|(entry_name, log)| async move {
+                let transactions = log
+                    .read()
+                    .await
+                    .map_err(either::Either::Left)?
+                    .front(batch_max_records)
+                    .await
+                    .map_err(|err| {
+                        error!("Failed to read transaction: {err:?}");
+                        either::Either::Right(SyncState::BrokenLog(entry_name.clone()))
+                    });
+                transactions.map(|transactions| (entry_name, log, transactions))
+            })
+            .buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
+            .try_filter(|item| future::ready(!item.2.is_empty()))
+            .map_ok(|(entry_name, log, transactions)| {
+                let src_bucket = self.settings.src_bucket.clone();
+                let storage = self.storage.clone();
+                async move {
+                    let mut counter = Vec::with_capacity(1); // it will have at least `Ok()`
+                    let entry_name_ref = entry_name.as_str();
 
-                    const STRATEGY: FibonacciBackoff = FibonacciBackoff::from_millis(5).factor(2); // https://github.com/reductstore/reductstore/pull/1419#pullrequestreview-4447002753
-                    let record_to_sync = RetryIf::start(
-                        STRATEGY
-                        // .map(tokio_retry::strategy::jitter)
-                        .take(6),
-                        async || {
-                            storage
-                                .get_bucket(&src_bucket)
-                                .await?
-                                .upgrade()?
-                                .get_entry(entry_name_ref)
-                                .await?
-                                .upgrade()?
-                        .begin_read(transaction.timestamp()).await
-                        },
-                        |error: &ReductError| error.status == ErrorCode::TooEarly
-                    ).await;
-                    processed_transactions += 1;
+                    let mut batch = Vec::new();
+                    let mut total_size = 0;
+                    let mut processed_transactions = 0;
+                    for transaction in transactions {
+                        debug!(
+                            "Replicating transaction {}/{}/{:?}",
+                            src_bucket, entry_name_ref, transaction
+                        );
 
-                    match record_to_sync {
-                        Ok(record_to_sync) => {
-                            let record_size = record_to_sync.meta().content_length();
-                            total_size += record_size;
-                            batch.push((Box::new(
-                                record_to_sync
-                            ) as BoxedReadRecord, transaction));
+                        const STRATEGY: FibonacciBackoff =
+                            FibonacciBackoff::from_millis(5).factor(2); // https://github.com/reductstore/reductstore/pull/1419#pullrequestreview-4447002753
+                        let record_to_sync = RetryIf::start(
+                            STRATEGY
+                                // .map(tokio_retry::strategy::jitter)
+                                .take(6),
+                            async || {
+                                storage
+                                    .get_bucket(&src_bucket)
+                                    .await?
+                                    .upgrade()?
+                                    .get_entry(entry_name_ref)
+                                    .await?
+                                    .upgrade()?
+                                    .begin_read(transaction.timestamp())
+                                    .await
+                            },
+                            |error: &ReductError| error.status == ErrorCode::TooEarly,
+                        )
+                        .await;
+                        processed_transactions += 1;
 
-                            if total_size >= batch_max_size {
-                                break;
+                        match record_to_sync {
+                            Ok(record_to_sync) => {
+                                let record_size = record_to_sync.meta().content_length();
+                                total_size += record_size;
+                                batch.push((
+                                    Box::new(record_to_sync) as BoxedReadRecord,
+                                    transaction,
+                                ));
+
+                                if total_size >= batch_max_size {
+                                    break;
+                                }
+                            }
+                            Err(err) => {
+                                error!(
+                                    "Failed to read record {}/{}/{}: {:?}",
+                                    src_bucket,
+                                    entry_name_ref,
+                                    transaction.timestamp(),
+                                    err
+                                );
+                                counter.push((Err(err), 1));
                             }
                         }
-                        Err(err) => {
-                            error!(
-                                "Failed to read record {}/{}/{}: {:?}",
-                                src_bucket,
-                                entry_name_ref,
-                                transaction.timestamp(),
-                                err
-                            );
-                            counter.push((Err(err), 1));
-                        }
                     }
-                }
 
-                Ok((entry_name, log, batch.len() as u64, batch, counter, processed_transactions))
-            }
-        }).try_buffer_unordered(DEFAULT_CONCURRENCY_LIMIT);
-        while let Some(item) = buffered.next().await  { 
+                    Ok((
+                        entry_name,
+                        log,
+                        batch.len() as u64,
+                        batch,
+                        counter,
+                        processed_transactions,
+                    ))
+                }
+            })
+            .try_buffer_unordered(DEFAULT_CONCURRENCY_LIMIT);
+        while let Some(item) = buffered.next().await {
             match item {
                 Err(Either::Left(e)) => return Err(e),
                 Err(Either::Right(ok)) => return Ok(ok),
-                Ok((
-                    entry_name, 
-                    log, 
-                    batch_size,
-                    batch,
-                    mut counter, 
-                    processed_transactions
-                )) => {
+                Ok((entry_name, log, batch_size, batch, mut counter, processed_transactions)) => {
                     match self.bucket.write_batch(entry_name.as_str(), batch).await {
                         Ok(map) => {
                             counter.push((Ok(()), batch_size - map.len() as u64));
@@ -180,12 +189,12 @@ impl ReplicationSender {
 
                     if self.bucket.is_active() {
                         // remove processed transactions from the log
-                        if let Err(err) = 
-                            log.write().await?.pop_front(processed_transactions).await {
-                                error!("Failed to remove transaction: {err:?}");
-                            }
+                        if let Err(err) = log.write().await?.pop_front(processed_transactions).await
+                        {
+                            error!("Failed to remove transaction: {err:?}");
+                        }
                     }
-                    
+
                     counter_aggregated.append(counter.as_mut());
                 }
             }

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -4,15 +4,20 @@
 use crate::cfg::io::IoConfig;
 use crate::replication::remote_bucket::RemoteBucket;
 use crate::replication::transaction_log::TransactionLogMap;
-use crate::replication::Transaction;
 use crate::storage::engine::StorageEngine;
+use futures_util::{TryStreamExt, StreamExt, future, stream};
 use log::{debug, error};
 use reduct_base::error::{ErrorCode, ReductError};
-use reduct_base::io::BoxedReadRecord;
+use reduct_base::io::{BoxedReadRecord, ReadRecord};
 use reduct_base::msg::replication_api::ReplicationSettings;
+use tokio_retry::RetryIf;
+use tokio_retry::strategy::ExponentialBackoff;
+use either::Either;
 use std::cmp::PartialEq;
 use std::sync::Arc;
-use tokio::time::{sleep, Duration};
+
+/// TODO just a guess, someone knowing the context should tune this, also foreshadowing this with global parameter would be nice
+pub const DEFAULT_CONCURRENCY_LIMIT: usize = 300;
 
 /// Internal worker for replication to process a sole iteration of the replication loop.
 pub(super) struct ReplicationSender {
@@ -56,72 +61,101 @@ impl ReplicationSender {
     }
 
     pub async fn run(&mut self) -> Result<SyncState, ReductError> {
-        let entries = self
-            .log_map
-            .read()
-            .await?
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
+        let batch_max_size = self.io_config.batch_max_size;
+        let batch_max_records = self.io_config.batch_max_records;
+        
+        let log_map_lock = self
+        .log_map
+        .read()
+        .await?;
+        let log_map = log_map_lock.clone();
+        drop(log_map_lock);
 
-        let mut counter = Vec::new();
+        let mut counter_aggregated = Vec::with_capacity(log_map.len()); // can be estimated slightly better
+        
+        let mut buffered = stream::iter(log_map)
+        .map(|(entry_name, log)| async move {
+            let transactions = log.read().await.map_err(either::Either::Left)?.front(batch_max_records).await.map_err(|err| {
+                error!("Failed to read transaction: {err:?}");
+                either::Either::Right(SyncState::BrokenLog(entry_name.clone()))
+            });
+            transactions.map(|transactions| (entry_name, log, transactions))
+        }).buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
+        .try_filter(|item| future::ready(!item.2.is_empty()))
+        .map_ok(|(entry_name, log, transactions)| {
+            let src_bucket = self.settings.src_bucket.clone();
+            let storage = self.storage.clone();
+            async move {
+                let mut counter = Vec::with_capacity(1); // it will have at least `Ok()`
+                let entry_name_ref = entry_name.as_str();
+                    
+                let mut batch = Vec::new();
+                let mut total_size = 0;
+                let mut processed_transactions = 0;
+                for transaction in transactions {
+                    debug!(
+                        "Replicating transaction {}/{}/{:?}",
+                        src_bucket, entry_name_ref, transaction
+                    );
 
-        for entry_name in entries.iter() {
-            let log = {
-                // Take only the handle, drop the map lock before touching the log itself.
-                let map = self.log_map.read().await?;
-                match map.get(entry_name) {
-                    Some(log) => Arc::clone(log),
-                    None => continue, // log might be removed
-                }
-            };
+                    const STRATEGY: ExponentialBackoff = ExponentialBackoff::from_millis(5).factor(2); // https://github.com/reductstore/reductstore/pull/1419#pullrequestreview-4447002753
+                    let record_to_sync = RetryIf::start(
+                        STRATEGY.map(tokio_retry::strategy::jitter).take(7), 
+                        async || {
+                            storage
+                            .get_bucket(&src_bucket)
+                            .await?
+                            .upgrade()?
+                            .get_entry(entry_name_ref)
+                            .await?
+                            .upgrade()?
+                            .begin_read(transaction.timestamp()).await
+                        }, 
+                        |error: &ReductError| error.status == ErrorCode::TooEarly
+                    ).await;
+                    processed_transactions += 1;
 
-            let transactions = {
-                let log = log.write().await?;
-                log.front(self.io_config.batch_max_records).await
-            };
-            match transactions {
-                Ok(vec) => {
-                    if vec.is_empty() {
-                        continue;
-                    }
-                    let mut batch = Vec::new();
-                    let mut total_size = 0;
-                    let mut processed_transactions = 0;
-                    for transaction in vec {
-                        debug!(
-                            "Replicating transaction {}/{}/{:?}",
-                            self.settings.src_bucket, entry_name, transaction
-                        );
+                    match record_to_sync {
+                        Ok(record_to_sync) => {
+                            let record_size = record_to_sync.meta().content_length();
+                            total_size += record_size;
+                            batch.push((Box::new(
+                                record_to_sync
+                            ) as BoxedReadRecord, transaction));
 
-                        let record_to_sync = self.read_record(entry_name, &transaction).await;
-                        processed_transactions += 1;
-
-                        match record_to_sync {
-                            Ok(record_to_sync) => {
-                                let record_size = record_to_sync.meta().content_length();
-                                total_size += record_size;
-                                batch.push((record_to_sync, transaction));
-
-                                if total_size >= self.io_config.batch_max_size {
-                                    break;
-                                }
-                            }
-                            Err(err) => {
-                                error!(
-                                    "Failed to read record {}/{}/{}: {:?}",
-                                    self.settings.src_bucket,
-                                    entry_name,
-                                    transaction.timestamp(),
-                                    err
-                                );
-                                counter.push((Err(err), 1));
+                            if total_size >= batch_max_size {
+                                break;
                             }
                         }
+                        Err(err) => {
+                            error!(
+                                "Failed to read record {}/{}/{}: {:?}",
+                                src_bucket,
+                                entry_name_ref,
+                                transaction.timestamp(),
+                                err
+                            );
+                            counter.push((Err(err), 1));
+                        }
                     }
+                }
 
-                    let batch_size = batch.len() as u64;
-                    match self.bucket.write_batch(entry_name, batch).await {
+                Ok((entry_name, log, batch.len() as u64, batch, counter, processed_transactions))
+            }
+        }).try_buffer_unordered(DEFAULT_CONCURRENCY_LIMIT);
+        while let Some(item) = buffered.next().await  { 
+            match item {
+                Err(Either::Left(e)) => return Err(e),
+                Err(Either::Right(ok)) => return Ok(ok),
+                Ok((
+                    entry_name, 
+                    log, 
+                    batch_size,
+                    batch,
+                    mut counter, 
+                    processed_transactions
+                )) => {
+                    match self.bucket.write_batch(entry_name.as_str(), batch).await {
                         Ok(map) => {
                             counter.push((Ok(()), batch_size - map.len() as u64));
                             for (timestamp, err) in map.into_iter() {
@@ -142,79 +176,26 @@ impl ReplicationSender {
                         }
                     }
 
-                    if !self.bucket.is_active() {
-                        break;
+                    if self.bucket.is_active() {
+                        // remove processed transactions from the log
+                        if let Err(err) = 
+                            log.write().await?.pop_front(processed_transactions).await {
+                                error!("Failed to remove transaction: {err:?}");
+                            }
                     }
-
-                    // remove processed transactions from the log
-                    if let Err(err) = log.write().await?.pop_front(processed_transactions).await {
-                        error!("Failed to remove transaction: {:?}", err);
-                    }
+                    
+                    counter_aggregated.append(counter.as_mut());
                 }
-
-                Err(err) => {
-                    error!("Failed to read transaction: {:?}", err);
-                    return Ok(SyncState::BrokenLog(entry_name.clone()));
-                }
-            };
+            }
         }
 
-        Ok(if !counter.is_empty() {
-            if self.bucket.is_active() {
-                SyncState::SyncedOrRemoved(counter)
-            } else {
-                SyncState::NotAvailable(counter)
-            }
-        } else {
+        Ok(if counter_aggregated.is_empty() {
             SyncState::NoTransactions
+        } else if self.bucket.is_active() {
+            SyncState::SyncedOrRemoved(counter_aggregated)
+        } else {
+            SyncState::NotAvailable(counter_aggregated)
         })
-    }
-
-    async fn read_record(
-        &self,
-        entry_name: &str,
-        transaction: &Transaction,
-    ) -> Result<BoxedReadRecord, ReductError> {
-        let read_record_from_storage = async || {
-            let mut attempts = 3;
-            loop {
-                let read_record = async || {
-                    self.storage
-                        .get_bucket(&self.settings.src_bucket)
-                        .await?
-                        .upgrade()?
-                        .get_entry(&entry_name)
-                        .await?
-                        .upgrade()?
-                        .begin_read(*transaction.timestamp())
-                        .await
-                };
-                let record = read_record().await;
-                match record {
-                    Err(ReductError {
-                        status: ErrorCode::TooEarly,
-                        ..
-                    }) => {
-                        debug!("Transaction is too early, retrying later");
-                        sleep(Duration::from_millis(10)).await;
-                        attempts -= 1;
-                    }
-
-                    _ => {
-                        attempts = 0;
-                    }
-                }
-
-                if attempts == 0 {
-                    break record;
-                }
-            }
-        };
-
-        match read_record_from_storage().await {
-            Ok(record) => Ok(Box::new(record)),
-            Err(err) => Err(err),
-        }
     }
 }
 
@@ -259,7 +240,6 @@ mod tests {
 
             fn is_active(&self) -> bool;
         }
-
     }
 
     #[rstest]
@@ -665,7 +645,7 @@ mod tests {
             .upgrade_and_unwrap()
             .begin_write(
                 "test",
-                *transaction.timestamp(),
+                transaction.timestamp(),
                 size,
                 "text/plain".to_string(),
                 Labels::new(),

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -122,7 +122,7 @@ impl ReplicationSender {
                                     let mut counter = Vec::with_capacity(1); // it will have at least `Ok()`
                                     let mut batch = Vec::new();
 
-                                    /* *Note* that it's the *other* stream iterator -- folded/internal one. 
+                                    /* *Note* that it's *other* stream iterator -- nested one. 
                                     Which stresses importance of fine parameterization of `CONCURRENCY_LIMIT` stub. */
                                     let mut transactions = stream::iter(transactions)
                                     .map(async |transaction| {

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -80,11 +80,11 @@ impl ReplicationSender {
             let (write_batches_send, mut write_batches_recv) = tokio::sync::mpsc::channel(capacity);
             let mut writing_results = Vec::with_capacity(capacity);
 
-            /* Writing the batches is naturally sequential so it's second here, fed by first when a batch is ready. (So first is referred
+            /* Writing the batches is currently sequential so it's second here, fed by first when a batch is ready. (So first is referred
             as 'reading' through this code for brevity despite it ends with popping / reading out processed lengthes from the logs). */
             match future::try_join(
                 async {
-                    let mut reading = stream::iter(log_map)
+                    stream::iter(log_map)
                     .map(async |(entry_name, log)| {
                         let transactions = log
                         .read()
@@ -100,7 +100,7 @@ impl ReplicationSender {
                         transactions.map(|transactions| (entry_name, log, transactions))
                     }).buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
                     .try_filter(|(_, _, transactions)| future::ready(!transactions.is_empty()))
-                    .map_ok(async |(entry_name, log, transactions)| {
+                    .and_then(async |(entry_name, log, transactions)| {
                         let entry_name_ref = entry_name.as_str();
                         Ok((
                             log,
@@ -184,9 +184,7 @@ impl ReplicationSender {
                                 }
                             }
                         ))
-                    }).try_buffer_unordered(DEFAULT_CONCURRENCY_LIMIT);
-
-                    while let Some((log, processed_transactions)) = reading.try_next().await? {
+                    }).try_for_each_concurrent(capacity, async |(log, processed_transactions)| {
                         let guard = self_mutex.lock().await;
                         if guard.bucket.is_active() {
                             drop(guard);
@@ -195,8 +193,8 @@ impl ReplicationSender {
                                 error!("Failed to remove transaction: {err:?}")
                             }
                         };
-                    }
-                    drop(reading);
+                        Ok(())
+                    }).await?;
 
                     log::trace!["concurrent part finished: communicating this to sequential"];
                     Ok(drop(write_batches_send))

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -98,19 +98,21 @@ impl ReplicationSender {
                         src_bucket, entry_name_ref, transaction
                     );
 
-                    const STRATEGY: ExponentialBackoff = ExponentialBackoff::from_millis(5).factor(2); // https://github.com/reductstore/reductstore/pull/1419#pullrequestreview-4447002753
+                    const STRATEGY: FibonacciBackoff = FibonacciBackoff::from_millis(5).factor(2); // https://github.com/reductstore/reductstore/pull/1419#pullrequestreview-4447002753
                     let record_to_sync = RetryIf::start(
-                        STRATEGY.map(tokio_retry::strategy::jitter).take(7), 
+                        STRATEGY
+                        // .map(tokio_retry::strategy::jitter)
+                        .take(6),
                         async || {
                             storage
-                            .get_bucket(&src_bucket)
-                            .await?
-                            .upgrade()?
-                            .get_entry(entry_name_ref)
-                            .await?
-                            .upgrade()?
-                            .begin_read(transaction.timestamp()).await
-                        }, 
+                                .get_bucket(&src_bucket)
+                                .await?
+                                .upgrade()?
+                                .get_entry(entry_name_ref)
+                                .await?
+                                .upgrade()?
+                        .begin_read(transaction.timestamp()).await
+                        },
                         |error: &ReductError| error.status == ErrorCode::TooEarly
                     ).await;
                     processed_transactions += 1;

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -5,7 +5,6 @@ use crate::cfg::io::IoConfig;
 use crate::replication::remote_bucket::RemoteBucket;
 use crate::replication::transaction_log::TransactionLogMap;
 use crate::storage::engine::StorageEngine;
-use either::Either;
 use futures_util::{future, stream, StreamExt, TryStreamExt};
 use log::{debug, error};
 use reduct_base::error::{ErrorCode, ReductError};
@@ -17,7 +16,9 @@ use tokio_retry::strategy::FibonacciBackoff;
 use tokio_retry::RetryIf;
 
 /// TODO just a guess, someone knowing the context should tune this, also shadowing this with global parameter would be nice
-pub const DEFAULT_CONCURRENCY_LIMIT: usize = 300;
+pub const DEFAULT_CONCURRENCY_LIMIT: usize = 17;
+
+const EXPECTMSG: &str = "the writing awaits on the channel";
 
 /// Internal worker for replication to process a sole iteration of the replication loop.
 pub(super) struct ReplicationSender {
@@ -34,6 +35,7 @@ type ResultResult = (Result<(), ReductError>, u64);
 pub(super) enum SyncState {
     SyncedOrRemoved(Vec<ResultResult>),
     NotAvailable(Vec<ResultResult>),
+    /// When `TransactionLogMap` is empty or all of its items are. Former case does not activate `is_active` flag.
     NoTransactions,
     BrokenLog(String),
 }
@@ -61,152 +63,189 @@ impl ReplicationSender {
     }
 
     pub async fn run(&mut self) -> Result<SyncState, ReductError> {
-        let batch_max_size = self.io_config.batch_max_size;
-        let batch_max_records = self.io_config.batch_max_records;
-
         let log_map_lock = self.log_map.read().await?;
         let log_map = log_map_lock.clone();
         drop(log_map_lock);
 
-        let mut counter_aggregated = Vec::with_capacity(log_map.len()); // can be estimated slightly better
+        let capacity = log_map.len();
+        if capacity == 0 {
+            Ok(SyncState::NoTransactions)
+        } else {
+            let batch_max_size = self.io_config.batch_max_size;
+            let batch_max_records = self.io_config.batch_max_records;
+            let storage = self.storage.clone();
+            let src_bucket = self.settings.src_bucket.clone();
+            let self_mutex = tokio::sync::Mutex::new(self);
 
-        let mut buffered = stream::iter(log_map)
-            .map(|(entry_name, log)| async move {
-                let transactions = log
-                    .read()
-                    .await
-                    .map_err(either::Either::Left)?
-                    .front(batch_max_records)
-                    .await
-                    .map_err(|err| {
-                        error!("Failed to read transaction: {err:?}");
-                        either::Either::Right(SyncState::BrokenLog(entry_name.clone()))
-                    });
-                transactions.map(|transactions| (entry_name, log, transactions))
-            })
-            .buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
-            .try_filter(|(_, _, transactions)| future::ready(!transactions.is_empty()))
-            .map_ok(|(entry_name, log, transactions)| {
-                let src_bucket = self.settings.src_bucket.clone();
-                let storage = self.storage.clone();
-                async move {
-                    let mut counter = Vec::with_capacity(1); // it will have at least `Ok()`
-                    let entry_name_ref = entry_name.as_str();
+            let (write_batches_send, mut write_batches_recv) = tokio::sync::mpsc::channel(capacity);
+            let mut writing_results = Vec::with_capacity(capacity);
 
-                    let mut batch = Vec::new();
-                    let mut total_size = 0;
-                    let mut processed_transactions = 0;
-                    for transaction in transactions {
-                        debug!(
-                            "Replicating transaction {}/{}/{:?}",
-                            src_bucket, entry_name_ref, transaction
-                        );
+            /* Writing the batches is naturally sequential so it's second here, fed by first when a batch is ready. (So first is referred
+            as 'reading' through this code for brevity despite it ends with popping / reading out processed lengthes from the logs). */
+            match future::try_join(
+                async {
+                    let mut reading = stream::iter(log_map)
+                    .map(async |(entry_name, log)| {
+                        let transactions = log
+                        .read()
+                        .await
+                        .map_err(Result::Err)?
+                        .front(batch_max_records)
+                        .await
+                        .map_err(|err| {
+                            error!("Failed to read transaction: {err:?}");
+                            Ok(SyncState::BrokenLog(entry_name.clone()))
+                        });
+                        log::trace!["attempted the transactions from the log for {entry_name}"];
+                        transactions.map(|transactions| (entry_name, log, transactions))
+                    }).buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
+                    .try_filter(|(_, _, transactions)| future::ready(!transactions.is_empty()))
+                    .map_ok(async |(entry_name, log, transactions)| {
+                        let entry_name_ref = entry_name.as_str();
+                        Ok((
+                            log,
+                            // this step is infallible: it feeds sequential writing, and tells the length to pop from `log`
+                            match storage.get_entry_strong(src_bucket.as_str(), entry_name_ref).await {
+                                Err(err) => {
+                                    error!("Failed to get the entry {src_bucket}/{entry_name_ref}. {err:?}");
+                                    let transactions_len = transactions.len();
+                                    
+                                    write_batches_send.send((
+                                        entry_name,
+                                        vec![],
+                                        vec![(Err(err), transactions_len as u64)]
+                                    )).await.expect(EXPECTMSG);
 
-                        const STRATEGY: FibonacciBackoff =
-                            FibonacciBackoff::from_millis(5).factor(2); // https://github.com/reductstore/reductstore/pull/1419#pullrequestreview-4447002753
-                        let record_to_sync = RetryIf::start(
-                            STRATEGY
-                                // .map(tokio_retry::strategy::jitter)
-                                .take(6),
-                            async || {
-                                storage
-                                    .get_bucket(&src_bucket)
-                                    .await?
-                                    .upgrade()?
-                                    .get_entry(entry_name_ref)
-                                    .await?
-                                    .upgrade()?
-                                    .begin_read(transaction.timestamp())
-                                    .await
-                            },
-                            |error: &ReductError| error.status == ErrorCode::TooEarly,
-                        )
-                        .await;
-                        processed_transactions += 1;
+                                    transactions_len
+                                }
+                                Ok(entry) => {
+                                    let mut counter = Vec::with_capacity(1); // it will have at least `Ok()`
+                                    let mut batch = Vec::new();
 
-                        match record_to_sync {
-                            Ok(record_to_sync) => {
-                                let record_size = record_to_sync.meta().content_length();
-                                total_size += record_size;
-                                batch.push((
-                                    Box::new(record_to_sync) as BoxedReadRecord,
-                                    transaction,
-                                ));
+                                    /* *Note* that it's the *other* stream iterator -- folded/internal one. 
+                                    Which stresses importance of fine parameterization of `CONCURRENCY_LIMIT` stub. */
+                                    let mut transactions = stream::iter(transactions)
+                                    .map(async |transaction| {
+                                        debug!(
+                                            "Replicating transaction {}/{}/{:?}",
+                                            src_bucket, entry_name_ref, transaction
+                                        );
 
-                                if total_size >= batch_max_size {
-                                    break;
+                                        const STRATEGY: FibonacciBackoff = FibonacciBackoff::from_millis(5).factor(2); // https://github.com/reductstore/reductstore/pull/1419#pullrequestreview-4447002753
+
+                                        (
+                                            // retrying to get `RecordReader`
+                                            RetryIf::start(
+                                                STRATEGY
+                                                    // .map(tokio_retry::strategy::jitter)
+                                                    .take(6),
+                                                || entry.begin_read(transaction.timestamp()),
+                                                |error: &ReductError| error.status == ErrorCode::TooEarly,
+                                            ).await,
+                                            transaction
+                                        )
+                                    }).buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
+                                    .scan(0u64, |total_size, record_and_transaction| {
+                                        if let (Ok(record_to_sync), _) = &record_and_transaction {
+                                            if *total_size >= batch_max_size {
+                                                return future::ready(None)
+                                            }
+                                            // This backwards order is intentional. https://github.com/reductstore/reductstore/issues/1433#issuecomment-4700929658
+                                            *total_size += record_to_sync.meta().content_length();
+                                        }
+                                        future::ready(Some(record_and_transaction))
+                                    });
+
+                                    while let Some((record_to_sync, transaction)) = transactions.next().await {
+                                        match record_to_sync {
+                                            Ok(record_to_sync) => {
+                                                batch.push((
+                                                    Box::new(record_to_sync) as BoxedReadRecord,
+                                                    transaction,
+                                                ));
+                                            }
+                                            Err(err) => {
+                                                error!("Failed to read record {src_bucket}/{entry_name_ref}/{}: {err:?}", transaction.timestamp());
+                                                counter.push((Err(err), 1));
+                                            }
+                                        }
+                                    }
+                                    drop(transactions);
+                                    let batch_len = batch.len();
+                                    
+                                    write_batches_send.send((
+                                        entry_name,
+                                        batch,
+                                        counter
+                                    )).await.expect(EXPECTMSG);
+
+                                    batch_len
+                                }
+                            }
+                        ))
+                    }).try_buffer_unordered(DEFAULT_CONCURRENCY_LIMIT);
+                    
+                    while let Some((log, processed_transactions)) = reading.try_next().await? {
+                        let guard = self_mutex.lock().await;
+                        if guard.bucket.is_active() {
+                            drop(guard);
+                            // remove processed transactions from the log
+                            if let Err(err) = log.write().await.map_err(Result::Err)?.pop_front(processed_transactions).await {
+                                error!("Failed to remove transaction: {err:?}")
+                            }
+                        };
+                    }
+                    drop(reading);
+                    
+                    log::trace!["concurrent part finished: communicating this to sequential"];
+                    Ok(drop(write_batches_send))
+                },
+                async {
+                    Ok(while let Some((entry_name, batch, counter)) = write_batches_recv.recv().await {
+                        log::trace!["writing the batch for {entry_name}"];
+                        let batch_len = batch.len() as u64;
+
+                        let mut guard = self_mutex.lock().await;
+                        let result = guard.bucket.write_batch(entry_name.as_str(), batch).await;
+                        drop(guard);
+
+                        writing_results.push((entry_name, batch_len, result, counter));
+                    })
+                }
+            ).await {
+                Err(early) => early,
+                Ok(_) => {
+                    let counter: Vec<(Result<(), ReductError>, u64)> = writing_results.into_iter()
+                    .flat_map(|(entry_name, batch_size, wrote, mut counter)| {
+                        match wrote {
+                            Ok(map) => {
+                                counter.push((Ok(()), batch_size - map.len() as u64));
+                                for (timestamp, err) in map {
+                                    debug!("Failed to replicate record {src_bucket}/{entry_name}/{timestamp}: {err:?}");
+                                    counter.push((Err(err), 1));
                                 }
                             }
                             Err(err) => {
-                                error!(
-                                    "Failed to read record {}/{}/{}: {:?}",
-                                    src_bucket,
-                                    entry_name_ref,
-                                    transaction.timestamp(),
-                                    err
-                                );
-                                counter.push((Err(err), 1));
+                                debug!("Failed to replicate batch of records from {src_bucket}/{entry_name} {err:?}");
+
+                                counter.push((Err(err), batch_size));
                             }
                         }
-                    }
-
-                    Ok((
-                        entry_name,
-                        log,
-                        batch.len() as u64,
-                        batch,
-                        counter,
-                        processed_transactions,
-                    ))
-                }
-            })
-            .try_buffer_unordered(DEFAULT_CONCURRENCY_LIMIT);
-        while let Some(item) = buffered.next().await {
-            match item {
-                Err(Either::Left(e)) => return Err(e),
-                Err(Either::Right(ok)) => return Ok(ok),
-                Ok((entry_name, log, batch_size, batch, mut counter, processed_transactions)) => {
-                    match self.bucket.write_batch(entry_name.as_str(), batch).await {
-                        Ok(map) => {
-                            counter.push((Ok(()), batch_size - map.len() as u64));
-                            for (timestamp, err) in map.into_iter() {
-                                debug!(
-                                    "Failed to replicate record {}/{}/{}: {:?}",
-                                    self.settings.src_bucket, entry_name, timestamp, err
-                                );
-                                counter.push((Err(err), 1));
-                            }
+                        counter
+                    }).collect();
+                    // let self_ = ;
+                    Ok(
+                        if counter.is_empty() {
+                            SyncState::NoTransactions
+                        } else if self_mutex.into_inner().bucket.is_active() {
+                            SyncState::SyncedOrRemoved(counter)
+                        } else {
+                            SyncState::NotAvailable(counter)
                         }
-                        Err(err) => {
-                            debug!(
-                                "Failed to replicate batch of records from {}/{} {:?}",
-                                self.settings.src_bucket, entry_name, err
-                            );
-
-                            counter.push((Err(err), batch_size));
-                        }
-                    }
-
-                    if self.bucket.is_active() {
-                        // remove processed transactions from the log
-                        if let Err(err) = log.write().await?.pop_front(processed_transactions).await
-                        {
-                            error!("Failed to remove transaction: {err:?}");
-                        }
-                    }
-
-                    counter_aggregated.append(counter.as_mut());
+                    )
                 }
             }
         }
-
-        Ok(if counter_aggregated.is_empty() {
-            SyncState::NoTransactions
-        } else if self.bucket.is_active() {
-            SyncState::SyncedOrRemoved(counter_aggregated)
-        } else {
-            SyncState::NotAvailable(counter_aggregated)
-        })
     }
 }
 
@@ -233,7 +272,6 @@ mod tests {
     use reduct_base::{conflict, not_found, timeout, too_early, Labels};
     use rstest::*;
     use std::collections::HashMap;
-    use tokio::task::JoinHandle;
     use tokio::time::{sleep, Duration};
 
     mock! {
@@ -428,6 +466,7 @@ mod tests {
                 .await
                 .unwrap();
         }
+        dbg!["wrote `log`"];
 
         let bucket = sender
             .storage
@@ -440,7 +479,9 @@ mod tests {
             .await
             .unwrap();
 
-        let handle: JoinHandle<Result<SyncState, ReductError>> =
+        dbg!["spawning"];
+
+        let handle: tokio::task::JoinHandle<Result<SyncState, ReductError>> =
             tokio::spawn(async move { sender.run().await });
 
         writer.send(Ok(Some(Bytes::from("xxxx")))).await.unwrap();

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use tokio_retry::strategy::FibonacciBackoff;
 use tokio_retry::RetryIf;
 
-/// TODO just a guess, someone knowing the context should tune this, also foreshadowing this with global parameter would be nice
+/// TODO just a guess, someone knowing the context should tune this, also shadowing this with global parameter would be nice
 pub const DEFAULT_CONCURRENCY_LIMIT: usize = 300;
 
 /// Internal worker for replication to process a sole iteration of the replication loop.
@@ -85,7 +85,7 @@ impl ReplicationSender {
                 transactions.map(|transactions| (entry_name, log, transactions))
             })
             .buffer_unordered(DEFAULT_CONCURRENCY_LIMIT)
-            .try_filter(|item| future::ready(!item.2.is_empty()))
+            .try_filter(|(_, _, transactions)| future::ready(!transactions.is_empty()))
             .map_ok(|(entry_name, log, transactions)| {
                 let src_bucket = self.settings.src_bucket.clone();
                 let storage = self.storage.clone();

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -88,7 +88,7 @@ impl ReplicationTask {
 
         let system_options = ReplicationSystemOptions {
             transaction_log_size: config.replication_conf.replication_log_size,
-            remote_bucket_unavailable_timeout: config.replication_conf.connection_timeout.clone(),
+            remote_bucket_unavailable_timeout: config.replication_conf.connection_timeout,
             ..Default::default()
         };
 
@@ -253,7 +253,7 @@ impl ReplicationTask {
                         .await;
                     }
                     Ok(SyncState::NoTransactions) => {
-                        // NOTE: we don't want to spin the CPU when there is nothing to do or the bucket is not available
+                        // NOTE: we don't want to spin the CPU when there is nothing to do or the bucket is not available.
                         thr_is_active.store(true, Ordering::Relaxed);
                         ReplicationTask::sleep_with_stop(
                             &thr_stop_flag,
@@ -318,7 +318,7 @@ impl ReplicationTask {
                                 diagnostics.count(result, count);
                             }
                         }
-                        Err(err) => error!("Failed to acquire hourly diagnostics lock: {:?}", err),
+                        Err(err) => error!("Failed to acquire hourly diagnostics lock: {err:?}"),
                     }
                 }
             }
@@ -343,7 +343,7 @@ impl ReplicationTask {
         if matches!(self.load_mode(), ReplicationMode::Disabled) {
             return Ok(());
         }
-        // We need to have a filter for each entry
+        // We need to have a filter for each entry.
         let entry_name = notification.entry.clone();
         let notifications = {
             if !self.filter_map.contains_key(&notification.entry) {
@@ -361,8 +361,7 @@ impl ReplicationTask {
             filter.filter(notification)
         };
 
-        // NOTE: very important not to lock the log_map for too long
-        // because it is used by the replication thread
+        // NOTE: very important not to lock the log_map for too long because it is used by the replication thread.
         let exists = { self.log_map.read().await?.contains_key(&entry_name) };
         if !exists {
             let log = TransactionLog::try_load_or_create(
@@ -421,7 +420,7 @@ impl ReplicationTask {
     }
 
     pub fn set_mode(&mut self, mode: ReplicationMode) {
-        self.settings.mode = mode.clone();
+        self.settings.mode = mode;
         self.mode.store(mode as u8, Ordering::Relaxed);
     }
 
@@ -431,14 +430,14 @@ impl ReplicationTask {
 
     pub async fn info(&self) -> Result<ReplicationInfo, ReductError> {
         let mut pending_records = 0;
-        for (_, log) in self.log_map.read().await?.iter() {
+        for log in self.log_map.read().await?.values() {
             pending_records += log.read().await?.len() as u64;
         }
 
         let mode = self.load_mode();
         Ok(ReplicationInfo {
             name: self.name.clone(),
-            mode: mode.clone(),
+            mode,
             is_active: matches!(mode, ReplicationMode::Enabled | ReplicationMode::Paused)
                 && self.is_active.load(Ordering::Relaxed),
             is_provisioned: self.is_provisioned,

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -24,7 +24,7 @@ pub(super) struct TransactionFilter {
 
 impl FilterRecord for TransactionNotification {
     fn timestamp(&self) -> u64 {
-        *self.event.timestamp()
+        self.event.timestamp()
     }
 
     fn labels(&self) -> HashMap<&String, &String> {
@@ -480,7 +480,7 @@ mod tests {
         #[rstest]
         fn test_filter_record_impl(notification: TransactionNotification) {
             let record: Box<dyn FilterRecord> = Box::new(notification.clone());
-            assert_eq!(record.timestamp(), *notification.event.timestamp());
+            assert_eq!(record.timestamp(), notification.event.timestamp());
 
             for (key, value) in notification.meta.labels() {
                 assert_eq!(record.labels().get(key), Some(&value));

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -28,7 +28,7 @@ impl FilterRecord for TransactionNotification {
     }
 
     fn labels(&self) -> HashMap<&String, &String> {
-        self.meta.labels().iter().map(|(k, v)| (k, v)).collect()
+        self.meta.labels().iter().collect()
     }
 
     fn set_labels(&mut self, labels: HashMap<String, String>) {
@@ -38,11 +38,7 @@ impl FilterRecord for TransactionNotification {
     }
 
     fn computed_labels(&self) -> HashMap<&String, &String> {
-        self.meta
-            .computed_labels()
-            .iter()
-            .map(|(k, v)| (k, v))
-            .collect()
+        self.meta.computed_labels().iter().collect()
     }
 
     fn state(&self) -> i32 {

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -223,15 +223,11 @@ impl Bucket {
         })
     }
 
-    /// Get an entry in the bucket
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the entry
-    ///
+    /// Get an entry in the bucket.
+    /// # Argument.
+    /// `name` - The name of the entry.
     /// # Returns
-    ///
-    /// * `&Entry` - The entry or an HTTPError
+    /// `&Entry` - The entry or an HTTPError.
     pub async fn get_entry(&self, name: &str) -> Result<Weak<Entry>, ReductError> {
         self.reload().await?;
         let entries = self.entries.read().await?;
@@ -341,12 +337,7 @@ impl Bucket {
             self.get_or_create_entry(name).await?.upgrade()
         };
 
-        let entry = match get_entry().await {
-            Ok(entry) => entry,
-            Err(e) => {
-                return Err(e).into();
-            }
-        };
+        let entry = get_entry().await?;
 
         entry
             .begin_write(time, content_size, content_type, labels)

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -279,15 +279,11 @@ impl StorageEngine {
         Ok(bucket.into())
     }
 
-    /// Get a bucket by name
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the bucket
-    ///
-    /// # Returns
-    ///
-    /// * `Bucket` - The bucket or an HTTPError
+    /// Get a bucket by name.
+    /// # Argument.
+    /// `name` - The name of the bucket.
+    /// # Returns.
+    /// `Bucket` - The bucket or an HTTPError.
     pub(crate) async fn get_bucket(&self, name: &str) -> Result<Weak<Bucket>, ReductError> {
         self.reload().await?;
         let buckets = self.buckets.read().await?;

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -472,6 +472,19 @@ impl StorageEngine {
     pub fn data_path(&self) -> &PathBuf {
         &self.data_path
     }
+
+    pub(crate) async fn get_entry_strong(
+        &self,
+        bucket: &str,
+        entry: &str,
+    ) -> Result<Arc<super::entry::Entry>, ReductError> {
+        self.get_bucket(bucket)
+            .await?
+            .upgrade()?
+            .get_entry(entry)
+            .await?
+            .upgrade()
+    }
 }
 
 pub(super) fn check_name_convention(name: &str) -> Result<(), ReductError> {

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -400,8 +400,8 @@ impl StorageEngine {
         let infos = {
             let buckets = self.buckets.read().await?;
             buckets
-                .iter()
-                .map(|(_, bucket)| bucket.clone().info())
+                .values()
+                .map(|bucket| bucket.clone().info())
                 .collect::<Vec<_>>()
         };
 
@@ -443,7 +443,7 @@ impl StorageEngine {
             .read()
             .await?
             .values()
-            .map(|bucket| Arc::clone(bucket))
+            .map(Arc::clone)
             .collect::<Vec<_>>();
         for bucket in buckets {
             handlers.push(tokio::spawn(async move {

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use tokio::sync::OwnedSemaphorePermit;
 
 /// Responsible for reading the content of a record from the storage.
+#[derive(Debug)]
 pub(crate) struct RecordReader {
     meta: RecordMeta,
     file_path: Option<PathBuf>,
@@ -132,7 +133,7 @@ impl RecordReader {
                 let mut file_guard = FILE_CACHE
                     .read(&path, SeekFrom::Start(offset + pos))
                     .await
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+                    .map_err(|e| io::Error::other(e.to_string()))?;
                 file_guard.read(buf)
             })
         });
@@ -228,7 +229,7 @@ pub(in crate::storage) async fn read_in_chunks(
     let mut buf = vec![0; chunk_size as usize];
 
     let mut file = FILE_CACHE
-        .read(&file_path, SeekFrom::Start(offset + read_bytes))
+        .read(file_path, SeekFrom::Start(offset + read_bytes))
         .await?;
 
     let read = match file.read(&mut buf) {

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::OwnedSemaphorePermit;
 
-/// RecordReader is responsible for reading the content of a record from the storage.
+/// Responsible for reading the content of a record from the storage.
 pub(crate) struct RecordReader {
     meta: RecordMeta,
     file_path: Option<PathBuf>,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?
- Performance upgrade.
- development on `TooEarly` timeout

### What was changed?

Move `futures` into `dev-dependencies`.

Develop `ReplicationSender::run` to be fully concurrent on reading.

Internalize `async fn read_record` replacing it with the crate.

Move `CoreExtCfgParser` from function arguments to generic.

Also some lateral changes from active reading while I was getting to know around.

### Related issues

#1389 

### Does this PR introduce a breaking change?

No

### Other information:
