### PR TITLE
Fix compressed block sync after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep lifecycle compression running when individual blocks fail and sync compressed block files and indexes to avoid inconsistent restores, [PR-1477](https://github.com/reductstore/reductstore/pull/1477)
+
 ## 1.20.3 - 2026-06-23
 
 ### Fixed

--- a/reductstore/src/backend/file.rs
+++ b/reductstore/src/backend/file.rs
@@ -148,6 +148,8 @@ impl File {
             return Ok(());
         }
 
+        self.is_synced = false;
+
         Self::run_blocking_io(|| self.inner.sync_all())?;
         Ok(())
     }

--- a/reductstore/src/storage/block_manager/block_index.rs
+++ b/reductstore/src/storage/block_manager/block_index.rs
@@ -270,6 +270,14 @@ impl BlockIndex {
         &self.index_info
     }
 
+    pub async fn sync_all(&mut self) -> Result<(), ReductError> {
+        let mut lock = FILE_CACHE
+            .write_or_create(&self.path_buf, SeekFrom::Start(0))
+            .await?;
+        lock.sync_all().await?;
+        Ok(())
+    }
+
     fn insert(&mut self, block: BlockEntry) {
         self.index_info.insert(block.block_id, block);
         self.index.insert(block.block_id);

--- a/reductstore/src/storage/block_manager/compress.rs
+++ b/reductstore/src/storage/block_manager/compress.rs
@@ -109,6 +109,7 @@ impl BlockManager {
         })?;
         block.compression = Some(i32::from(algorithm));
         self.block_index.save().await?;
+        self.block_index.sync_all().await?;
 
         let data_path = self.path_to_data(block_id);
         let desc_path = self.path_to_desc(block_id);
@@ -230,6 +231,18 @@ impl BlockManager {
                 err
             ));
         }
+        {
+            // we need to sync files after rename,
+            // which doesn't work for S3 storage
+            let mut file = FILE_CACHE
+                .write_or_create(&compressed_data_path, SeekFrom::Start(0))
+                .await?;
+            file.sync_all().await?;
+            let mut file = FILE_CACHE
+                .write_or_create(&compressed_desc_path, SeekFrom::Start(0))
+                .await?;
+            file.sync_all().await?;
+        }
 
         let compressed_data_size = tokio::fs::metadata(&compressed_data_path)
             .await
@@ -333,19 +346,11 @@ async fn decompress_file_zstd(
         internal_server_error!("Failed to decompress file {:?}: {}", compressed_path, err)
     })?;
 
-    let mut out = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(output_path)
-        .map_err(|err| {
-            internal_server_error!("Failed to create file {:?}: {}", output_path, err)
-        })?;
-    out.write_all(&decompressed)
-        .map_err(|err| internal_server_error!("Failed to write file {:?}: {}", output_path, err))?;
-    out.sync_all()
-        .map_err(|err| internal_server_error!("Failed to sync file {:?}: {}", output_path, err))?;
-
+    let mut out = FILE_CACHE
+        .write_or_create(output_path, SeekFrom::Start(0))
+        .await?;
+    out.write_all(&decompressed)?;
+    out.sync_all().await?;
     Ok(())
 }
 

