### PR TITLE
Disable integrity checks for read-only replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable storage integrity checks for read-only replica instances so they do not attempt local index rebuilds, [PR-1461](https://github.com/reductstore/reductstore/pull/1461)
+
 ## 1.20.1 - 2026-06-17
 
 ### Fixed

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -283,6 +283,11 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
 
         let ext_cfg = ext_parser.from_env(&mut env, version).await;
 
+        let mut engine_config = Self::parse_storage_engine_config(&mut env);
+        if ext_cfg.role() == InstanceRole::Replica {
+            engine_config.enable_integrity_checks = false;
+        }
+
         let replications = Self::parse_replications(&mut env);
         let lifecycles = Self::parse_lifecycles(&mut env);
         let has_lifecycles = !lifecycles.is_empty();
@@ -319,7 +324,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             backend_config: ext_cfg.remote_storage_config(),
             lock_file_config: Self::parse_lock_file_config(&mut env),
             rw_lock_config: Self::parse_rw_lock_config(&mut env),
-            engine_config: Self::parse_storage_engine_config(&mut env),
+            engine_config,
             limits_config: Self::parse_limits_config(&mut env),
             #[cfg(feature = "zenoh-api")]
             zenoh_api: Self::parse_zenoh_api_config(&mut env),
@@ -1076,6 +1081,29 @@ mod tests {
             .catch_unwind()
             .await;
             assert!(result.is_err());
+        }
+
+        #[rstest]
+        #[tokio::test(flavor = "current_thread")]
+        async fn test_replica_disables_integrity_checks(mut env_getter: MockEnvGetter) {
+            env_getter
+                .expect_get()
+                .with(eq("RS_INSTANCE_ROLE"))
+                .times(1)
+                .return_const(Ok("REPLICA".to_string()));
+            env_getter
+                .expect_get()
+                .with(eq("RS_ENGINE_ENABLE_INTEGRITY_CHECKS"))
+                .times(1)
+                .return_const(Ok("true".to_string()));
+            env_getter
+                .expect_get()
+                .return_const(Err(VarError::NotPresent));
+
+            let parser = CfgParser::from_env(env_getter, "0.0.0").await;
+
+            assert_eq!(parser.cfg.role, InstanceRole::Replica);
+            assert!(!parser.cfg.engine_config.enable_integrity_checks);
         }
 
         #[rstest]


### PR DESCRIPTION
Closes #1460

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Replica instances now force storage integrity checks off during configuration parsing, even when `RS_ENGINE_ENABLE_INTEGRITY_CHECKS=true` is set. This prevents read-only replicas from attempting integrity-check-driven index rebuilds and keeps them relying on primary-side storage state.

A regression test covers the replica configuration path and verifies that the parsed engine config disables integrity checks for `RS_INSTANCE_ROLE=REPLICA`.

### Related issues

Closes #1460

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo test -p reductstore cfg::tests::role::test_replica_disables_integrity_checks`
- `cargo fmt --all --check`
