### PR TITLE
Harden entry removal for missing folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevent repeated compaction and sync failures for entries whose storage folders disappeared during deletion by making entry removal idempotent and cleaning up stale in-memory state, [PR-1454](https://github.com/reductstore/reductstore/pull/1454)
 - Fix replication diagnostics timestamp conflicts and recover corrupted transaction logs created on demand for `$meta` notifications, [PR-1452](https://github.com/reductstore/reductstore/pull/1452)
 
 ## 1.20.0 - 2026-06-16

--- a/reductstore/src/backend/file.rs
+++ b/reductstore/src/backend/file.rs
@@ -73,15 +73,19 @@ impl OpenOptions {
     }
 
     pub async fn open<P: AsRef<std::path::Path>>(&mut self, path: P) -> std::io::Result<File> {
+        let create = self.create && !self.ignore_write;
         if self.ignore_write {
             self.inner.write(false);
             self.inner.create(false);
         }
 
-        let full_path = self.backend.path().join(path.as_ref());
-        if self.create {
+        let backend_path = self.backend.path().clone();
+        let full_path = backend_path.join(path.as_ref());
+        if create {
             if let Some(parent) = full_path.parent() {
-                self.backend.create_dir_all(parent).await?;
+                if parent != backend_path.as_path() {
+                    self.backend.create_dir_all(parent).await?;
+                }
             }
         }
 
@@ -89,7 +93,7 @@ impl OpenOptions {
             // the call initiates downloading the file from remote storage if needed
             if self.backend.try_exists(&full_path).await? {
                 self.backend.download(&full_path).await?;
-            } else if !self.create {
+            } else if !create {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     format!("File {:?} does not exist", full_path),
@@ -287,13 +291,7 @@ mod tests {
             let path = mock_backend.path().to_path_buf();
             let copy_path = path.clone();
 
-            mock_backend
-                .expect_create_dir_all()
-                .times(1)
-                .returning(move |p| {
-                    fs::create_dir_all(p)?;
-                    Ok(())
-                });
+            mock_backend.expect_create_dir_all().times(0);
 
             mock_backend
                 .expect_try_exists()

--- a/reductstore/src/backend/file.rs
+++ b/reductstore/src/backend/file.rs
@@ -79,6 +79,12 @@ impl OpenOptions {
         }
 
         let full_path = self.backend.path().join(path.as_ref());
+        if self.create {
+            if let Some(parent) = full_path.parent() {
+                self.backend.create_dir_all(parent).await?;
+            }
+        }
+
         if !full_path.exists() {
             // the call initiates downloading the file from remote storage if needed
             if self.backend.try_exists(&full_path).await? {
@@ -282,6 +288,14 @@ mod tests {
             let copy_path = path.clone();
 
             mock_backend
+                .expect_create_dir_all()
+                .times(1)
+                .returning(move |p| {
+                    fs::create_dir_all(p)?;
+                    Ok(())
+                });
+
+            mock_backend
                 .expect_try_exists()
                 .times(1)
                 .returning(move |p| {
@@ -300,6 +314,40 @@ mod tests {
             assert_eq!(file.mode(), &AccessMode::ReadWrite);
             assert!(file.is_synced());
             assert_eq!(file.path(), &path.join("new_file.txt"));
+            assert_eq!(file.metadata().unwrap().len(), 0);
+        }
+
+        #[rstest]
+        #[tokio::test(flavor = "current_thread")]
+        async fn test_open_options_create_nested_parent_directory(mut mock_backend: MockBackend) {
+            let path = mock_backend.path().to_path_buf();
+            let copy_path = path.clone();
+
+            mock_backend
+                .expect_create_dir_all()
+                .times(1)
+                .returning(move |p| {
+                    fs::create_dir_all(p)?;
+                    Ok(())
+                });
+            mock_backend
+                .expect_try_exists()
+                .times(1)
+                .returning(move |p| {
+                    assert_eq!(p, copy_path.join("missing/parent/new_file.txt").as_path());
+                    Ok(false)
+                });
+            mock_backend.expect_download().times(0);
+
+            let file = OpenOptions::new(Arc::new(Box::new(mock_backend)))
+                .write(true)
+                .create(true)
+                .open("missing/parent/new_file.txt")
+                .await
+                .unwrap();
+
+            assert_eq!(file.mode(), &AccessMode::ReadWrite);
+            assert_eq!(file.path(), &path.join("missing/parent/new_file.txt"));
             assert_eq!(file.metadata().unwrap().len(), 0);
         }
     }

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -978,13 +978,9 @@ mod tests {
             .unwrap();
         tokio_sleep(Duration::from_millis(100)).await;
 
-        assert!(
-                !path.exists(),
-                "We could not recover the transaction log, it was removed. However, the replication should continue"
-            );
-
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
         tokio_sleep(Duration::from_millis(200)).await;
+
+        assert!(path.exists(), "Transaction log was recovered");
 
         assert_eq!(
             get_entries_from_transaction_log(&mut replication, "test1").await,

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -415,6 +415,35 @@ impl Bucket {
             .collect::<Vec<_>>();
         let mut count = 0usize;
         for entry in entries {
+            if entry.status().await? == ResourceStatus::Deleting {
+                debug!(
+                    "Skipping compact/sync for deleting entry '{}' in bucket '{}'",
+                    entry.name(),
+                    bucket_name
+                );
+                continue;
+            }
+
+            if !FILE_CACHE.try_exists(entry.path()).await? {
+                debug!(
+                    "Remove stale entry '{}' from bucket '{}' because its folder is missing",
+                    entry.name(),
+                    bucket_name
+                );
+                if let Err(err) = self.folder_keeper.remove_folder(entry.name()).await {
+                    if err.status() != reduct_base::error::ErrorCode::NotFound {
+                        error!(
+                            "Failed to remove stale folder map entry '{}' from bucket '{}': {}",
+                            entry.name(),
+                            bucket_name,
+                            err
+                        );
+                    }
+                }
+                self.entries.write().await?.remove(entry.name());
+                continue;
+            }
+
             let result = match mode {
                 EntryMaintenanceMode::Compact => entry.compact().await,
                 EntryMaintenanceMode::SyncFs => entry.sync_fs().await,

--- a/reductstore/src/storage/bucket/remove_entry.rs
+++ b/reductstore/src/storage/bucket/remove_entry.rs
@@ -2,13 +2,19 @@
 // Licensed under the Apache License, Version 2.0
 
 use super::Bucket;
+use crate::cfg::Cfg;
 use crate::core::file_cache::FILE_CACHE;
+use crate::core::sync::AsyncRwLock;
 use crate::storage::entry::is_system_meta_entry;
 use crate::storage::entry::Entry;
+use crate::storage::in_flight::InFlightIoLimiter;
+use crate::storage::usage::UsageCounters;
 use log::{debug, error, warn};
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::status::ResourceStatus;
 use reduct_base::{conflict, not_found};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
@@ -124,51 +130,17 @@ impl Bucket {
                 };
 
                 if !folder_removed {
-                    let recovered_entry = match entry.settings().await {
-                        Ok(settings) => {
-                            Entry::restore_with_limiter(
-                                path.clone(),
-                                entry_name.clone(),
-                                bucket_name.clone(),
-                                settings,
-                                cfg.clone(),
-                                io_limiter.clone(),
-                                Arc::clone(&usage_counters),
-                            )
-                            .await
-                        }
-                        Err(err) => Err(err),
-                    };
-
-                    match recovered_entry {
-                        Ok(Some(recovered_entry)) => {
-                            if let Err(err) = Self::replace_entry_in_map_with_retry(
-                                &entries_map,
-                                &entry_name,
-                                &bucket_name,
-                                Arc::new(recovered_entry),
-                            )
-                            .await
-                            {
-                                error!(
-                                    "Entry '{}' in bucket '{}' stays DELETING because recovery replacement failed: {}",
-                                    entry_name, bucket_name, err
-                                );
-                            }
-                        }
-                        Ok(None) => {
-                            error!(
-                                "Entry '{}' in bucket '{}' stays DELETING because it could not be restored",
-                                entry_name, bucket_name
-                            );
-                        }
-                        Err(err) => {
-                            error!(
-                                "Entry '{}' in bucket '{}' stays DELETING because recovery failed: {}",
-                                entry_name, bucket_name, err
-                            );
-                        }
-                    }
+                    Self::recover_entry_after_failed_removal(
+                        &entries_map,
+                        &entry_name,
+                        &bucket_name,
+                        path,
+                        &entry,
+                        cfg.clone(),
+                        io_limiter.clone(),
+                        Arc::clone(&usage_counters),
+                    )
+                    .await;
                     continue;
                 }
 
@@ -235,9 +207,7 @@ impl Bucket {
     }
 
     async fn remove_entry_from_map_with_retry(
-        entries_map: &Arc<
-            crate::core::sync::AsyncRwLock<std::collections::BTreeMap<String, Arc<Entry>>>,
-        >,
+        entries_map: &Arc<AsyncRwLock<BTreeMap<String, Arc<Entry>>>>,
         entry_name: &str,
         bucket_name: &str,
     ) {
@@ -265,9 +235,7 @@ impl Bucket {
     }
 
     async fn replace_entry_in_map_with_retry(
-        entries_map: &Arc<
-            crate::core::sync::AsyncRwLock<std::collections::BTreeMap<String, Arc<Entry>>>,
-        >,
+        entries_map: &Arc<AsyncRwLock<BTreeMap<String, Arc<Entry>>>>,
         entry_name: &str,
         bucket_name: &str,
         entry: Arc<Entry>,
@@ -297,18 +265,76 @@ impl Bucket {
 
         Ok(())
     }
+
+    async fn recover_entry_after_failed_removal(
+        entries_map: &Arc<AsyncRwLock<BTreeMap<String, Arc<Entry>>>>,
+        entry_name: &str,
+        bucket_name: &str,
+        path: PathBuf,
+        entry: &Arc<Entry>,
+        cfg: Arc<Cfg>,
+        io_limiter: InFlightIoLimiter,
+        usage_counters: Arc<UsageCounters>,
+    ) {
+        let recovered_entry = match entry.settings().await {
+            Ok(settings) => {
+                Entry::restore_with_limiter(
+                    path,
+                    entry_name.to_string(),
+                    bucket_name.to_string(),
+                    settings,
+                    cfg,
+                    io_limiter,
+                    usage_counters,
+                )
+                .await
+            }
+            Err(err) => Err(err),
+        };
+
+        match recovered_entry {
+            Ok(Some(recovered_entry)) => {
+                if let Err(err) = Self::replace_entry_in_map_with_retry(
+                    entries_map,
+                    entry_name,
+                    bucket_name,
+                    Arc::new(recovered_entry),
+                )
+                .await
+                {
+                    error!(
+                        "Entry '{}' in bucket '{}' stays DELETING because recovery replacement failed: {}",
+                        entry_name, bucket_name, err
+                    );
+                }
+            }
+            Ok(None) => {
+                error!(
+                    "Entry '{}' in bucket '{}' stays DELETING because it could not be restored",
+                    entry_name, bucket_name
+                );
+            }
+            Err(err) => {
+                error!(
+                    "Entry '{}' in bucket '{}' stays DELETING because recovery failed: {}",
+                    entry_name, bucket_name, err
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Bucket;
-    use crate::cfg::Cfg;
+    use crate::cfg::{Cfg, InstanceRole};
     use crate::core::file_cache::FILE_CACHE;
     use prost::bytes::Bytes;
     use reduct_base::conflict;
     use reduct_base::error::ReductError;
     use reduct_base::internal_server_error;
     use reduct_base::msg::bucket_api::{BucketSettings, QuotaType};
+    use reduct_base::msg::status::ResourceStatus;
     use reduct_base::Labels;
     use rstest::{fixture, rstest};
     use std::path::PathBuf;
@@ -456,6 +482,136 @@ mod tests {
             Some(ReductError::not_found(
                 "Entry 'test-1' not found in bucket 'test'"
             ))
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn sync_fs_removes_stale_entry_when_folder_is_missing(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+        let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+
+        FILE_CACHE.remove_dir(entry.path()).await.unwrap();
+        bucket.sync_fs().await.unwrap();
+
+        assert_eq!(
+            bucket.get_entry("test-1").await.err(),
+            Some(ReductError::not_found(
+                "Entry 'test-1' not found in bucket 'test'"
+            ))
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn recover_entry_after_failed_removal_replaces_deleting_entry(
+        #[future] bucket: Arc<Bucket>,
+    ) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+        let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+        entry.mark_deleting().await.unwrap();
+
+        Bucket::recover_entry_after_failed_removal(
+            &bucket.entries,
+            "test-1",
+            &bucket.name,
+            entry.path().clone(),
+            &entry,
+            Arc::clone(&bucket.cfg),
+            bucket.io_limiter.clone(),
+            Arc::clone(&bucket.usage_counters),
+        )
+        .await;
+
+        let recovered_entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+        assert!(!Arc::ptr_eq(&entry, &recovered_entry));
+        assert_eq!(entry.status().await.unwrap(), ResourceStatus::Deleting);
+        assert_eq!(
+            recovered_entry.status().await.unwrap(),
+            ResourceStatus::Ready
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn recover_entry_after_failed_removal_keeps_deleting_when_replica_cannot_restore(
+        #[future] bucket: Arc<Bucket>,
+    ) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+        let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+        entry.mark_deleting().await.unwrap();
+        FILE_CACHE.remove_dir(entry.path()).await.unwrap();
+
+        let cfg = Arc::new(Cfg {
+            role: InstanceRole::Replica,
+            ..Cfg::default()
+        });
+
+        Bucket::recover_entry_after_failed_removal(
+            &bucket.entries,
+            "test-1",
+            &bucket.name,
+            entry.path().clone(),
+            &entry,
+            cfg,
+            bucket.io_limiter.clone(),
+            Arc::clone(&bucket.usage_counters),
+        )
+        .await;
+
+        let stored_entry = bucket
+            .entries
+            .read()
+            .await
+            .unwrap()
+            .get("test-1")
+            .cloned()
+            .unwrap();
+        assert!(Arc::ptr_eq(&entry, &stored_entry));
+        assert_eq!(
+            stored_entry.status().await.unwrap(),
+            ResourceStatus::Deleting
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn recover_entry_after_failed_removal_keeps_deleting_when_recovery_fails(
+        #[future] bucket: Arc<Bucket>,
+    ) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+        let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+        entry.mark_deleting().await.unwrap();
+        FILE_CACHE.remove_dir(entry.path()).await.unwrap();
+
+        Bucket::recover_entry_after_failed_removal(
+            &bucket.entries,
+            "test-1",
+            &bucket.name,
+            entry.path().clone(),
+            &entry,
+            Arc::clone(&bucket.cfg),
+            bucket.io_limiter.clone(),
+            Arc::clone(&bucket.usage_counters),
+        )
+        .await;
+
+        let stored_entry = bucket
+            .entries
+            .read()
+            .await
+            .unwrap()
+            .get("test-1")
+            .cloned()
+            .unwrap();
+        assert!(Arc::ptr_eq(&entry, &stored_entry));
+        assert_eq!(
+            stored_entry.status().await.unwrap(),
+            ResourceStatus::Deleting
         );
     }
 

--- a/reductstore/src/storage/bucket/remove_entry.rs
+++ b/reductstore/src/storage/bucket/remove_entry.rs
@@ -211,27 +211,16 @@ impl Bucket {
         entry_name: &str,
         bucket_name: &str,
     ) {
-        for attempt in 1..=REMOVE_ENTRY_MAP_RETRIES {
-            match entries_map.write().await {
-                Ok(mut entries) => {
-                    entries.remove(entry_name);
-                    return;
-                }
-                Err(err) if attempt == REMOVE_ENTRY_MAP_RETRIES => {
-                    error!(
-                        "Failed to remove entry '{}' from bucket map '{}' after {} attempts: {}",
-                        entry_name, bucket_name, attempt, err
-                    );
-                }
-                Err(err) => {
-                    warn!(
-                        "Failed to remove entry '{}' from bucket map '{}' on attempt {}: {}",
-                        entry_name, bucket_name, attempt, err
-                    );
-                    sleep(REMOVE_ENTRY_MAP_RETRY_DELAY).await;
-                }
-            }
-        }
+        let _ = Self::write_entry_map_with_retry(
+            entries_map,
+            entry_name,
+            bucket_name,
+            "remove",
+            |entries| {
+                entries.remove(entry_name);
+            },
+        )
+        .await;
     }
 
     async fn replace_entry_in_map_with_retry(
@@ -240,23 +229,42 @@ impl Bucket {
         bucket_name: &str,
         entry: Arc<Entry>,
     ) -> Result<(), ReductError> {
+        Self::write_entry_map_with_retry(
+            entries_map,
+            entry_name,
+            bucket_name,
+            "recover",
+            |entries| {
+                entries.insert(entry_name.to_string(), Arc::clone(&entry));
+            },
+        )
+        .await
+    }
+
+    async fn write_entry_map_with_retry(
+        entries_map: &Arc<AsyncRwLock<BTreeMap<String, Arc<Entry>>>>,
+        entry_name: &str,
+        bucket_name: &str,
+        action: &str,
+        mut write_map: impl FnMut(&mut BTreeMap<String, Arc<Entry>>),
+    ) -> Result<(), ReductError> {
         for attempt in 1..=REMOVE_ENTRY_MAP_RETRIES {
             match entries_map.write().await {
                 Ok(mut entries) => {
-                    entries.insert(entry_name.to_string(), Arc::clone(&entry));
+                    write_map(&mut entries);
                     return Ok(());
                 }
                 Err(err) if attempt == REMOVE_ENTRY_MAP_RETRIES => {
                     error!(
-                        "Failed to recover entry '{}' in bucket map '{}' after {} attempts: {}",
-                        entry_name, bucket_name, attempt, err
+                        "Failed to {} entry '{}' in bucket map '{}' after {} attempts: {}",
+                        action, entry_name, bucket_name, attempt, err
                     );
                     return Err(err);
                 }
                 Err(err) => {
                     warn!(
-                        "Failed to recover entry '{}' in bucket map '{}' on attempt {}: {}",
-                        entry_name, bucket_name, attempt, err
+                        "Failed to {} entry '{}' in bucket map '{}' on attempt {}: {}",
+                        action, entry_name, bucket_name, attempt, err
                     );
                     sleep(REMOVE_ENTRY_MAP_RETRY_DELAY).await;
                 }
@@ -329,6 +337,7 @@ mod tests {
     use super::Bucket;
     use crate::cfg::{Cfg, InstanceRole};
     use crate::core::file_cache::FILE_CACHE;
+    use crate::core::sync::{reset_rwlock_config, set_rwlock_timeout};
     use prost::bytes::Bytes;
     use reduct_base::conflict;
     use reduct_base::error::ReductError;
@@ -337,6 +346,7 @@ mod tests {
     use reduct_base::msg::status::ResourceStatus;
     use reduct_base::Labels;
     use rstest::{fixture, rstest};
+    use serial_test::serial;
     use std::path::PathBuf;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -613,6 +623,70 @@ mod tests {
             stored_entry.status().await.unwrap(),
             ResourceStatus::Deleting
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn remove_entry_from_map_with_retry_removes_entry(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+
+        Bucket::remove_entry_from_map_with_retry(&bucket.entries, "test-1", &bucket.name).await;
+
+        assert!(!bucket.entries.read().await.unwrap().contains_key("test-1"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn replace_entry_in_map_with_retry_inserts_entry(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+        let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+        bucket.entries.write().await.unwrap().remove("test-1");
+
+        Bucket::replace_entry_in_map_with_retry(&bucket.entries, "test-1", &bucket.name, entry)
+            .await
+            .unwrap();
+
+        assert!(bucket.entries.read().await.unwrap().contains_key("test-1"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[serial]
+    async fn write_entry_map_with_retry_retries_after_lock_timeout(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+        let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+        let entries_map = Arc::clone(&bucket.entries);
+
+        set_rwlock_timeout(Duration::from_millis(5));
+        let guard = entries_map.write().await.unwrap();
+        let retry_entries_map = Arc::clone(&entries_map);
+        let retry_task = tokio::spawn(async move {
+            Bucket::write_entry_map_with_retry(
+                &retry_entries_map,
+                "retry-entry",
+                "test",
+                "test",
+                |entries| {
+                    entries.insert("retry-entry".to_string(), Arc::clone(&entry));
+                },
+            )
+            .await
+        });
+
+        sleep(Duration::from_millis(20)).await;
+        drop(guard);
+        let result = retry_task.await.unwrap();
+        reset_rwlock_config();
+
+        result.unwrap();
+        assert!(entries_map
+            .read()
+            .await
+            .unwrap()
+            .contains_key("retry-entry"));
     }
 
     #[rstest]

--- a/reductstore/src/storage/bucket/remove_entry.rs
+++ b/reductstore/src/storage/bucket/remove_entry.rs
@@ -2,13 +2,18 @@
 // Licensed under the Apache License, Version 2.0
 
 use super::Bucket;
+use crate::core::file_cache::FILE_CACHE;
 use crate::storage::entry::is_system_meta_entry;
 use crate::storage::entry::Entry;
-use log::{debug, error};
-use reduct_base::conflict;
+use log::{debug, error, warn};
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::status::ResourceStatus;
+use reduct_base::{conflict, not_found};
 use std::sync::Arc;
+use tokio::time::{sleep, Duration};
+
+const REMOVE_ENTRY_MAP_RETRIES: usize = 3;
+const REMOVE_ENTRY_MAP_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 fn sort_entries_for_removal(entries: &mut [(String, Arc<Entry>)]) {
     // Remove system meta entries first to avoid removing a parent folder
@@ -57,7 +62,7 @@ impl Bucket {
         };
 
         if entries_to_remove.is_empty() {
-            return Err(ReductError::not_found(&format!(
+            return Err(not_found!(&format!(
                 "Entry '{}' not found in bucket '{}'",
                 name, self.name
             )));
@@ -73,50 +78,96 @@ impl Bucket {
         let entries_map = self.entries.clone();
         let bucket_name = self.name.clone();
         let folder_keeper = self.folder_keeper.clone();
+        let cfg = self.cfg.clone();
+        let io_limiter = self.io_limiter.clone();
+        let usage_counters = self.usage_counters.clone();
 
         tokio::spawn(async move {
             for (entry_name, entry) in entries_to_remove {
                 let path = entry.path().to_path_buf();
-                let mut failed = false;
 
-                if let Err(err) = entry.remove_all_blocks().await {
-                    error!(
-                        "Failed to remove blocks for entry '{}' in bucket '{}': {}",
-                        entry_name, bucket_name, err
-                    );
-                    failed = true;
-                }
-
-                if !failed {
-                    match crate::core::file_cache::FILE_CACHE.try_exists(&path).await {
-                        Ok(true) => {
-                            if let Err(err) = folder_keeper.remove_folder(&entry_name).await {
-                                if err.status() != ErrorCode::NotFound {
-                                    error!(
-                                        "Failed to remove folder for entry '{}' in bucket '{}': {}",
-                                        entry_name, bucket_name, err
-                                    );
-                                    failed = true;
-                                }
-                            }
-                        }
-                        Ok(false) => {}
-                        Err(err) => {
-                            error!(
-                                "Failed to check folder for entry '{}' in bucket '{}': {}",
+                match FILE_CACHE.try_exists(&path).await {
+                    Ok(true) => {
+                        if let Err(err) = entry.remove_all_blocks().await {
+                            warn!(
+                                "Failed to remove blocks for entry '{}' in bucket '{}', trying folder cleanup: {}",
                                 entry_name, bucket_name, err
                             );
-                            failed = true;
                         }
+                    }
+                    Ok(false) => {
+                        debug!(
+                            "Skip removing blocks for entry '{}' in bucket '{}' because folder '{}' is already missing",
+                            entry_name,
+                            bucket_name,
+                            path.display()
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Failed to check folder for entry '{}' in bucket '{}', trying folder cleanup: {}",
+                            entry_name, bucket_name, err
+                        );
                     }
                 }
 
-                if failed {
-                    if let Err(err) = entry.mark_ready().await {
+                let folder_removed = match folder_keeper.remove_folder(&entry_name).await {
+                    Ok(()) => true,
+                    Err(err) if err.status() == ErrorCode::NotFound => true,
+                    Err(err) => {
                         error!(
-                            "Failed to recover entry '{}' to READY in bucket '{}': {}",
+                            "Failed to remove folder for entry '{}' in bucket '{}': {}",
                             entry_name, bucket_name, err
                         );
+                        false
+                    }
+                };
+
+                if !folder_removed {
+                    let recovered_entry = match entry.settings().await {
+                        Ok(settings) => {
+                            Entry::restore_with_limiter(
+                                path.clone(),
+                                entry_name.clone(),
+                                bucket_name.clone(),
+                                settings,
+                                cfg.clone(),
+                                io_limiter.clone(),
+                                Arc::clone(&usage_counters),
+                            )
+                            .await
+                        }
+                        Err(err) => Err(err),
+                    };
+
+                    match recovered_entry {
+                        Ok(Some(recovered_entry)) => {
+                            if let Err(err) = Self::replace_entry_in_map_with_retry(
+                                &entries_map,
+                                &entry_name,
+                                &bucket_name,
+                                Arc::new(recovered_entry),
+                            )
+                            .await
+                            {
+                                error!(
+                                    "Entry '{}' in bucket '{}' stays DELETING because recovery replacement failed: {}",
+                                    entry_name, bucket_name, err
+                                );
+                            }
+                        }
+                        Ok(None) => {
+                            error!(
+                                "Entry '{}' in bucket '{}' stays DELETING because it could not be restored",
+                                entry_name, bucket_name
+                            );
+                        }
+                        Err(err) => {
+                            error!(
+                                "Entry '{}' in bucket '{}' stays DELETING because recovery failed: {}",
+                                entry_name, bucket_name, err
+                            );
+                        }
                     }
                     continue;
                 }
@@ -128,17 +179,8 @@ impl Bucket {
                     path.display()
                 );
 
-                match entries_map.write().await {
-                    Ok(mut entries) => {
-                        entries.remove(&entry_name);
-                    }
-                    Err(err) => {
-                        error!(
-                            "Failed to remove entry '{}' from bucket map '{}': {}",
-                            entry_name, bucket_name, err
-                        );
-                    }
-                }
+                Self::remove_entry_from_map_with_retry(&entries_map, &entry_name, &bucket_name)
+                    .await;
             }
         });
 
@@ -191,6 +233,70 @@ impl Bucket {
 
         Ok(())
     }
+
+    async fn remove_entry_from_map_with_retry(
+        entries_map: &Arc<
+            crate::core::sync::AsyncRwLock<std::collections::BTreeMap<String, Arc<Entry>>>,
+        >,
+        entry_name: &str,
+        bucket_name: &str,
+    ) {
+        for attempt in 1..=REMOVE_ENTRY_MAP_RETRIES {
+            match entries_map.write().await {
+                Ok(mut entries) => {
+                    entries.remove(entry_name);
+                    return;
+                }
+                Err(err) if attempt == REMOVE_ENTRY_MAP_RETRIES => {
+                    error!(
+                        "Failed to remove entry '{}' from bucket map '{}' after {} attempts: {}",
+                        entry_name, bucket_name, attempt, err
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        "Failed to remove entry '{}' from bucket map '{}' on attempt {}: {}",
+                        entry_name, bucket_name, attempt, err
+                    );
+                    sleep(REMOVE_ENTRY_MAP_RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+
+    async fn replace_entry_in_map_with_retry(
+        entries_map: &Arc<
+            crate::core::sync::AsyncRwLock<std::collections::BTreeMap<String, Arc<Entry>>>,
+        >,
+        entry_name: &str,
+        bucket_name: &str,
+        entry: Arc<Entry>,
+    ) -> Result<(), ReductError> {
+        for attempt in 1..=REMOVE_ENTRY_MAP_RETRIES {
+            match entries_map.write().await {
+                Ok(mut entries) => {
+                    entries.insert(entry_name.to_string(), Arc::clone(&entry));
+                    return Ok(());
+                }
+                Err(err) if attempt == REMOVE_ENTRY_MAP_RETRIES => {
+                    error!(
+                        "Failed to recover entry '{}' in bucket map '{}' after {} attempts: {}",
+                        entry_name, bucket_name, attempt, err
+                    );
+                    return Err(err);
+                }
+                Err(err) => {
+                    warn!(
+                        "Failed to recover entry '{}' in bucket map '{}' on attempt {}: {}",
+                        entry_name, bucket_name, attempt, err
+                    );
+                    sleep(REMOVE_ENTRY_MAP_RETRY_DELAY).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -203,7 +309,6 @@ mod tests {
     use reduct_base::error::ReductError;
     use reduct_base::internal_server_error;
     use reduct_base::msg::bucket_api::{BucketSettings, QuotaType};
-    use reduct_base::msg::status::ResourceStatus;
     use reduct_base::Labels;
     use rstest::{fixture, rstest};
     use std::path::PathBuf;
@@ -318,7 +423,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_remove_entry_recovers_when_blocks_are_missing(#[future] bucket: Arc<Bucket>) {
+    async fn test_remove_entry_is_idempotent_when_folder_is_missing(#[future] bucket: Arc<Bucket>) {
         let bucket = bucket.await;
         write(&bucket, "test-1", 1, b"test").await.unwrap();
         let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
@@ -327,14 +432,31 @@ mod tests {
         bucket.remove_entry("test-1").await.unwrap();
 
         for _ in 0..50 {
-            if entry.status().await.unwrap() == ResourceStatus::Ready {
+            if bucket.get_entry("test-1").await.is_err() {
                 break;
             }
             sleep(Duration::from_millis(20)).await;
         }
 
-        assert_eq!(entry.status().await.unwrap(), ResourceStatus::Ready);
-        assert!(bucket.get_entry("test-1").await.is_ok());
+        assert!(bucket.get_entry("test-1").await.is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn compact_removes_stale_entry_when_folder_is_missing(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "test-1", 1, b"test").await.unwrap();
+        let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+
+        FILE_CACHE.remove_dir(entry.path()).await.unwrap();
+        bucket.compact().await.unwrap();
+
+        assert_eq!(
+            bucket.get_entry("test-1").await.err(),
+            Some(ReductError::not_found(
+                "Entry 'test-1' not found in bucket 'test'"
+            ))
+        );
     }
 
     #[rstest]

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -341,11 +341,6 @@ impl Entry {
         Ok(())
     }
 
-    pub(crate) async fn mark_ready(&self) -> Result<(), ReductError> {
-        *self.status.write().await? = ResourceStatus::Ready;
-        Ok(())
-    }
-
     pub(crate) async fn ensure_not_deleting(&self) -> Result<(), ReductError> {
         if self.status().await? == ResourceStatus::Deleting {
             Err(conflict!(
@@ -359,6 +354,10 @@ impl Entry {
     }
 
     pub(super) async fn remove_all_blocks(&self) -> Result<(), ReductError> {
+        if !FILE_CACHE.try_exists(&self.path).await? {
+            return Ok(());
+        }
+
         let block_ids = {
             let block_manager = self.block_manager.read().await?;
             Ok::<BTreeSet<u64>, ReductError>(block_manager.index().tree().clone())
@@ -366,7 +365,13 @@ impl Entry {
 
         for block_id in block_ids? {
             let mut block_manager = self.block_manager.write().await?;
-            block_manager.remove_block(block_id).await?;
+            if let Err(err) = block_manager.remove_block(block_id).await {
+                if !FILE_CACHE.try_exists(&self.path).await? {
+                    return Ok(());
+                }
+
+                return Err(err);
+            }
         }
         Ok(())
     }
@@ -415,6 +420,14 @@ impl Entry {
 
     // Compacts the entry by saving the block manager cache on disk and update index from WALs
     pub async fn compact(&self) -> Result<(), ReductError> {
+        if !FILE_CACHE.try_exists(&self.path).await? {
+            debug!(
+                "Skipping compact for {}/{} because entry folder is missing",
+                self.bucket_name, self.name
+            );
+            return Ok(());
+        }
+
         if let Some(mut bm) = self.block_manager.try_write() {
             bm.save_cache_metadata_on_disk().await
         } else {
@@ -432,6 +445,14 @@ impl Entry {
     /// Unlike [`Self::compact`], this method waits for the block manager lock and
     /// must be used for strict sync points (e.g. graceful shutdown).
     pub async fn sync_fs(&self) -> Result<(), ReductError> {
+        if !FILE_CACHE.try_exists(&self.path).await? {
+            debug!(
+                "Skipping sync for {}/{} because entry folder is missing",
+                self.bucket_name, self.name
+            );
+            return Ok(());
+        }
+
         let mut bm = self.block_manager.write().await?;
         bm.save_cache_metadata_on_disk().await
     }

--- a/reductstore/src/storage/folder_keeper.rs
+++ b/reductstore/src/storage/folder_keeper.rs
@@ -10,7 +10,7 @@ use crate::storage::proto::folder_map::Item;
 use crate::storage::proto::FolderMap;
 use log::warn;
 use prost::Message;
-use reduct_base::error::ReductError;
+use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::internal_server_error;
 use std::io::SeekFrom::Start;
 use std::io::{Read, Write};
@@ -146,7 +146,11 @@ impl FolderKeeper {
 
     pub async fn remove_folder(&self, folder_name: &str) -> Result<(), ReductError> {
         let folder_path = self.path.join(folder_name);
-        FILE_CACHE.remove_dir(&folder_path).await?;
+        if let Err(err) = FILE_CACHE.remove_dir(&folder_path).await {
+            if err.status() != ErrorCode::NotFound {
+                return Err(err);
+            }
+        }
         {
             let mut map = self.map.write().await?;
             map.items.retain(|item| {


### PR DESCRIPTION
Closes #1451

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Hardened asynchronous entry removal so missing folders are treated as already removed.
- Added whole-folder cleanup fallback when per-block deletion fails.
- Kept failed folder removals in the `Deleting` state unless the entry can be restored safely.
- Skipped `Deleting` and missing-folder entries during bucket compact/sync maintenance.
- Removed stale in-memory entries and folder-map records when backing entry folders are missing.
- Ensured created backend files also create missing parent directories.

### Related issues

https://github.com/reductstore/reductstore/issues/1451

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo test -p reductstore storage::bucket::remove_entry --features fs-backend`
- `cargo test -p reductstore storage::folder_keeper --features fs-backend`
- `cargo test -p reductstore backend::file::tests::open_options --features fs-backend`
- `cargo check --workspace --features fs-backend`
- `git diff --check`
