### PR TITLE
throttle lifecycle policy execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Ops assets: `snap/`, `buildx.Dockerfile`, `.github/actions/`; sample certs/data in `misc/`.
 - Key modules: `reductstore/src/{api,asset,auth,backend,cfg,core,ext,proto,replication,storage}`;
   `reduct_base/src/{logging,msg,io,ext}`.
+- Lifecycle design notes: `reductstore/src/lifecycle/README.md`.
 
 ## Build, Test, and Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Throttle lifecycle delete and compression runs using progress persisted in existing lifecycle system event stats, while preserving full-range processing when system events are disabled, [PR-1475](https://github.com/reductstore/reductstore/pull/1475)
+- Throttle lifecycle delete and compression runs using progress persisted in existing lifecycle system event stats [PR-1475](https://github.com/reductstore/reductstore/pull/1475)
 - Report both processed record and block counts for lifecycle compression events, [PR-1470](https://github.com/reductstore/reductstore/pull/1470) by @rohankumardubey
 
 ## 1.20.2 - 2026-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Throttle lifecycle delete and compression runs using progress persisted in existing lifecycle system event stats, while preserving full-range processing when system events are disabled, [PR-1475](https://github.com/reductstore/reductstore/pull/1475)
 - Report both processed record and block counts for lifecycle compression events, [PR-1470](https://github.com/reductstore/reductstore/pull/1470) by @rohankumardubey
 
 ## 1.20.2 - 2026-06-18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2791,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -2828,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3165,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
  "bitflags",
  "once_cell",
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3984,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "js-sys",
@@ -4005,9 +4005,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5641,9 +5641,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/reductstore/src/lifecycle/README.md
+++ b/reductstore/src/lifecycle/README.md
@@ -1,0 +1,189 @@
+# Lifecycle Module
+
+This module implements background lifecycle policies for buckets.
+
+Supported actions:
+- `delete`: remove records older than `older_than`
+- `compress`: recompress eligible blocks older than `older_than`
+
+The module is built around three layers:
+- repository: stores lifecycle definitions, validates settings, and starts/stops workers
+- task: runs one lifecycle policy on a schedule and writes system events
+- action: executes the policy against storage and reports progress/statistics
+
+## Files
+
+- `action.rs`: shared action interface, action context, and action result type
+- `action/delete.rs`: delete lifecycle implementation
+- `action/compress.rs`: compress lifecycle implementation
+- `action/progress.rs`: shared progress-window calculation and progress loading from system events
+- `lifecycle_task.rs`: worker loop for one lifecycle policy
+- `lifecycle_repository.rs`: builder which selects normal or read-only repository
+- `lifecycle_repository/repo.rs`: mutable repository implementation persisted in `.lifecycles`
+- `lifecycle_repository/read_only.rs`: replica-safe no-op repository
+- `system_event_payload.rs`: lifecycle system event payload builder
+
+## Design
+
+The repository owns all configured lifecycle policies.
+
+Each policy becomes a `LifecycleTask` with:
+- immutable policy settings for bucket, entries, interval, and `older_than`
+- a concrete action implementation selected by lifecycle type
+- a shared storage handle
+- optional system-event sink
+
+The task wakes up on its configured interval, executes the action, and emits a lifecycle system event.
+
+For primary nodes, lifecycle definitions are loaded from and saved to `.lifecycles` in the data directory.
+For replica nodes, the builder returns a read-only repository and no workers are started.
+
+## Execution Flow
+
+```text
+                    +------------------------+
+API / provisioning  | LifecycleRepository    |
+------------------->| - validate settings    |
+                    | - persist .lifecycles  |
+                    | - create LifecycleTask |
+                    +-----------+------------+
+                                |
+                                v
+                    +------------------------+
+                    | LifecycleTask          |
+                    | - sleeps interval      |
+                    | - runs action          |
+                    | - logs system event    |
+                    +-----------+------------+
+                                |
+                    +-----------+-----------+
+                    |                       |
+                    v                       v
+          +------------------+    +------------------+
+          | DeleteAction     |    | CompressAction   |
+          | query/remove     |    | estimate/compress|
+          +---------+--------+    +---------+--------+
+                    |                       |
+                    +-----------+-----------+
+                                |
+                                v
+                    +------------------------+
+                    | progress::processing_  |
+                    | window()               |
+                    | - oldest matching ts   |
+                    | - latest matching ts   |
+                    | - saved last progress  |
+                    +-----------+------------+
+                                |
+                                v
+                    +------------------------+
+                    | StorageEngine / Bucket |
+                    | / Entry operations     |
+                    +------------------------+
+```
+
+## Progress Model
+
+When system events are disabled, actions process the full eligible data range:
+- `start = oldest matching record`
+- `stop = min(latest matching record + 1, now - older_than + 1)`
+
+When system events are enabled, lifecycle uses persisted progress from the latest lifecycle stats event:
+- progress source: `$system/lifecycle/<instance>/<policy>`
+- stored field: `last_processed_ts`
+
+The shared window calculation works like this:
+1. Find the oldest matching record across selected entries.
+2. Find the latest matching record across selected entries.
+3. Compute `effective_cutoff_stop = min(latest_matching_record + 1, now - older_than + 1)`.
+4. Load `last_processed_ts`; if absent, start from the oldest matching record.
+5. Advance by a bounded data window: `24 * interval`.
+
+Effective range for one run:
+- `start = oldest matching record`, clamped so `start <= stop`
+- `stop = min(last_processed_ts + 24 * interval, effective_cutoff_stop)`
+
+Important behavior:
+- tasks always scan from the oldest matching record
+- tasks do not short-circuit just because historical progress reached the current stop
+- this allows old data to be re-processed if later mutations make it eligible again
+  for example: label updates after delete rules, or decompressed blocks after compress rules
+- `caught_up` means the current run reached the effective stop for the currently visible data
+
+## Why Tasks Always Start From The Oldest Record
+
+Delete and compress are not purely append-only operations.
+
+Previously processed historical data can become eligible again later:
+- a compressed block can be decompressed by a later write or label update path
+- an old record can become removable after label changes affecting a `when` condition
+
+Because of that, the lifecycle worker must always query from the oldest matching record instead of
+from the last processed timestamp. The progress marker only limits how far forward the task needs
+to advance in the current run.
+
+## Task Loop Semantics
+
+`LifecycleTask` runs an inner loop with one special case:
+- if a run returns `affected_records == 0` and `caught_up == false`, the worker retries after 100 ms
+- this lets the task continue advancing through empty windows until it reaches the current cutoff
+- once `caught_up == true` or some records were affected, the worker returns to the normal interval
+
+This behavior is important for sparse data where many windows may contain no eligible records.
+
+## System Events
+
+Each run produces a `lifecycle_run` system event when a sink is configured.
+
+Success payload fields:
+- `policy_name`
+- `action_type`
+- `bucket`
+- `duration`
+- `processed_records`
+- `processed_blocks`
+- `caught_up`
+- `last_processed_ts` when available
+
+Error payload fields:
+- the same identity fields
+- `processed_records = 0`
+- `processed_blocks = 0`
+- `caught_up = false`
+- `error_code`
+- `error_message`
+
+The same event stream is also used as the source of persisted lifecycle progress.
+
+## Repository Responsibilities
+
+The repository is responsible for:
+- validating lifecycle settings
+- enforcing minimum `older_than` and interval limits
+- persisting lifecycle definitions in `.lifecycles`
+- starting and stopping tasks
+- switching task mode at runtime
+- exposing lifecycle info and settings to the API layer
+
+## Action Responsibilities
+
+Delete action:
+- builds a query with `QueryType::Remove` or `QueryType::Query` for dry run
+- returns affected record and block counts
+
+Compress action:
+- estimates or compresses eligible blocks in the computed time range
+- returns affected block and record counts
+
+Both actions:
+- share the same progress-window logic
+- operate only on the configured bucket and matching entries
+- report `caught_up` when the run reaches the effective current stop
+
+## Operational Summary
+
+In short, the lifecycle module is a persistent scheduler around storage actions:
+- repository decides what should run
+- task decides when it should run
+- action decides what data range should be processed now
+- system events record what happened and also feed the next progress calculation

--- a/reductstore/src/lifecycle/action.rs
+++ b/reductstore/src/lifecycle/action.rs
@@ -39,6 +39,7 @@ pub(super) struct LifecycleRunResult {
     pub(super) affected_records: u64,
     pub(super) affected_blocks: Option<u64>,
     pub(super) last_processed_ts: Option<u64>,
+    pub(super) caught_up: bool,
 }
 
 #[async_trait]

--- a/reductstore/src/lifecycle/action.rs
+++ b/reductstore/src/lifecycle/action.rs
@@ -7,6 +7,7 @@ use reduct_base::msg::lifecycle_api::{LifecycleSettings, LifecycleType};
 use std::sync::Arc;
 mod compress;
 mod delete;
+mod progress;
 use compress::CompressLifecycleAction;
 use delete::DeleteLifecycleAction;
 
@@ -15,11 +16,21 @@ use crate::storage::engine::StorageEngine;
 #[derive(Clone)]
 pub(super) struct LifecycleContext {
     pub(super) storage: Arc<StorageEngine>,
+    pub(super) system_events_enabled: bool,
+    pub(super) system_event_instance: String,
 }
 
 impl LifecycleContext {
-    pub(super) fn new(storage: Arc<StorageEngine>) -> Self {
-        Self { storage }
+    pub(super) fn new(
+        storage: Arc<StorageEngine>,
+        system_events_enabled: bool,
+        system_event_instance: String,
+    ) -> Self {
+        Self {
+            storage,
+            system_events_enabled,
+            system_event_instance,
+        }
     }
 }
 
@@ -27,6 +38,7 @@ impl LifecycleContext {
 pub(super) struct LifecycleRunResult {
     pub(super) affected_records: u64,
     pub(super) affected_blocks: Option<u64>,
+    pub(super) last_processed_ts: Option<u64>,
 }
 
 #[async_trait]

--- a/reductstore/src/lifecycle/action/compress.rs
+++ b/reductstore/src/lifecycle/action/compress.rs
@@ -346,15 +346,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 2);
-        assert_eq!(result.affected_blocks, Some(2));
+        assert_eq!(result.affected_records, 3);
+        assert_eq!(result.affected_blocks, Some(3));
         assert_eq!(
             test_bucket
                 .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
                 .await
                 .unwrap()
                 .records,
-            1
+            0
         );
     }
 

--- a/reductstore/src/lifecycle/action/compress.rs
+++ b/reductstore/src/lifecycle/action/compress.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 use crate::core::duration::parse_duration_to_micros;
+use crate::lifecycle::action::progress;
 use crate::lifecycle::action::{LifecycleAction, LifecycleContext, LifecycleRunResult};
 use async_trait::async_trait;
 use reduct_base::error::ReductError;
@@ -18,7 +19,7 @@ impl LifecycleAction for CompressLifecycleAction {
 
     async fn run(
         &self,
-        _name: &str,
+        name: &str,
         settings: &LifecycleSettings,
         context: LifecycleContext,
     ) -> Result<LifecycleRunResult, ReductError> {
@@ -29,8 +30,15 @@ impl LifecycleAction for CompressLifecycleAction {
             .as_micros() as u64;
 
         let cutoff = now_us.saturating_sub(older_than_us.max(0) as u64);
-        let start = Some(0u64);
-        let stop = Some(cutoff.saturating_add(1));
+        let cutoff_stop = cutoff.saturating_add(1);
+        let window = progress::processing_window(settings, &context, name, cutoff_stop).await?;
+        if window.caught_up {
+            return Ok(LifecycleRunResult {
+                affected_records: 0,
+                affected_blocks: Some(0),
+                last_processed_ts: window.last_processed_ts,
+            });
+        }
         let entries = if settings.entries.is_empty() {
             None
         } else {
@@ -45,15 +53,18 @@ impl LifecycleAction for CompressLifecycleAction {
 
         let stats = if settings.mode == LifecycleMode::DryRun {
             bucket
-                .estimate_compressible_data(entries, start, stop)
+                .estimate_compressible_data(entries, window.start, window.stop)
                 .await?
         } else {
-            bucket.compress_blocks(entries, start, stop).await?
+            bucket
+                .compress_blocks(entries, window.start, window.stop)
+                .await?
         };
 
         Ok(LifecycleRunResult {
             affected_records: stats.records,
             affected_blocks: Some(stats.blocks),
+            last_processed_ts: window.last_processed_ts,
         })
     }
 }
@@ -62,10 +73,12 @@ impl LifecycleAction for CompressLifecycleAction {
 mod tests {
     use super::*;
     use crate::cfg::Cfg;
-    use crate::lifecycle::lifecycle_task::tests::{settings, storage};
+    use crate::lifecycle::action::progress;
+    use crate::lifecycle::lifecycle_task::tests::{settings, settings_fixture, storage};
     use crate::storage::bucket::tests::{write, write_meta};
     use crate::storage::bucket::Bucket;
     use crate::storage::engine::StorageEngine;
+    use reduct_base::msg::bucket_api::BucketSettings;
     use rstest::{fixture, rstest};
     use serial_test::serial;
     use std::sync::Arc;
@@ -78,6 +91,24 @@ mod tests {
             .await
             .unwrap()
             .upgrade()
+            .unwrap();
+        (storage, bucket)
+    }
+
+    async fn test_context_with_one_record_blocks() -> (Arc<StorageEngine>, Arc<Bucket>) {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        bucket
+            .set_settings(BucketSettings {
+                max_block_records: Some(1),
+                ..BucketSettings::default()
+            })
+            .await
             .unwrap();
         (storage, bucket)
     }
@@ -125,7 +156,11 @@ mod tests {
         settings.older_than = "0s".to_string();
 
         let result = action
-            .run("test", &settings, LifecycleContext::new(test_storage))
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
             .await
             .unwrap();
 
@@ -159,7 +194,11 @@ mod tests {
         settings.older_than = "0s".to_string();
 
         let result = action
-            .run("test", &settings, LifecycleContext::new(test_storage))
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
             .await
             .unwrap();
 
@@ -194,7 +233,7 @@ mod tests {
         settings.lifecycle_type = LifecycleType::Compress;
         settings.older_than = "0s".to_string();
 
-        let context = LifecycleContext::new(test_storage);
+        let context = LifecycleContext::new(test_storage, false, "unknown".to_string());
         assert_eq!(
             action
                 .run("test", &settings, context.clone())
@@ -231,7 +270,11 @@ mod tests {
         settings.entries = vec![];
 
         let result = action
-            .run("test", &settings, LifecycleContext::new(test_storage))
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
             .await
             .unwrap();
 
@@ -263,12 +306,171 @@ mod tests {
         settings.entries = vec!["entry-1/$meta".to_string()];
 
         let result = action
-            .run("test", &settings, LifecycleContext::new(test_storage))
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
             .await
             .unwrap();
 
         assert_eq!(result.affected_records, 0);
         assert_eq!(result.affected_blocks, Some(0));
         assert!(test_bucket.begin_read("entry-1/$meta", 1).await.is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn compress_processes_windowed_data_when_system_events_enabled() {
+        let (test_storage, test_bucket) = test_context_with_one_record_blocks().await;
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        write(&test_bucket, "entry-1", 23_999_999, b"r2")
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 24_000_000, b"r3")
+            .await
+            .unwrap();
+        test_bucket.sync_fs().await.unwrap();
+        let (test_storage, test_bucket) = restore_storage(&test_storage).await;
+        let mut settings = settings_fixture();
+        settings.lifecycle_type = LifecycleType::Compress;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = CompressLifecycleAction
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_blocks, Some(2));
+        assert_eq!(
+            test_bucket
+                .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
+                .await
+                .unwrap()
+                .records,
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn compress_resumes_from_last_progress() {
+        let (test_storage, test_bucket) = test_context_with_one_record_blocks().await;
+        progress::tests::write_lifecycle_stats(&test_storage, "instance-1", "test", 24_000_000)
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 23_999_999, b"r1")
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 24_000_000, b"r2")
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 48_000_000, b"r3")
+            .await
+            .unwrap();
+        test_bucket.sync_fs().await.unwrap();
+        let (test_storage, test_bucket) = restore_storage(&test_storage).await;
+        let mut settings = settings_fixture();
+        settings.lifecycle_type = LifecycleType::Compress;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = CompressLifecycleAction
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_blocks, Some(1));
+        assert_eq!(
+            test_bucket
+                .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
+                .await
+                .unwrap()
+                .records,
+            2
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn compress_returns_zero_when_caught_up() {
+        let (test_storage, test_bucket) = test_context_with_one_record_blocks().await;
+        progress::tests::write_lifecycle_stats(&test_storage, "instance-1", "test", u64::MAX)
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        test_bucket.sync_fs().await.unwrap();
+        let (test_storage, test_bucket) = restore_storage(&test_storage).await;
+        let mut settings = settings_fixture();
+        settings.lifecycle_type = LifecycleType::Compress;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = CompressLifecycleAction
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 0);
+        assert_eq!(result.affected_blocks, Some(0));
+        assert_eq!(
+            test_bucket
+                .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
+                .await
+                .unwrap()
+                .records,
+            1
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn compress_processes_all_data_when_system_events_disabled() {
+        let (test_storage, test_bucket) = test_context_with_one_record_blocks().await;
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        write(&test_bucket, "entry-1", 48_000_000, b"r2")
+            .await
+            .unwrap();
+        test_bucket.sync_fs().await.unwrap();
+        let (test_storage, test_bucket) = restore_storage(&test_storage).await;
+        let mut settings = settings_fixture();
+        settings.lifecycle_type = LifecycleType::Compress;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = CompressLifecycleAction
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_blocks, Some(2));
+        assert_eq!(
+            test_bucket
+                .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
+                .await
+                .unwrap()
+                .records,
+            0
+        );
     }
 }

--- a/reductstore/src/lifecycle/action/compress.rs
+++ b/reductstore/src/lifecycle/action/compress.rs
@@ -390,15 +390,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 1);
-        assert_eq!(result.affected_blocks, Some(1));
+        assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_blocks, Some(2));
         assert_eq!(
             test_bucket
                 .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
                 .await
                 .unwrap()
                 .records,
-            2
+            1
         );
     }
 

--- a/reductstore/src/lifecycle/action/compress.rs
+++ b/reductstore/src/lifecycle/action/compress.rs
@@ -32,14 +32,6 @@ impl LifecycleAction for CompressLifecycleAction {
         let cutoff = now_us.saturating_sub(older_than_us.max(0) as u64);
         let cutoff_stop = cutoff.saturating_add(1);
         let window = progress::processing_window(settings, &context, name, cutoff_stop).await?;
-        if window.caught_up {
-            return Ok(LifecycleRunResult {
-                affected_records: 0,
-                affected_blocks: Some(0),
-                last_processed_ts: window.last_processed_ts,
-                caught_up: true,
-            });
-        }
         let entries = if settings.entries.is_empty() {
             None
         } else {
@@ -406,7 +398,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn compress_returns_zero_when_caught_up() {
+    async fn compress_still_processes_oldest_blocks_when_caught_up() {
         let (test_storage, test_bucket) = test_context_with_one_record_blocks().await;
         progress::tests::write_lifecycle_stats(&test_storage, "instance-1", "test", u64::MAX)
             .await
@@ -428,8 +420,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 0);
-        assert_eq!(result.affected_blocks, Some(0));
+        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_blocks, Some(1));
         assert!(result.caught_up);
         assert_eq!(
             test_bucket
@@ -437,7 +429,7 @@ mod tests {
                 .await
                 .unwrap()
                 .records,
-            1
+            0
         );
     }
 
@@ -469,8 +461,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 0);
-        assert_eq!(result.affected_blocks, Some(0));
+        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_blocks, Some(1));
         assert!(result.caught_up);
     }
 

--- a/reductstore/src/lifecycle/action/compress.rs
+++ b/reductstore/src/lifecycle/action/compress.rs
@@ -37,6 +37,7 @@ impl LifecycleAction for CompressLifecycleAction {
                 affected_records: 0,
                 affected_blocks: Some(0),
                 last_processed_ts: window.last_processed_ts,
+                caught_up: true,
             });
         }
         let entries = if settings.entries.is_empty() {
@@ -65,6 +66,7 @@ impl LifecycleAction for CompressLifecycleAction {
             affected_records: stats.records,
             affected_blocks: Some(stats.blocks),
             last_processed_ts: window.last_processed_ts,
+            caught_up: window.reaches_cutoff,
         })
     }
 }
@@ -428,6 +430,7 @@ mod tests {
 
         assert_eq!(result.affected_records, 0);
         assert_eq!(result.affected_blocks, Some(0));
+        assert!(result.caught_up);
         assert_eq!(
             test_bucket
                 .estimate_compressible_data(Some(vec!["entry-1".into()]), None, None)
@@ -436,6 +439,39 @@ mod tests {
                 .records,
             1
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn compress_marks_result_caught_up_when_progress_is_past_latest_data() {
+        let (test_storage, test_bucket) = test_context_with_one_record_blocks().await;
+        let now_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        progress::tests::write_lifecycle_stats(&test_storage, "instance-1", "test", now_us)
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        test_bucket.sync_fs().await.unwrap();
+        let (test_storage, _test_bucket) = restore_storage(&test_storage).await;
+        let mut settings = settings_fixture();
+        settings.lifecycle_type = LifecycleType::Compress;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = CompressLifecycleAction
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 0);
+        assert_eq!(result.affected_blocks, Some(0));
+        assert!(result.caught_up);
     }
 
     #[tokio::test]

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -59,8 +59,8 @@ impl LifecycleAction for DeleteLifecycleAction {
                 QueryType::Remove
             },
             entries,
-            // Use absolute range start to avoid invalid (start > stop) when
-            // an entry contains only fresh records newer than `cutoff`.
+            // Use the oldest matching record, clamped to stop, to keep the
+            // range valid even when an entry only contains fresher data.
             start: window.start,
             stop: window.stop,
             when: settings.when.clone(),
@@ -269,8 +269,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 1);
-        assert!(test_bucket.begin_read("entry-1", 23_999_999).await.is_ok());
+        assert_eq!(result.affected_records, 2);
+        assert!(test_bucket.begin_read("entry-1", 23_999_999).await.is_err());
         assert!(test_bucket.begin_read("entry-1", 24_000_000).await.is_err());
         assert!(test_bucket.begin_read("entry-1", 48_000_000).await.is_ok());
     }

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -33,14 +33,6 @@ impl LifecycleAction for DeleteLifecycleAction {
         let cutoff = now_us.saturating_sub(older_than_us.max(0) as u64);
         let cutoff_stop = cutoff.saturating_add(1);
         let window = progress::processing_window(settings, &context, name, cutoff_stop).await?;
-        if window.caught_up {
-            return Ok(LifecycleRunResult {
-                affected_records: 0,
-                affected_blocks: Some(0),
-                last_processed_ts: window.last_processed_ts,
-                caught_up: true,
-            });
-        }
 
         let entries = if settings.entries.is_empty() {
             None
@@ -279,7 +271,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[rstest]
-    async fn delete_returns_zero_when_caught_up(
+    async fn delete_still_processes_oldest_records_when_caught_up(
         #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
         action: DeleteLifecycleAction,
         mut settings: LifecycleSettings,
@@ -302,10 +294,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 0);
-        assert_eq!(result.affected_blocks, Some(0));
+        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_blocks, Some(1));
         assert!(result.caught_up);
-        assert!(test_bucket.begin_read("entry-1", 1).await.is_ok());
+        assert!(test_bucket.begin_read("entry-1", 1).await.is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -337,8 +329,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 0);
-        assert_eq!(result.affected_blocks, Some(0));
+        assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_blocks, Some(1));
         assert!(result.caught_up);
     }
 

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -230,10 +230,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_records, 3);
         assert!(test_bucket.begin_read("entry-1", 1).await.is_err());
         assert!(test_bucket.begin_read("entry-1", 23_999_999).await.is_err());
-        assert!(test_bucket.begin_read("entry-1", 24_000_000).await.is_ok());
+        assert!(test_bucket.begin_read("entry-1", 24_000_000).await.is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -58,15 +58,15 @@ impl LifecycleAction for DeleteLifecycleAction {
             ..Default::default()
         };
 
-        let affected_records = if settings.mode == LifecycleMode::DryRun {
-            bucket.query_count_records(query_entry).await?
+        let stats = if settings.mode == LifecycleMode::DryRun {
+            bucket.query_count_records_with_stats(query_entry).await?
         } else {
-            bucket.query_remove_records(query_entry).await?
+            bucket.query_remove_records_with_stats(query_entry).await?
         };
 
         Ok(LifecycleRunResult {
-            affected_records,
-            ..Default::default()
+            affected_records: stats.records,
+            affected_blocks: Some(stats.blocks),
         })
     }
 }
@@ -117,6 +117,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.affected_records, 2);
+        assert_eq!(result.affected_blocks, Some(1));
         assert!(test_bucket.begin_read("entry-1", 1).await.is_ok());
         assert!(test_bucket.begin_read("entry-1", 2).await.is_ok());
     }
@@ -145,6 +146,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.affected_records, 0);
+        assert_eq!(result.affected_blocks, Some(0));
         assert!(test_bucket.begin_read("entry-1", now_us).await.is_ok());
     }
 
