### PR TITLE
fix lifecycle compression metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Report both processed record and block counts for lifecycle compression events, [PR-1470](https://github.com/reductstore/reductstore/pull/1470) by @rohankumardubey
+
 ## 1.20.2 - 2026-06-18
 
 ### Changed

--- a/reductstore/src/lifecycle/action.rs
+++ b/reductstore/src/lifecycle/action.rs
@@ -26,6 +26,7 @@ impl LifecycleContext {
 #[derive(Clone, Debug, Default)]
 pub(super) struct LifecycleRunResult {
     pub(super) affected_records: u64,
+    pub(super) affected_blocks: Option<u64>,
 }
 
 #[async_trait]

--- a/reductstore/src/lifecycle/action/compress.rs
+++ b/reductstore/src/lifecycle/action/compress.rs
@@ -45,7 +45,7 @@ impl LifecycleAction for CompressLifecycleAction {
 
         let stats = if settings.mode == LifecycleMode::DryRun {
             bucket
-                .count_compressible_blocks(entries, start, stop)
+                .estimate_compressible_data(entries, start, stop)
                 .await?
         } else {
             bucket.compress_blocks(entries, start, stop).await?
@@ -134,7 +134,7 @@ mod tests {
         assert_eq!(
             test_bucket
                 .clone()
-                .count_compressible_blocks(Some(vec!["entry-1".into()]), None, None)
+                .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
                 .await
                 .unwrap(),
             crate::storage::entry::CompressionStats::default()
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(
             test_bucket
                 .clone()
-                .count_compressible_blocks(Some(vec!["entry-1".into()]), None, None)
+                .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
                 .await
                 .unwrap(),
             crate::storage::entry::CompressionStats {

--- a/reductstore/src/lifecycle/action/compress.rs
+++ b/reductstore/src/lifecycle/action/compress.rs
@@ -43,7 +43,7 @@ impl LifecycleAction for CompressLifecycleAction {
             .await?
             .upgrade()?;
 
-        let affected_records = if settings.mode == LifecycleMode::DryRun {
+        let stats = if settings.mode == LifecycleMode::DryRun {
             bucket
                 .count_compressible_blocks(entries, start, stop)
                 .await?
@@ -51,7 +51,10 @@ impl LifecycleAction for CompressLifecycleAction {
             bucket.compress_blocks(entries, start, stop).await?
         };
 
-        Ok(LifecycleRunResult { affected_records })
+        Ok(LifecycleRunResult {
+            affected_records: stats.records,
+            affected_blocks: Some(stats.blocks),
+        })
     }
 }
 
@@ -126,14 +129,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_blocks, Some(1));
         assert_eq!(
             test_bucket
                 .clone()
                 .count_compressible_blocks(Some(vec!["entry-1".into()]), None, None)
                 .await
                 .unwrap(),
-            0
+            crate::storage::entry::CompressionStats::default()
         );
     }
 
@@ -159,14 +163,18 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_blocks, Some(1));
         assert_eq!(
             test_bucket
                 .clone()
                 .count_compressible_blocks(Some(vec!["entry-1".into()]), None, None)
                 .await
                 .unwrap(),
-            1
+            crate::storage::entry::CompressionStats {
+                blocks: 1,
+                records: 2
+            }
         );
     }
 
@@ -193,7 +201,7 @@ mod tests {
                 .await
                 .unwrap()
                 .affected_records,
-            1
+            2
         );
         assert_eq!(
             action
@@ -227,7 +235,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_blocks, Some(1));
     }
 
     #[rstest]
@@ -259,6 +268,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.affected_records, 0);
+        assert_eq!(result.affected_blocks, Some(0));
         assert!(test_bucket.begin_read("entry-1/$meta", 1).await.is_ok());
     }
 }

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -64,7 +64,10 @@ impl LifecycleAction for DeleteLifecycleAction {
             bucket.query_remove_records(query_entry).await?
         };
 
-        Ok(LifecycleRunResult { affected_records })
+        Ok(LifecycleRunResult {
+            affected_records,
+            ..Default::default()
+        })
     }
 }
 

