### PR TITLE
fix directive parser panic on ROS extension input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Return `422 Unprocessable Entity` for unsupported nested directive values instead of panicking when parsing queries, [PR-1449](https://github.com/reductstore/reductstore/pull/1449)
 - Avoid a historical query panic when a bounded query is exhausted after a block that also contains records beyond the query stop time, [PR-1446](https://github.com/reductstore/reductstore/pull/1446)
 
 ## 1.19.9 - 2026-06-12

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -74,8 +74,14 @@ impl Parser {
                     match v {
                         JsonValue::Bool(value) => Ok(Value::Bool(*value)),
                         JsonValue::Number(value) => {
-                            if value.is_i64() || value.is_u64() {
-                                Ok(Value::Int(value.as_i64().unwrap()))
+                            if let Some(value) = value.as_i64() {
+                                Ok(Value::Int(value))
+                            } else if value.is_u64() {
+                                Err(unprocessable_entity!(
+                                    "Directive '{}' contains integer value out of range: {}",
+                                    key,
+                                    value
+                                ))
                             } else {
                                 Ok(Value::Float(value.as_f64().unwrap()))
                             }
@@ -584,6 +590,19 @@ mod tests {
             });
             let (_, directives) = parser.parse(json).unwrap();
             assert_eq!(directives["#ctx_before"], vec![expected]);
+        }
+
+        #[rstest]
+        fn test_parse_directive_unsigned_integer_overflow(parser: Parser) {
+            let json = json!({
+                "#batch_size": u64::MAX,
+            });
+
+            let result = parser.parse(json);
+            assert_eq!(
+                result.err().unwrap().to_string(),
+                "[UnprocessableEntity] Directive '#batch_size' contains integer value out of range: 18446744073709551615"
+            );
         }
 
         #[rstest]

--- a/reductstore/src/storage/query/condition/parser.rs
+++ b/reductstore/src/storage/query/condition/parser.rs
@@ -70,24 +70,28 @@ impl Parser {
                     ));
                 }
 
-                let parse_primitive = |v: &JsonValue| -> Value {
+                let parse_primitive = |v: &JsonValue| -> Result<Value, ReductError> {
                     match v {
-                        JsonValue::Bool(value) => Value::Bool(*value),
+                        JsonValue::Bool(value) => Ok(Value::Bool(*value)),
                         JsonValue::Number(value) => {
                             if value.is_i64() || value.is_u64() {
-                                Value::Int(value.as_i64().unwrap())
+                                Ok(Value::Int(value.as_i64().unwrap()))
                             } else {
-                                Value::Float(value.as_f64().unwrap())
+                                Ok(Value::Float(value.as_f64().unwrap()))
                             }
                         }
                         JsonValue::String(value) => {
                             if let Ok(duration) = parse_duration(value) {
-                                duration
+                                Ok(duration)
                             } else {
-                                Value::String(value.to_string())
+                                Ok(Value::String(value.to_string()))
                             }
                         }
-                        _ => panic!("Unsupported directive value type: {}", v), // panic because it's programming error
+                        _ => Err(unprocessable_entity!(
+                            "Directive '{}' contains unsupported value type: {}",
+                            key,
+                            v
+                        )),
                     }
                 };
 
@@ -100,10 +104,10 @@ impl Parser {
                     parsed_values.push(Value::String(value.to_string()));
                 } else if value.is_array() {
                     for item in value.as_array().unwrap() {
-                        parsed_values.push(parse_primitive(item));
+                        parsed_values.push(parse_primitive(item)?);
                     }
                 } else {
-                    parsed_values.push(parse_primitive(value))
+                    parsed_values.push(parse_primitive(value)?)
                 }
                 directives.insert(key.to_string(), parsed_values);
                 keys_to_remove.push(key.to_string());
@@ -618,6 +622,27 @@ mod tests {
             assert_eq!(
                 directives.get("#ext").unwrap(),
                 &vec![Value::String(r#"{"key":"value"}"#.to_string())]
+            );
+        }
+
+        #[rstest]
+        fn test_parse_array_directive_with_object(parser: Parser) {
+            let json = json!({
+                "#ext": [
+                    {
+                        "ros": {
+                            "extract": {
+                                "topic": "/rosout"
+                            }
+                        }
+                    }
+                ]
+            });
+
+            let result = parser.parse(json);
+            assert_eq!(
+                result.err().unwrap().to_string(),
+                r#"[UnprocessableEntity] Directive '#ext' contains unsupported value type: {"ros":{"extract":{"topic":"/rosout"}}}"#
             );
         }
 


### PR DESCRIPTION
Closes #1448

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Return `422 UnprocessableEntity` when directive arrays contain unsupported nested values instead of panicking.
- Added a regression test for `#ext` with a ROS extraction object inside an array.
- Preserved the existing behavior for top-level object-valued directives, which are stored as JSON strings.

### Related issues

- https://github.com/reductstore/reductstore/issues/1448

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo test -p reductstore storage::query::condition::parser::tests::parse_directives --features fs-backend`
