### PR TITLE
Fix historical query range panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid a historical query panic when a bounded query is exhausted after a block that also contains records beyond the query stop time, [PR-1446](https://github.com/reductstore/reductstore/pull/1446)
+
 ## 1.19.9 - 2026-06-12
 
 ### Fixed

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -27,7 +27,7 @@ use log::{debug, error};
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::{EntryInfo, QueryEntry};
 use reduct_base::msg::status::ResourceStatus;
-use reduct_base::{conflict, internal_server_error, not_found};
+use reduct_base::{conflict, internal_server_error, not_found, unprocessable_entity};
 use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -489,6 +489,10 @@ impl Entry {
             info.latest_record + 1
         };
 
+        if start > end && !query.continuous.unwrap_or(false) {
+            return Err(unprocessable_entity!("Start time must be before stop time"));
+        }
+
         Ok((start, end))
     }
 }
@@ -681,6 +685,28 @@ mod tests {
                     id
                 ))
             );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn reject_reversed_historical_query_range(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            write_stub_record(&entry, 1000000).await;
+
+            let err = entry
+                .query(QueryEntry {
+                    start: Some(2000000),
+                    stop: Some(1000000),
+                    ..Default::default()
+                })
+                .await
+                .unwrap_err();
+
+            assert_eq!(
+                err,
+                ReductError::unprocessable_entity("Start time must be before stop time")
+            );
+            assert!(entry.queries.read().await.unwrap().is_empty());
         }
 
         #[rstest]

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -160,11 +160,15 @@ impl Query for HistoricalQuery {
                     }
                     Err(_) => 0,
                 };
-                bm.index()
-                    .tree()
-                    .range(first_block..self.stop_time)
-                    .map(|k| *k)
-                    .collect::<Vec<u64>>()
+                if first_block > self.stop_time {
+                    Vec::new()
+                } else {
+                    bm.index()
+                        .tree()
+                        .range(first_block..self.stop_time)
+                        .map(|k| *k)
+                        .collect::<Vec<u64>>()
+                }
             };
 
             for block_id in block_range {
@@ -438,6 +442,61 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].0.meta().timestamp(), 0);
         assert_eq!(records[1].0.meta().timestamp(), 5);
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_stops_when_current_block_latest_time_reaches_next_block(
+        #[future] block_manager: Arc<AsyncRwLock<BlockManager>>,
+    ) {
+        let block_manager = block_manager.await;
+
+        {
+            let block_ref = block_manager
+                .write()
+                .await
+                .unwrap()
+                .load_block(0)
+                .await
+                .unwrap();
+            block_ref
+                .write()
+                .await
+                .unwrap()
+                .insert_or_update_record(Record {
+                    timestamp: Some(us_to_ts(&1000)),
+                    begin: 0,
+                    end: 10,
+                    state: record::State::Finished as i32,
+                    labels: vec![],
+                    content_type: "".to_string(),
+                });
+        }
+
+        let mut query = build_query(0, 500, QueryOptions::default()).unwrap();
+
+        assert_eq!(
+            query
+                .next(block_manager.clone())
+                .await
+                .unwrap()
+                .meta()
+                .timestamp(),
+            0
+        );
+        assert_eq!(
+            query
+                .next(block_manager.clone())
+                .await
+                .unwrap()
+                .meta()
+                .timestamp(),
+            5
+        );
+        assert_eq!(
+            query.next(block_manager).await.err(),
+            Some(no_content!("No content"))
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #1445

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Prevent historical queries from panicking when the refill cursor advances beyond the query stop time.
- Return `NoContent` when the derived block range is exhausted instead of constructing an invalid `BTreeSet` range.
- Reject explicit reversed non-continuous query ranges before spawning a query task.
- Add regression tests for reversed query ranges and valid bounded queries that stop before the next block.

### Related issues

- https://github.com/reductstore/reductstore/issues/1445

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:

- `cargo fmt --all`
- `cargo test -p reductstore storage::query::historical::tests::test_query_stops_when_current_block_latest_time_reaches_next_block`
- `cargo test -p reductstore storage::query::historical::tests`
- `cargo test -p reductstore storage::entry::tests::query`
- `cargo test -p reductstore storage::query::tests::test_bad_start_stop`
