### PR TITLE
Feat/per bucket usage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Emit per-bucket usage statistics as system events under `usage/<instance>/<bucket>` alongside the existing instance total, and add `written_entries`, `read_entries`, and `record_count` fields to usage events, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @DibbayajyotiRoy
+
 ## 1.20.2 - 2026-06-18
 
 ### Changed

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -764,6 +764,10 @@ impl BlockManager {
         &self.usage_counters
     }
 
+    pub(in crate::storage) fn usage_counters_arc(&self) -> Arc<UsageCounters> {
+        Arc::clone(&self.usage_counters)
+    }
+
     pub(in crate::storage) fn is_block_in_write_cache(&self, block_id: u64) -> bool {
         self.block_cache.get_write(&block_id).is_some()
     }

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -9,7 +9,7 @@ use crate::core::weak::Weak;
 use crate::storage::bucket::Bucket;
 use crate::storage::folder_keeper::{DiscoveryDepth, FolderKeeper};
 use crate::storage::in_flight::InFlightIoLimiter;
-use crate::storage::usage::{UsageCounters, UsageSnapshot};
+use crate::storage::usage::{BucketSnapshot, UsageCounters, UsageSnapshot};
 use log::{debug, error, info};
 use reduct_base::error::ReductError;
 use reduct_base::io::WriteRecord;
