### PR TITLE
Guard mutations while deleting buckets and entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject storage mutations for buckets and entries that are already being deleted, including writes, settings updates, record updates/removals, query removals, and bucket renames, [PR-1456](https://github.com/reductstore/reductstore/pull/1456)
 - Prevent repeated compaction and sync failures for entries whose storage folders disappeared during deletion by making entry removal idempotent and cleaning up stale in-memory state, [PR-1454](https://github.com/reductstore/reductstore/pull/1454)
 - Fix replication diagnostics timestamp conflicts and recover corrupted transaction logs created on demand for `$meta` notifications, [PR-1452](https://github.com/reductstore/reductstore/pull/1452)
 

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -543,6 +543,9 @@ pub(crate) mod tests {
 
     mod status {
         use super::*;
+        use crate::storage::bucket::update_records::UpdateLabelsMulti;
+        use reduct_base::msg::entry_api::QueryEntry;
+        use std::collections::HashSet;
 
         #[rstest]
         #[tokio::test]
@@ -641,6 +644,75 @@ pub(crate) mod tests {
             let bucket = bucket.await;
             bucket.mark_deleting().await.unwrap();
             let err = bucket.get_or_create_entry("new-entry").await.err().unwrap();
+            assert_eq!(err, conflict!("Bucket 'test' is being deleted"));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn set_settings_returns_conflict_when_bucket_deleting(#[future] bucket: Arc<Bucket>) {
+            let bucket = bucket.await;
+            bucket.mark_deleting().await.unwrap();
+
+            let err = bucket
+                .set_settings(BucketSettings::default())
+                .await
+                .err()
+                .unwrap();
+            assert_eq!(err, conflict!("Bucket 'test' is being deleted"));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn update_labels_returns_conflict_when_bucket_deleting(
+            #[future] bucket: Arc<Bucket>,
+        ) {
+            let bucket = bucket.await;
+            bucket.mark_deleting().await.unwrap();
+
+            let err = bucket
+                .update_labels(vec![UpdateLabelsMulti {
+                    entry_name: "entry".to_string(),
+                    time: 1,
+                    update: Labels::new(),
+                    remove: HashSet::new(),
+                }])
+                .await
+                .err()
+                .unwrap();
+            assert_eq!(err, conflict!("Bucket 'test' is being deleted"));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn remove_records_returns_conflict_when_bucket_deleting(
+            #[future] bucket: Arc<Bucket>,
+        ) {
+            let bucket = bucket.await;
+            bucket.mark_deleting().await.unwrap();
+
+            let err = bucket
+                .clone()
+                .remove_records(HashMap::from([("entry".to_string(), vec![1])]))
+                .await
+                .err()
+                .unwrap();
+            assert_eq!(err, conflict!("Bucket 'test' is being deleted"));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn query_remove_records_returns_conflict_when_bucket_deleting(
+            #[future] bucket: Arc<Bucket>,
+        ) {
+            let bucket = bucket.await;
+            bucket.mark_deleting().await.unwrap();
+
+            let err = bucket
+                .clone()
+                .query_remove_records(QueryEntry::default())
+                .await
+                .err()
+                .unwrap();
             assert_eq!(err, conflict!("Bucket 'test' is being deleted"));
         }
 

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -348,6 +348,9 @@ impl Bucket {
         labels: Labels,
     ) -> Result<Box<dyn WriteRecord + Sync + Send>, ReductError> {
         self.check_mode()?;
+        crate::storage::engine::check_entry_name_convention(name)?;
+        self.ensure_not_deleting().await?;
+        self.ensure_entry_path_not_deleting(name).await?;
 
         let get_entry = async || {
             self.keep_quota_for(content_size).await?;
@@ -364,6 +367,22 @@ impl Bucket {
         entry
             .begin_write(time, content_size, content_type, labels)
             .await
+    }
+
+    async fn ensure_entry_path_not_deleting(&self, name: &str) -> Result<(), ReductError> {
+        let entries_in_path = {
+            let entries = self.entries.read().await?;
+            Self::parent_prefixes(name)
+                .into_iter()
+                .filter_map(|prefix| entries.get(&prefix).cloned())
+                .collect::<Vec<_>>()
+        };
+
+        for entry in entries_in_path {
+            entry.ensure_not_deleting().await?;
+        }
+
+        Ok(())
     }
 
     /// Starts a new record read with
@@ -738,6 +757,36 @@ pub(crate) mod tests {
             entry.mark_deleting().await.unwrap();
 
             let err = bucket.begin_read("test-1", 1).await.err().unwrap();
+            assert_eq!(
+                err,
+                conflict!("Entry 'test-1' in bucket 'test' is being deleted")
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn begin_write_returns_conflict_when_target_entry_deleting_before_quota(
+            path: PathBuf,
+        ) {
+            let bucket = bucket(
+                BucketSettings {
+                    quota_type: Some(QuotaType::HARD),
+                    quota_size: Some(100),
+                    ..BucketSettings::default()
+                },
+                path,
+            )
+            .await;
+            write(&bucket, "test-1", 1, b"test").await.unwrap();
+            let entry = bucket.get_entry("test-1").await.unwrap().upgrade().unwrap();
+            entry.mark_deleting().await.unwrap();
+            *bucket.settings.write().await.unwrap() = BucketSettings {
+                quota_type: Some(QuotaType::HARD),
+                quota_size: Some(1),
+                ..BucketSettings::default()
+            };
+
+            let err = write(&bucket, "test-1", 2, b"x").await.err().unwrap();
             assert_eq!(
                 err,
                 conflict!("Entry 'test-1' in bucket 'test' is being deleted")

--- a/reductstore/src/storage/bucket/quotas.rs
+++ b/reductstore/src/storage/bucket/quotas.rs
@@ -6,7 +6,6 @@ use crate::storage::entry::Entry;
 use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::msg::bucket_api::QuotaType;
-use reduct_base::msg::status::ResourceStatus;
 use reduct_base::{bad_request, internal_server_error};
 use std::sync::Arc;
 
@@ -22,14 +21,8 @@ impl Bucket {
             QuotaType::FIFO => self.remove_oldest_block(content_size, quota_size).await,
             QuotaType::HARD => {
                 let entries = self.entries.read().await?;
-                let entry_list: Vec<_> = entries.values().cloned().collect();
-                drop(entries);
-
                 let mut total_size = 0u64;
-                for entry in entry_list {
-                    if entry.status().await? == ResourceStatus::Deleting {
-                        continue;
-                    }
+                for entry in entries.values() {
                     total_size += entry.size().await?;
                 }
                 if total_size + content_size as u64 > quota_size {
@@ -51,9 +44,6 @@ impl Bucket {
 
             let mut total_size = 0u64;
             for entry in entries.values() {
-                if entry.status().await? == ResourceStatus::Deleting {
-                    continue;
-                }
                 total_size += entry.size().await?;
             }
             Ok::<u64, ReductError>(total_size)
@@ -72,9 +62,6 @@ impl Bucket {
                 let mut candidates: Vec<(u64, &Entry)> = vec![];
                 let entries = self.entries.read().await?;
                 for (_, entry) in entries.iter() {
-                    if entry.status().await? == ResourceStatus::Deleting {
-                        continue;
-                    }
                     if !entry.is_eligible_for_fifo_eviction() {
                         continue;
                     }
@@ -210,32 +197,6 @@ mod tests {
 
         let err = write(&bucket, "test-3", 2, blob).await.err().unwrap();
         assert_eq!(err, ReductError::bad_request("Quota of 'test' exceeded"));
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_hard_quota_ignores_deleting_entries(path: PathBuf) {
-        let bucket = bucket(
-            BucketSettings {
-                quota_type: Some(QuotaType::HARD),
-                quota_size: Some(50),
-                ..BucketSettings::default()
-            },
-            path,
-        )
-        .await;
-
-        let blob: &[u8] = &[0u8; 40];
-        write(&bucket, "deleting", 0, blob).await.unwrap();
-        let entry = bucket
-            .get_entry("deleting")
-            .await
-            .unwrap()
-            .upgrade()
-            .unwrap();
-        entry.mark_deleting().await.unwrap();
-
-        write(&bucket, "active", 1, blob).await.unwrap();
     }
 
     #[rstest]

--- a/reductstore/src/storage/bucket/quotas.rs
+++ b/reductstore/src/storage/bucket/quotas.rs
@@ -6,6 +6,7 @@ use crate::storage::entry::Entry;
 use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::msg::bucket_api::QuotaType;
+use reduct_base::msg::status::ResourceStatus;
 use reduct_base::{bad_request, internal_server_error};
 use std::sync::Arc;
 
@@ -26,6 +27,9 @@ impl Bucket {
 
                 let mut total_size = 0u64;
                 for entry in entry_list {
+                    if entry.status().await? == ResourceStatus::Deleting {
+                        continue;
+                    }
                     total_size += entry.size().await?;
                 }
                 if total_size + content_size as u64 > quota_size {
@@ -47,6 +51,9 @@ impl Bucket {
 
             let mut total_size = 0u64;
             for entry in entries.values() {
+                if entry.status().await? == ResourceStatus::Deleting {
+                    continue;
+                }
                 total_size += entry.size().await?;
             }
             Ok::<u64, ReductError>(total_size)
@@ -65,6 +72,9 @@ impl Bucket {
                 let mut candidates: Vec<(u64, &Entry)> = vec![];
                 let entries = self.entries.read().await?;
                 for (_, entry) in entries.iter() {
+                    if entry.status().await? == ResourceStatus::Deleting {
+                        continue;
+                    }
                     if !entry.is_eligible_for_fifo_eviction() {
                         continue;
                     }
@@ -200,6 +210,32 @@ mod tests {
 
         let err = write(&bucket, "test-3", 2, blob).await.err().unwrap();
         assert_eq!(err, ReductError::bad_request("Quota of 'test' exceeded"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_hard_quota_ignores_deleting_entries(path: PathBuf) {
+        let bucket = bucket(
+            BucketSettings {
+                quota_type: Some(QuotaType::HARD),
+                quota_size: Some(50),
+                ..BucketSettings::default()
+            },
+            path,
+        )
+        .await;
+
+        let blob: &[u8] = &[0u8; 40];
+        write(&bucket, "deleting", 0, blob).await.unwrap();
+        let entry = bucket
+            .get_entry("deleting")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        entry.mark_deleting().await.unwrap();
+
+        write(&bucket, "active", 1, blob).await.unwrap();
     }
 
     #[rstest]

--- a/reductstore/src/storage/bucket/remove_records.rs
+++ b/reductstore/src/storage/bucket/remove_records.rs
@@ -45,6 +45,7 @@ impl Bucket {
         self: Arc<Self>,
         record_ids: HashMap<String, Vec<u64>>,
     ) -> Result<BTreeMap<u64, ReductError>, ReductError> {
+        self.ensure_not_deleting().await?;
         let mut results = BTreeMap::new();
 
         for (entry_name, ids) in record_ids {
@@ -77,6 +78,7 @@ impl Bucket {
         self: Arc<Self>,
         options: QueryEntry,
     ) -> Result<u64, ReductError> {
+        self.ensure_not_deleting().await?;
         let entries = self.entries.read().await?.clone();
         let requested_entries = Self::requested_entries(&options.entries);
         let mut total_removed = 0;
@@ -90,6 +92,7 @@ impl Bucket {
                 continue;
             }
 
+            entry.ensure_not_deleting().await?;
             let removed_records = entry.query_remove_records(options.clone()).await?;
             total_removed += removed_records;
         }
@@ -135,7 +138,7 @@ mod tests {
     use super::*;
     use crate::storage::bucket::tests::{bucket, write, write_meta};
     use reduct_base::msg::entry_api::{QueryEntry, QueryType};
-    use reduct_base::not_found;
+    use reduct_base::{conflict, not_found};
     use rstest::rstest;
     use std::collections::HashMap;
 
@@ -208,6 +211,41 @@ mod tests {
         );
         assert!(bucket.begin_read("entry-a", 4).await.is_ok());
         assert!(bucket.begin_read("entry-c", 2).await.is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn query_remove_records_returns_conflict_when_target_entry_deleting(
+        #[future] bucket: Arc<Bucket>,
+    ) {
+        let bucket = bucket.await;
+        write(&bucket, "entry-a", 1, b"a1").await.unwrap();
+        let entry = bucket
+            .get_entry("entry-a")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        entry.mark_deleting().await.unwrap();
+
+        let request = QueryEntry {
+            query_type: QueryType::Remove,
+            entries: Some(vec!["entry-a".into()]),
+            start: Some(1),
+            stop: Some(2),
+            ..Default::default()
+        };
+
+        let err = bucket
+            .clone()
+            .query_remove_records(request)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(
+            err,
+            conflict!("Entry 'entry-a' in bucket 'test' is being deleted")
+        );
     }
 
     #[rstest]

--- a/reductstore/src/storage/bucket/settings.rs
+++ b/reductstore/src/storage/bucket/settings.rs
@@ -82,6 +82,7 @@ impl Bucket {
     }
 
     pub async fn set_settings(&self, settings: BucketSettings) -> Result<(), ReductError> {
+        self.ensure_not_deleting().await?;
         if self
             .is_provisioned
             .load(std::sync::atomic::Ordering::Relaxed)
@@ -94,17 +95,21 @@ impl Bucket {
         }
 
         {
-            let mut my_settings = self.settings.write().await?;
-            let entries = self.entries.write().await?;
-
-            *my_settings = Self::fill_settings(settings, my_settings.clone());
+            let entries = self.entries.read().await?;
             for entry in entries.values() {
-                entry
-                    .set_settings(EntrySettings {
-                        max_block_size: my_settings.max_block_size.unwrap(),
-                        max_block_records: my_settings.max_block_records.unwrap(),
-                    })
-                    .await?;
+                entry.ensure_not_deleting().await?;
+            }
+
+            let mut my_settings = self.settings.write().await?;
+            let new_settings = Self::fill_settings(settings, my_settings.clone());
+            let entry_settings = EntrySettings {
+                max_block_size: new_settings.max_block_size.unwrap(),
+                max_block_records: new_settings.max_block_records.unwrap(),
+            };
+
+            *my_settings = new_settings;
+            for entry in entries.values() {
+                entry.set_settings(entry_settings.clone()).await?;
             }
         }
         self.save_settings().await
@@ -133,6 +138,8 @@ mod tests {
     use crate::cfg::Cfg;
     use crate::storage::bucket::tests::{bucket, settings};
     use crate::storage::bucket::Bucket;
+    use reduct_base::conflict;
+    use reduct_base::error::ReductError;
     use reduct_base::msg::bucket_api::BucketSettings;
     use rstest::rstest;
     use std::sync::Arc;
@@ -209,6 +216,38 @@ mod tests {
             assert_eq!(entry_settings.max_block_size, 200);
             assert_eq!(entry_settings.max_block_records, 200);
         }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn set_settings_returns_conflict_and_keeps_settings_when_entry_deleting(
+        settings: BucketSettings,
+        #[future] bucket: Arc<Bucket>,
+    ) {
+        let bucket = bucket.await;
+        let entry = bucket
+            .get_or_create_entry("entry-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        entry.mark_deleting().await.unwrap();
+
+        let err = bucket
+            .set_settings(BucketSettings {
+                max_block_size: Some(200),
+                max_block_records: Some(200),
+                ..settings.clone()
+            })
+            .await
+            .err()
+            .unwrap();
+
+        assert_eq!(
+            err,
+            conflict!("Entry 'entry-1' in bucket 'test' is being deleted")
+        );
+        assert_eq!(bucket.settings().await.unwrap(), settings);
     }
 
     #[rstest]

--- a/reductstore/src/storage/bucket/update_records.rs
+++ b/reductstore/src/storage/bucket/update_records.rs
@@ -35,6 +35,7 @@ impl Bucket {
         &self,
         updates: Vec<UpdateLabelsMulti>,
     ) -> Result<UpdateResult, ReductError> {
+        self.ensure_not_deleting().await?;
         let mut result: UpdateResult = BTreeMap::new();
         let mut updates_per_entry: BTreeMap<String, Vec<(u64, Labels, HashSet<String>)>> =
             BTreeMap::new();

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -436,6 +436,7 @@ impl StorageEngine {
                     ));
                 }
 
+                bucket.ensure_not_deleting().await?;
                 bucket.sync_fs().await?;
             } else {
                 Err(not_found!("Bucket '{}' is not found", old_name))?;
@@ -1391,6 +1392,25 @@ mod tests {
                 result,
                 Err(conflict!("Can't rename provisioned bucket 'test'"))
             );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn rename_bucket_returns_conflict_when_bucket_deleting(
+            #[future] storage: Arc<StorageEngine>,
+        ) {
+            let storage = storage.await;
+            let bucket = storage
+                .create_bucket("test", BucketSettings::default())
+                .await
+                .unwrap()
+                .upgrade_and_unwrap();
+            bucket.mark_deleting().await.unwrap();
+
+            let result = storage
+                .rename_bucket("test".to_string(), "new".to_string())
+                .await;
+            assert_eq!(result, Err(conflict!("Bucket 'test' is being deleted")));
         }
     }
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -295,6 +295,8 @@ impl Entry {
     /// Returns stats about the entry.
     pub async fn info(&self) -> Result<EntryInfo, ReductError> {
         let name = self.name.clone();
+        let status_result = self.status();
+
         let bm = self.block_manager.read().await?;
         let index = bm.index();
         let oldest_record = index
@@ -316,6 +318,8 @@ impl Entry {
             })
             .unwrap_or(0);
 
+        let status = status_result.await?;
+
         Ok(EntryInfo {
             name,
             size: index.size(),
@@ -323,7 +327,7 @@ impl Entry {
             block_count: index.tree().len() as u64,
             oldest_record,
             latest_record,
-            status: self.status().await?,
+            status,
         })
     }
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -486,6 +486,7 @@ impl Entry {
     }
 
     pub async fn set_settings(&self, settings: EntrySettings) -> Result<(), ReductError> {
+        self.ensure_not_deleting().await?;
         *self.settings.write().await? = settings;
         Ok(())
     }
@@ -547,20 +548,97 @@ mod tests {
 
     mod deleting {
         use super::*;
+        use crate::storage::entry::update_labels::UpdateLabels;
+        use std::collections::HashSet;
+
+        fn deleting_conflict(entry: &Entry) -> ReductError {
+            conflict!(
+                "Entry '{}' in bucket '{}' is being deleted",
+                entry.name(),
+                entry.bucket_name()
+            )
+        }
 
         #[rstest]
         #[tokio::test]
         async fn mark_deleting_returns_conflict_when_already_deleting(#[future] entry: Arc<Entry>) {
             let entry = entry.await;
             entry.mark_deleting().await.unwrap();
-            assert_eq!(
-                entry.mark_deleting().await,
-                Err(conflict!(
-                    "Entry '{}' in bucket '{}' is being deleted",
-                    entry.name(),
-                    entry.bucket_name()
-                ))
-            );
+            assert_eq!(entry.mark_deleting().await, Err(deleting_conflict(&entry)));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn begin_write_returns_conflict_when_deleting(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            entry.mark_deleting().await.unwrap();
+
+            let err = entry
+                .begin_write(1, 1, "text/plain".to_string(), Labels::new())
+                .await
+                .err()
+                .unwrap();
+            assert_eq!(err, deleting_conflict(&entry));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn update_labels_returns_conflict_when_deleting(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            entry.mark_deleting().await.unwrap();
+
+            let err = entry
+                .clone()
+                .update_labels(vec![UpdateLabels {
+                    time: 1,
+                    update: Labels::new(),
+                    remove: HashSet::new(),
+                }])
+                .await
+                .err()
+                .unwrap();
+            assert_eq!(err, deleting_conflict(&entry));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn remove_records_returns_conflict_when_deleting(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            entry.mark_deleting().await.unwrap();
+
+            let err = entry.clone().remove_records(vec![1]).await.err().unwrap();
+            assert_eq!(err, deleting_conflict(&entry));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn query_remove_records_returns_conflict_when_deleting(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            entry.mark_deleting().await.unwrap();
+
+            let err = entry
+                .query_remove_records(QueryEntry::default())
+                .await
+                .err()
+                .unwrap();
+            assert_eq!(err, deleting_conflict(&entry));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn set_settings_returns_conflict_when_deleting(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            entry.mark_deleting().await.unwrap();
+
+            let err = entry
+                .set_settings(EntrySettings {
+                    max_block_size: 1,
+                    max_block_records: 1,
+                })
+                .await
+                .err()
+                .unwrap();
+            assert_eq!(err, deleting_conflict(&entry));
         }
     }
 

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -295,8 +295,6 @@ impl Entry {
     /// Returns stats about the entry.
     pub async fn info(&self) -> Result<EntryInfo, ReductError> {
         let name = self.name.clone();
-        let status_result = self.status();
-
         let bm = self.block_manager.read().await?;
         let index = bm.index();
         let oldest_record = index
@@ -318,8 +316,6 @@ impl Entry {
             })
             .unwrap_or(0);
 
-        let status = status_result.await?;
-
         Ok(EntryInfo {
             name,
             size: index.size(),
@@ -327,7 +323,7 @@ impl Entry {
             block_count: index.tree().len() as u64,
             oldest_record,
             latest_record,
-            status,
+            status: self.status().await?,
         })
     }
 

--- a/reductstore/src/storage/entry/remove_records.rs
+++ b/reductstore/src/storage/entry/remove_records.rs
@@ -30,6 +30,7 @@ impl Entry {
         self: Arc<Self>,
         timestamps: Vec<u64>,
     ) -> Result<BTreeMap<u64, ReductError>, ReductError> {
+        self.ensure_not_deleting().await?;
         let block_manager = self.block_manager.clone();
         Self::inner_remove_records(timestamps, block_manager, &self.bucket_name, &self.name).await
     }
@@ -50,6 +51,7 @@ impl Entry {
     ///
     /// * If the query fails.
     pub async fn query_remove_records(&self, mut options: QueryEntry) -> Result<u64, ReductError> {
+        self.ensure_not_deleting().await?;
         options.continuous = None; // force non-continuous query
 
         let rx = async || {
@@ -95,6 +97,7 @@ impl Entry {
             }
 
             // Send the records to remove
+            self.ensure_not_deleting().await?;
             total_records += records_to_remove.len() as u64;
             let copy_block_manager = block_manager.clone();
 

--- a/reductstore/src/storage/entry/update_labels.rs
+++ b/reductstore/src/storage/entry/update_labels.rs
@@ -37,6 +37,7 @@ impl Entry {
         self: Arc<Self>,
         updates: Vec<UpdateLabels>,
     ) -> Result<UpdateResult, ReductError> {
+        self.ensure_not_deleting().await?;
         let mut result = UpdateResult::new();
         let mut records_per_block = BTreeMap::new();
         for UpdateLabels {

--- a/reductstore/src/storage/entry/write_record.rs
+++ b/reductstore/src/storage/entry/write_record.rs
@@ -65,6 +65,7 @@ impl Entry {
         content_type: String,
         labels: Labels,
     ) -> Result<Box<dyn WriteRecord + Sync + Send>, ReductError> {
+        self.ensure_not_deleting().await?;
         let permit = self.acquire_writer_slot().await?;
         // Strategy validates labels and can perform pre-write maintenance.
         self.system_behavior.prepare_write(self, &labels).await?;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

This PR guards storage-layer mutation chokepoints so buckets and entries reject writes, settings updates, label updates, record removals, query removals, and bucket renames after they enter `ResourceStatus::Deleting`.

It also makes bucket settings updates fail before mutating bucket settings when any existing entry is deleting, preserving atomic behavior for that path.

A follow-up fix moves target-entry deletion checks ahead of quota maintenance in the bucket write path, so writes to entries that are already being deleted return `409 Conflict` before quota errors or quota-related lock waits. Quota accounting/eviction and entry info still inspect deleting entries normally.

Focused tests cover deleting-state conflicts for entry mutations, bucket mutations, query removal targeting deleting entries, bucket rename, and write rejection before quota errors.

### Related issues



### Does this PR introduce a breaking change?

No.

### Other information:

Validation run locally:

- `cargo fmt --all`
- `cargo test -p reductstore storage::entry::tests::deleting`
- `cargo test -p reductstore storage::bucket::tests::status`
- `cargo test -p reductstore storage::bucket::settings`
- `cargo test -p reductstore storage::bucket::remove_records`
- `cargo test -p reductstore storage::bucket::update_records`
- `cargo test -p reductstore storage::bucket::quotas`
- `cargo test -p reductstore storage::engine::tests`
- `cargo test -p reductstore api::http::bucket`
- `cargo test -p reductstore api::components::tests`
- `cargo check --workspace`