### PR TITLE
fix crash on malformed headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Return `422 Unprocessable Entity` for malformed/non-UTF8 write headers instead of panicking, [PR-1432](https://github.com/reductstore/reductstore/pull/1432)
+
 ## 1.19.8 - 2026-05-21
 
 ### Fixed

--- a/reductstore/src/api/http/entry/update_batched.rs
+++ b/reductstore/src/api/http/entry/update_batched.rs
@@ -9,7 +9,9 @@ use axum::extract::{Path, State};
 use axum_extra::headers::HeaderMap;
 
 use reduct_base::batch::{parse_batched_header, sort_headers_by_time};
+use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;
+use reduct_base::unprocessable_entity;
 use reduct_base::Labels;
 
 use crate::api::http::entry::common::err_to_batched_header;
@@ -42,7 +44,12 @@ pub(super) async fn update_batched_records(
     let mut records_to_update = Vec::new();
 
     for (time, v) in record_headers {
-        let header = parse_batched_header(v.to_str().unwrap())?;
+        let header = match v.to_str() {
+            Ok(raw_header) => parse_batched_header(raw_header)?,
+            Err(err) => {
+                return Err(unprocessable_entity!("Malformed header received: {}", err).into())
+            }
+        };
         let mut labels_to_update = Labels::new();
         let mut labels_to_remove = HashSet::new();
 
@@ -165,6 +172,32 @@ mod tests {
             err,
             HttpError::new(ErrorCode::UnprocessableEntity, "Invalid batched header")
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_batched_non_utf8_header(
+        #[future] keeper: Arc<StateKeeper>,
+        mut headers: HeaderMap,
+        path_to_entry_1: Path<HashMap<String, String>>,
+        #[future] empty_body: Body,
+    ) {
+        headers.insert(
+            "x-reduct-time-1",
+            HeaderValue::from_bytes(b"10,text/plain,\xff").unwrap(),
+        );
+
+        let err = update_batched_records(
+            State(keeper.await),
+            headers,
+            path_to_entry_1,
+            empty_body.await,
+        )
+        .await
+        .err()
+        .unwrap();
+
+        assert_eq!(err.into_inner().status(), ErrorCode::UnprocessableEntity);
     }
 
     #[rstest]

--- a/reductstore/src/api/http/entry/write_batched.rs
+++ b/reductstore/src/api/http/entry/write_batched.rs
@@ -54,7 +54,13 @@ pub(super) async fn write_batched_records(
     let process_stream = async {
         let mut timed_headers: Vec<(u64, RecordHeader)> = Vec::new();
         for (time, v) in record_headers {
-            let header = parse_batched_header(v.to_str().unwrap())?;
+            let header = match v.to_str() {
+                Ok(raw_header) => parse_batched_header(raw_header)?,
+                Err(err) => {
+                    return Err(unprocessable_entity!("Malformed header received: {}", err));
+                }
+            };
+
             timed_headers.push((time, header));
         }
 
@@ -100,7 +106,7 @@ pub(super) async fn write_batched_records(
                 debug!("draining the stream");
                 while let Some(_) = stream.next().await {}
             }
-            Err::<HeaderMap, HttpError>(err)
+            Err::<HeaderMap, HttpError>(err.into())
         }
     }
 }

--- a/reductstore/src/api/http/entry/write_single.rs
+++ b/reductstore/src/api/http/entry/write_single.rs
@@ -53,7 +53,12 @@ pub(super) async fn write_record(
             .await?;
         let content_type = headers
             .get("content-type")
-            .map_or("application/octet-stream", |v| v.to_str().unwrap())
+            .map(|v| {
+                v.to_str()
+                    .map_err(|err| unprocessable_entity!("Malformed content-type header: {}", err))
+            })
+            .transpose()?
+            .unwrap_or("application/octet-stream")
             .to_string();
 
         let mut labels = Labels::new();
@@ -153,7 +158,7 @@ mod tests {
         empty_body, ingress_limited_keeper, keeper, path_to_entry_1, storage_limited_keeper,
     };
 
-    use axum_extra::headers::{Authorization, HeaderMapExt};
+    use axum_extra::headers::{Authorization, HeaderMapExt, HeaderValue};
     use reduct_base::error::ErrorCode;
     use reduct_base::io::ReadRecord;
     use reduct_base::not_found;
@@ -271,6 +276,33 @@ mod tests {
             err,
             unprocessable_entity!("'ts' must be an unix timestamp in microseconds").into()
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_write_non_utf8_content_type(
+        #[future] keeper: Arc<StateKeeper>,
+        mut headers: HeaderMap,
+        path_to_entry_1: Path<HashMap<String, String>>,
+        #[future] empty_body: Body,
+    ) {
+        headers.insert("content-type", HeaderValue::from_bytes(b"\xff").unwrap());
+
+        let err = write_record(
+            State(keeper.await),
+            headers,
+            path_to_entry_1,
+            Query(HashMap::from_iter(vec![(
+                "ts".to_string(),
+                "2".to_string(),
+            )])),
+            empty_body.await,
+        )
+        .await
+        .err()
+        .unwrap();
+
+        assert_eq!(err.into_inner().status(), ErrorCode::UnprocessableEntity);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Return `422 Unprocessable Entity` for malformed/non-UTF8 batched record headers instead of panicking.
- Return `422 Unprocessable Entity` for malformed/non-UTF8 single-write `content-type` headers instead of panicking.
- Add regression tests for non-UTF8 batch update headers and single-write content type handling.

### Related issues

No linked issue.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo test -p reductstore non_utf8`
