### PR TITLE
Install CA certificates in build image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.20.5 - 2026-06-25
+
 ### Fixed
 
 - Install CA certificates in the build image to prevent TLS validation failures for HTTPS clients, [PR-1478](https://github.com/reductstore/reductstore/pull/1478)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Install CA certificates in the build image to prevent TLS validation failures for HTTPS clients, [PR-1478](https://github.com/reductstore/reductstore/pull/1478)
+
 ## 1.20.4 - 2026-06-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.20.4"
+version = "1.20.5"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.20.4"
+version = "1.20.5"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.91.0"

--- a/buildx.Dockerfile
+++ b/buildx.Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=${BUILDPLATFORM} ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da
 ARG BUILDPLATFORM
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 10001 reduct \


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Added the `ca-certificates` package to `buildx.Dockerfile` so the Ubuntu-based build image includes trusted root certificates. This prevents TLS certificate validation failures for tools such as `reduct-cli` when they connect to HTTPS endpoints from the container image.

### Related issues



### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:

- Reviewed the branch diff against `origin/main`.