--- a/reductstore/src/lifecycle/lifecycle_repository/repo.rs
+++ b/reductstore/src/lifecycle/lifecycle_repository/repo.rs
@@ -715,6 +715,7 @@ mod tests {
                 tx.send((name.to_string(), bucket_name)).unwrap();
                 Ok(LifecycleRunResult {
                     affected_records: 1,
+                    ..Default::default()
                 })
             });
         let action: Arc<dyn LifecycleAction + Send + Sync> = Arc::new(action);

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use crate::lifecycle::action::{LifecycleAction, LifecycleContext};
+use crate::lifecycle::action::{LifecycleAction, LifecycleContext, LifecycleRunResult};
 use crate::lifecycle::system_event_payload::LifecycleSystemEventPayload;
 use crate::syslog::SystemEvent;
 
@@ -96,7 +96,7 @@ impl LifecycleTask {
                             action.lifecycle_type(),
                             &settings.bucket,
                             started.elapsed().as_secs_f64(),
-                            Ok(result.affected_records),
+                            Ok(result),
                         )
                         .await;
                     }
@@ -205,7 +205,7 @@ impl LifecycleTask {
         action_type: LifecycleType,
         bucket: &str,
         duration: f64,
-        result: Result<u64, ReductError>,
+        result: Result<LifecycleRunResult, ReductError>,
     ) {
         let Some(sink) = system_event_sink else {
             debug!(
@@ -216,7 +216,7 @@ impl LifecycleTask {
         };
 
         let (status, message, payload) = match result {
-            Ok(processed_records) => (
+            Ok(result) => (
                 200u16,
                 "".to_string(),
                 LifecycleSystemEventPayload::success(
@@ -224,7 +224,8 @@ impl LifecycleTask {
                     &format!("{:?}", action_type).to_lowercase(),
                     bucket,
                     duration,
-                    processed_records,
+                    result.affected_records,
+                    result.affected_blocks,
                 )
                 .to_value(),
             ),
@@ -425,6 +426,7 @@ pub(super) mod tests {
             tx.send(name.to_string()).unwrap();
             Ok(LifecycleRunResult {
                 affected_records: 1,
+                ..Default::default()
             })
         });
 
@@ -453,6 +455,7 @@ pub(super) mod tests {
             tx.send(name.to_string()).unwrap();
             Ok(LifecycleRunResult {
                 affected_records: 1,
+                ..Default::default()
             })
         });
 
@@ -480,6 +483,7 @@ pub(super) mod tests {
             tx.send(name.to_string()).unwrap();
             Ok(LifecycleRunResult {
                 affected_records: 1,
+                ..Default::default()
             })
         });
 
@@ -528,7 +532,10 @@ pub(super) mod tests {
             LifecycleType::Delete,
             "bucket-1",
             0.25,
-            Ok(42),
+            Ok(LifecycleRunResult {
+                affected_records: 42,
+                ..Default::default()
+            }),
         )
         .await;
 
@@ -545,8 +552,41 @@ pub(super) mod tests {
         assert_eq!(event.payload["action_type"], "delete");
         assert_eq!(event.payload["bucket"], "bucket-1");
         assert_eq!(event.payload["processed_records"], 42);
+        assert!(event.payload.get("processed_blocks").is_none());
         assert!(event.payload.get("error_code").is_none());
         assert!(event.payload.get("error_message").is_none());
+    }
+
+    #[tokio::test]
+    async fn log_system_event_writes_compression_metrics() {
+        let captured = Arc::new(Mutex::new(Vec::<SystemEvent>::new()));
+        let sink = SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingSystemLogger {
+                events: Arc::clone(&captured),
+            })
+                as Box<dyn LogSystemEvent + Send + Sync>)),
+            instance_name: "instance-1".to_string(),
+        };
+
+        LifecycleTask::log_system_event(
+            Some(sink),
+            "policy-1",
+            LifecycleType::Compress,
+            "bucket-1",
+            0.25,
+            Ok(LifecycleRunResult {
+                affected_records: 42,
+                affected_blocks: Some(3),
+            }),
+        )
+        .await;
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+
+        assert_eq!(event.payload["processed_records"], 42);
+        assert_eq!(event.payload["processed_blocks"], 3);
     }
 
     #[tokio::test]