@@ -172,6 +174,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.affected_records, 1);
+        assert_eq!(result.affected_blocks, Some(1));
         assert!(test_bucket.begin_read("entry-1", 1).await.is_err());
         assert!(test_bucket.begin_read("entry-1/$meta", 1).await.is_ok());
     }

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 use crate::core::duration::parse_duration_to_micros;
+use crate::lifecycle::action::progress;
 use crate::lifecycle::action::{LifecycleAction, LifecycleContext, LifecycleRunResult};
 use async_trait::async_trait;
 use reduct_base::error::ReductError;
@@ -19,7 +20,7 @@ impl LifecycleAction for DeleteLifecycleAction {
 
     async fn run(
         &self,
-        _name: &str,
+        name: &str,
         settings: &LifecycleSettings,
         context: LifecycleContext,
     ) -> Result<LifecycleRunResult, ReductError> {
@@ -30,7 +31,15 @@ impl LifecycleAction for DeleteLifecycleAction {
             .as_micros() as u64;
 
         let cutoff = now_us.saturating_sub(older_than_us.max(0) as u64);
-        let stop = Some(cutoff.saturating_add(1));
+        let cutoff_stop = cutoff.saturating_add(1);
+        let window = progress::processing_window(settings, &context, name, cutoff_stop).await?;
+        if window.caught_up {
+            return Ok(LifecycleRunResult {
+                affected_records: 0,
+                affected_blocks: Some(0),
+                last_processed_ts: window.last_processed_ts,
+            });
+        }
 
         let entries = if settings.entries.is_empty() {
             None
@@ -52,8 +61,8 @@ impl LifecycleAction for DeleteLifecycleAction {
             entries,
             // Use absolute range start to avoid invalid (start > stop) when
             // an entry contains only fresh records newer than `cutoff`.
-            start: Some(0),
-            stop,
+            start: window.start,
+            stop: window.stop,
             when: settings.when.clone(),
             ..Default::default()
         };
@@ -67,6 +76,7 @@ impl LifecycleAction for DeleteLifecycleAction {
         Ok(LifecycleRunResult {
             affected_records: stats.records,
             affected_blocks: Some(stats.blocks),
+            last_processed_ts: window.last_processed_ts,
         })
     }
 }
@@ -74,6 +84,7 @@ impl LifecycleAction for DeleteLifecycleAction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lifecycle::action::progress;
     use crate::lifecycle::lifecycle_task::tests::{settings, storage};
     use crate::storage::bucket::tests::{write, write_meta};
     use crate::storage::bucket::Bucket;
@@ -112,7 +123,11 @@ mod tests {
         settings.older_than = "0s".to_string();
 
         let result = action
-            .run("test", &settings, LifecycleContext::new(test_storage))
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
             .await
             .unwrap();
 
@@ -141,7 +156,11 @@ mod tests {
             .unwrap();
 
         let result = action
-            .run("test", &settings, LifecycleContext::new(test_storage))
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
             .await
             .unwrap();
 
@@ -169,7 +188,11 @@ mod tests {
         settings.entries = vec!["entry-1*".to_string()];
 
         let result = action
-            .run("test", &settings, LifecycleContext::new(test_storage))
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
             .await
             .unwrap();
 
@@ -177,5 +200,138 @@ mod tests {
         assert_eq!(result.affected_blocks, Some(1));
         assert!(test_bucket.begin_read("entry-1", 1).await.is_err());
         assert!(test_bucket.begin_read("entry-1/$meta", 1).await.is_ok());
+    }
+
+    #[tokio::test]
+    #[rstest]
+    async fn delete_processes_windowed_data_when_system_events_enabled(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        write(&test_bucket, "entry-1", 23_999_999, b"r2")
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 24_000_000, b"r3")
+            .await
+            .unwrap();
+        settings.mode = LifecycleMode::Enabled;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 2);
+        assert!(test_bucket.begin_read("entry-1", 1).await.is_err());
+        assert!(test_bucket.begin_read("entry-1", 23_999_999).await.is_err());
+        assert!(test_bucket.begin_read("entry-1", 24_000_000).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn delete_resumes_from_last_progress(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        progress::tests::write_lifecycle_stats(&test_storage, "instance-1", "test", 24_000_000)
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 23_999_999, b"r1")
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 24_000_000, b"r2")
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 48_000_000, b"r3")
+            .await
+            .unwrap();
+        settings.mode = LifecycleMode::Enabled;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 1);
+        assert!(test_bucket.begin_read("entry-1", 23_999_999).await.is_ok());
+        assert!(test_bucket.begin_read("entry-1", 24_000_000).await.is_err());
+        assert!(test_bucket.begin_read("entry-1", 48_000_000).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn delete_returns_zero_when_caught_up(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        progress::tests::write_lifecycle_stats(&test_storage, "instance-1", "test", u64::MAX)
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        settings.mode = LifecycleMode::Enabled;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 0);
+        assert_eq!(result.affected_blocks, Some(0));
+        assert!(test_bucket.begin_read("entry-1", 1).await.is_ok());
+    }
+
+    #[tokio::test]
+    #[rstest]
+    async fn delete_processes_all_data_when_system_events_disabled(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        write(&test_bucket, "entry-1", 48_000_000, b"r2")
+            .await
+            .unwrap();
+        settings.mode = LifecycleMode::Enabled;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 2);
+        assert!(test_bucket.begin_read("entry-1", 1).await.is_err());
+        assert!(test_bucket.begin_read("entry-1", 48_000_000).await.is_err());
     }
 }

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -38,6 +38,7 @@ impl LifecycleAction for DeleteLifecycleAction {
                 affected_records: 0,
                 affected_blocks: Some(0),
                 last_processed_ts: window.last_processed_ts,
+                caught_up: true,
             });
         }
 
