### PR TITLE
update web-console up to v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Web Console to v1.15.1, [PR-1462](https://github.com/reductstore/reductstore/pull/1462)
+
 ### Fixed
 
 - Disable storage integrity checks for read-only replica instances so they do not attempt local index rebuilds, [PR-1461](https://github.com/reductstore/reductstore/pull/1461)

--- a/reductstore/build.rs
+++ b/reductstore/build.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to compile protos");
 
     #[cfg(feature = "web-console")]
-    download_web_console("v1.15.0");
+    download_web_console("v1.15.1");
     // get build time and commit
     let build_time = chrono::DateTime::<chrono::Utc>::from(SystemTime::now())
         .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Dependency/update

### What was changed?

Updated the bundled Web Console version downloaded during `web-console` builds from `v1.15.0` to `v1.15.1`.

### Related issues

None.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation was not run locally because this is a version-only web console bump in the build script.
