### PR TITLE
Avoid panics during shutdown cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Avoid panics during shutdown cleanup by logging individual shutdown step failures and continuing through storage sync, [PR-1444](https://github.com/reductstore/reductstore/pull/1444)
 - Preserve attachment metadata (`entry/$meta`) during lifecycle delete cleanup by enforcing and documenting exclusion of system metadata entries from lifecycle matching, [PR-1395](https://github.com/reductstore/reductstore/pull/1395)
 - Fix lifecycle delete worker first-run failure (`422 Start time must be before stop time`) by ensuring delete queries use a valid initial time range even when all records are newer than `older_than`, [PR-1394](https://github.com/reductstore/reductstore/pull/1394)
 - Fix runtime default for lifecycle interval by implementing manual Default for LifecycleSettings, [PR-1385](https://github.com/reductstore/reductstore/pull/1385)

--- a/reductstore/src/api/components.rs
+++ b/reductstore/src/api/components.rs
@@ -283,7 +283,119 @@ impl From<ComponentError> for ReductError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::http::tests::{keeper, not_ready_keeper};
+    use crate::core::sync::{reset_rwlock_config, set_rwlock_timeout};
+    use bytes::Bytes;
+    use reduct_base::msg::lifecycle_api::LifecycleSettings;
     use rstest::rstest;
+    use serial_test::serial;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct ResetRwLockConfig;
+
+    impl Drop for ResetRwLockConfig {
+        fn drop(&mut self) {
+            reset_rwlock_config();
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_stop_replication_tasks(#[future] keeper: Arc<StateKeeper>) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        {
+            let mut repo = components.replication_repo.write().await.unwrap();
+            repo.start();
+            assert!(repo.is_replication_running("api-test").await.unwrap());
+        }
+
+        keeper.stop_replication_tasks().await.unwrap();
+
+        let components = keeper.get_anonymous().await.unwrap();
+        let repo = components.replication_repo.read().await.unwrap();
+        assert!(!repo.is_replication_running("api-test").await.unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_stop_lifecycle_tasks(#[future] keeper: Arc<StateKeeper>) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+
+        {
+            let mut repo = components.lifecycle_repo.write().await.unwrap();
+            repo.create_lifecycle(
+                "api-test",
+                LifecycleSettings {
+                    bucket: "bucket-1".to_string(),
+                    older_than: "1d".to_string(),
+                    interval: "1h".to_string(),
+                    ..LifecycleSettings::default()
+                },
+            )
+            .await
+            .unwrap();
+            repo.start().await.unwrap();
+            assert!(repo.is_lifecycle_running("api-test").await.unwrap());
+        }
+
+        keeper.stop_lifecycle_tasks().await.unwrap();
+
+        let components = keeper.get_anonymous().await.unwrap();
+        let repo = components.lifecycle_repo.read().await.unwrap();
+        assert!(!repo.is_lifecycle_running("api-test").await.unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_sync_storage(#[future] keeper: Arc<StateKeeper>) {
+        let keeper = keeper.await;
+        let components = keeper.get_anonymous().await.unwrap();
+        let bucket = components
+            .storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+
+        let mut writer = bucket
+            .begin_write("entry-sync", 1, 4, "text/plain".to_string(), HashMap::new())
+            .await
+            .unwrap();
+        writer.send(Ok(Some(Bytes::from("test")))).await.unwrap();
+        writer.send(Ok(None)).await.unwrap();
+
+        keeper.sync_storage().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_stop_replication_tasks_not_ready(#[future] not_ready_keeper: Arc<StateKeeper>) {
+        let err = not_ready_keeper
+            .await
+            .stop_replication_tasks()
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(err.status, ErrorCode::ServiceUnavailable);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[serial]
+    async fn test_shutdown_continues_when_all_steps_fail(#[future] keeper: Arc<StateKeeper>) {
+        let _reset = ResetRwLockConfig;
+        set_rwlock_timeout(Duration::from_millis(10));
+
+        let keeper = keeper.await;
+        let _components_guard = keeper.components.read().await.unwrap();
+
+        keeper.shutdown().await;
+    }
 
     #[rstest]
     fn test_component_error_new_and_accessors() {

--- a/reductstore/src/api/components.rs
+++ b/reductstore/src/api/components.rs
@@ -19,6 +19,7 @@ use crate::storage::engine::StorageEngine;
 use crate::storage::usage::UsageEventAggregator;
 use crate::syslog::LogSystemEvent;
 use axum::http::HeaderMap;
+use log::error;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::BoxedReadRecord;
 use reduct_base::service_unavailable;
@@ -151,23 +152,39 @@ impl StateKeeper {
         self.wait_components().await
     }
 
-    pub async fn stop_replication_tasks(&self) -> Result<(), ReductError> {
+    pub async fn shutdown(&self) {
+        if let Err(err) = self.stop_lifecycle_tasks().await {
+            error!("Failed to stop lifecycle policies: {}", err);
+        }
+
+        if let Err(err) = self.stop_replication_tasks().await {
+            error!("Failed to stop replication tasks: {}", err);
+        }
+
+        if let Err(err) = self.stop_usage_stats_task().await {
+            error!("Failed to stop usage statistics task: {}", err);
+        }
+
+        if let Err(err) = self.sync_storage().await {
+            error!("Failed to shutdown storage: {}", err);
+        }
+    }
+
+    async fn stop_replication_tasks(&self) -> Result<(), ReductError> {
         let components = self.wait_components().await?.clone();
         let mut repo = components.replication_repo.write().await?;
         repo.stop().await;
         Ok(())
     }
 
-    pub async fn stop_lifecycle_tasks(&self) -> Result<(), ReductError> {
+    async fn stop_lifecycle_tasks(&self) -> Result<(), ReductError> {
         let components = self.wait_components().await?.clone();
         let mut repo = components.lifecycle_repo.write().await?;
         repo.stop().await;
         Ok(())
     }
 
-    /// Stop the usage statistics task, flushing the final interval. Run before
-    /// `sync_storage` so the flushed event is persisted by the storage sync.
-    pub async fn stop_usage_stats_task(&self) -> Result<(), ReductError> {
+    async fn stop_usage_stats_task(&self) -> Result<(), ReductError> {
         let components = self.wait_components().await?.clone();
         if let Some(aggregator) = components.usage_stat_logger.write().await?.as_mut() {
             aggregator.stop().await;
@@ -175,7 +192,7 @@ impl StateKeeper {
         Ok(())
     }
 
-    pub async fn sync_storage(&self) -> Result<(), ReductError> {
+    async fn sync_storage(&self) -> Result<(), ReductError> {
         let components = self.wait_components().await?.clone();
         let storage = &components.storage;
         storage.sync_fs().await?;

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -313,7 +313,6 @@ pub(crate) mod tests {
     use reduct_base::error::ReductError as BaseHttpError;
     use reduct_base::ext::ExtSettings;
     use reduct_base::msg::bucket_api::BucketSettings;
-    use reduct_base::msg::lifecycle_api::LifecycleSettings;
     use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
     use reduct_base::msg::server_api::ServerInfo;
     use reduct_base::msg::token_api::{Permissions, TokenCreateRequest};
@@ -542,91 +541,6 @@ pub(crate) mod tests {
             let keeper = keeper.await;
             let components = keeper.get_anonymous().await.unwrap();
             assert!(components.storage.info().await.is_ok());
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_stop_replication_tasks(#[future] keeper: Arc<StateKeeper>) {
-            let keeper = keeper.await;
-            let components = keeper.get_anonymous().await.unwrap();
-
-            {
-                let mut repo = components.replication_repo.write().await.unwrap();
-                repo.start();
-                assert!(repo.is_replication_running("api-test").await.unwrap());
-            }
-
-            keeper.stop_replication_tasks().await.unwrap();
-
-            let components = keeper.get_anonymous().await.unwrap();
-            let repo = components.replication_repo.read().await.unwrap();
-            assert!(!repo.is_replication_running("api-test").await.unwrap());
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_stop_lifecycle_tasks(#[future] keeper: Arc<StateKeeper>) {
-            let keeper = keeper.await;
-            let components = keeper.get_anonymous().await.unwrap();
-
-            {
-                let mut repo = components.lifecycle_repo.write().await.unwrap();
-                repo.create_lifecycle(
-                    "api-test",
-                    LifecycleSettings {
-                        bucket: "bucket-1".to_string(),
-                        older_than: "1d".to_string(),
-                        interval: "1h".to_string(),
-                        ..LifecycleSettings::default()
-                    },
-                )
-                .await
-                .unwrap();
-                repo.start().await.unwrap();
-                assert!(repo.is_lifecycle_running("api-test").await.unwrap());
-            }
-
-            keeper.stop_lifecycle_tasks().await.unwrap();
-
-            let components = keeper.get_anonymous().await.unwrap();
-            let repo = components.lifecycle_repo.read().await.unwrap();
-            assert!(!repo.is_lifecycle_running("api-test").await.unwrap());
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_sync_storage(#[future] keeper: Arc<StateKeeper>) {
-            let keeper = keeper.await;
-            let components = keeper.get_anonymous().await.unwrap();
-            let bucket = components
-                .storage
-                .get_bucket("bucket-1")
-                .await
-                .unwrap()
-                .upgrade_and_unwrap();
-
-            let mut writer = bucket
-                .begin_write("entry-sync", 1, 4, "text/plain".to_string(), HashMap::new())
-                .await
-                .unwrap();
-            writer.send(Ok(Some(Bytes::from("test")))).await.unwrap();
-            writer.send(Ok(None)).await.unwrap();
-
-            keeper.sync_storage().await.unwrap();
-        }
-
-        #[rstest]
-        #[tokio::test]
-        async fn test_stop_replication_tasks_not_ready(
-            #[future] not_ready_keeper: Arc<StateKeeper>,
-        ) {
-            let err = not_ready_keeper
-                .await
-                .stop_replication_tasks()
-                .await
-                .err()
-                .unwrap();
-            assert_eq!(err.status, ErrorCode::ServiceUnavailable);
         }
 
         #[rstest]

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -38,7 +38,7 @@ pub fn maybe_print_version_and_exit() {
     }
 }
 
-pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_pareser: Parser)
+pub async fn launch_server<Parser, ExtCfg: ExtCfgBounds + 'static>(ext_cfg_parser: Parser)
 where
     Parser: ExtCfgParser<StdEnvGetter, Cfg = ExtCfg>,
 {
@@ -52,7 +52,7 @@ where
     );
 
     let parser =
-        CfgParser::from_env_with_ext(StdEnvGetter::default(), &ext_cfg_pareser, version).await;
+        CfgParser::from_env_with_ext(StdEnvGetter::default(), &ext_cfg_parser, version).await;
     let handle = Handle::new();
     let lock_file = Arc::new(parser.build_lock_file().unwrap());
 
@@ -185,22 +185,7 @@ where
     // remote synchronization can lock resources for a long time,
     // so we set rwlock timeout to 1 hour to avoid panics during shutdown
     set_rwlock_timeout(RW_LOCK_SHUTDOWN_TIMEOUT);
-    state_keeper
-        .stop_lifecycle_tasks()
-        .await
-        .expect("Failed to stop lifecycle policies");
-    state_keeper
-        .stop_replication_tasks()
-        .await
-        .expect("Failed to stop replication tasks");
-    state_keeper
-        .stop_usage_stats_task()
-        .await
-        .expect("Failed to stop usage statistics task");
-    state_keeper
-        .sync_storage()
-        .await
-        .expect("Failed to shutdown storage");
+    state_keeper.shutdown().await;
     FILE_CACHE.stop_sync_worker();
     drop(lock_file);
     info!("Server has been shut down.");


### PR DESCRIPTION
Closes #1443

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Move the shutdown cleanup sequence into `StateKeeper::shutdown`.
- Ensure shutdown cleanup logs individual step failures instead of panicking.
- Continue through lifecycle, replication, usage statistics, and storage sync cleanup even when an earlier step fails.
- Fix a typo in the launcher extension config parser argument name.

### Related issues

Closes #1443

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo fmt --all --check`
- `cargo check -p reductstore`
