### PR TITLE
preallocate replication batch

### DIFF
--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -89,7 +89,7 @@ impl ReplicationSender {
                     if vec.is_empty() {
                         continue;
                     }
-                    let mut batch = Vec::new();
+                    let mut batch = Vec::with_capacity(vec.len());
                     let mut batch_sizes: BTreeMap<u64, u64> = BTreeMap::new();
                     let mut total_size = 0;
                     let mut processed_transactions = 0;


### PR DESCRIPTION
Closes #1418

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Code cleanup / small performance improvement

### What was changed?

Preallocated the replication batch vector using the known transaction count.

This avoids unnecessary vector reallocations while building a batch of records for replication.

### Related issues

https://github.com/reductstore/reductstore/issues/1418

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run locally:

- `cargo fmt --all -- --check`
- `cargo check --workspace --features "fs-backend,ci"`
- `cargo test -p reductstore --features "fs-backend,ci" test_replication`