### PR TITLE
Add type and last_run to lifecycle info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Extend `LifecycleInfo` with lifecycle `type` and `last_run` timestamp, with `last_run` tracked directly by the lifecycle worker instead of system events, [PR-1442](https://github.com/reductstore/reductstore/pull/1442)
 - Clarify README guidance for when ReductStore should and should not be used, [PR-1430](https://github.com/reductstore/reductstore/pull/1430)
 - Rename lifecycle policy settings field `older_than` to `older_than`, [PR-1429](https://github.com/reductstore/reductstore/pull/1429)
 - Enforce SSDLC-style build/release input pinning by adding a repository Rust toolchain pin (`1.89.0`), lockfile-enforced cargo invocations, digest-pinned Docker base images, and checksum-verified external artifact downloads in CI/build actions, [PR-1400](https://github.com/reductstore/reductstore/pull/1400)

--- a/reduct_base/src/msg/lifecycle_api.rs
+++ b/reduct_base/src/msg/lifecycle_api.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -93,9 +94,9 @@ pub struct LifecycleInfo {
     /// Lifecycle mode.
     #[serde(default)]
     pub mode: LifecycleMode,
-    /// Last lifecycle run timestamp in microseconds since Unix epoch.
+    /// Last lifecycle run timestamp.
     #[serde(default)]
-    pub last_run: Option<u64>,
+    pub last_run: Option<DateTime<Utc>>,
 }
 
 /// Payload for updating lifecycle mode.

--- a/reduct_base/src/msg/lifecycle_api.rs
+++ b/reduct_base/src/msg/lifecycle_api.rs
@@ -87,9 +87,15 @@ pub struct LifecycleInfo {
     pub is_provisioned: bool,
     /// Lifecycle worker is running.
     pub is_running: bool,
+    /// Lifecycle policy action type.
+    #[serde(default, rename = "type")]
+    pub lifecycle_type: LifecycleType,
     /// Lifecycle mode.
     #[serde(default)]
     pub mode: LifecycleMode,
+    /// Last lifecycle run timestamp in microseconds since Unix epoch.
+    #[serde(default)]
+    pub last_run: Option<u64>,
 }
 
 /// Payload for updating lifecycle mode.
@@ -198,7 +204,9 @@ mod tests {
         )
         .unwrap();
 
+        assert_eq!(info.lifecycle_type, LifecycleType::Delete);
         assert_eq!(info.mode, LifecycleMode::Enabled);
+        assert_eq!(info.last_run, None);
     }
 
     #[test]

--- a/reductstore/src/lifecycle/lifecycle_repository/repo.rs
+++ b/reductstore/src/lifecycle/lifecycle_repository/repo.rs
@@ -418,6 +418,8 @@ mod tests {
         assert_eq!(lifecycles[0].name, "test");
         assert!(!lifecycles[0].is_provisioned);
         assert!(!lifecycles[0].is_running);
+        assert_eq!(lifecycles[0].lifecycle_type, LifecycleType::Delete);
+        assert_eq!(lifecycles[0].last_run, None);
         assert_eq!(repo.get_lifecycle_settings("test").await.unwrap(), settings);
     }
 

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -11,7 +11,7 @@ use reduct_base::error::ReductError;
 use reduct_base::msg::lifecycle_api::{
     LifecycleInfo, LifecycleMode, LifecycleSettings, LifecycleType,
 };
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -27,6 +27,7 @@ pub(super) struct LifecycleTask {
     system_event_sink: Option<SystemEventSink>,
     stop_flag: Arc<AtomicBool>,
     mode: Arc<AtomicU8>,
+    last_run: Arc<AtomicU64>,
     worker_handle: Option<JoinHandle<()>>,
 }
 
@@ -50,6 +51,7 @@ impl LifecycleTask {
             system_event_sink,
             stop_flag: Arc::new(AtomicBool::new(false)),
             mode: Arc::new(AtomicU8::new(mode as u8)),
+            last_run: Arc::new(AtomicU64::new(0)),
             worker_handle: None,
         }
     }
@@ -68,6 +70,7 @@ impl LifecycleTask {
         let system_event_sink = self.system_event_sink.clone();
         let stop_flag = Arc::clone(&self.stop_flag);
         let mode = Arc::clone(&self.mode);
+        let last_run = Arc::clone(&self.last_run);
 
         let handle = tokio::spawn(async move {
             debug!("Lifecycle worker '{}' started", name);
@@ -82,6 +85,7 @@ impl LifecycleTask {
                     break;
                 }
 
+                Self::mark_last_run(&last_run);
                 let started = std::time::Instant::now();
                 match action.run(&name, &settings, context.clone()).await {
                     Ok(result) => {
@@ -129,7 +133,9 @@ impl LifecycleTask {
             name: self.name.clone(),
             is_provisioned: self.is_provisioned,
             is_running: self.is_running(),
+            lifecycle_type: self.settings.lifecycle_type,
             mode: self.load_mode(),
+            last_run: self.load_last_run(),
         }
     }
 
@@ -164,6 +170,21 @@ impl LifecycleTask {
             x if x == LifecycleMode::DryRun as u8 => LifecycleMode::DryRun,
             _ => LifecycleMode::Enabled,
         }
+    }
+
+    fn load_last_run(&self) -> Option<u64> {
+        match self.last_run.load(Ordering::Relaxed) {
+            0 => None,
+            ts => Some(ts),
+        }
+    }
+
+    fn mark_last_run(last_run: &Arc<AtomicU64>) {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        last_run.store(timestamp, Ordering::Relaxed);
     }
 
     async fn sleep_with_stop(interval: Duration, stop_flag: Arc<AtomicBool>) {
@@ -362,7 +383,9 @@ pub(super) mod tests {
         assert_eq!(info.name, "test");
         assert!(info.is_provisioned);
         assert!(info.is_running);
+        assert_eq!(info.lifecycle_type, LifecycleType::Delete);
         assert_eq!(info.mode, LifecycleMode::Enabled);
+        assert_eq!(info.last_run, None);
 
         task.stop().await;
     }
@@ -413,6 +436,7 @@ pub(super) mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(call, "test");
+        assert!(task.info().last_run.is_some());
 
         task.stop().await;
     }

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -6,6 +6,7 @@ use crate::lifecycle::system_event_payload::LifecycleSystemEventPayload;
 use crate::syslog::SystemEvent;
 
 use crate::lifecycle::SystemEventSink;
+use chrono::{DateTime, Utc};
 use log::{debug, error};
 use reduct_base::error::ReductError;
 use reduct_base::msg::lifecycle_api::{
@@ -172,10 +173,10 @@ impl LifecycleTask {
         }
     }
 
-    fn load_last_run(&self) -> Option<u64> {
+    fn load_last_run(&self) -> Option<DateTime<Utc>> {
         match self.last_run.load(Ordering::Relaxed) {
             0 => None,
-            ts => Some(ts),
+            ts => DateTime::<Utc>::from_timestamp_micros(ts as i64),
         }
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- extended `LifecycleInfo` with `type`, sourced directly from `LifecycleSettings`
- added `last_run` to `LifecycleInfo` as an optional Unix timestamp in microseconds
- tracked `last_run` in the lifecycle worker with a simple in-memory atomic timestamp updated when a run starts
- kept the implementation independent from system events
- added/updated tests for lifecycle info defaults, lifecycle task state, and repository info

### Related issues

None linked.

### Does this PR introduce a breaking change?

No.

### Other information:

The branch is based on the latest `main` (`origin/main`) before the changes were committed.