--- a/reductstore/src/storage/block_manager/compress.rs
+++ b/reductstore/src/storage/block_manager/compress.rs
@@ -177,6 +177,20 @@ impl BlockManager {
         block_size: u64,
     ) -> Result<(u64, u64), ReductError> {
         let data_path = self.path_to_data(block_id);
+        let data_size = FILE_CACHE
+            .read(&data_path, SeekFrom::Start(0))
+            .await?
+            .metadata()?
+            .len();
+        if data_size != block_size {
+            return Err(internal_server_error!(
+                "Block data file {:?} size mismatch: index expects {} bytes, actual file size is {} bytes",
+                data_path,
+                block_size,
+                data_size
+            ));
+        }
+
         let compressed_data_path = self.path_to_compressed_data(block_id);
         let compressed_data_tmp_path = self
             .path
@@ -529,6 +543,31 @@ mod tests {
             .path()
             .join(format!("{}{}.tmp", block_id, COMPRESSED_DATA_FILE_EXT))
             .exists());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[serial]
+    async fn test_compress_block_rejects_data_file_size_mismatch() {
+        let (mut block_manager, block_id, original_data, _) =
+            block_manager_with_data(b"short data".to_vec()).await;
+        block_manager
+            .index_mut()
+            .get_block_mut(block_id)
+            .unwrap()
+            .size = original_data.len() as u64 + 1;
+
+        let err = block_manager
+            .compress_block(block_id, CompressionAlgorithm::Zstd)
+            .await
+            .err()
+            .unwrap();
+
+        assert_eq!(err.status(), ErrorCode::InternalServerError);
+        assert!(err.message.contains("Block data file"));
+        assert!(err.message.contains("size mismatch"));
+        assert!(block_manager.path_to_data(block_id).exists());
+        assert!(!block_manager.path_to_compressed_data(block_id).exists());
     }
 
     #[rstest]

--- a/reductstore/src/storage/block_manager/compress.rs
+++ b/reductstore/src/storage/block_manager/compress.rs
@@ -56,7 +56,7 @@ impl BlockManager {
         block_id: u64,
         algorithm: CompressionAlgorithm,
     ) -> Result<(), ReductError> {
-        let block_size = {
+        {
             let block = self.block_index.get_block(block_id).ok_or_else(|| {
                 not_found!(
                     "Block {} not found in entry {}/{}",
@@ -78,14 +78,12 @@ impl BlockManager {
                     block_id
                 ));
             }
-
-            block.size
-        };
+        }
 
         match algorithm {
             CompressionAlgorithm::None => return Ok(()),
             CompressionAlgorithm::Zstd => {
-                let (data_size, desc_size) = self.compress_block_zstd(block_id, block_size).await?;
+                let (data_size, desc_size) = self.compress_block_zstd(block_id).await?;
                 let block = self.block_index.get_block_mut(block_id).ok_or_else(|| {
                     not_found!(
                         "Block {} not found in entry {}/{}",
@@ -171,25 +169,13 @@ impl BlockManager {
         Ok(())
     }
 
-    async fn compress_block_zstd(
-        &self,
-        block_id: u64,
-        block_size: u64,
-    ) -> Result<(u64, u64), ReductError> {
+    async fn compress_block_zstd(&self, block_id: u64) -> Result<(u64, u64), ReductError> {
         let data_path = self.path_to_data(block_id);
         let data_size = FILE_CACHE
             .read(&data_path, SeekFrom::Start(0))
             .await?
             .metadata()?
             .len();
-        if data_size != block_size {
-            return Err(internal_server_error!(
-                "Block data file {:?} size mismatch: index expects {} bytes, actual file size is {} bytes",
-                data_path,
-                block_size,
-                data_size
-            ));
-        }
 
         let compressed_data_path = self.path_to_compressed_data(block_id);
         let compressed_data_tmp_path = self
@@ -203,8 +189,7 @@ impl BlockManager {
             block_id, COMPRESSED_DESCRIPTOR_FILE_EXT
         ));
 
-        if let Err(err) =
-            compress_file_zstd(&data_path, &compressed_data_tmp_path, block_size).await
+        if let Err(err) = compress_file_zstd(&data_path, &compressed_data_tmp_path, data_size).await
         {
             cleanup_tmp(&compressed_data_tmp_path);
             return Err(err);
@@ -550,7 +535,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_compress_block_rejects_data_file_size_mismatch() {
+    async fn test_compress_block_uses_data_file_size() {
         let (mut block_manager, block_id, original_data, _) =
             block_manager_with_data(b"short data".to_vec()).await;
         block_manager
@@ -559,17 +544,17 @@ mod tests {
             .unwrap()
             .size = original_data.len() as u64 + 1;
 
-        let err = block_manager
+        block_manager
             .compress_block(block_id, CompressionAlgorithm::Zstd)
             .await
-            .err()
             .unwrap();
 
-        assert_eq!(err.status(), ErrorCode::InternalServerError);
-        assert!(err.message.contains("Block data file"));
-        assert!(err.message.contains("size mismatch"));
-        assert!(block_manager.path_to_data(block_id).exists());
-        assert!(!block_manager.path_to_compressed_data(block_id).exists());
+        let decompressed_data = zstd::decode_all(
+            std::fs::File::open(block_manager.path_to_compressed_data(block_id)).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(decompressed_data, original_data);
     }
 
     #[rstest]
@@ -750,7 +735,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_decompress_file_zstd_missing_output_parent() {
+    async fn test_decompress_file_zstd_creates_output_parent() {
         let dir = tempdir().unwrap().keep();
         let compressed_path = dir.join("source.blk.zst");
         let output_path = dir.join("missing").join("source.blk");
@@ -760,12 +745,11 @@ mod tests {
         )
         .unwrap();
 
-        let err = decompress_file_zstd(&compressed_path, &output_path)
+        decompress_file_zstd(&compressed_path, &output_path)
             .await
-            .err()
             .unwrap();
 
-        assert_eq!(err.status(), ErrorCode::InternalServerError);
+        assert_eq!(std::fs::read(output_path).unwrap(), b"data");
     }
 
     #[rstest]

--- a/reductstore/src/storage/block_manager/compress.rs
+++ b/reductstore/src/storage/block_manager/compress.rs
@@ -251,10 +251,12 @@ impl BlockManager {
             let mut file = FILE_CACHE
                 .write_or_create(&compressed_data_path, SeekFrom::Start(0))
                 .await?;
+            file.flush_local().await?;
             file.sync_all().await?;
             let mut file = FILE_CACHE
                 .write_or_create(&compressed_desc_path, SeekFrom::Start(0))
                 .await?;
+            file.flush_local().await?;
             file.sync_all().await?;
         }
 

--- a/reductstore/src/storage/entry/compress.rs
+++ b/reductstore/src/storage/entry/compress.rs
@@ -3,6 +3,7 @@
 
 use super::{CompressionStats, Entry};
 use crate::storage::block_manager::compress::CompressionAlgorithm;
+use log::error;
 use reduct_base::error::{ErrorCode, ReductError};
 use std::collections::BTreeSet;
 
@@ -67,9 +68,16 @@ impl Entry {
                         stats.blocks += 1;
                         stats.records += record_count;
                     }
-                    Err(err)
-                        if matches!(err.status(), ErrorCode::Conflict | ErrorCode::NotFound) => {}
-                    Err(err) => return Err(err),
+                    Err(err) if matches!(err.status(), ErrorCode::Conflict) => {}
+                    Err(err) => {
+                        error!(
+                            "Failed to compress block {}/{}/{}: {}",
+                            bm.bucket_name(),
+                            bm.entry_name(),
+                            block_id,
+                            err
+                        );
+                    }
                 }
             }
             tokio::task::yield_now().await;
@@ -406,7 +414,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_compress_blocks_returns_internal_error(path: PathBuf) {
+    async fn test_compress_blocks_logs_and_continues_on_internal_error(path: PathBuf) {
         let entry = entry(multi_block_settings(), path.clone()).await;
         write_blocks(&entry, &[1_000_000]).await;
         let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
@@ -418,9 +426,10 @@ mod tests {
                 .unwrap();
         }
 
-        let err = entry.compress_blocks(None, None).await.err().unwrap();
-
-        assert_eq!(err.status(), ErrorCode::InternalServerError);
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats::default()
+        );
     }
 
     #[fixture]

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -401,11 +401,13 @@ impl EntryLoader {
                 .compression
                 .unwrap_or(i32::from(CompressionAlgorithm::None))
                 != i32::from(CompressionAlgorithm::None);
+
             let desc_path = if compressed {
                 path.join(format!("{}{}", block_id, COMPRESSED_DESCRIPTOR_FILE_EXT))
             } else {
                 path.join(format!("{}{}", block_id, DESCRIPTOR_FILE_EXT))
             };
+
             if file_list.contains(&desc_path) {
                 let data_path = if compressed {
                     path.join(format!("{}{}", block_id, COMPRESSED_DATA_FILE_EXT))


### PR DESCRIPTION
Closes #1476

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Sync compressed block data, descriptors, and block indexes after compression so remote backends do not restore inconsistent state after restart.
- Preserve file cache sync state when `sync_all` is requested so backend synchronization can upload newly renamed compressed files.
- Compress the actual current `.blk` file contents instead of relying on the logical block size stored in `blocks.idx`, which also supports preallocated data files.
- Keep lifecycle compression running when an individual block cannot be compressed, logging the failed block instead of aborting the worker.

### Related issues

#1476

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with targeted `fs-backend,ci` coverage-failure tests:

- `cargo test --features fs-backend,ci -p reductstore storage::block_manager::compress::tests`
- `cargo test --features fs-backend,ci -p reductstore storage::entry::compress::tests`
- `cargo test --features fs-backend,ci -p reductstore storage::bucket::compress_blocks::tests`
- `cargo test --features fs-backend,ci -p reductstore lifecycle::action::compress::tests`
- `cargo test --features fs-backend,ci -p reductstore storage::entry::entry_loader::tests::test_create_block_index_with_compressed_block`
- `cargo test --features fs-backend,ci -p reductstore storage::entry::entry_loader::tests::test_restore_compressed_block_missing_data`
- `cargo test --features fs-backend,ci -p reductstore storage::entry::entry_loader::tests::test_integrity_check_compressed_block_missing_data`
- `cargo test --features fs-backend,ci -p reductstore storage::entry::entry_loader::tests::test_restore_compressed_block_with_corrupted_descriptor`
- `cargo test --features fs-backend,ci -p reductstore storage::entry::write_record::tests::test_write_to_compressed_latest_block_decompresses`