@@ -584,6 +624,7 @@ pub(super) mod tests {
         assert_eq!(event.payload["action_type"], "delete");
         assert_eq!(event.payload["bucket"], "bucket-1");
         assert_eq!(event.payload["processed_records"], serde_json::Value::Null);
+        assert!(event.payload.get("processed_blocks").is_none());
         assert_eq!(event.payload["error_code"], 422);
         assert_eq!(event.payload["error_message"], "failed to run");
     }

--- a/reductstore/src/lifecycle/system_event_payload.rs
+++ b/reductstore/src/lifecycle/system_event_payload.rs
@@ -13,6 +13,8 @@ pub(crate) struct LifecycleSystemEventPayload {
     #[serde(default)]
     pub processed_records: Option<u64>,
     #[serde(default)]
+    pub processed_blocks: Option<u64>,
+    #[serde(default)]
     pub error_code: Option<u16>,
     #[serde(default)]
     pub error_message: Option<String>,
@@ -25,6 +27,7 @@ impl LifecycleSystemEventPayload {
         bucket: &str,
         duration: f64,
         processed_records: u64,
+        processed_blocks: Option<u64>,
     ) -> Self {
         Self {
             policy_name: policy_name.to_string(),
@@ -32,6 +35,7 @@ impl LifecycleSystemEventPayload {
             bucket: bucket.to_string(),
             duration,
             processed_records: Some(processed_records),
+            processed_blocks,
             error_code: None,
             error_message: None,
         }
@@ -51,6 +55,7 @@ impl LifecycleSystemEventPayload {
             bucket: bucket.to_string(),
             duration,
             processed_records: None,
+            processed_blocks: None,
             error_code: Some(error_code),
             error_message: Some(error_message.to_string()),
         }
@@ -67,6 +72,10 @@ impl LifecycleSystemEventPayload {
 
         if let Some(error_code) = self.error_code {
             payload["error_code"] = json!(error_code);
+        }
+
+        if let Some(processed_blocks) = self.processed_blocks {
+            payload["processed_blocks"] = json!(processed_blocks);
         }
 
         if let Some(error_message) = &self.error_message {

--- a/reductstore/src/storage/bucket/compress_blocks.rs
+++ b/reductstore/src/storage/bucket/compress_blocks.rs
@@ -6,6 +6,11 @@ use crate::storage::entry::{is_system_meta_entry, CompressionStats};
 use reduct_base::error::ReductError;
 use std::sync::Arc;
 
+enum CompressionMode {
+    Compress,
+    Estimate,
+}
+
 impl Bucket {
     /// Compress blocks over a timestamp range across matching entries.
     pub async fn compress_blocks(
@@ -14,33 +19,27 @@ impl Bucket {
         start: Option<u64>,
         stop: Option<u64>,
     ) -> Result<CompressionStats, ReductError> {
-        let entries = self.entries.read().await?.clone();
-        let requested_entries = Self::requested_entries(&entries_filter);
-        let mut total = CompressionStats::default();
-
-        for (entry_name, entry) in entries {
-            if !Self::is_requested_entry(&entry_name, &requested_entries) {
-                continue;
-            }
-
-            if is_system_meta_entry(&entry_name) {
-                continue;
-            }
-
-            let stats = entry.compress_blocks(start, stop).await?;
-            total.blocks += stats.blocks;
-            total.records += stats.records;
-        }
-
-        Ok(total)
+        self.process_compressible_data(entries_filter, start, stop, CompressionMode::Compress)
+            .await
     }
 
-    /// Count blocks that would be compressed over a timestamp range.
-    pub async fn count_compressible_blocks(
+    /// Estimate blocks and records that would be compressed over a timestamp range.
+    pub async fn estimate_compressible_data(
         self: Arc<Self>,
         entries_filter: Option<Vec<String>>,
         start: Option<u64>,
         stop: Option<u64>,
+    ) -> Result<CompressionStats, ReductError> {
+        self.process_compressible_data(entries_filter, start, stop, CompressionMode::Estimate)
+            .await
+    }
+
+    async fn process_compressible_data(
+        self: Arc<Self>,
+        entries_filter: Option<Vec<String>>,
+        start: Option<u64>,
+        stop: Option<u64>,
+        mode: CompressionMode,
     ) -> Result<CompressionStats, ReductError> {
         let entries = self.entries.read().await?.clone();
         let requested_entries = Self::requested_entries(&entries_filter);
@@ -55,7 +54,10 @@ impl Bucket {
                 continue;
             }
 
-            let stats = entry.count_compressible_blocks(start, stop).await?;
+            let stats = match mode {
+                CompressionMode::Compress => entry.compress_blocks(start, stop).await?,
+                CompressionMode::Estimate => entry.estimate_compressible_data(start, stop).await?,
+            };
             total.blocks += stats.blocks;
             total.records += stats.records;
         }
@@ -103,7 +105,7 @@ mod tests {
         assert_eq!(
             bucket
                 .clone()
-                .count_compressible_blocks(None, None, None)
+                .estimate_compressible_data(None, None, None)
                 .await
                 .unwrap(),
             CompressionStats {
@@ -114,7 +116,7 @@ mod tests {
         assert_eq!(
             bucket
                 .clone()
-                .count_compressible_blocks(Some(vec!["entry-c".into()]), None, None)
+                .estimate_compressible_data(Some(vec!["entry-c".into()]), None, None)
                 .await
                 .unwrap(),
             CompressionStats {
@@ -149,7 +151,7 @@ mod tests {
         assert_eq!(
             bucket
                 .clone()
-                .count_compressible_blocks(Some(vec!["entry-a/$meta".into()]), None, None)
+                .estimate_compressible_data(Some(vec!["entry-a/$meta".into()]), None, None)
                 .await
                 .unwrap(),
             CompressionStats::default()

--- a/reductstore/src/storage/bucket/compress_blocks.rs
+++ b/reductstore/src/storage/bucket/compress_blocks.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 use crate::storage::bucket::Bucket;
-use crate::storage::entry::is_system_meta_entry;
+use crate::storage::entry::{is_system_meta_entry, CompressionStats};
 use reduct_base::error::ReductError;
 use std::sync::Arc;
 
@@ -13,10 +13,10 @@ impl Bucket {
         entries_filter: Option<Vec<String>>,
         start: Option<u64>,
         stop: Option<u64>,
-    ) -> Result<u64, ReductError> {
+    ) -> Result<CompressionStats, ReductError> {
         let entries = self.entries.read().await?.clone();
         let requested_entries = Self::requested_entries(&entries_filter);
-        let mut total = 0;
+        let mut total = CompressionStats::default();
 
         for (entry_name, entry) in entries {
             if !Self::is_requested_entry(&entry_name, &requested_entries) {
@@ -27,7 +27,9 @@ impl Bucket {
                 continue;
             }
 
-            total += entry.compress_blocks(start, stop).await?;
+            let stats = entry.compress_blocks(start, stop).await?;
+            total.blocks += stats.blocks;
+            total.records += stats.records;
         }
 
         Ok(total)
@@ -39,10 +41,10 @@ impl Bucket {
         entries_filter: Option<Vec<String>>,
         start: Option<u64>,
         stop: Option<u64>,
-    ) -> Result<u64, ReductError> {
+    ) -> Result<CompressionStats, ReductError> {
         let entries = self.entries.read().await?.clone();
         let requested_entries = Self::requested_entries(&entries_filter);
-        let mut total = 0;
+        let mut total = CompressionStats::default();
 
         for (entry_name, entry) in entries {
             if !Self::is_requested_entry(&entry_name, &requested_entries) {
@@ -53,7 +55,9 @@ impl Bucket {
                 continue;
             }
 
-            total += entry.count_compressible_blocks(start, stop).await?;
+            let stats = entry.count_compressible_blocks(start, stop).await?;
+            total.blocks += stats.blocks;
+            total.records += stats.records;
         }
 
         Ok(total)
@@ -89,14 +93,23 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(compressed, 2);
+        assert_eq!(
+            compressed,
+            CompressionStats {
+                blocks: 2,
+                records: 2
+            }
+        );
         assert_eq!(
             bucket
                 .clone()
                 .count_compressible_blocks(None, None, None)
                 .await
                 .unwrap(),
-            1
+            CompressionStats {
+                blocks: 1,
+                records: 1
+            }
         );
         assert_eq!(
             bucket
@@ -104,7 +117,10 @@ mod tests {
                 .count_compressible_blocks(Some(vec!["entry-c".into()]), None, None)
                 .await
                 .unwrap(),
-            1
+            CompressionStats {
+                blocks: 1,
+                records: 1
+            }
         );
     }
 
@@ -129,14 +145,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(compressed, 0);
+        assert_eq!(compressed, CompressionStats::default());
         assert_eq!(
             bucket
                 .clone()
                 .count_compressible_blocks(Some(vec!["entry-a/$meta".into()]), None, None)
                 .await
                 .unwrap(),
-            0
+            CompressionStats::default()
         );
         assert!(bucket.begin_read("entry-a/$meta", 1).await.is_ok());
     }

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -81,6 +81,12 @@ pub struct EntrySettings {
     pub max_block_records: u64,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CompressionStats {
+    pub(crate) blocks: u64,
+    pub(crate) records: u64,
+}
+
 impl Entry {
     #[allow(dead_code)]
     pub async fn try_build(

--- a/reductstore/src/storage/entry/compress.rs
+++ b/reductstore/src/storage/entry/compress.rs
@@ -69,8 +69,8 @@ impl Entry {
         Ok(stats)
     }
 
-    /// Count uncompressed blocks and their records whose block IDs fall within `[start, stop)`.
-    pub async fn count_compressible_blocks(
+    /// Estimate uncompressed blocks and records whose block IDs fall within `[start, stop)`.
+    pub async fn estimate_compressible_data(
         &self,
         start: Option<u64>,
         stop: Option<u64>,
@@ -286,13 +286,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_count_compressible_blocks_full_range(path: PathBuf) {
+    async fn test_estimate_compressible_data_full_range(path: PathBuf) {
         let entry = entry(multi_block_settings(), path.clone()).await;
         write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
 
         assert_eq!(
-            entry.count_compressible_blocks(None, None).await.unwrap(),
+            entry.estimate_compressible_data(None, None).await.unwrap(),
             CompressionStats {
                 blocks: 3,
                 records: 3
@@ -300,7 +300,7 @@ mod tests {
         );
         assert_eq!(
             entry
-                .count_compressible_blocks(Some(2_000_000), Some(3_000_000))
+                .estimate_compressible_data(Some(2_000_000), Some(3_000_000))
                 .await
                 .unwrap(),
             CompressionStats {
@@ -313,14 +313,14 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_count_compressible_blocks_start_only(path: PathBuf) {
+    async fn test_estimate_compressible_data_start_only(path: PathBuf) {
         let entry = entry(multi_block_settings(), path.clone()).await;
         write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
 
         assert_eq!(
             entry
-                .count_compressible_blocks(Some(2_000_000), None)
+                .estimate_compressible_data(Some(2_000_000), None)
                 .await
                 .unwrap(),
             CompressionStats {
@@ -333,14 +333,14 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_count_compressible_blocks_stop_only(path: PathBuf) {
+    async fn test_estimate_compressible_data_stop_only(path: PathBuf) {
         let entry = entry(multi_block_settings(), path.clone()).await;
         write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
 
         assert_eq!(
             entry
-                .count_compressible_blocks(None, Some(3_000_000))
+                .estimate_compressible_data(None, Some(3_000_000))
                 .await
                 .unwrap(),
             CompressionStats {
@@ -353,7 +353,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_count_compressible_blocks_after_compression(path: PathBuf) {
+    async fn test_estimate_compressible_data_after_compression(path: PathBuf) {
         let entry = entry(multi_block_settings(), path.clone()).await;
         write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
@@ -366,7 +366,7 @@ mod tests {
             }
         );
         assert_eq!(
-            entry.count_compressible_blocks(None, None).await.unwrap(),
+            entry.estimate_compressible_data(None, None).await.unwrap(),
             CompressionStats::default()
         );
     }

--- a/reductstore/src/storage/entry/compress.rs
+++ b/reductstore/src/storage/entry/compress.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use super::Entry;
+use super::{CompressionStats, Entry};
 use crate::storage::block_manager::compress::CompressionAlgorithm;
 use reduct_base::error::{ErrorCode, ReductError};
 
@@ -14,8 +14,8 @@ impl Entry {
         &self,
         start: Option<u64>,
         stop: Option<u64>,
-    ) -> Result<u64, ReductError> {
-        let block_ids = {
+    ) -> Result<CompressionStats, ReductError> {
+        let blocks = {
             let bm = self.block_manager.read().await?;
             let index = bm.index();
 
@@ -34,12 +34,16 @@ impl Entry {
                         .unwrap_or(i32::from(CompressionAlgorithm::None))
                         == i32::from(CompressionAlgorithm::None)
                 })
-                .copied()
+                .filter_map(|&block_id| {
+                    index
+                        .get_block(block_id)
+                        .map(|block| (block_id, block.record_count))
+                })
                 .collect::<Vec<_>>()
         };
 
-        let mut compressed_count = 0;
-        for block_id in block_ids {
+        let mut stats = CompressionStats::default();
+        for (block_id, record_count) in blocks {
             {
                 let mut bm = self.block_manager.write().await?;
                 if bm.is_block_in_write_cache(block_id) {
@@ -50,7 +54,10 @@ impl Entry {
                     .compress_block(block_id, CompressionAlgorithm::Zstd)
                     .await
                 {
-                    Ok(()) => compressed_count += 1,
+                    Ok(()) => {
+                        stats.blocks += 1;
+                        stats.records += record_count;
+                    }
                     Err(err)
                         if matches!(err.status(), ErrorCode::Conflict | ErrorCode::NotFound) => {}
                     Err(err) => return Err(err),
@@ -59,15 +66,15 @@ impl Entry {
             tokio::task::yield_now().await;
         }
 
-        Ok(compressed_count)
+        Ok(stats)
     }
 
-    /// Count uncompressed blocks whose block IDs fall within `[start, stop)`.
+    /// Count uncompressed blocks and their records whose block IDs fall within `[start, stop)`.
     pub async fn count_compressible_blocks(
         &self,
         start: Option<u64>,
         stop: Option<u64>,
-    ) -> Result<u64, ReductError> {
+    ) -> Result<CompressionStats, ReductError> {
         let bm = self.block_manager.read().await?;
         let index = bm.index();
 
@@ -78,7 +85,7 @@ impl Entry {
             (None, None) => Box::new(index.tree().iter()),
         };
 
-        let count = range
+        let stats = range
             .filter(|&&block_id| {
                 !bm.is_block_in_write_cache(block_id)
                     && index
@@ -87,9 +94,14 @@ impl Entry {
                         .unwrap_or(i32::from(CompressionAlgorithm::None))
                         == i32::from(CompressionAlgorithm::None)
             })
-            .count() as u64;
+            .filter_map(|block_id| index.get_block(*block_id))
+            .fold(CompressionStats::default(), |mut stats, block| {
+                stats.blocks += 1;
+                stats.records += block.record_count;
+                stats
+            });
 
-        Ok(count)
+        Ok(stats)
     }
 }
 
@@ -116,7 +128,13 @@ mod tests {
         write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
 
-        assert_eq!(entry.compress_blocks(None, None).await.unwrap(), 3);
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats {
+                blocks: 3,
+                records: 3
+            }
+        );
 
         assert_compressed(&entry, 1_000_000, true).await;
         assert_compressed(&entry, 2_000_000, true).await;
@@ -136,7 +154,10 @@ mod tests {
                 .compress_blocks(Some(2_000_000), Some(3_000_000))
                 .await
                 .unwrap(),
-            1
+            CompressionStats {
+                blocks: 1,
+                records: 1
+            }
         );
 
         assert_compressed(&entry, 1_000_000, false).await;
@@ -154,7 +175,10 @@ mod tests {
 
         assert_eq!(
             entry.compress_blocks(Some(2_000_000), None).await.unwrap(),
-            2
+            CompressionStats {
+                blocks: 2,
+                records: 2
+            }
         );
 
         assert_compressed(&entry, 1_000_000, false).await;
@@ -172,7 +196,10 @@ mod tests {
 
         assert_eq!(
             entry.compress_blocks(None, Some(3_000_000)).await.unwrap(),
-            2
+            CompressionStats {
+                blocks: 2,
+                records: 2
+            }
         );
 
         assert_compressed(&entry, 1_000_000, true).await;
@@ -188,8 +215,17 @@ mod tests {
         write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
 
-        assert_eq!(entry.compress_blocks(None, None).await.unwrap(), 3);
-        assert_eq!(entry.compress_blocks(None, None).await.unwrap(), 0);
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats {
+                blocks: 3,
+                records: 3
+            }
+        );
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats::default()
+        );
     }
 
     #[rstest]
@@ -227,7 +263,13 @@ mod tests {
             .expect("concurrent read should not wait for all blocks to compress")
             .unwrap();
 
-        assert_eq!(compressor.await.unwrap().unwrap(), block_ids.len() as u64);
+        assert_eq!(
+            compressor.await.unwrap().unwrap(),
+            CompressionStats {
+                blocks: block_ids.len() as u64,
+                records: block_ids.len() as u64,
+            }
+        );
     }
 
     #[rstest]
@@ -235,7 +277,10 @@ mod tests {
     #[serial]
     async fn test_compress_blocks_empty_entry(path: PathBuf) {
         let entry = entry(multi_block_settings(), path).await;
-        assert_eq!(entry.compress_blocks(None, None).await.unwrap(), 0);
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats::default()
+        );
     }
 
     #[rstest]
@@ -248,14 +293,20 @@ mod tests {
 
         assert_eq!(
             entry.count_compressible_blocks(None, None).await.unwrap(),
-            3
+            CompressionStats {
+                blocks: 3,
+                records: 3
+            }
         );
         assert_eq!(
             entry
                 .count_compressible_blocks(Some(2_000_000), Some(3_000_000))
                 .await
                 .unwrap(),
-            1
+            CompressionStats {
+                blocks: 1,
+                records: 1
+            }
         );
     }
 
@@ -272,7 +323,10 @@ mod tests {
                 .count_compressible_blocks(Some(2_000_000), None)
                 .await
                 .unwrap(),
-            2
+            CompressionStats {
+                blocks: 2,
+                records: 2
+            }
         );
     }
 
@@ -289,7 +343,10 @@ mod tests {
                 .count_compressible_blocks(None, Some(3_000_000))
                 .await
                 .unwrap(),
-            2
+            CompressionStats {
+                blocks: 2,
+                records: 2
+            }
         );
     }
 
@@ -301,10 +358,16 @@ mod tests {
         write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
 
-        assert_eq!(entry.compress_blocks(None, None).await.unwrap(), 3);
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats {
+                blocks: 3,
+                records: 3
+            }
+        );
         assert_eq!(
             entry.count_compressible_blocks(None, None).await.unwrap(),
-            0
+            CompressionStats::default()
         );
     }
 
@@ -323,7 +386,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(entry.compress_blocks(None, None).await.unwrap(), 1);
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats {
+                blocks: 1,
+                records: 1
+            }
+        );
 
         assert_compressed(&entry, 1_000_000, true).await;
         assert_compressed(&entry, 2_000_000, false).await;


### PR DESCRIPTION
Closes #1464

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (not required)
- [x] CHANGELOG.md has been updated (not required)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

Fixed lifecycle compression statistics to report both:

- `processed_records`: number of records in successfully compressed blocks
- `processed_blocks`: number of successfully compressed blocks

Dry-run mode now reports the same prospective metrics. Delete lifecycle event behavior remains unchanged.

### Related issues

- #1464

### Does this PR introduce a breaking change?

No. The existing `processed_records` field is corrected, and `processed_blocks` is added to compression lifecycle events.

### Other information:

Validated with formatting, workspace checks, focused tests, and the full workspace test suite.