### PR TITLE
Fix replication log cleanup on task deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Remove replication transaction log files when deleting a replication while preserving system diagnostics entries, [PR-1458](https://github.com/reductstore/reductstore/pull/1458)
 - Reject storage mutations for buckets and entries that are already being deleted, including writes, settings updates, record updates/removals, query removals, and bucket renames, [PR-1456](https://github.com/reductstore/reductstore/pull/1456)
 - Prevent repeated compaction and sync failures for entries whose storage folders disappeared during deletion by making entry removal idempotent and cleaning up stale in-memory state, [PR-1454](https://github.com/reductstore/reductstore/pull/1454)
 - Fix replication diagnostics timestamp conflicts and recover corrupted transaction logs created on demand for `$meta` notifications, [PR-1452](https://github.com/reductstore/reductstore/pull/1452)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef60ac202874e574ce7a7158cc8bca7313dd344322482e4fadee288bf4a306b8"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common 0.2.2",
  "inout 0.2.2",
@@ -792,7 +792,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -1305,17 +1305,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1714,12 +1712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,12 +1953,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
@@ -2347,7 +2333,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "phc",
 ]
 
@@ -2455,7 +2441,7 @@ checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
 dependencies = [
  "base64ct",
  "ctutils",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -2889,7 +2875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3857,9 +3843,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3893,7 +3879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4465,7 +4451,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4543,16 +4529,7 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4611,28 +4588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4643,18 +4598,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -4679,18 +4622,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5018,97 +4961,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -5769,7 +5624,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hmac 0.13.0",
  "indexmap 2.14.0",
  "lzma-rust2",

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use log::{debug, error, warn};
 use prost::Message;
-use reduct_base::error::ReductError;
+use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::replication_api::{
     FullReplicationInfo, ReplicationInfo, ReplicationMode, ReplicationSettings,
 };
@@ -271,7 +271,8 @@ impl ManageReplications for ReplicationRepository {
         if let Some(mut repl) = removed {
             repl.stop().await;
         }
-        self.save_repo().await
+        self.save_repo().await?;
+        self.remove_transaction_logs_for_replication(name).await
     }
 
     async fn set_mode(&mut self, name: &str, mode: ReplicationMode) -> Result<(), ReductError> {
@@ -554,6 +555,43 @@ impl ReplicationRepository {
             });
         }
         self.started = true;
+    }
+
+    async fn remove_transaction_logs_for_replication(
+        &self,
+        replication_name: &str,
+    ) -> Result<(), ReductError> {
+        let log_file_name = format!("{}.log", replication_name);
+        let mut dirs = vec![self.storage.data_path().clone()];
+
+        while let Some(dir) = dirs.pop() {
+            let mut entries = match tokio::fs::read_dir(&dir).await {
+                Ok(entries) => entries,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(err.into()),
+            };
+
+            while let Some(entry) = entries.next_entry().await? {
+                let path = entry.path();
+                let file_type = entry.file_type().await?;
+                if file_type.is_dir() {
+                    dirs.push(path);
+                    continue;
+                }
+
+                if path.file_name().and_then(|name| name.to_str()) != Some(log_file_name.as_str()) {
+                    continue;
+                }
+
+                match FILE_CACHE.remove(&path).await {
+                    Ok(()) => {}
+                    Err(err) if err.status() == ErrorCode::NotFound => {}
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -871,9 +909,32 @@ mod tests {
             settings: ReplicationSettings,
         ) {
             let mut repo = repo.await;
+            let storage = Arc::clone(&repo.storage);
             repo.create_replication("test", settings.clone())
                 .await
                 .unwrap();
+
+            let bucket = storage
+                .get_bucket("bucket-1")
+                .await
+                .unwrap()
+                .upgrade_and_unwrap();
+            let mut writer = bucket
+                .begin_write("entry-1", 1, 4, "text/plain".to_string(), Labels::default())
+                .await
+                .unwrap();
+            writer
+                .send(Ok(Some(bytes::Bytes::from_static(b"data"))))
+                .await
+                .unwrap();
+            writer.send(Ok(None)).await.unwrap();
+
+            let log_path = storage
+                .data_path()
+                .join("bucket-1")
+                .join("entry-1")
+                .join("test.log");
+            std::fs::write(&log_path, b"pending transactions").unwrap();
 
             let mut updated = settings;
             updated.dst_bucket = "bucket-3".to_string();
@@ -883,6 +944,10 @@ mod tests {
             let replication = repo.get_replication_settings("test").await.unwrap();
             assert_eq!(replication.dst_bucket, "bucket-3");
             assert_eq!(replication.dst_token, Some("token".to_string()));
+            assert!(
+                log_path.exists(),
+                "Should keep transaction log when replication settings change"
+            );
         }
     }
 
@@ -892,17 +957,39 @@ mod tests {
         #[tokio::test]
         async fn test_remove_replication(
             #[future] mut repo: ReplicationRepository,
-            #[future] storage: Arc<StorageEngine>,
             settings: ReplicationSettings,
         ) {
             let mut repo = repo.await;
-            let storage = storage.await;
+            let storage = Arc::clone(&repo.storage);
             repo.create_replication("test", settings.clone())
                 .await
                 .unwrap();
 
+            let bucket = storage
+                .get_bucket("bucket-1")
+                .await
+                .unwrap()
+                .upgrade_and_unwrap();
+            let mut writer = bucket
+                .begin_write("entry-1", 1, 4, "text/plain".to_string(), Labels::default())
+                .await
+                .unwrap();
+            writer
+                .send(Ok(Some(bytes::Bytes::from_static(b"data"))))
+                .await
+                .unwrap();
+            writer.send(Ok(None)).await.unwrap();
+
+            let log_path = storage
+                .data_path()
+                .join("bucket-1")
+                .join("entry-1")
+                .join("test.log");
+            std::fs::write(&log_path, b"pending transactions").unwrap();
+
             repo.remove_replication("test").await.unwrap();
             assert_eq!(repo.replications().await.unwrap().len(), 0);
+            assert!(!log_path.exists(), "Should remove transaction log");
 
             // check if replication is removed from file
             let repo =
@@ -912,6 +999,119 @@ mod tests {
                 repo.replications().await.unwrap().len(),
                 0,
                 "Should remove replication permanently"
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_remove_transaction_logs_for_replication(
+            #[future] repo: ReplicationRepository,
+        ) {
+            let repo = repo.await;
+            let storage = Arc::clone(&repo.storage);
+            storage
+                .create_system_bucket("$system", BucketSettings::default())
+                .await
+                .unwrap();
+
+            let bucket = storage
+                .get_bucket("bucket-1")
+                .await
+                .unwrap()
+                .upgrade_and_unwrap();
+            let mut writer = bucket
+                .begin_write("entry-1", 1, 4, "text/plain".to_string(), Labels::default())
+                .await
+                .unwrap();
+            writer
+                .send(Ok(Some(bytes::Bytes::from_static(b"data"))))
+                .await
+                .unwrap();
+            writer.send(Ok(None)).await.unwrap();
+
+            let log_path = storage
+                .data_path()
+                .join("bucket-1")
+                .join("entry-1")
+                .join("test.log");
+            std::fs::write(&log_path, b"pending transactions").unwrap();
+
+            let mut writer = storage
+                .begin_write(
+                    "$system",
+                    "replications/instance/test",
+                    1,
+                    4,
+                    "application/json".to_string(),
+                    Labels::default(),
+                )
+                .await
+                .unwrap();
+            writer
+                .send(Ok(Some(bytes::Bytes::from_static(b"data"))))
+                .await
+                .unwrap();
+            writer.send(Ok(None)).await.unwrap();
+
+            let system_transaction_log_paths = [
+                storage
+                    .data_path()
+                    .join("$system")
+                    .join("replications")
+                    .join("instance")
+                    .join("test")
+                    .join("test.log"),
+                storage
+                    .data_path()
+                    .join("$system")
+                    .join("usage")
+                    .join("instance")
+                    .join("total")
+                    .join("test.log"),
+                storage
+                    .data_path()
+                    .join("$system")
+                    .join("audit")
+                    .join("instance")
+                    .join("api")
+                    .join("test.log"),
+            ];
+            for path in &system_transaction_log_paths {
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, b"pending transactions").unwrap();
+            }
+
+            let system_event_data_path = storage
+                .data_path()
+                .join("$system")
+                .join("usage")
+                .join("instance")
+                .join("total")
+                .join("1.blk");
+            std::fs::write(&system_event_data_path, b"system event").unwrap();
+
+            repo.remove_transaction_logs_for_replication("test")
+                .await
+                .unwrap();
+
+            assert!(!log_path.exists(), "Should remove transaction log");
+            for path in &system_transaction_log_paths {
+                assert!(!path.exists(), "Should remove diagnostics transaction log");
+            }
+            assert!(
+                system_event_data_path.exists(),
+                "Should keep diagnostics data"
+            );
+            assert!(
+                storage
+                    .get_bucket("$system")
+                    .await
+                    .unwrap()
+                    .upgrade_and_unwrap()
+                    .get_entry("replications/instance/test")
+                    .await
+                    .is_ok(),
+                "Should keep system event entry"
             );
         }
 

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -495,7 +495,7 @@ impl ReplicationTask {
         }
     }
 
-    fn build_path_to_transaction_log(
+    pub(super) fn build_path_to_transaction_log(
         storage_path: &PathBuf,
         bucket: &str,
         entry: &str,


### PR DESCRIPTION
Closes #1453

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Deleting a replication now removes its persisted transaction log files for that replication from the storage/cache tree. The cleanup matches only the deleted replication's `<name>.log` files recursively, including nested `$system` diagnostics paths such as replication, usage, and audit entries, while preserving the system event data itself.

Replication settings updates continue to keep existing transaction logs so pending transactions are not lost.

### Related issues

https://github.com/reductstore/reductstore/issues/1453

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with:

- `cargo test -p reductstore test_remove_transaction_logs_for_replication`
- `cargo test -p reductstore test_remove_replication`
- `cargo test -p reductstore test_update_replication_keep_dst_token_if_not_set`
