### PR TITLE
Fix replication diagnostics and transaction log recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix replication diagnostics timestamp conflicts and recover corrupted transaction logs created on demand for `$meta` notifications, [PR-1452](https://github.com/reductstore/reductstore/pull/1452)
+
 ## 1.20.0 - 2026-06-16
 
 ### Breaking Changes

--- a/reductstore/src/replication/replication_aggregator.rs
+++ b/reductstore/src/replication/replication_aggregator.rs
@@ -84,6 +84,7 @@ pub(super) struct ReplicationEventAggregator {
     sink: SystemEventSink,
     replication_name: String,
     active: Option<ReplicationAggregate>,
+    last_event_timestamp: u64,
 }
 
 impl ReplicationEventAggregator {
@@ -92,7 +93,14 @@ impl ReplicationEventAggregator {
             sink,
             replication_name,
             active: None,
+            last_event_timestamp: 0,
         }
+    }
+
+    fn next_event_timestamp(&mut self) -> u64 {
+        let timestamp = now_micros().max(self.last_event_timestamp + 1);
+        self.last_event_timestamp = timestamp;
+        timestamp
     }
 
     /// Record one replication pass as a list of `(result, records, data_size)`.
@@ -125,7 +133,6 @@ impl ReplicationEventAggregator {
             return;
         }
 
-        let timestamp = now_micros();
         let mut first = true;
         for (status, (records, data_size, message)) in per_status {
             let pass_duration = if first { duration } else { 0.0 };
@@ -157,6 +164,7 @@ impl ReplicationEventAggregator {
                     aggregate.flush_at = now + Duration::from_secs(AGGREGATION_WINDOW_SECS);
                 }
                 None => {
+                    let timestamp = self.next_event_timestamp();
                     let success = is_success(status);
                     self.active = Some(ReplicationAggregate {
                         status,
@@ -306,6 +314,26 @@ mod tests {
         assert_eq!(captured[1].payload["failed_records"], 4);
         assert_eq!(captured[1].payload["written_records"], 0);
         assert_eq!(captured[1].message, "missing");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn mixed_status_pass_uses_unique_event_timestamps(events: Arc<Mutex<Vec<SystemEvent>>>) {
+        let mut agg = aggregator(Arc::clone(&events), false);
+
+        agg.record_pass(
+            1,
+            0.1,
+            &[(Ok(()), 1, 10), (Err(not_found!("missing")), 1, 0)],
+        )
+        .await;
+        agg.record_pass(0, 0.1, &[(Ok(()), 1, 10)]).await;
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[0].status, 200);
+        assert_eq!(captured[1].status, 404);
+        assert_ne!(captured[0].timestamp, captured[1].timestamp);
     }
 
     /// Schema invariant (#4): success and failure events carry the identical

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -186,27 +186,12 @@ impl ReplicationTask {
                         &entry.name,
                         &replication_name,
                     );
-                    let log = match TransactionLog::try_load_or_create(
+                    let log = Self::load_or_recreate_transaction_log(
                         &path,
                         thr_system_options.transaction_log_size,
+                        &entry.name,
                     )
-                    .await
-                    {
-                        Ok(log) => log,
-                        Err(err) => {
-                            error!(
-                                "Failed to load transaction log for entry '{}': {:?}",
-                                entry.name, err
-                            );
-                            info!("Creating a new transaction log for entry '{}'", entry.name);
-                            FILE_CACHE.remove(&path).await?;
-                            TransactionLog::try_load_or_create(
-                                &path,
-                                thr_system_options.transaction_log_size,
-                            )
-                            .await?
-                        }
-                    };
+                    .await?;
 
                     logs.insert(entry.name, Arc::new(AsyncRwLock::new(log)));
                 }
@@ -398,14 +383,16 @@ impl ReplicationTask {
         // because it is used by the replication thread
         let exists = { self.log_map.read().await?.contains_key(&entry_name) };
         if !exists {
-            let log = TransactionLog::try_load_or_create(
-                &Self::build_path_to_transaction_log(
-                    self.storage.data_path(),
-                    &self.settings.src_bucket,
-                    &entry_name,
-                    &self.name,
-                ),
+            let path = Self::build_path_to_transaction_log(
+                self.storage.data_path(),
+                &self.settings.src_bucket,
+                &entry_name,
+                &self.name,
+            );
+            let log = Self::load_or_recreate_transaction_log(
+                &path,
                 self.system_options.transaction_log_size,
+                &entry_name,
             )
             .await?;
             let mut map = self.log_map.write().await?;
@@ -515,6 +502,25 @@ impl ReplicationTask {
         name: &str,
     ) -> PathBuf {
         storage_path.join(format!("{}/{}/{}.log", bucket, entry, name))
+    }
+
+    async fn load_or_recreate_transaction_log(
+        path: &PathBuf,
+        transaction_log_size: usize,
+        entry_name: &str,
+    ) -> Result<TransactionLog, ReductError> {
+        match TransactionLog::try_load_or_create(path, transaction_log_size).await {
+            Ok(log) => Ok(log),
+            Err(err) => {
+                error!(
+                    "Failed to load transaction log for entry '{}': {:?}",
+                    entry_name, err
+                );
+                info!("Creating a new transaction log for entry '{}'", entry_name);
+                FILE_CACHE.remove(path).await?;
+                TransactionLog::try_load_or_create(path, transaction_log_size).await
+            }
+        }
     }
 
     fn load_mode(&self) -> ReplicationMode {
@@ -699,6 +705,40 @@ mod tests {
                 is_provisioned: false,
                 pending_records: 0,
             }
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_add_meta_entry_with_broken_transaction_log(
+        mut remote_bucket: MockRmBucket,
+        mut notification: TransactionNotification,
+        settings: ReplicationSettings,
+        path: PathBuf,
+    ) {
+        remote_bucket.expect_is_active().return_const(false);
+        let mut replication = build_replication(path, remote_bucket, settings.clone()).await;
+
+        notification.entry = "test1/$meta".to_string();
+        let log_path = ReplicationTask::build_path_to_transaction_log(
+            replication.storage.data_path(),
+            &settings.src_bucket,
+            &notification.entry,
+            replication.name(),
+        );
+
+        fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+        let mut log_file = fs::File::create(&log_path).unwrap();
+        log_file.write_all(&916usize.to_be_bytes()).unwrap();
+        log_file.write_all(&16usize.to_be_bytes()).unwrap();
+        log_file.set_len(916).unwrap();
+
+        replication.notify(notification).await.unwrap();
+
+        assert_eq!(fs::metadata(&log_path).unwrap().len(), 9016);
+        assert_eq!(
+            get_entries_from_transaction_log(&mut replication, "test1/$meta").await,
+            vec![Transaction::WriteRecord(10)]
         );
     }
 


### PR DESCRIPTION
Closes #1450

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Ensure replication diagnostics events use unique monotonic timestamps within the process, preventing mixed-status replication passes from conflicting in the diagnostics log.
- Recreate corrupted transaction logs when replication notifications create logs on demand, including `$meta` entries that are not initialized during replication task startup.
- Add regression tests for mixed-status diagnostics timestamps and corrupted `$meta` transaction log recovery during notification.

### Related issues

#1450

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo fmt --all`
- `cargo test -p reductstore replication::replication_task::tests::test_add_meta_entry_with_broken_transaction_log --features fs-backend`
- `cargo test -p reductstore replication::replication_task::tests --features fs-backend`