@@ -18,7 +18,7 @@ use reduct_base::msg::server_api::{BucketInfoList, Defaults, License, ServerInfo
 use reduct_base::{
     conflict, forbidden, internal_server_error, not_found, unprocessable_entity, Labels,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -228,17 +228,21 @@ impl StorageEngine {
         let writer = bucket
             .begin_write(entry_name, time, content_size, content_type, labels)
             .await?;
-        self.usage_counters.count_write(content_size);
+        self.usage_counters
+            .count_write(bucket_name, entry_name, content_size);
         Ok(writer)
     }
 
-    /// Collect point-in-time usage totals in a single walk over all buckets.
-    pub(crate) async fn usage_snapshot(&self) -> Result<UsageSnapshot, ReductError> {
+    /// Collect point-in-time usage totals in a single walk over all buckets,
+    /// returning the instance aggregate and a per-bucket breakdown.
+    pub(crate) async fn usage_snapshot(
+        &self,
+    ) -> Result<(UsageSnapshot, HashMap<String, BucketSnapshot>), ReductError> {
         let infos = {
             let buckets = self.buckets.read().await?;
             buckets
                 .values()
-                .map(|bucket| bucket.clone().info())
+                .map(|bucket| (bucket.name().to_string(), bucket.clone().info()))
                 .collect::<Vec<_>>()
         };
 
@@ -246,18 +250,37 @@ impl StorageEngine {
             bucket_count: infos.len() as u64,
             ..UsageSnapshot::default()
         };
-        for task in infos {
+        let mut bucket_snapshots = HashMap::new();
+        for (name, task) in infos {
             let bucket = task.await?;
-            snapshot.storage_bytes += bucket.info.size;
-            snapshot.entry_count += bucket.info.entry_count;
-            snapshot.block_count += bucket
+            let block_count = bucket
                 .entries
                 .iter()
                 .map(|entry| entry.block_count)
                 .sum::<u64>();
+            let record_count = bucket
+                .entries
+                .iter()
+                .map(|entry| entry.record_count)
+                .sum::<u64>();
+
+            snapshot.storage_bytes += bucket.info.size;
+            snapshot.entry_count += bucket.info.entry_count;
+            snapshot.block_count += block_count;
+            snapshot.record_count += record_count;
+
+            bucket_snapshots.insert(
+                name,
+                BucketSnapshot {
+                    storage_bytes: bucket.info.size,
+                    entry_count: bucket.info.entry_count,
+                    block_count,
+                    record_count,
+                },
+            );
         }
 
-        Ok(snapshot)
+        Ok((snapshot, bucket_snapshots))
     }
 
     async fn total_usage(&self) -> Result<u64, ReductError> {
@@ -787,11 +810,19 @@ mod tests {
             writer.send(Ok(None)).await.unwrap();
         }
 
-        let snapshot = storage.usage_snapshot().await.unwrap();
+        let (snapshot, bucket_snapshots) = storage.usage_snapshot().await.unwrap();
         assert_eq!(snapshot.bucket_count, 2);
         assert_eq!(snapshot.entry_count, 2);
         assert_eq!(snapshot.block_count, 2);
+        assert_eq!(snapshot.record_count, 2);
         assert!(snapshot.storage_bytes > 0);
+
+        assert_eq!(bucket_snapshots.len(), 2);
+        let snap_1 = bucket_snapshots.get("snap-1").unwrap();
+        assert_eq!(snap_1.entry_count, 1);
+        assert_eq!(snap_1.block_count, 1);
+        assert_eq!(snap_1.record_count, 1);
+        assert!(snap_1.storage_bytes > 0);
     }
 
     #[rstest]
@@ -821,9 +852,11 @@ mod tests {
         writer.send(Ok(None)).await.unwrap();
 
         let drained = storage.usage_counters().drain();
-        assert_eq!(drained.write_bytes, 10);
-        assert_eq!(drained.records_written, 1);
-        assert_eq!(drained.records_read, 0);
+        assert_eq!(drained.total.write_bytes, 10);
+        assert_eq!(drained.total.records_written, 1);
+        assert_eq!(drained.total.records_read, 0);
+        assert_eq!(drained.total.written_entries, 1);
+        assert_eq!(drained.buckets.get("test").unwrap().write_bytes, 10);
 
         let _reader = storage
             .get_bucket("test")
@@ -835,9 +868,11 @@ mod tests {
             .unwrap();
 
         let drained = storage.usage_counters().drain();
-        assert_eq!(drained.read_bytes, 10);
-        assert_eq!(drained.records_read, 1);
-        assert_eq!(drained.records_written, 0);
+        assert_eq!(drained.total.read_bytes, 10);
+        assert_eq!(drained.total.records_read, 1);
+        assert_eq!(drained.total.records_written, 0);
+        assert_eq!(drained.total.read_entries, 1);
+        assert_eq!(drained.buckets.get("test").unwrap().read_bytes, 10);
     }
 
     mod recovery {

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -225,11 +225,11 @@ impl StorageEngine {
     ) -> Result<Box<dyn WriteRecord + Sync + Send>, ReductError> {
         self.ensure_storage_limit(content_size).await?;
         let bucket = self.get_bucket(bucket_name).await?.upgrade()?;
+        // Write traffic is counted at `RecordWriter` creation, alongside reads
+        // at `RecordReader` creation.
         let writer = bucket
             .begin_write(entry_name, time, content_size, content_type, labels)
             .await?;
-        self.usage_counters
-            .count_write(bucket_name, entry_name, content_size);
         Ok(writer)
     }
 
@@ -851,7 +851,7 @@ mod tests {
             .unwrap();
         writer.send(Ok(None)).await.unwrap();
 
-        let drained = storage.usage_counters().drain();
+        let drained = storage.usage_counters().drain().await.unwrap();
         assert_eq!(drained.total.write_bytes, 10);
         assert_eq!(drained.total.records_written, 1);
         assert_eq!(drained.total.records_read, 0);
@@ -867,7 +867,7 @@ mod tests {
             .await
             .unwrap();
 
-        let drained = storage.usage_counters().drain();
+        let drained = storage.usage_counters().drain().await.unwrap();
         assert_eq!(drained.total.read_bytes, 10);
         assert_eq!(drained.total.records_read, 1);
         assert_eq!(drained.total.records_written, 0);

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -81,7 +81,8 @@ impl RecordReader {
         };
 
         bm.usage_counters()
-            .count_read(bm.bucket_name(), bm.entry_name(), content_size);
+            .count_read(bm.bucket_name(), bm.entry_name(), content_size)
+            .await?;
 
         Ok(Self {
             meta,

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -80,7 +80,8 @@ impl RecordReader {
             None
         };
 
-        bm.usage_counters().count_read(content_size);
+        bm.usage_counters()
+            .count_read(bm.bucket_name(), bm.entry_name(), content_size);
 
         Ok(Self {
             meta,

--- a/reductstore/src/storage/entry/io/record_writer.rs
+++ b/reductstore/src/storage/entry/io/record_writer.rs
@@ -57,7 +57,7 @@ impl RecordWriter {
         block_ref: BlockRef,
         time: u64,
     ) -> Result<Self, ReductError> {
-        let (file_path, offset, bucket_name, entry_name) = {
+        let (file_path, offset, bucket_name, entry_name, usage_counters) = {
             let mut bm = block_manager.write().await?;
             let block = block_ref.read().await?;
 
@@ -73,6 +73,7 @@ impl RecordWriter {
                 offset,
                 bm.bucket_name().to_string(),
                 bm.entry_name().to_string(),
+                bm.usage_counters_arc(),
             )
         };
 
@@ -80,6 +81,11 @@ impl RecordWriter {
         let block_id = block.block_id();
         let record_index = block.get_record(time).unwrap();
         let content_size = record_index.end - record_index.begin;
+
+        // Count the write at record creation, mirroring `RecordReader`.
+        usage_counters
+            .count_write(&bucket_name, &entry_name, content_size)
+            .await?;
 
         let ctx = WriteContext {
             bucket_name,

--- a/reductstore/src/storage/usage.rs
+++ b/reductstore/src/storage/usage.rs
@@ -15,49 +15,115 @@ mod usage_event_payload;
 
 pub(crate) use usage_aggregator::UsageEventAggregator;
 
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 /// Interval traffic counters incremented at the storage engine choke points.
 ///
-/// Plain relaxed atomics: the counters are independent tallies, no ordering
-/// between them is required. `drain` swaps each counter to zero, so
-/// increments that race with a flush roll into the next interval instead of
-/// being lost.
+/// The instance-wide tallies are plain relaxed atomics: independent counters,
+/// no ordering between them is required. Per-bucket traffic — including each
+/// bucket's set of distinct entries written to / read from — is kept in
+/// `per_bucket` behind a single mutex so each `count_*` updates it in the same
+/// critical section. `drain` resets everything, so increments that race with a
+/// flush roll into the next interval instead of being lost.
 #[derive(Debug, Default)]
 pub(crate) struct UsageCounters {
     write_bytes: AtomicU64,
     read_bytes: AtomicU64,
     records_written: AtomicU64,
     records_read: AtomicU64,
+    per_bucket: Mutex<HashMap<String, BucketTraffic>>,
 }
 
-/// Counter values drained for one flush interval.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Interval traffic tallied for a single bucket.
+#[derive(Debug, Default)]
+struct BucketTraffic {
+    write_bytes: u64,
+    read_bytes: u64,
+    records_written: u64,
+    records_read: u64,
+    written_entries: HashSet<String>,
+    read_entries: HashSet<String>,
+}
+
+/// Counter values drained for one flush interval, for the instance total or a
+/// single bucket.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct DrainedUsageCounters {
     pub write_bytes: u64,
     pub read_bytes: u64,
     pub records_written: u64,
     pub records_read: u64,
+    pub written_entries: u64,
+    pub read_entries: u64,
+}
+
+/// Result of draining the counters: the instance total plus per-bucket traffic.
+#[derive(Debug)]
+pub(crate) struct DrainedUsage {
+    pub total: DrainedUsageCounters,
+    pub buckets: HashMap<String, DrainedUsageCounters>,
 }
 
 impl UsageCounters {
-    pub(crate) fn count_write(&self, bytes: u64) {
+    pub(crate) fn count_write(&self, bucket_name: &str, entry_name: &str, bytes: u64) {
         self.write_bytes.fetch_add(bytes, Ordering::Relaxed);
         self.records_written.fetch_add(1, Ordering::Relaxed);
+
+        let mut buckets = self.per_bucket.lock().unwrap();
+        let bucket = buckets.entry(bucket_name.to_string()).or_default();
+        bucket.write_bytes += bytes;
+        bucket.records_written += 1;
+        bucket.written_entries.insert(entry_name.to_string());
     }
 
-    pub(crate) fn count_read(&self, bytes: u64) {
+    pub(crate) fn count_read(&self, bucket_name: &str, entry_name: &str, bytes: u64) {
         self.read_bytes.fetch_add(bytes, Ordering::Relaxed);
         self.records_read.fetch_add(1, Ordering::Relaxed);
+
+        let mut buckets = self.per_bucket.lock().unwrap();
+        let bucket = buckets.entry(bucket_name.to_string()).or_default();
+        bucket.read_bytes += bytes;
+        bucket.records_read += 1;
+        bucket.read_entries.insert(entry_name.to_string());
     }
 
-    pub(crate) fn drain(&self) -> DrainedUsageCounters {
-        DrainedUsageCounters {
+    pub(crate) fn drain(&self) -> DrainedUsage {
+        let mut buckets_guard = self.per_bucket.lock().unwrap();
+
+        // Draining the whole map drops every bucket; only buckets with traffic
+        // in the next interval are re-inserted, so a deleted bucket cannot grow
+        // the map unbounded.
+        let buckets: HashMap<String, DrainedUsageCounters> = buckets_guard
+            .drain()
+            .map(|(name, traffic)| {
+                (
+                    name,
+                    DrainedUsageCounters {
+                        write_bytes: traffic.write_bytes,
+                        read_bytes: traffic.read_bytes,
+                        records_written: traffic.records_written,
+                        records_read: traffic.records_read,
+                        written_entries: traffic.written_entries.len() as u64,
+                        read_entries: traffic.read_entries.len() as u64,
+                    },
+                )
+            })
+            .collect();
+
+        // An entry is identified by bucket + name, so the instance-total
+        // distinct-entry counts are the sum of the per-bucket counts.
+        let total = DrainedUsageCounters {
             write_bytes: self.write_bytes.swap(0, Ordering::Relaxed),
             read_bytes: self.read_bytes.swap(0, Ordering::Relaxed),
             records_written: self.records_written.swap(0, Ordering::Relaxed),
             records_read: self.records_read.swap(0, Ordering::Relaxed),
-        }
+            written_entries: buckets.values().map(|bucket| bucket.written_entries).sum(),
+            read_entries: buckets.values().map(|bucket| bucket.read_entries).sum(),
+        };
+
+        DrainedUsage { total, buckets }
     }
 }
 
@@ -68,6 +134,16 @@ pub(crate) struct UsageSnapshot {
     pub bucket_count: u64,
     pub entry_count: u64,
     pub block_count: u64,
+    pub record_count: u64,
+}
+
+/// Point-in-time storage totals for a single bucket.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct BucketSnapshot {
+    pub storage_bytes: u64,
+    pub entry_count: u64,
+    pub block_count: u64,
+    pub record_count: u64,
 }
 
 #[cfg(test)]
@@ -78,27 +154,24 @@ mod tests {
     #[rstest]
     fn drain_returns_counts_and_resets() {
         let counters = UsageCounters::default();
-        counters.count_write(10);
-        counters.count_write(5);
-        counters.count_read(7);
+        counters.count_write("bucket-1", "entry-1", 10);
+        counters.count_write("bucket-1", "entry-1", 5);
+        counters.count_read("bucket-1", "entry-1", 7);
 
         assert_eq!(
-            counters.drain(),
+            counters.drain().total,
             DrainedUsageCounters {
                 write_bytes: 15,
                 read_bytes: 7,
                 records_written: 2,
                 records_read: 1,
+                written_entries: 1,
+                read_entries: 1,
             }
         );
         assert_eq!(
-            counters.drain(),
-            DrainedUsageCounters {
-                write_bytes: 0,
-                read_bytes: 0,
-                records_written: 0,
-                records_read: 0,
-            },
+            counters.drain().total,
+            DrainedUsageCounters::default(),
             "drain must reset the counters"
         );
     }
@@ -106,15 +179,109 @@ mod tests {
     #[rstest]
     fn counts_after_drain_land_in_next_interval() {
         let counters = UsageCounters::default();
-        counters.count_write(10);
+        counters.count_write("bucket-1", "entry-1", 10);
         counters.drain();
 
-        counters.count_write(3);
-        counters.count_read(4);
-        let drained = counters.drain();
+        counters.count_write("bucket-1", "entry-1", 3);
+        counters.count_read("bucket-1", "entry-1", 4);
+        let drained = counters.drain().total;
         assert_eq!(drained.write_bytes, 3);
         assert_eq!(drained.records_written, 1);
         assert_eq!(drained.read_bytes, 4);
         assert_eq!(drained.records_read, 1);
+    }
+
+    #[rstest]
+    fn per_bucket_counts_isolate_by_bucket() {
+        let counters = UsageCounters::default();
+        counters.count_write("bucket-1", "entry-1", 10);
+        counters.count_write("bucket-2", "entry-1", 25);
+        counters.count_read("bucket-2", "entry-2", 7);
+
+        let drained = counters.drain();
+        assert_eq!(drained.total.write_bytes, 35);
+
+        let b1 = drained.buckets.get("bucket-1").unwrap();
+        assert_eq!(b1.write_bytes, 10);
+        assert_eq!(b1.records_written, 1);
+        assert_eq!(b1.read_bytes, 0);
+
+        let b2 = drained.buckets.get("bucket-2").unwrap();
+        assert_eq!(b2.write_bytes, 25);
+        assert_eq!(b2.read_bytes, 7);
+        assert_eq!(b2.records_read, 1);
+    }
+
+    #[rstest]
+    fn drained_buckets_are_removed_from_the_map() {
+        let counters = UsageCounters::default();
+        counters.count_write("bucket-1", "entry-1", 10);
+
+        let drained = counters.drain();
+        assert!(drained.buckets.contains_key("bucket-1"));
+
+        // Nothing was written in this interval, so the bucket must be gone.
+        let drained = counters.drain();
+        assert!(
+            drained.buckets.is_empty(),
+            "a bucket that drains to zero must be removed from the map"
+        );
+    }
+
+    #[rstest]
+    fn distinct_entries_count_unique_names_not_operations() {
+        let counters = UsageCounters::default();
+        // Same entry written five times in one interval.
+        for _ in 0..5 {
+            counters.count_write("bucket-1", "entry-1", 10);
+        }
+        // Two distinct entries read.
+        counters.count_read("bucket-1", "entry-1", 4);
+        counters.count_read("bucket-1", "entry-2", 4);
+
+        let drained = counters.drain();
+        assert_eq!(drained.total.records_written, 5);
+        assert_eq!(
+            drained.total.written_entries, 1,
+            "five writes to one entry is one distinct written entry"
+        );
+        assert_eq!(drained.total.records_read, 2);
+        assert_eq!(drained.total.read_entries, 2);
+
+        let bucket = drained.buckets.get("bucket-1").unwrap();
+        assert_eq!(bucket.written_entries, 1);
+        assert_eq!(bucket.read_entries, 2);
+    }
+
+    #[rstest]
+    fn distinct_written_entries_count_two_different_entries() {
+        let counters = UsageCounters::default();
+        counters.count_write("bucket-1", "entry-1", 10);
+        counters.count_write("bucket-1", "entry-2", 10);
+
+        let drained = counters.drain();
+        assert_eq!(drained.total.written_entries, 2);
+        assert_eq!(drained.total.records_written, 2);
+    }
+
+    #[rstest]
+    fn distinct_entries_are_keyed_by_bucket_and_name() {
+        let counters = UsageCounters::default();
+        // The same entry name in two different buckets in one interval.
+        counters.count_write("bucket-a", "sensor-1", 10);
+        counters.count_write("bucket-b", "sensor-1", 10);
+        counters.count_read("bucket-a", "sensor-1", 10);
+        counters.count_read("bucket-b", "sensor-1", 10);
+
+        let drained = counters.drain();
+        assert_eq!(drained.buckets.get("bucket-a").unwrap().written_entries, 1);
+        assert_eq!(drained.buckets.get("bucket-b").unwrap().written_entries, 1);
+        assert_eq!(drained.buckets.get("bucket-a").unwrap().read_entries, 1);
+        assert_eq!(drained.buckets.get("bucket-b").unwrap().read_entries, 1);
+
+        // Composite keying: an entry is identified by bucket + name, so the same
+        // name in two buckets is two distinct entries in the instance total.
+        assert_eq!(drained.total.written_entries, 2);
+        assert_eq!(drained.total.read_entries, 2);
     }
 }

--- a/reductstore/src/storage/usage.rs
+++ b/reductstore/src/storage/usage.rs
@@ -3,37 +3,49 @@
 
 //! Periodic usage statistics emitted as `$system` events.
 //!
-//! Traffic is counted at the storage engine choke points — all writes in
-//! [`crate::storage::engine::StorageEngine::begin_write`] and all reads at
-//! `RecordReader` creation — so external, replication and Zenoh traffic
-//! count uniformly. [`UsageEventAggregator`] owns a background task that
-//! drains the counters every [`usage_aggregator::USAGE_FLUSH_INTERVAL`] and
-//! writes one flat-JSON event per instance to `$system/usage/<instance>/total`.
+//! Traffic is counted at the storage IO choke points — all writes at
+//! `RecordWriter` creation and all reads at `RecordReader` creation — so
+//! external, replication and Zenoh traffic count uniformly.
+//! [`UsageEventAggregator`] owns a background task that drains the counters
+//! every [`usage_aggregator::USAGE_FLUSH_INTERVAL`] and writes one flat-JSON
+//! event per instance to `$system/usage/<instance>/total`.
 
 mod usage_aggregator;
 mod usage_event_payload;
 
 pub(crate) use usage_aggregator::UsageEventAggregator;
 
+use crate::core::sync::AsyncRwLock;
+use reduct_base::error::ReductError;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
 
 /// Interval traffic counters incremented at the storage engine choke points.
 ///
 /// The instance-wide tallies are plain relaxed atomics: independent counters,
 /// no ordering between them is required. Per-bucket traffic — including each
 /// bucket's set of distinct entries written to / read from — is kept in
-/// `per_bucket` behind a single mutex so each `count_*` updates it in the same
+/// `per_bucket` behind a single async lock so each `count_*` updates it in one
 /// critical section. `drain` resets everything, so increments that race with a
 /// flush roll into the next interval instead of being lost.
-#[derive(Debug, Default)]
 pub(crate) struct UsageCounters {
     write_bytes: AtomicU64,
     read_bytes: AtomicU64,
     records_written: AtomicU64,
     records_read: AtomicU64,
-    per_bucket: Mutex<HashMap<String, BucketTraffic>>,
+    per_bucket: AsyncRwLock<HashMap<String, BucketTraffic>>,
+}
+
+impl Default for UsageCounters {
+    fn default() -> Self {
+        Self {
+            write_bytes: AtomicU64::new(0),
+            read_bytes: AtomicU64::new(0),
+            records_written: AtomicU64::new(0),
+            records_read: AtomicU64::new(0),
+            per_bucket: AsyncRwLock::new(HashMap::new()),
+        }
+    }
 }
 
 /// Interval traffic tallied for a single bucket.
@@ -67,30 +79,42 @@ pub(crate) struct DrainedUsage {
 }
 
 impl UsageCounters {
-    pub(crate) fn count_write(&self, bucket_name: &str, entry_name: &str, bytes: u64) {
+    pub(crate) async fn count_write(
+        &self,
+        bucket_name: &str,
+        entry_name: &str,
+        bytes: u64,
+    ) -> Result<(), ReductError> {
         self.write_bytes.fetch_add(bytes, Ordering::Relaxed);
         self.records_written.fetch_add(1, Ordering::Relaxed);
 
-        let mut buckets = self.per_bucket.lock().unwrap();
+        let mut buckets = self.per_bucket.write().await?;
         let bucket = buckets.entry(bucket_name.to_string()).or_default();
         bucket.write_bytes += bytes;
         bucket.records_written += 1;
         bucket.written_entries.insert(entry_name.to_string());
+        Ok(())
     }
 
-    pub(crate) fn count_read(&self, bucket_name: &str, entry_name: &str, bytes: u64) {
+    pub(crate) async fn count_read(
+        &self,
+        bucket_name: &str,
+        entry_name: &str,
+        bytes: u64,
+    ) -> Result<(), ReductError> {
         self.read_bytes.fetch_add(bytes, Ordering::Relaxed);
         self.records_read.fetch_add(1, Ordering::Relaxed);
 
-        let mut buckets = self.per_bucket.lock().unwrap();
+        let mut buckets = self.per_bucket.write().await?;
         let bucket = buckets.entry(bucket_name.to_string()).or_default();
         bucket.read_bytes += bytes;
         bucket.records_read += 1;
         bucket.read_entries.insert(entry_name.to_string());
+        Ok(())
     }
 
-    pub(crate) fn drain(&self) -> DrainedUsage {
-        let mut buckets_guard = self.per_bucket.lock().unwrap();
+    pub(crate) async fn drain(&self) -> Result<DrainedUsage, ReductError> {
+        let mut buckets_guard = self.per_bucket.write().await?;
 
         // Draining the whole map drops every bucket; only buckets with traffic
         // in the next interval are re-inserted, so a deleted bucket cannot grow
@@ -123,7 +147,7 @@ impl UsageCounters {
             read_entries: buckets.values().map(|bucket| bucket.read_entries).sum(),
         };
 
-        DrainedUsage { total, buckets }
+        Ok(DrainedUsage { total, buckets })
     }
 }
 
@@ -152,14 +176,21 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    fn drain_returns_counts_and_resets() {
+    #[tokio::test]
+    async fn drain_returns_counts_and_resets() {
         let counters = UsageCounters::default();
-        counters.count_write("bucket-1", "entry-1", 10);
-        counters.count_write("bucket-1", "entry-1", 5);
-        counters.count_read("bucket-1", "entry-1", 7);
+        counters
+            .count_write("bucket-1", "entry-1", 10)
+            .await
+            .unwrap();
+        counters
+            .count_write("bucket-1", "entry-1", 5)
+            .await
+            .unwrap();
+        counters.count_read("bucket-1", "entry-1", 7).await.unwrap();
 
         assert_eq!(
-            counters.drain().total,
+            counters.drain().await.unwrap().total,
             DrainedUsageCounters {
                 write_bytes: 15,
                 read_bytes: 7,
@@ -170,21 +201,28 @@ mod tests {
             }
         );
         assert_eq!(
-            counters.drain().total,
+            counters.drain().await.unwrap().total,
             DrainedUsageCounters::default(),
             "drain must reset the counters"
         );
     }
 
     #[rstest]
-    fn counts_after_drain_land_in_next_interval() {
+    #[tokio::test]
+    async fn counts_after_drain_land_in_next_interval() {
         let counters = UsageCounters::default();
-        counters.count_write("bucket-1", "entry-1", 10);
-        counters.drain();
+        counters
+            .count_write("bucket-1", "entry-1", 10)
+            .await
+            .unwrap();
+        counters.drain().await.unwrap();
 
-        counters.count_write("bucket-1", "entry-1", 3);
-        counters.count_read("bucket-1", "entry-1", 4);
-        let drained = counters.drain().total;
+        counters
+            .count_write("bucket-1", "entry-1", 3)
+            .await
+            .unwrap();
+        counters.count_read("bucket-1", "entry-1", 4).await.unwrap();
+        let drained = counters.drain().await.unwrap().total;
         assert_eq!(drained.write_bytes, 3);
         assert_eq!(drained.records_written, 1);
         assert_eq!(drained.read_bytes, 4);
@@ -192,13 +230,20 @@ mod tests {
     }
 
     #[rstest]
-    fn per_bucket_counts_isolate_by_bucket() {
+    #[tokio::test]
+    async fn per_bucket_counts_isolate_by_bucket() {
         let counters = UsageCounters::default();
-        counters.count_write("bucket-1", "entry-1", 10);
-        counters.count_write("bucket-2", "entry-1", 25);
-        counters.count_read("bucket-2", "entry-2", 7);
+        counters
+            .count_write("bucket-1", "entry-1", 10)
+            .await
+            .unwrap();
+        counters
+            .count_write("bucket-2", "entry-1", 25)
+            .await
+            .unwrap();
+        counters.count_read("bucket-2", "entry-2", 7).await.unwrap();
 
-        let drained = counters.drain();
+        let drained = counters.drain().await.unwrap();
         assert_eq!(drained.total.write_bytes, 35);
 
         let b1 = drained.buckets.get("bucket-1").unwrap();
@@ -213,15 +258,19 @@ mod tests {
     }
 
     #[rstest]
-    fn drained_buckets_are_removed_from_the_map() {
+    #[tokio::test]
+    async fn drained_buckets_are_removed_from_the_map() {
         let counters = UsageCounters::default();
-        counters.count_write("bucket-1", "entry-1", 10);
+        counters
+            .count_write("bucket-1", "entry-1", 10)
+            .await
+            .unwrap();
 
-        let drained = counters.drain();
+        let drained = counters.drain().await.unwrap();
         assert!(drained.buckets.contains_key("bucket-1"));
 
         // Nothing was written in this interval, so the bucket must be gone.
-        let drained = counters.drain();
+        let drained = counters.drain().await.unwrap();
         assert!(
             drained.buckets.is_empty(),
             "a bucket that drains to zero must be removed from the map"
@@ -229,17 +278,21 @@ mod tests {
     }
 
     #[rstest]
-    fn distinct_entries_count_unique_names_not_operations() {
+    #[tokio::test]
+    async fn distinct_entries_count_unique_names_not_operations() {
         let counters = UsageCounters::default();
         // Same entry written five times in one interval.
         for _ in 0..5 {
-            counters.count_write("bucket-1", "entry-1", 10);
+            counters
+                .count_write("bucket-1", "entry-1", 10)
+                .await
+                .unwrap();
         }
         // Two distinct entries read.
-        counters.count_read("bucket-1", "entry-1", 4);
-        counters.count_read("bucket-1", "entry-2", 4);
+        counters.count_read("bucket-1", "entry-1", 4).await.unwrap();
+        counters.count_read("bucket-1", "entry-2", 4).await.unwrap();
 
-        let drained = counters.drain();
+        let drained = counters.drain().await.unwrap();
         assert_eq!(drained.total.records_written, 5);
         assert_eq!(
             drained.total.written_entries, 1,
@@ -254,26 +307,46 @@ mod tests {
     }
 
     #[rstest]
-    fn distinct_written_entries_count_two_different_entries() {
+    #[tokio::test]
+    async fn distinct_written_entries_count_two_different_entries() {
         let counters = UsageCounters::default();
-        counters.count_write("bucket-1", "entry-1", 10);
-        counters.count_write("bucket-1", "entry-2", 10);
+        counters
+            .count_write("bucket-1", "entry-1", 10)
+            .await
+            .unwrap();
+        counters
+            .count_write("bucket-1", "entry-2", 10)
+            .await
+            .unwrap();
 
-        let drained = counters.drain();
+        let drained = counters.drain().await.unwrap();
         assert_eq!(drained.total.written_entries, 2);
         assert_eq!(drained.total.records_written, 2);
     }
 
     #[rstest]
-    fn distinct_entries_are_keyed_by_bucket_and_name() {
+    #[tokio::test]
+    async fn distinct_entries_are_keyed_by_bucket_and_name() {
         let counters = UsageCounters::default();
         // The same entry name in two different buckets in one interval.
-        counters.count_write("bucket-a", "sensor-1", 10);
-        counters.count_write("bucket-b", "sensor-1", 10);
-        counters.count_read("bucket-a", "sensor-1", 10);
-        counters.count_read("bucket-b", "sensor-1", 10);
+        counters
+            .count_write("bucket-a", "sensor-1", 10)
+            .await
+            .unwrap();
+        counters
+            .count_write("bucket-b", "sensor-1", 10)
+            .await
+            .unwrap();
+        counters
+            .count_read("bucket-a", "sensor-1", 10)
+            .await
+            .unwrap();
+        counters
+            .count_read("bucket-b", "sensor-1", 10)
+            .await
+            .unwrap();
 
-        let drained = counters.drain();
+        let drained = counters.drain().await.unwrap();
         assert_eq!(drained.buckets.get("bucket-a").unwrap().written_entries, 1);
         assert_eq!(drained.buckets.get("bucket-b").unwrap().written_entries, 1);
         assert_eq!(drained.buckets.get("bucket-a").unwrap().read_entries, 1);

--- a/reductstore/src/storage/usage/usage_aggregator.rs
+++ b/reductstore/src/storage/usage/usage_aggregator.rs
@@ -6,9 +6,10 @@
 use crate::lifecycle::SystemEventSink;
 use crate::storage::engine::StorageEngine;
 use crate::storage::usage::usage_event_payload::UsageSystemEventPayload;
-use crate::storage::usage::{DrainedUsageCounters, UsageCounters, UsageSnapshot};
+use crate::storage::usage::UsageCounters;
 use crate::syslog::SystemEvent;
 use log::error;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
@@ -29,25 +30,7 @@ fn now_micros() -> u64 {
         .as_micros() as u64
 }
 
-fn make_event(
-    instance: &str,
-    entry_name: &str,
-    duration: f64,
-    counters: DrainedUsageCounters,
-    snapshot: UsageSnapshot,
-) -> SystemEvent {
-    let payload = UsageSystemEventPayload {
-        duration,
-        write_bytes: counters.write_bytes,
-        read_bytes: counters.read_bytes,
-        records_written: counters.records_written,
-        records_read: counters.records_read,
-        storage_bytes: snapshot.storage_bytes,
-        bucket_count: snapshot.bucket_count,
-        entry_count: snapshot.entry_count,
-        block_count: snapshot.block_count,
-    };
-
+fn make_event(instance: &str, entry_name: &str, payload: UsageSystemEventPayload) -> SystemEvent {
     SystemEvent {
         event_type: USAGE_EVENT_TYPE.to_string(),
         timestamp: now_micros(),
@@ -136,28 +119,88 @@ impl UsageEventAggregator {
         *last_flush = Instant::now();
         let drained = counters.drain();
 
-        let snapshot = match storage.usage_snapshot().await {
-            Ok(snapshot) => snapshot,
+        let (snapshot, bucket_snapshots) = match storage.usage_snapshot().await {
+            Ok(snapshots) => snapshots,
             Err(err) => {
                 error!("Failed to collect usage snapshot: {}", err);
                 return;
             }
         };
 
-        let event = make_event(
-            &sink.instance_name,
-            USAGE_TOTAL_ENTRY_NAME,
+        let total_payload = UsageSystemEventPayload {
             duration,
-            drained,
-            snapshot,
-        );
-        match sink.system_logger.write().await {
-            Ok(mut logger) => {
-                if let Err(err) = logger.log_event(event).await {
-                    error!("Failed to persist usage statistics: {}", err);
-                }
+            write_bytes: drained.total.write_bytes,
+            read_bytes: drained.total.read_bytes,
+            records_written: drained.total.records_written,
+            records_read: drained.total.records_read,
+            written_entries: drained.total.written_entries,
+            read_entries: drained.total.read_entries,
+            storage_bytes: snapshot.storage_bytes,
+            bucket_count: snapshot.bucket_count,
+            entry_count: snapshot.entry_count,
+            block_count: snapshot.block_count,
+            record_count: snapshot.record_count,
+        };
+
+        // Hold the logger lock once for the whole interval. Per-event errors are
+        // logged but never abort the loop, so telemetry can't break the server.
+        let mut logger = match sink.system_logger.write().await {
+            Ok(logger) => logger,
+            Err(err) => {
+                error!("Failed to lock system logger for usage statistics: {}", err);
+                return;
             }
-            Err(err) => error!("Failed to lock system logger for usage statistics: {}", err),
+        };
+
+        // Emit the instance total exactly as before.
+        let total_event = make_event(&sink.instance_name, USAGE_TOTAL_ENTRY_NAME, total_payload);
+        if let Err(err) = logger.log_event(total_event).await {
+            error!("Failed to persist usage statistics: {}", err);
+        }
+
+        // Then one event per bucket with traffic or storage this interval,
+        // excluding the `$`-prefixed system buckets (their names are not valid
+        // entry-path segments and we do not report telemetry on telemetry).
+        let mut bucket_names: BTreeSet<&str> = BTreeSet::new();
+        bucket_names.extend(drained.buckets.keys().map(String::as_str));
+        bucket_names.extend(bucket_snapshots.keys().map(String::as_str));
+
+        for bucket_name in bucket_names {
+            if bucket_name.starts_with('$') {
+                continue;
+            }
+
+            let traffic = drained
+                .buckets
+                .get(bucket_name)
+                .copied()
+                .unwrap_or_default();
+            let bucket_snapshot = bucket_snapshots
+                .get(bucket_name)
+                .copied()
+                .unwrap_or_default();
+            let payload = UsageSystemEventPayload {
+                duration,
+                write_bytes: traffic.write_bytes,
+                read_bytes: traffic.read_bytes,
+                records_written: traffic.records_written,
+                records_read: traffic.records_read,
+                written_entries: traffic.written_entries,
+                read_entries: traffic.read_entries,
+                storage_bytes: bucket_snapshot.storage_bytes,
+                bucket_count: 1,
+                entry_count: bucket_snapshot.entry_count,
+                block_count: bucket_snapshot.block_count,
+                record_count: bucket_snapshot.record_count,
+            };
+
+            let event = make_event(&sink.instance_name, bucket_name, payload);
+            if let Err(err) = logger.log_event(event).await {
+                error!(
+                    "Failed to persist usage statistics for bucket {}: {}",
+                    bucket_name, err
+                );
+            }
         }
     }
 }
@@ -259,7 +302,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn flush_emits_event_with_all_nine_payload_fields(
+    async fn flush_emits_total_and_per_bucket_events(
         events: Arc<Mutex<Vec<SystemEvent>>>,
         #[future] storage: Arc<StorageEngine>,
     ) {
@@ -272,15 +315,24 @@ mod tests {
         UsageEventAggregator::flush(&sink, &storage, &counters, &mut last_flush).await;
 
         let captured = events.lock().unwrap();
-        assert_eq!(captured.len(), 1);
-        let event = &captured[0];
-        assert_eq!(event.event_type, "usage_stats");
-        assert_eq!(event.instance, "instance-1");
-        assert_eq!(event.entry_name, "total");
-        assert_eq!(event.status, 200);
+        // One instance total plus one event for the single bucket.
+        assert_eq!(captured.len(), 2);
 
-        let payload = event.payload.as_object().unwrap();
-        let mut keys = payload.keys().cloned().collect::<Vec<_>>();
+        let total = captured
+            .iter()
+            .find(|event| event.entry_name == "total")
+            .expect("total event must be emitted");
+        assert_eq!(total.event_type, "usage_stats");
+        assert_eq!(total.instance, "instance-1");
+        assert_eq!(total.status, 200);
+
+        let mut keys = total
+            .payload
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
         keys.sort();
         assert_eq!(
             keys,
@@ -290,21 +342,92 @@ mod tests {
                 "duration",
                 "entry_count",
                 "read_bytes",
+                "read_entries",
+                "record_count",
                 "records_read",
                 "records_written",
                 "storage_bytes",
                 "write_bytes",
+                "written_entries",
             ]
         );
-        assert!(event.payload["duration"].as_f64().unwrap() >= 0.0);
-        assert_eq!(event.payload["write_bytes"], 20);
-        assert_eq!(event.payload["read_bytes"], 10);
-        assert_eq!(event.payload["records_written"], 2);
-        assert_eq!(event.payload["records_read"], 1);
-        assert!(event.payload["storage_bytes"].as_u64().unwrap() > 0);
-        assert_eq!(event.payload["bucket_count"], 1);
-        assert_eq!(event.payload["entry_count"], 1);
-        assert_eq!(event.payload["block_count"], 1);
+        assert!(total.payload["duration"].as_f64().unwrap() >= 0.0);
+        assert_eq!(total.payload["write_bytes"], 20);
+        assert_eq!(total.payload["read_bytes"], 10);
+        assert_eq!(total.payload["records_written"], 2);
+        assert_eq!(total.payload["records_read"], 1);
+        assert_eq!(total.payload["written_entries"], 1);
+        assert_eq!(total.payload["read_entries"], 1);
+        assert!(total.payload["storage_bytes"].as_u64().unwrap() > 0);
+        assert_eq!(total.payload["bucket_count"], 1);
+        assert_eq!(total.payload["entry_count"], 1);
+        assert_eq!(total.payload["block_count"], 1);
+        assert_eq!(total.payload["record_count"], 2);
+
+        let bucket = captured
+            .iter()
+            .find(|event| event.entry_name == "bucket-1")
+            .expect("per-bucket event must be emitted");
+        assert_eq!(bucket.payload["write_bytes"], 20);
+        assert_eq!(bucket.payload["read_bytes"], 10);
+        assert_eq!(bucket.payload["records_written"], 2);
+        assert_eq!(bucket.payload["records_read"], 1);
+        assert_eq!(bucket.payload["written_entries"], 1);
+        assert_eq!(bucket.payload["read_entries"], 1);
+        assert_eq!(bucket.payload["bucket_count"], 1);
+        assert_eq!(bucket.payload["entry_count"], 1);
+        assert_eq!(bucket.payload["block_count"], 1);
+        assert_eq!(bucket.payload["record_count"], 2);
+        assert!(bucket.payload["storage_bytes"].as_u64().unwrap() > 0);
+    }
+
+    /// `$`-prefixed system buckets must never get a per-bucket event (their
+    /// names are not valid entry-path segments).
+    #[rstest]
+    #[tokio::test]
+    async fn flush_excludes_system_buckets_from_per_bucket_events(
+        events: Arc<Mutex<Vec<SystemEvent>>>,
+        #[future] storage: Arc<StorageEngine>,
+    ) {
+        let storage = storage.await;
+        generate_traffic(&storage).await;
+
+        // A system bucket with traffic this interval.
+        storage
+            .create_system_bucket("$system", BucketSettings::default())
+            .await
+            .unwrap();
+        let mut writer = storage
+            .begin_write(
+                "$system",
+                "entry-1",
+                1,
+                10,
+                "application/json".to_string(),
+                Labels::new(),
+            )
+            .await
+            .unwrap();
+        writer
+            .send(Ok(Some(Bytes::from("0123456789"))))
+            .await
+            .unwrap();
+        writer.send(Ok(None)).await.unwrap();
+
+        let sink = capturing_sink(Arc::clone(&events), false);
+        let counters = Arc::clone(storage.usage_counters());
+        let mut last_flush = Instant::now();
+        UsageEventAggregator::flush(&sink, &storage, &counters, &mut last_flush).await;
+
+        let captured = events.lock().unwrap();
+        assert!(
+            captured
+                .iter()
+                .all(|event| !event.entry_name.starts_with('$')),
+            "system buckets must be excluded from per-bucket events"
+        );
+        assert!(captured.iter().any(|event| event.entry_name == "total"));
+        assert!(captured.iter().any(|event| event.entry_name == "bucket-1"));
     }
 
     #[rstest]
@@ -323,10 +446,15 @@ mod tests {
         UsageEventAggregator::flush(&sink, &storage, &counters, &mut last_flush).await;
 
         let captured = events.lock().unwrap();
-        assert_eq!(captured.len(), 2);
-        let second = &captured[1];
+        let totals = captured
+            .iter()
+            .filter(|event| event.entry_name == "total")
+            .collect::<Vec<_>>();
+        assert_eq!(totals.len(), 2);
+        let second = totals[1];
         assert_eq!(second.payload["write_bytes"], 0);
         assert_eq!(second.payload["records_written"], 0);
+        assert_eq!(second.payload["written_entries"], 0);
         assert_eq!(
             second.payload["bucket_count"], 1,
             "snapshot fields must still be populated"
@@ -402,14 +530,17 @@ mod tests {
         aggregator.stop().await;
 
         let captured = events.lock().unwrap();
-        assert_eq!(captured.len(), 1);
-        assert_eq!(captured[0].event_type, "usage_stats");
-        assert_eq!(captured[0].payload["write_bytes"], 20);
-        assert_eq!(captured[0].payload["read_bytes"], 10);
+        let total = captured
+            .iter()
+            .find(|event| event.entry_name == "total")
+            .expect("total event must be emitted on shutdown");
+        assert_eq!(total.event_type, "usage_stats");
+        assert_eq!(total.payload["write_bytes"], 20);
+        assert_eq!(total.payload["read_bytes"], 10);
     }
 
-    /// Entry path: events land at `$system/usage/<instance>/total` as flat
-    /// JSON with the 9 payload fields.
+    /// Entry path: the total lands at `$system/usage/<instance>/total` and each
+    /// bucket at `$system/usage/<instance>/<bucket>`, as flat JSON.
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
     async fn writes_event_to_usage_entry_path() {
@@ -471,6 +602,34 @@ mod tests {
         assert_eq!(event["bucket_count"], 1);
         assert_eq!(event["entry_count"], 1);
         assert_eq!(event["block_count"], 1);
+        assert_eq!(event["record_count"], 2);
+        assert_eq!(event["written_entries"], 1);
+        assert_eq!(event["read_entries"], 1);
         assert!(event["duration"].as_f64().unwrap() >= 0.0);
+
+        // The per-bucket event lands at usage/<instance>/<bucket>.
+        let bucket_entry_path = "usage/instance-1/bucket-1";
+        let latest_bucket_record = Arc::clone(&bucket)
+            .info()
+            .await
+            .unwrap()
+            .entries
+            .into_iter()
+            .find(|entry| entry.name == bucket_entry_path)
+            .expect("per-bucket usage entry must exist")
+            .latest_record;
+        let mut bucket_reader = bucket
+            .begin_read(bucket_entry_path, latest_bucket_record)
+            .await
+            .unwrap();
+        let bucket_record = bucket_reader.read_chunk().unwrap().unwrap();
+        let bucket_event: serde_json::Value = serde_json::from_slice(&bucket_record).unwrap();
+        assert_eq!(bucket_event["instance"], "instance-1");
+        assert_eq!(bucket_event["write_bytes"], 20);
+        assert_eq!(bucket_event["read_bytes"], 10);
+        assert_eq!(bucket_event["records_written"], 2);
+        assert_eq!(bucket_event["written_entries"], 1);
+        assert_eq!(bucket_event["record_count"], 2);
+        assert_eq!(bucket_event["bucket_count"], 1);
     }
 }

--- a/reductstore/src/storage/usage/usage_aggregator.rs
+++ b/reductstore/src/storage/usage/usage_aggregator.rs
@@ -117,7 +117,13 @@ impl UsageEventAggregator {
     ) {
         let duration = last_flush.elapsed().as_secs_f64();
         *last_flush = Instant::now();
-        let drained = counters.drain();
+        let drained = match counters.drain().await {
+            Ok(drained) => drained,
+            Err(err) => {
+                error!("Failed to drain usage counters: {}", err);
+                return;
+            }
+        };
 
         let (snapshot, bucket_snapshots) = match storage.usage_snapshot().await {
             Ok(snapshots) => snapshots,
@@ -479,6 +485,27 @@ mod tests {
         let working_sink = capturing_sink(Arc::clone(&events), false);
         UsageEventAggregator::flush(&working_sink, &storage, &counters, &mut last_flush).await;
         assert_eq!(events.lock().unwrap().len(), 1);
+    }
+
+    /// A failing sink with buckets present exercises the per-bucket emission
+    /// path too: each per-bucket failure is swallowed and the flush completes.
+    #[rstest]
+    #[tokio::test]
+    async fn per_bucket_emission_failure_does_not_break_flushing(
+        events: Arc<Mutex<Vec<SystemEvent>>>,
+        #[future] storage: Arc<StorageEngine>,
+    ) {
+        let storage = storage.await;
+        generate_traffic(&storage).await;
+        let counters = Arc::clone(storage.usage_counters());
+        let mut last_flush = Instant::now();
+
+        let failing_sink = capturing_sink(Arc::clone(&events), true);
+        UsageEventAggregator::flush(&failing_sink, &storage, &counters, &mut last_flush).await;
+
+        // Both the total and the bucket-1 emissions failed, but the flush ran to
+        // completion without propagating either error.
+        assert!(events.lock().unwrap().is_empty());
     }
 
     /// Shutdown flush: closing the channel (as dropping the aggregator does)

--- a/reductstore/src/storage/usage/usage_event_payload.rs
+++ b/reductstore/src/storage/usage/usage_event_payload.rs
@@ -6,10 +6,12 @@ use serde_json::{json, Value};
 
 /// Usage statistics carried by a usage system event.
 ///
-/// The first five fields describe the flush interval: `duration` is the
-/// measured elapsed time between flushes in seconds, the counters are the
-/// traffic tallied during that interval. The last four fields are a
-/// point-in-time snapshot of the storage taken at flush time.
+/// The interval fields describe the flush window: `duration` is the measured
+/// elapsed time between flushes in seconds, the traffic counters are tallied
+/// during that interval, and `written_entries`/`read_entries` count the
+/// distinct entries used for writing/reading in it. The remaining fields are a
+/// point-in-time snapshot of the storage taken at flush time. The same schema
+/// is used for the instance `total` event and the per-bucket events.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub(crate) struct UsageSystemEventPayload {
     pub duration: f64,
@@ -17,10 +19,13 @@ pub(crate) struct UsageSystemEventPayload {
     pub read_bytes: u64,
     pub records_written: u64,
     pub records_read: u64,
+    pub written_entries: u64,
+    pub read_entries: u64,
     pub storage_bytes: u64,
     pub bucket_count: u64,
     pub entry_count: u64,
     pub block_count: u64,
+    pub record_count: u64,
 }
 
 impl UsageSystemEventPayload {
@@ -31,10 +36,13 @@ impl UsageSystemEventPayload {
             "read_bytes": self.read_bytes,
             "records_written": self.records_written,
             "records_read": self.records_read,
+            "written_entries": self.written_entries,
+            "read_entries": self.read_entries,
             "storage_bytes": self.storage_bytes,
             "bucket_count": self.bucket_count,
             "entry_count": self.entry_count,
             "block_count": self.block_count,
+            "record_count": self.record_count,
         })
     }
 }


### PR DESCRIPTION
Closes #1468.

## Summary

Extends the usage-stats feature (#1431) with per-bucket granularity and two new metrics. Each user bucket now gets its own event at `$system/usage/{instance}/{bucket}` alongside the existing `total`, using the same flat schema.

## New fields

Added to both the `total` event and each per-bucket event:

| Field | Type | Meaning |
|-------|------|---------|
| `written_entries` | interval | Distinct entries written to during the interval |
| `read_entries` | interval | Distinct entries read from during the interval |
| `record_count` | snapshot | Total record count (and per-bucket record count) |

## Notes

- **Total reporting is unchanged.** Per-bucket counters are additive alongside the existing global atomics, so the `total` event behaves exactly as before.
- **`written_entries` / `read_entries` use composite keying.** An entry is identified by bucket + name, so the same entry name in two different buckets counts as **2** in the instance total (per-bucket counts are always exact). This matches "how many entries are used for writing and reading data." It's a one-line change to name-only keying if you'd prefer that instead.
- **System buckets are excluded** from per-bucket events. `$`-prefixed names (`$system`, `$audit`) are invalid as entry-path segments, and telemetry shouldn't report on itself.

## Tests

| Test | Verifies |
|------|----------|
| `distinct_entries_count_unique_names_not_operations` | 5 writes to one entry → `written_entries=1`, `records_written=5` |
| `distinct_entries_are_keyed_by_bucket_and_name` | Same name in two buckets → total = 2 |
| `per_bucket_counts_isolate_by_bucket` | Counts attributed to the correct bucket |
| `drained_buckets_are_removed_from_the_map` | Deleted buckets don't grow the map unbounded |
| `flush_emits_total_and_per_bucket_events` | One event per bucket plus `total` |
| `flush_excludes_system_buckets_from_per_bucket_events` | `$`-prefixed buckets skipped |

16 usage tests pass; `cargo fmt --all -- --check` clean.