@@ -77,6 +78,7 @@ impl LifecycleAction for DeleteLifecycleAction {
             affected_records: stats.records,
             affected_blocks: Some(stats.blocks),
             last_processed_ts: window.last_processed_ts,
+            caught_up: window.reaches_cutoff,
         })
     }
 }
@@ -302,7 +304,42 @@ mod tests {
 
         assert_eq!(result.affected_records, 0);
         assert_eq!(result.affected_blocks, Some(0));
+        assert!(result.caught_up);
         assert!(test_bucket.begin_read("entry-1", 1).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn delete_marks_result_caught_up_when_progress_is_past_latest_data(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        let now_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        progress::tests::write_lifecycle_stats(&test_storage, "instance-1", "test", now_us)
+            .await
+            .unwrap();
+        write(&test_bucket, "entry-1", 1, b"r1").await.unwrap();
+        settings.mode = LifecycleMode::Enabled;
+        settings.older_than = "0s".to_string();
+        settings.interval = "1s".to_string();
+
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, true, "instance-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 0);
+        assert_eq!(result.affected_blocks, Some(0));
+        assert!(result.caught_up);
     }
 
     #[tokio::test]

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -23,10 +23,13 @@ pub(crate) async fn processing_window(
     policy_name: &str,
     cutoff_stop: u64,
 ) -> Result<ProcessingWindow, ReductError> {
+    let first_record_start = first_record_start(settings, context, cutoff_stop).await?;
+
     if !context.system_events_enabled {
+        let stop = cutoff_stop;
         return Ok(ProcessingWindow {
-            start: Some(0),
-            stop: Some(cutoff_stop),
+            start: Some(first_record_start.min(stop)),
+            stop: Some(stop),
             last_processed_ts: None,
             caught_up: false,
         });
@@ -34,29 +37,78 @@ pub(crate) async fn processing_window(
 
     let interval_us = parse_duration_to_micros(&settings.interval)?.max(0) as u64;
     let data_window = interval_us.saturating_mul(24);
-    let window_start = read_progress(
+    let last_processed = read_progress(
         &context.storage,
         &context.system_event_instance,
         policy_name,
     )
     .await
-    .unwrap_or(0);
+    .unwrap_or(first_record_start);
 
-    if window_start >= cutoff_stop {
+    if last_processed >= cutoff_stop {
+        let stop = cutoff_stop;
         return Ok(ProcessingWindow {
-            start: Some(window_start),
-            stop: Some(window_start),
-            last_processed_ts: Some(window_start),
+            start: Some(first_record_start.min(stop)),
+            stop: Some(stop),
+            last_processed_ts: Some(last_processed),
             caught_up: true,
         });
     }
 
-    let window_stop = window_start.saturating_add(data_window).min(cutoff_stop);
+    let window_stop = last_processed.saturating_add(data_window).min(cutoff_stop);
     Ok(ProcessingWindow {
-        start: Some(window_start),
+        start: Some(first_record_start.min(window_stop)),
         stop: Some(window_stop),
         last_processed_ts: Some(window_stop),
         caught_up: false,
+    })
+}
+
+async fn first_record_start(
+    settings: &LifecycleSettings,
+    context: &LifecycleContext,
+    cutoff_stop: u64,
+) -> Result<u64, ReductError> {
+    let bucket = context
+        .storage
+        .get_bucket(&settings.bucket)
+        .await?
+        .upgrade()?;
+    let bucket_info = bucket.info().await?;
+    let requested_entries = requested_entries(&settings.entries);
+    let oldest_record = bucket_info
+        .entries
+        .into_iter()
+        .filter(|entry| entry.record_count > 0)
+        .filter(|entry| is_requested_entry(&entry.name, &requested_entries))
+        .map(|entry| entry.oldest_record)
+        .min()
+        .unwrap_or(cutoff_stop);
+
+    Ok(oldest_record.min(cutoff_stop))
+}
+
+fn requested_entries(entries: &[String]) -> Option<&[String]> {
+    if entries.is_empty() || entries.iter().any(|entry| entry == "*") {
+        None
+    } else {
+        Some(entries)
+    }
+}
+
+fn is_requested_entry(entry_name: &str, requested_entries: &Option<&[String]>) -> bool {
+    requested_entries
+        .map(|patterns| entry_matches_patterns(entry_name, patterns))
+        .unwrap_or(true)
+}
+
+fn entry_matches_patterns(entry_name: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            entry_name.starts_with(prefix)
+        } else {
+            entry_name == pattern
+        }
     })
 }
 
@@ -119,7 +171,9 @@ fn sanitize_policy_name(name: &str) -> String {
 #[cfg(test)]
 pub(super) mod tests {
     use super::*;
-    use crate::lifecycle::lifecycle_task::tests::storage;
+    use crate::lifecycle::action::LifecycleContext;
+    use crate::lifecycle::lifecycle_task::tests::{settings_fixture, storage};
+    use crate::storage::bucket::tests::write;
     use reduct_base::msg::bucket_api::BucketSettings;
 
     #[tokio::test]
@@ -175,6 +229,93 @@ pub(super) mod tests {
             read_progress(&storage, "instance-1", "policy-1").await,
             Some(67890)
         );
+    }
+
+    #[tokio::test]
+    async fn processing_window_uses_oldest_matching_record_as_start() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let mut settings = settings_fixture();
+        settings.entries = vec!["entry-a*".to_string()];
+        write(&bucket, "entry-a", 50, b"a").await.unwrap();
+        write(&bucket, "entry-b", 10, b"b").await.unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, true, "instance-1".to_string()),
+            "policy-1",
+            100,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(window.start, Some(50));
+        assert_eq!(window.stop, Some(100));
+        assert_eq!(window.last_processed_ts, Some(100));
+        assert!(!window.caught_up);
+    }
+
+    #[tokio::test]
+    async fn processing_window_clamps_start_when_all_matching_records_are_newer_than_stop() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let settings = settings_fixture();
+        write(&bucket, "entry-1", 150, b"fresh").await.unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, true, "instance-1".to_string()),
+            "policy-1",
+            100,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(window.start, Some(100));
+        assert_eq!(window.stop, Some(100));
+        assert_eq!(window.last_processed_ts, Some(100));
+        assert!(!window.caught_up);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn processing_window_clamps_start_to_window_stop_when_progress_lags_behind_data() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let mut settings = settings_fixture();
+        settings.interval = "0s".to_string();
+        write_lifecycle_stats(&storage, "instance-1", "policy-1", 1)
+            .await
+            .unwrap();
+        write(&bucket, "entry-1", 100, b"fresh").await.unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, true, "instance-1".to_string()),
+            "policy-1",
+            1_000,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(window.start, Some(1));
+        assert_eq!(window.stop, Some(1));
+        assert_eq!(window.last_processed_ts, Some(1));
+        assert!(!window.caught_up);
     }
 
     pub(crate) async fn write_lifecycle_stats(

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -1,0 +1,222 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::core::duration::parse_duration_to_micros;
+use crate::lifecycle::action::LifecycleContext;
+use crate::storage::engine::StorageEngine;
+use crate::syslog::{SYSTEM_BUCKET_NAME, SYSTEM_LIFECYCLE_ENTRY_PREFIX};
+use reduct_base::error::ReductError;
+use reduct_base::io::ReadRecord;
+use reduct_base::msg::lifecycle_api::LifecycleSettings;
+use std::sync::Arc;
+
+pub(crate) struct ProcessingWindow {
+    pub(crate) start: Option<u64>,
+    pub(crate) stop: Option<u64>,
+    pub(crate) last_processed_ts: Option<u64>,
+    pub(crate) caught_up: bool,
+}
+
+pub(crate) async fn processing_window(
+    settings: &LifecycleSettings,
+    context: &LifecycleContext,
+    policy_name: &str,
+    cutoff_stop: u64,
+) -> Result<ProcessingWindow, ReductError> {
+    if !context.system_events_enabled {
+        return Ok(ProcessingWindow {
+            start: Some(0),
+            stop: Some(cutoff_stop),
+            last_processed_ts: None,
+            caught_up: false,
+        });
+    }
+
+    let interval_us = parse_duration_to_micros(&settings.interval)?.max(0) as u64;
+    let data_window = interval_us.saturating_mul(24);
+    let window_start = read_progress(
+        &context.storage,
+        &context.system_event_instance,
+        policy_name,
+    )
+    .await
+    .unwrap_or(0);
+
+    if window_start >= cutoff_stop {
+        return Ok(ProcessingWindow {
+            start: Some(window_start),
+            stop: Some(window_start),
+            last_processed_ts: Some(window_start),
+            caught_up: true,
+        });
+    }
+
+    let window_stop = window_start.saturating_add(data_window).min(cutoff_stop);
+    Ok(ProcessingWindow {
+        start: Some(window_start),
+        stop: Some(window_stop),
+        last_processed_ts: Some(window_stop),
+        caught_up: false,
+    })
+}
+
+pub(crate) async fn read_progress(
+    storage: &StorageEngine,
+    instance_name: &str,
+    policy_name: &str,
+) -> Option<u64> {
+    let entry_path = lifecycle_stats_entry_path(instance_name, policy_name);
+    let bucket = storage
+        .get_bucket(SYSTEM_BUCKET_NAME)
+        .await
+        .ok()?
+        .upgrade()
+        .ok()?;
+    let latest_record = Arc::clone(&bucket)
+        .info()
+        .await
+        .ok()?
+        .entries
+        .into_iter()
+        .find(|entry| entry.name == entry_path)?
+        .latest_record;
+
+    let entry = bucket.get_entry(&entry_path).await.ok()?.upgrade().ok()?;
+    let mut reader = entry.begin_read(latest_record).await.ok()?;
+    let record = reader.read_chunk()?.ok()?;
+    serde_json::from_slice::<serde_json::Value>(&record)
+        .ok()?
+        .get("last_processed_ts")?
+        .as_u64()
+}
+
+fn lifecycle_stats_entry_path(instance_name: &str, policy_name: &str) -> String {
+    let instance = if instance_name.is_empty() {
+        "unknown"
+    } else {
+        instance_name
+    };
+    format!(
+        "{}/{}/{}",
+        SYSTEM_LIFECYCLE_ENTRY_PREFIX,
+        instance,
+        sanitize_policy_name(policy_name)
+    )
+}
+
+fn sanitize_policy_name(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+    use crate::lifecycle::lifecycle_task::tests::storage;
+    use reduct_base::msg::bucket_api::BucketSettings;
+
+    #[tokio::test]
+    async fn read_progress_returns_none_when_no_system_bucket() {
+        let storage = storage().await;
+
+        assert_eq!(
+            read_progress(&storage, "instance-1", "policy-1").await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn read_progress_returns_none_when_no_entry() {
+        let storage = storage().await;
+        storage
+            .create_system_bucket(SYSTEM_BUCKET_NAME, BucketSettings::default())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_progress(&storage, "instance-1", "policy-1").await,
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_progress_reads_latest_lifecycle_stats() {
+        let storage = storage().await;
+
+        write_lifecycle_stats(&storage, "instance-1", "policy/1", 12345)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_progress(&storage, "instance-1", "policy/1").await,
+            Some(12345)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_progress_uses_latest_lifecycle_stats_record() {
+        let storage = storage().await;
+
+        write_lifecycle_stats(&storage, "instance-1", "policy-1", 12345)
+            .await
+            .unwrap();
+        write_lifecycle_stats(&storage, "instance-1", "policy-1", 67890)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_progress(&storage, "instance-1", "policy-1").await,
+            Some(67890)
+        );
+    }
+
+    pub(crate) async fn write_lifecycle_stats(
+        storage: &StorageEngine,
+        instance_name: &str,
+        policy_name: &str,
+        last_processed_ts: u64,
+    ) -> Result<(), reduct_base::error::ReductError> {
+        use bytes::Bytes;
+        use reduct_base::Labels;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let payload = serde_json::json!({
+            "policy_name": policy_name,
+            "action_type": "delete",
+            "bucket": "bucket-1",
+            "duration": 0.1,
+            "processed_records": 1,
+            "last_processed_ts": last_processed_ts,
+        })
+        .to_string()
+        .into_bytes();
+        storage
+            .create_system_bucket(SYSTEM_BUCKET_NAME, BucketSettings::default())
+            .await
+            .ok();
+        let now_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        let mut writer = storage
+            .begin_write(
+                SYSTEM_BUCKET_NAME,
+                &lifecycle_stats_entry_path(instance_name, policy_name),
+                now_us,
+                payload.len() as u64,
+                "application/json".to_string(),
+                Labels::default(),
+            )
+            .await?;
+        writer.send(Ok(Some(Bytes::from(payload)))).await?;
+        writer.send(Ok(None)).await?;
+        Ok(())
+    }
+}

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -284,7 +284,7 @@ pub(super) mod tests {
         assert_eq!(window.start, Some(100));
         assert_eq!(window.stop, Some(100));
         assert_eq!(window.last_processed_ts, Some(100));
-        assert!(!window.caught_up);
+        assert!(window.caught_up);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -15,6 +15,7 @@ pub(crate) struct ProcessingWindow {
     pub(crate) stop: Option<u64>,
     pub(crate) last_processed_ts: Option<u64>,
     pub(crate) caught_up: bool,
+    pub(crate) reaches_cutoff: bool,
 }
 
 pub(crate) async fn processing_window(
@@ -23,15 +24,17 @@ pub(crate) async fn processing_window(
     policy_name: &str,
     cutoff_stop: u64,
 ) -> Result<ProcessingWindow, ReductError> {
-    let first_record_start = first_record_start(settings, context, cutoff_stop).await?;
+    let (first_record_start, effective_cutoff_stop) =
+        matching_record_window(settings, context, cutoff_stop).await?;
 
     if !context.system_events_enabled {
-        let stop = cutoff_stop;
+        let stop = effective_cutoff_stop;
         return Ok(ProcessingWindow {
             start: Some(first_record_start.min(stop)),
             stop: Some(stop),
             last_processed_ts: None,
             caught_up: false,
+            reaches_cutoff: false,
         });
     }
 
@@ -45,30 +48,34 @@ pub(crate) async fn processing_window(
     .await
     .unwrap_or(first_record_start);
 
-    if last_processed >= cutoff_stop {
-        let stop = cutoff_stop;
+    if last_processed >= effective_cutoff_stop {
+        let stop = effective_cutoff_stop;
         return Ok(ProcessingWindow {
             start: Some(first_record_start.min(stop)),
             stop: Some(stop),
             last_processed_ts: Some(last_processed),
             caught_up: true,
+            reaches_cutoff: true,
         });
     }
 
-    let window_stop = last_processed.saturating_add(data_window).min(cutoff_stop);
+    let window_stop = last_processed
+        .saturating_add(data_window)
+        .min(effective_cutoff_stop);
     Ok(ProcessingWindow {
         start: Some(first_record_start.min(window_stop)),
         stop: Some(window_stop),
         last_processed_ts: Some(window_stop),
         caught_up: false,
+        reaches_cutoff: window_stop >= effective_cutoff_stop,
     })
 }
 
-async fn first_record_start(
+async fn matching_record_window(
     settings: &LifecycleSettings,
     context: &LifecycleContext,
     cutoff_stop: u64,
-) -> Result<u64, ReductError> {
+) -> Result<(u64, u64), ReductError> {
     let bucket = context
         .storage
         .get_bucket(&settings.bucket)
@@ -76,16 +83,31 @@ async fn first_record_start(
         .upgrade()?;
     let bucket_info = bucket.info().await?;
     let requested_entries = requested_entries(&settings.entries);
-    let oldest_record = bucket_info
+    let mut matching_records = bucket_info
         .entries
         .into_iter()
         .filter(|entry| entry.record_count > 0)
         .filter(|entry| is_requested_entry(&entry.name, &requested_entries))
+        .collect::<Vec<_>>();
+
+    if matching_records.is_empty() {
+        return Ok((cutoff_stop, cutoff_stop));
+    }
+
+    let first_record_start = matching_records
+        .iter()
         .map(|entry| entry.oldest_record)
         .min()
-        .unwrap_or(cutoff_stop);
+        .unwrap_or(cutoff_stop)
+        .min(cutoff_stop);
+    let effective_cutoff_stop = matching_records
+        .drain(..)
+        .map(|entry| entry.latest_record.saturating_add(1))
+        .max()
+        .unwrap_or(cutoff_stop)
+        .min(cutoff_stop);
 
-    Ok(oldest_record.min(cutoff_stop))
+    Ok((first_record_start, effective_cutoff_stop))
 }
 
 fn requested_entries(entries: &[String]) -> Option<&[String]> {
@@ -255,8 +277,8 @@ pub(super) mod tests {
         .unwrap();
 
         assert_eq!(window.start, Some(50));
-        assert_eq!(window.stop, Some(100));
-        assert_eq!(window.last_processed_ts, Some(100));
+        assert_eq!(window.stop, Some(51));
+        assert_eq!(window.last_processed_ts, Some(51));
         assert!(!window.caught_up);
     }
 
@@ -316,6 +338,36 @@ pub(super) mod tests {
         assert_eq!(window.stop, Some(1));
         assert_eq!(window.last_processed_ts, Some(1));
         assert!(!window.caught_up);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn processing_window_is_caught_up_when_progress_is_past_latest_matching_record() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let settings = settings_fixture();
+        write(&bucket, "entry-1", 100, b"old").await.unwrap();
+        write_lifecycle_stats(&storage, "instance-1", "policy-1", 101)
+            .await
+            .unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, true, "instance-1".to_string()),
+            "policy-1",
+            u64::MAX,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(window.start, Some(100));
+        assert_eq!(window.stop, Some(101));
+        assert_eq!(window.last_processed_ts, Some(101));
+        assert!(window.caught_up);
     }
 
     pub(crate) async fn write_lifecycle_stats(

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -14,7 +14,6 @@ pub(crate) struct ProcessingWindow {
     pub(crate) start: Option<u64>,
     pub(crate) stop: Option<u64>,
     pub(crate) last_processed_ts: Option<u64>,
-    pub(crate) caught_up: bool,
     pub(crate) reaches_cutoff: bool,
 }
 
@@ -33,7 +32,6 @@ pub(crate) async fn processing_window(
             start: Some(first_record_start.min(stop)),
             stop: Some(stop),
             last_processed_ts: None,
-            caught_up: false,
             reaches_cutoff: false,
         });
     }
@@ -54,7 +52,6 @@ pub(crate) async fn processing_window(
             start: Some(first_record_start.min(stop)),
             stop: Some(stop),
             last_processed_ts: Some(last_processed),
-            caught_up: true,
             reaches_cutoff: true,
         });
     }
@@ -66,7 +63,6 @@ pub(crate) async fn processing_window(
         start: Some(first_record_start.min(window_stop)),
         stop: Some(window_stop),
         last_processed_ts: Some(window_stop),
-        caught_up: false,
         reaches_cutoff: window_stop >= effective_cutoff_stop,
     })
 }
@@ -279,7 +275,7 @@ pub(super) mod tests {
         assert_eq!(window.start, Some(50));
         assert_eq!(window.stop, Some(51));
         assert_eq!(window.last_processed_ts, Some(51));
-        assert!(!window.caught_up);
+        assert!(window.reaches_cutoff);
     }
 
     #[tokio::test]
@@ -306,7 +302,7 @@ pub(super) mod tests {
         assert_eq!(window.start, Some(100));
         assert_eq!(window.stop, Some(100));
         assert_eq!(window.last_processed_ts, Some(100));
-        assert!(window.caught_up);
+        assert!(window.reaches_cutoff);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -337,7 +333,7 @@ pub(super) mod tests {
         assert_eq!(window.start, Some(1));
         assert_eq!(window.stop, Some(1));
         assert_eq!(window.last_processed_ts, Some(1));
-        assert!(!window.caught_up);
+        assert!(!window.reaches_cutoff);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -367,7 +363,7 @@ pub(super) mod tests {
         assert_eq!(window.start, Some(100));
         assert_eq!(window.stop, Some(101));
         assert_eq!(window.last_processed_ts, Some(101));
-        assert!(window.caught_up);
+        assert!(window.reaches_cutoff);
     }
 
     pub(crate) async fn write_lifecycle_stats(

--- a/reductstore/src/lifecycle/lifecycle_repository/repo.rs
+++ b/reductstore/src/lifecycle/lifecycle_repository/repo.rs
@@ -332,12 +332,21 @@ impl LifecycleRepository {
         }
 
         let interval = Duration::from_micros(interval_us.max(0) as u64);
+        let system_event_instance = self
+            .system_event_sink
+            .as_ref()
+            .map(|sink| sink.instance_name.clone())
+            .unwrap_or_else(|| "unknown".to_string());
         let mut lifecycle = LifecycleTask::new(
             name.to_string(),
             settings,
             interval,
             action,
-            LifecycleContext::new(Arc::clone(&self.storage)),
+            LifecycleContext::new(
+                Arc::clone(&self.storage),
+                self.system_event_sink.is_some(),
+                system_event_instance,
+            ),
             self.system_event_sink.clone(),
         );
         if self.started {

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -87,31 +87,48 @@ impl LifecycleTask {
                 }
 
                 Self::mark_last_run(&last_run);
-                let started = std::time::Instant::now();
-                match action.run(&name, &settings, context.clone()).await {
-                    Ok(result) => {
-                        Self::log_system_event(
-                            system_event_sink.clone(),
-                            &name,
-                            action.lifecycle_type(),
-                            &settings.bucket,
-                            started.elapsed().as_secs_f64(),
-                            Ok(result),
-                        )
-                        .await;
+                loop {
+                    let started = std::time::Instant::now();
+                    match action.run(&name, &settings, context.clone()).await {
+                        Ok(result) => {
+                            Self::log_system_event(
+                                system_event_sink.clone(),
+                                &name,
+                                action.lifecycle_type(),
+                                &settings.bucket,
+                                started.elapsed().as_secs_f64(),
+                                Ok(result.clone()),
+                            )
+                            .await;
+
+                            // in case we in the catching up state
+                            // we repeat the action until we catch up or we have affected records
+                            if !result.caught_up && result.affected_records == 0 {
+                                Self::sleep_with_stop(
+                                    Duration::from_millis(100),
+                                    Arc::clone(&stop_flag),
+                                )
+                                .await;
+                                if stop_flag.load(Ordering::Relaxed) {
+                                    break;
+                                }
+                                continue;
+                            }
+                        }
+                        Err(err) => {
+                            error!("Lifecycle worker '{}' failed: {}", name, err);
+                            Self::log_system_event(
+                                system_event_sink.clone(),
+                                &name,
+                                action.lifecycle_type(),
+                                &settings.bucket,
+                                started.elapsed().as_secs_f64(),
+                                Err(err),
+                            )
+                            .await;
+                        }
                     }
-                    Err(err) => {
-                        error!("Lifecycle worker '{}' failed: {}", name, err);
-                        Self::log_system_event(
-                            system_event_sink.clone(),
-                            &name,
-                            action.lifecycle_type(),
-                            &settings.bucket,
-                            started.elapsed().as_secs_f64(),
-                            Err(err),
-                        )
-                        .await;
-                    }
+                    break;
                 }
             }
             debug!("Lifecycle worker '{}' stopped", name);
@@ -227,6 +244,7 @@ impl LifecycleTask {
                     result.affected_records,
                     result.affected_blocks,
                     result.last_processed_ts,
+                    result.caught_up,
                 )
                 .to_value(),
             ),
@@ -537,6 +555,7 @@ pub(super) mod tests {
                 affected_records: 42,
                 affected_blocks: Some(3),
                 last_processed_ts: None,
+                caught_up: false,
             }),
         )
         .await;
@@ -555,6 +574,7 @@ pub(super) mod tests {
         assert_eq!(event.payload["bucket"], "bucket-1");
         assert_eq!(event.payload["processed_records"], 42);
         assert_eq!(event.payload["processed_blocks"], 3);
+        assert_eq!(event.payload["caught_up"], false);
         assert!(event.payload.get("error_code").is_none());
         assert!(event.payload.get("error_message").is_none());
     }
@@ -580,6 +600,7 @@ pub(super) mod tests {
                 affected_records: 42,
                 affected_blocks: Some(3),
                 last_processed_ts: Some(123),
+                caught_up: true,
             }),
         )
         .await;
@@ -591,6 +612,7 @@ pub(super) mod tests {
         assert_eq!(event.payload["processed_records"], 42);
         assert_eq!(event.payload["processed_blocks"], 3);
         assert_eq!(event.payload["last_processed_ts"], 123);
+        assert_eq!(event.payload["caught_up"], true);
     }
 
     #[tokio::test]
@@ -627,8 +649,9 @@ pub(super) mod tests {
         assert_eq!(event.payload["policy_name"], "policy-1");
         assert_eq!(event.payload["action_type"], "delete");
         assert_eq!(event.payload["bucket"], "bucket-1");
-        assert_eq!(event.payload["processed_records"], serde_json::Value::Null);
-        assert!(event.payload.get("processed_blocks").is_none());
+        assert_eq!(event.payload["processed_records"], 0);
+        assert_eq!(event.payload["processed_blocks"], 0);
+        assert_eq!(event.payload["caught_up"], false);
         assert_eq!(event.payload["error_code"], 422);
         assert_eq!(event.payload["error_message"], "failed to run");
     }

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -226,6 +226,7 @@ impl LifecycleTask {
                     duration,
                     result.affected_records,
                     result.affected_blocks,
+                    result.last_processed_ts,
                 )
                 .to_value(),
             ),
@@ -535,6 +536,7 @@ pub(super) mod tests {
             Ok(LifecycleRunResult {
                 affected_records: 42,
                 affected_blocks: Some(3),
+                last_processed_ts: None,
             }),
         )
         .await;
@@ -577,6 +579,7 @@ pub(super) mod tests {
             Ok(LifecycleRunResult {
                 affected_records: 42,
                 affected_blocks: Some(3),
+                last_processed_ts: Some(123),
             }),
         )
         .await;
@@ -587,6 +590,7 @@ pub(super) mod tests {
 
         assert_eq!(event.payload["processed_records"], 42);
         assert_eq!(event.payload["processed_blocks"], 3);
+        assert_eq!(event.payload["last_processed_ts"], 123);
     }
 
     #[tokio::test]
@@ -648,7 +652,7 @@ pub(super) mod tests {
             settings,
             Duration::from_millis(100),
             action,
-            LifecycleContext::new(storage().await),
+            LifecycleContext::new(storage().await, false, "unknown".to_string()),
             None,
         )
     }

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -534,7 +534,7 @@ pub(super) mod tests {
             0.25,
             Ok(LifecycleRunResult {
                 affected_records: 42,
-                ..Default::default()
+                affected_blocks: Some(3),
             }),
         )
         .await;
@@ -552,7 +552,7 @@ pub(super) mod tests {
         assert_eq!(event.payload["action_type"], "delete");
         assert_eq!(event.payload["bucket"], "bucket-1");
         assert_eq!(event.payload["processed_records"], 42);
-        assert!(event.payload.get("processed_blocks").is_none());
+        assert_eq!(event.payload["processed_blocks"], 3);
         assert!(event.payload.get("error_code").is_none());
         assert!(event.payload.get("error_message").is_none());
     }

--- a/reductstore/src/lifecycle/system_event_payload.rs
+++ b/reductstore/src/lifecycle/system_event_payload.rs
@@ -10,13 +10,10 @@ pub(crate) struct LifecycleSystemEventPayload {
     pub action_type: String,
     pub bucket: String,
     pub duration: f64,
-    #[serde(default)]
-    pub processed_records: Option<u64>,
-    #[serde(default)]
-    pub processed_blocks: Option<u64>,
-    #[serde(default)]
+    pub processed_records: u64,
+    pub processed_blocks: u64,
     pub last_processed_ts: Option<u64>,
-    #[serde(default)]
+    pub caught_up: bool,
     pub error_code: Option<u16>,
     #[serde(default)]
     pub error_message: Option<String>,
@@ -31,15 +28,17 @@ impl LifecycleSystemEventPayload {
         processed_records: u64,
         processed_blocks: Option<u64>,
         last_processed_ts: Option<u64>,
+        caught_up: bool,
     ) -> Self {
         Self {
             policy_name: policy_name.to_string(),
             action_type: action_type.to_string(),
             bucket: bucket.to_string(),
             duration,
-            processed_records: Some(processed_records),
-            processed_blocks,
+            processed_records,
+            processed_blocks: processed_blocks.unwrap_or(0),
             last_processed_ts,
+            caught_up,
             error_code: None,
             error_message: None,
         }
@@ -58,9 +57,10 @@ impl LifecycleSystemEventPayload {
             action_type: action_type.to_string(),
             bucket: bucket.to_string(),
             duration,
-            processed_records: None,
-            processed_blocks: None,
+            processed_records: 0,
+            processed_blocks: 0,
             last_processed_ts: None,
+            caught_up: false,
             error_code: Some(error_code),
             error_message: Some(error_message.to_string()),
         }
@@ -73,14 +73,12 @@ impl LifecycleSystemEventPayload {
             "bucket": self.bucket,
             "duration": self.duration,
             "processed_records": self.processed_records,
+            "processed_blocks": self.processed_blocks,
+            "caught_up": self.caught_up,
         });
 
         if let Some(error_code) = self.error_code {
             payload["error_code"] = json!(error_code);
-        }
-
-        if let Some(processed_blocks) = self.processed_blocks {
-            payload["processed_blocks"] = json!(processed_blocks);
         }
 
         if let Some(last_processed_ts) = self.last_processed_ts {

--- a/reductstore/src/lifecycle/system_event_payload.rs
+++ b/reductstore/src/lifecycle/system_event_payload.rs
@@ -15,6 +15,8 @@ pub(crate) struct LifecycleSystemEventPayload {
     #[serde(default)]
     pub processed_blocks: Option<u64>,
     #[serde(default)]
+    pub last_processed_ts: Option<u64>,
+    #[serde(default)]
     pub error_code: Option<u16>,
     #[serde(default)]
     pub error_message: Option<String>,
@@ -28,6 +30,7 @@ impl LifecycleSystemEventPayload {
         duration: f64,
         processed_records: u64,
         processed_blocks: Option<u64>,
+        last_processed_ts: Option<u64>,
     ) -> Self {
         Self {
             policy_name: policy_name.to_string(),
@@ -36,6 +39,7 @@ impl LifecycleSystemEventPayload {
             duration,
             processed_records: Some(processed_records),
             processed_blocks,
+            last_processed_ts,
             error_code: None,
             error_message: None,
         }
@@ -56,6 +60,7 @@ impl LifecycleSystemEventPayload {
             duration,
             processed_records: None,
             processed_blocks: None,
+            last_processed_ts: None,
             error_code: Some(error_code),
             error_message: Some(error_message.to_string()),
         }
@@ -76,6 +81,10 @@ impl LifecycleSystemEventPayload {
 
         if let Some(processed_blocks) = self.processed_blocks {
             payload["processed_blocks"] = json!(processed_blocks);
+        }
+
+        if let Some(last_processed_ts) = self.last_processed_ts {
+            payload["last_processed_ts"] = json!(last_processed_ts);
         }
 
         if let Some(error_message) = &self.error_message {

--- a/reductstore/src/storage/bucket/remove_records.rs
+++ b/reductstore/src/storage/bucket/remove_records.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 use crate::storage::bucket::Bucket;
+use crate::storage::entry::RecordQueryStats;
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::QueryEntry;
 use std::collections::{BTreeMap, HashMap};
@@ -78,10 +79,17 @@ impl Bucket {
         self: Arc<Self>,
         options: QueryEntry,
     ) -> Result<u64, ReductError> {
+        Ok(self.query_remove_records_with_stats(options).await?.records)
+    }
+
+    pub(crate) async fn query_remove_records_with_stats(
+        self: Arc<Self>,
+        options: QueryEntry,
+    ) -> Result<RecordQueryStats, ReductError> {
         self.ensure_not_deleting().await?;
         let entries = self.entries.read().await?.clone();
         let requested_entries = Self::requested_entries(&options.entries);
-        let mut total_removed = 0;
+        let mut total_removed = RecordQueryStats::default();
 
         for (entry_name, entry) in entries {
             if !Self::is_requested_entry(&entry_name, &requested_entries) {
@@ -93,8 +101,11 @@ impl Bucket {
             }
 
             entry.ensure_not_deleting().await?;
-            let removed_records = entry.query_remove_records(options.clone()).await?;
-            total_removed += removed_records;
+            let removed = entry
+                .query_remove_records_with_stats(options.clone())
+                .await?;
+            total_removed.records += removed.records;
+            total_removed.blocks += removed.blocks;
         }
 
         Ok(total_removed)
@@ -108,13 +119,21 @@ impl Bucket {
     ///
     /// # Returns
     /// The number of records matched by the query.
+    #[allow(dead_code)]
     pub async fn query_count_records(
         self: Arc<Self>,
         options: QueryEntry,
     ) -> Result<u64, ReductError> {
+        Ok(self.query_count_records_with_stats(options).await?.records)
+    }
+
+    pub(crate) async fn query_count_records_with_stats(
+        self: Arc<Self>,
+        options: QueryEntry,
+    ) -> Result<RecordQueryStats, ReductError> {
         let entries = self.entries.read().await?.clone();
         let requested_entries = Self::requested_entries(&options.entries);
-        let mut total_counted = 0;
+        let mut total_counted = RecordQueryStats::default();
 
         for (entry_name, entry) in entries {
             if !Self::is_requested_entry(&entry_name, &requested_entries) {
@@ -125,8 +144,11 @@ impl Bucket {
                 continue;
             }
 
-            let counted_records = entry.query_count_records(options.clone()).await?;
-            total_counted += counted_records;
+            let counted = entry
+                .query_count_records_with_stats(options.clone())
+                .await?;
+            total_counted.records += counted.records;
+            total_counted.blocks += counted.blocks;
         }
 
         Ok(total_counted)

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -87,6 +87,12 @@ pub(crate) struct CompressionStats {
     pub(crate) records: u64,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RecordQueryStats {
+    pub(crate) blocks: u64,
+    pub(crate) records: u64,
+}
+
 impl Entry {
     #[allow(dead_code)]
     pub async fn try_build(

--- a/reductstore/src/storage/entry/compress.rs
+++ b/reductstore/src/storage/entry/compress.rs
@@ -4,6 +4,20 @@
 use super::{CompressionStats, Entry};
 use crate::storage::block_manager::compress::CompressionAlgorithm;
 use reduct_base::error::{ErrorCode, ReductError};
+use std::collections::BTreeSet;
+
+fn block_id_range<'a>(
+    index: &'a BTreeSet<u64>,
+    start: Option<u64>,
+    stop: Option<u64>,
+) -> Box<dyn Iterator<Item = &'a u64> + 'a> {
+    match (start, stop) {
+        (Some(start), Some(stop)) => Box::new(index.range(start..stop)),
+        (Some(start), None) => Box::new(index.range(start..)),
+        (None, Some(stop)) => Box::new(index.range(..stop)),
+        (None, None) => Box::new(index.iter()),
+    }
+}
 
 impl Entry {
     /// Compress uncompressed blocks whose block IDs fall within `[start, stop)`.
@@ -19,12 +33,7 @@ impl Entry {
             let bm = self.block_manager.read().await?;
             let index = bm.index();
 
-            let range: Box<dyn Iterator<Item = &u64> + '_> = match (start, stop) {
-                (Some(start), Some(stop)) => Box::new(index.tree().range(start..stop)),
-                (Some(start), None) => Box::new(index.tree().range(start..)),
-                (None, Some(stop)) => Box::new(index.tree().range(..stop)),
-                (None, None) => Box::new(index.tree().iter()),
-            };
+            let range = block_id_range(index.tree(), start, stop);
 
             range
                 .filter(|&&block_id| {
@@ -78,12 +87,7 @@ impl Entry {
         let bm = self.block_manager.read().await?;
         let index = bm.index();
 
-        let range: Box<dyn Iterator<Item = &u64> + '_> = match (start, stop) {
-            (Some(start), Some(stop)) => Box::new(index.tree().range(start..stop)),
-            (Some(start), None) => Box::new(index.tree().range(start..)),
-            (None, Some(stop)) => Box::new(index.tree().range(..stop)),
-            (None, None) => Box::new(index.tree().iter()),
-        };
+        let range = block_id_range(index.tree(), start, stop);
 
         let stats = range
             .filter(|&&block_id| {

--- a/reductstore/src/storage/entry/remove_records.rs
+++ b/reductstore/src/storage/entry/remove_records.rs
@@ -3,14 +3,19 @@
 
 use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::BlockManager;
-use crate::storage::entry::Entry;
+use crate::storage::entry::{Entry, RecordQueryStats};
 use log::warn;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::ReadRecord;
 use reduct_base::msg::entry_api::QueryEntry;
 use reduct_base::not_found;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+
+struct RemoveRecordsResult {
+    errors: BTreeMap<u64, ReductError>,
+    block_ids: Vec<u64>,
+}
 
 impl Entry {
     /// Remove multiple records.
@@ -32,7 +37,11 @@ impl Entry {
     ) -> Result<BTreeMap<u64, ReductError>, ReductError> {
         self.ensure_not_deleting().await?;
         let block_manager = self.block_manager.clone();
-        Self::inner_remove_records(timestamps, block_manager, &self.bucket_name, &self.name).await
+        Ok(
+            Self::inner_remove_records(timestamps, block_manager, &self.bucket_name, &self.name)
+                .await?
+                .errors,
+        )
     }
 
     /// Query and remove multiple records over a range of timestamps.
@@ -50,7 +59,14 @@ impl Entry {
     /// # Errors
     ///
     /// * If the query fails.
-    pub async fn query_remove_records(&self, mut options: QueryEntry) -> Result<u64, ReductError> {
+    pub async fn query_remove_records(&self, options: QueryEntry) -> Result<u64, ReductError> {
+        Ok(self.query_remove_records_with_stats(options).await?.records)
+    }
+
+    pub(crate) async fn query_remove_records_with_stats(
+        &self,
+        mut options: QueryEntry,
+    ) -> Result<RecordQueryStats, ReductError> {
         self.ensure_not_deleting().await?;
         options.continuous = None; // force non-continuous query
 
@@ -70,7 +86,8 @@ impl Entry {
 
         // Loop until the query is done
         let mut continue_query = true;
-        let mut total_records = 0;
+        let mut stats = RecordQueryStats::default();
+        let mut affected_blocks = BTreeSet::new();
 
         while continue_query {
             let mut records_to_remove = vec![];
@@ -98,7 +115,7 @@ impl Entry {
 
             // Send the records to remove
             self.ensure_not_deleting().await?;
-            total_records += records_to_remove.len() as u64;
+            stats.records += records_to_remove.len() as u64;
             let copy_block_manager = block_manager.clone();
 
             match Self::inner_remove_records(
@@ -109,22 +126,24 @@ impl Entry {
             )
             .await
             {
-                Ok(error_map) => {
-                    for (timestamp, error) in error_map {
+                Ok(result) => {
+                    affected_blocks.extend(result.block_ids);
+                    for (timestamp, error) in result.errors {
                         // TODO: send the error to the client
                         warn!(
                             "Failed to remove record with timestamp {}: {}",
                             timestamp, error
                         );
 
-                        total_records -= 1;
+                        stats.records -= 1;
                     }
                 }
                 Err(e) => return Err(e),
             }
         }
 
-        Ok(total_records)
+        stats.blocks = affected_blocks.len() as u64;
+        Ok(stats)
     }
 
     /// Query and count multiple records over a range of timestamps.
@@ -140,7 +159,15 @@ impl Entry {
     /// # Errors
     ///
     /// * If the query fails.
-    pub async fn query_count_records(&self, mut options: QueryEntry) -> Result<u64, ReductError> {
+    #[allow(dead_code)]
+    pub async fn query_count_records(&self, options: QueryEntry) -> Result<u64, ReductError> {
+        Ok(self.query_count_records_with_stats(options).await?.records)
+    }
+
+    pub(crate) async fn query_count_records_with_stats(
+        &self,
+        mut options: QueryEntry,
+    ) -> Result<RecordQueryStats, ReductError> {
         options.continuous = None; // force non-continuous query
 
         let rx = async || {
@@ -155,13 +182,21 @@ impl Entry {
         };
 
         let mut continue_query = true;
-        let mut total_records = 0;
+        let mut stats = RecordQueryStats::default();
+        let mut affected_blocks = BTreeSet::new();
 
         while continue_query {
             let result = &mut rx.upgrade()?.write().await?.recv().await;
             match result {
-                Some(Ok(_)) => {
-                    total_records += 1;
+                Some(Ok(rec)) => {
+                    stats.records += 1;
+                    let block_ref = self
+                        .block_manager
+                        .write()
+                        .await?
+                        .find_block(rec.meta().timestamp())
+                        .await?;
+                    affected_blocks.insert(block_ref.read().await?.block_id());
                 }
                 Some(Err(ReductError {
                     status: ErrorCode::NoContent,
@@ -176,7 +211,8 @@ impl Entry {
             }
         }
 
-        Ok(total_records)
+        stats.blocks = affected_blocks.len() as u64;
+        Ok(stats)
     }
 
     async fn inner_remove_records(
@@ -184,7 +220,7 @@ impl Entry {
         block_manager: Arc<AsyncRwLock<BlockManager>>,
         bucket_name: &str,
         entry_name: &str,
-    ) -> Result<BTreeMap<u64, ReductError>, ReductError> {
+    ) -> Result<RemoveRecordsResult, ReductError> {
         let mut error_map = BTreeMap::new();
         let mut records_per_block = BTreeMap::new();
 
@@ -222,7 +258,9 @@ impl Entry {
 
         // Remove the records
         let mut handlers = vec![];
+        let mut block_ids = vec![];
         for (block_id, timestamps) in records_per_block {
+            block_ids.push(block_id);
             let local_block_manager = block_manager.clone();
             let handler = tokio::spawn(async move {
                 // TODO: we don't parallelize the removal of records in different blocks
@@ -237,7 +275,10 @@ impl Entry {
             handler.await.unwrap()?;
         }
 
-        Ok(error_map)
+        Ok(RemoveRecordsResult {
+            errors: error_map,
+            block_ids,
+        })
     }
 }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- throttle lifecycle delete and compress processing to a bounded window derived from the lifecycle interval when system events are enabled
- derive the lifecycle query start from the first matching record in the selected bucket entries instead of a hardcoded zero
- seed missing lifecycle progress from the first matching record and continue persisting progress in `$system/lifecycle/<instance>/<policy>` stats via `last_processed_ts`
- clamp lifecycle window start to the computed stop so delete and compress never build an invalid `start > stop` range
- mark caught-up lifecycle runs explicitly in action results and propagate that state into lifecycle system events
- make lifecycle system-event payloads always include `processed_records`, `processed_blocks`, and `caught_up`, while keeping `last_processed_ts` only when available
- keep the caught-up path using `cutoff_stop` semantics while returning a valid range, and keep the old non-windowed behavior when system events are disabled
- update lifecycle delete/compress expectations and lifecycle-task payload assertions, including error-path payload coverage

### Related issues

- lifecycle batching follow-up for the existing system event based lifecycle diagnostics implementation

### Does this PR introduce a breaking change?

No

### Other information:

Validation:
- `cargo fmt --all`
- `cargo test -p reductstore lifecycle::action`
- `cargo test -p reductstore lifecycle::lifecycle_task`
- `cargo test -p reductstore lifecycle::`
- `cargo check --workspace`
