### PR TITLE
fix: force synchronization of cache during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Force synchronization of cache during shutdown to ensure data consistency, [PR-1459](https://github.com/reductstore/reductstore/pull/1459)
+
 ## 1.20.1 - 2026-06-17
 
 ### Fixed

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -806,6 +806,7 @@ impl BlockManager {
 
     // Method save descriptor and update index
     // Note: it calls local sync but not sync_all to avoid blocking entry during synchronization with remote backend
+    // the blocks must be synced with backed from FILE_CACHE sync loop
     async fn save_meta_on_disk(&mut self, block_ref: BlockRef) -> Result<(), ReductError> {
         // Take a snapshot under a short-lived write lock to avoid blocking readers
         let (block_id, block_snapshot) = {

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -109,12 +109,11 @@ impl BlockManager {
     pub async fn save_cache_on_disk(&mut self) -> Result<(), ReductError> {
         let blocks = self.block_cache.write_values();
         for block in blocks.iter() {
-            let block_id = block.read().await?.block_id();
-            self.sync_data_block(block_id).await?;
-        }
-
-        for block in blocks {
-            self.save_meta_on_disk(block).await?;
+            {
+                let block_id = block.read().await?.block_id();
+                self.sync_data_block(block_id).await?;
+            }
+            self.save_meta_on_disk(block.clone()).await?;
         }
 
         Ok(())

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -320,6 +320,7 @@ impl BlockManager {
 
         let data_path = self.path_to_data(block_id);
         let desc_path = self.path_to_desc(block_id);
+        let index_path = self.path.join(BLOCK_INDEX_FILE);
 
         {
             // resize imminently for better testing.
@@ -328,6 +329,8 @@ impl BlockManager {
                 .await?;
             data_block.set_len(block_size)?;
         }
+
+        self.save_meta_on_disk(block.clone()).await?;
 
         let sync_block = async move {
             /* sync descriptor and data */
@@ -343,6 +346,20 @@ impl BlockManager {
                     .write_or_create(&desc_path, SeekFrom::Current(0))
                     .await?;
                 descr_block.sync_all().await?;
+            }
+
+            {
+                let mut descr_block = FILE_CACHE
+                    .write_or_create(&desc_path, SeekFrom::Current(0))
+                    .await?;
+                descr_block.sync_all().await?;
+            }
+
+            {
+                let mut index_file = FILE_CACHE
+                    .write_or_create(&index_path, SeekFrom::Current(0))
+                    .await?;
+                index_file.sync_all().await?;
             }
 
             Ok::<(), ReductError>(())
@@ -787,6 +804,8 @@ impl BlockManager {
             .join(format!("{}{}", block_id, COMPRESSED_DATA_FILE_EXT))
     }
 
+    // Method save descriptor and update index
+    // Note: it calls local sync but not sync_all to avoid blocking entry during synchronization with remote backend
     async fn save_meta_on_disk(&mut self, block_ref: BlockRef) -> Result<(), ReductError> {
         // Take a snapshot under a short-lived write lock to avoid blocking readers
         let (block_id, block_snapshot) = {

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -1086,7 +1086,7 @@ mod tests {
 
             assert_eq!(entry.info().await.unwrap().block_count, 2);
             assert_eq!(entry.info().await.unwrap().record_count, 4);
-            assert_eq!(entry.info().await.unwrap().size, 116);
+            assert_eq!(entry.info().await.unwrap().size, 138);
 
             entry.try_remove_oldest_block().await.unwrap();
             assert_eq!(entry.info().await.unwrap().block_count, 1);

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -454,7 +454,7 @@ impl Entry {
         }
 
         let mut bm = self.block_manager.write().await?;
-        bm.save_cache_metadata_on_disk().await
+        bm.save_cache_on_disk().await
     }
 
     pub fn name(&self) -> &str {

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -522,7 +522,6 @@ impl EntryLoader {
                 if block_removed {
                     block_manager.remove_block(block_id).await?;
                 } else {
-                    block_manager.save_block(block_ref.clone()).await?;
                     block_manager.finish_block(block_ref).await?;
                 }
             }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Fixed force synchronization of cache during shutdown in `BlockManager::save_cache_on_disk` to ensure all blocks are properly synced to disk before metadata is saved.
- Updated `Entry::sync_data` to call `BlockManager::save_cache_on_disk` instead of `save_cache_metadata_on_disk` to ensure full cache synchronization.

### Related issues

No related issues.

### Does this PR introduce a breaking change?

No breaking changes. This PR ensures data consistency during shutdown without affecting the public API.

### Other information:

- Unit tests were updated to verify the synchronization behavior.
