### PR TITLE
copy certificates into runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Copy CA certificates into the runtime image so HTTPS clients can validate TLS certificates, [PR-1479](https://github.com/reductstore/reductstore/pull/1479)
 - Install CA certificates in the build image to prevent TLS validation failures for HTTPS clients, [PR-1478](https://github.com/reductstore/reductstore/pull/1478)
 
 ## 1.20.4 - 2026-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 1.20.5 - 2026-06-25
+## 1.20.6 - 2026-06-25
 
 ### Fixed
 
 - Copy CA certificates into the runtime image so HTTPS clients can validate TLS certificates, [PR-1479](https://github.com/reductstore/reductstore/pull/1479)
+
+## 1.20.5 - 2026-06-25
+
+### Fixed
+
 - Install CA certificates in the build image to prevent TLS validation failures for HTTPS clients, [PR-1478](https://github.com/reductstore/reductstore/pull/1478)
 
 ## 1.20.4 - 2026-06-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.20.5"
+version = "1.20.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.20.5"
+version = "1.20.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.20.5"
+version = "1.20.6"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.20.5"
+version = "1.20.6"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.91.0"

--- a/buildx.Dockerfile
+++ b/buildx.Dockerfile
@@ -23,6 +23,12 @@ COPY --from=builder /etc/gshadow /etc/gshadow
 COPY --chown=10001:10001 --from=builder /data /data
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs
+
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 8383


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The runtime Docker image now copies CA certificate stores from the builder stage and sets `SSL_CERT_FILE` and `SSL_CERT_DIR` so HTTPS clients can validate TLS certificates inside the final image.

### Related issues


### Does this PR introduce a breaking change?

No.

### Other information:

Compared against `stable`.
