### PR TITLE
feat(syslog): capture log messages to $system/logs/<instance> (#1467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Emit per-bucket usage statistics as system events under `usage/<instance>/<bucket>` alongside the existing instance total, and add `written_entries`, `read_entries`, and `record_count` fields to usage events, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @DibbayajyotiRoy
+- Capture the instance's own log messages to `$system/logs/<instance>/messages` as system events with a `level` severity label, configurable via `RS_SYSTEM_EVENTS_LOG_LEVEL` (default `WARN`, `OFF` to disable), [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @DibbayajyotiRoy
 
 ## 1.20.6 - 2026-06-25
 

--- a/reduct_base/src/logger.rs
+++ b/reduct_base/src/logger.rs
@@ -8,9 +8,21 @@ use std::sync::{Arc, LazyLock, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use thread_id;
 
-static LOGGER: Logger = Logger;
+static LOGGER: Logger = Logger {
+    sink: RwLock::new(None),
+};
 
-pub struct Logger;
+/// A registered log sink: receives an owned [`LogSnapshot`] for every record
+/// that reaches the logger. It must be non-blocking and must not panic.
+pub type LogSink = Arc<dyn Fn(LogSnapshot) + Send + Sync>;
+
+pub struct Logger {
+    /// Optional capture sink, installed via [`Logger::init_with_sink`]. Held as
+    /// interior-mutable state on the single static logger rather than as a
+    /// separate global.
+    sink: RwLock<Option<LogSink>>,
+}
+
 static PATHS: LazyLock<RwLock<BTreeMap<String, Level>>> =
     LazyLock::new(|| RwLock::new(BTreeMap::new()));
 
@@ -32,8 +44,8 @@ pub struct LogSnapshot {
     pub message: String,
 }
 
-impl LogSnapshot {
-    fn from_record(record: &Record) -> Self {
+impl From<&Record<'_>> for LogSnapshot {
+    fn from(record: &Record) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_micros() as u64)
@@ -47,23 +59,6 @@ impl LogSnapshot {
             message: format!("{}", record.args()),
         }
     }
-}
-
-/// A registered log sink: receives an owned [`LogSnapshot`] for every record
-/// that reaches the logger. It must be non-blocking and must not panic.
-pub type LogSink = Arc<dyn Fn(LogSnapshot) + Send + Sync>;
-
-static LOG_SINK: RwLock<Option<LogSink>> = RwLock::new(None);
-
-/// Register (or replace) the global log sink. Called once at startup by the
-/// component that persists logs; `reduct_base` itself never inspects the sink.
-pub fn set_log_sink(sink: LogSink) {
-    *LOG_SINK.write().unwrap() = Some(sink);
-}
-
-/// Remove the global log sink (used on shutdown and in tests).
-pub fn clear_log_sink() {
-    *LOG_SINK.write().unwrap() = None;
 }
 
 /// Parse a single log level name (case-insensitive) into a [`Level`].
@@ -138,9 +133,9 @@ impl Log for Logger {
         // AFTER console output and is fully abstract: this crate knows nothing
         // about what the sink does. Any reentrancy guarding lives inside the
         // registered sink, never here, so console output is never suppressed.
-        let sink = LOG_SINK.read().unwrap().clone();
+        let sink = self.sink.read().unwrap().clone();
         if let Some(sink) = sink {
-            sink(LogSnapshot::from_record(record));
+            sink(LogSnapshot::from(record));
         }
     }
 
@@ -148,12 +143,25 @@ impl Log for Logger {
 }
 
 impl Logger {
-    /// Initialize the logger.
+    /// Initialize the logger with no capture sink (clearing any previously
+    /// installed one).
     ///
     /// # Arguments
     ///
     /// * `level` - The log level to use. Can be one of TRACE, DEBUG, INFO, WARN, ERROR.
     pub fn init(levels: &str) {
+        Self::setup(levels);
+        *LOGGER.sink.write().unwrap() = None;
+    }
+
+    /// Initialize the logger and install a capture [`LogSink`]. The sink is
+    /// invoked for every record after console output (see [`Logger::log`]).
+    pub fn init_with_sink(levels: &str, sink: LogSink) {
+        Self::setup(levels);
+        *LOGGER.sink.write().unwrap() = Some(sink);
+    }
+
+    fn setup(levels: &str) {
         let mut max_level = Level::Trace;
         {
             let mut paths = PATHS.write().unwrap();
@@ -241,18 +249,19 @@ mod tests {
     #[serial]
     fn sink_receives_owned_snapshot() {
         use std::sync::Mutex;
-        Logger::init("TRACE");
-        clear_log_sink();
         test_support::clear_console();
 
         let captured: Arc<Mutex<Vec<LogSnapshot>>> = Arc::new(Mutex::new(Vec::new()));
         let sink_captured = Arc::clone(&captured);
-        set_log_sink(Arc::new(move |snapshot| {
-            sink_captured.lock().unwrap().push(snapshot);
-        }));
+        Logger::init_with_sink(
+            "TRACE",
+            Arc::new(move |snapshot| {
+                sink_captured.lock().unwrap().push(snapshot);
+            }),
+        );
 
         log::warn!("hello sink");
-        clear_log_sink();
+        Logger::init("INFO"); // clears the sink
 
         let snapshots = captured.lock().unwrap();
         assert!(snapshots
@@ -267,23 +276,24 @@ mod tests {
     #[serial]
     fn console_prints_even_when_sink_reenters() {
         use std::sync::atomic::{AtomicBool, Ordering};
-        Logger::init("TRACE");
-        clear_log_sink();
         test_support::clear_console();
 
         // The sink simulates "a log happens during a capture write": the first
         // time it sees the outer message it logs again (once, to stay bounded).
         let reentered = Arc::new(AtomicBool::new(false));
         let guard = Arc::clone(&reentered);
-        set_log_sink(Arc::new(move |snapshot: LogSnapshot| {
-            if snapshot.message == "outer-message" && !guard.swap(true, Ordering::SeqCst) {
-                log::error!("inner-during-capture");
-            }
-        }));
+        Logger::init_with_sink(
+            "TRACE",
+            Arc::new(move |snapshot: LogSnapshot| {
+                if snapshot.message == "outer-message" && !guard.swap(true, Ordering::SeqCst) {
+                    log::error!("inner-during-capture");
+                }
+            }),
+        );
 
         log::warn!("outer-message");
         let console = test_support::captured_console();
-        clear_log_sink();
+        Logger::init("INFO"); // clears the sink
 
         assert!(
             console.iter().any(|line| line.contains("outer-message")),

--- a/reduct_base/src/logger.rs
+++ b/reduct_base/src/logger.rs
@@ -4,7 +4,8 @@
 use chrono::prelude::{DateTime, Utc};
 use log::{Level, Log, Metadata, Record};
 use std::collections::BTreeMap;
-use std::sync::{LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 use thread_id;
 
 static LOGGER: Logger = Logger;
@@ -12,6 +13,74 @@ static LOGGER: Logger = Logger;
 pub struct Logger;
 static PATHS: LazyLock<RwLock<BTreeMap<String, Level>>> =
     LazyLock::new(|| RwLock::new(BTreeMap::new()));
+
+/// An owned, `Send + 'static` snapshot of a single log record.
+///
+/// `log::Record` borrows its fields and is neither `Send` nor `'static`, so a
+/// sink that wants to process records off-thread must copy what it needs
+/// synchronously. This struct uses only types available to `reduct_base`
+/// (`log::Level` is from the `log` crate), keeping the hook fully decoupled from
+/// any consumer.
+#[derive(Clone, Debug)]
+pub struct LogSnapshot {
+    /// Microseconds since the Unix epoch, captured when the record was logged.
+    pub timestamp: u64,
+    pub level: Level,
+    pub target: String,
+    pub file: Option<String>,
+    pub line: Option<u32>,
+    pub message: String,
+}
+
+impl LogSnapshot {
+    fn from_record(record: &Record) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_micros() as u64)
+            .unwrap_or(0);
+        LogSnapshot {
+            timestamp,
+            level: record.level(),
+            target: record.target().to_string(),
+            file: record.file().map(|file| file.to_string()),
+            line: record.line(),
+            message: format!("{}", record.args()),
+        }
+    }
+}
+
+/// A registered log sink: receives an owned [`LogSnapshot`] for every record
+/// that reaches the logger. It must be non-blocking and must not panic.
+pub type LogSink = Arc<dyn Fn(LogSnapshot) + Send + Sync>;
+
+static LOG_SINK: RwLock<Option<LogSink>> = RwLock::new(None);
+
+/// Register (or replace) the global log sink. Called once at startup by the
+/// component that persists logs; `reduct_base` itself never inspects the sink.
+pub fn set_log_sink(sink: LogSink) {
+    *LOG_SINK.write().unwrap() = Some(sink);
+}
+
+/// Remove the global log sink (used on shutdown and in tests).
+pub fn clear_log_sink() {
+    *LOG_SINK.write().unwrap() = None;
+}
+
+/// Parse a single log level name (case-insensitive) into a [`Level`].
+///
+/// Returns `None` for unset / `OFF` / invalid input, which callers treat as
+/// "disabled". Unlike [`Logger::init`] this parses exactly one level and does
+/// not mutate any global logger state.
+pub fn parse_log_level(level: &str) -> Option<Level> {
+    match level.trim().to_uppercase().as_str() {
+        "ERROR" => Some(Level::Error),
+        "WARN" => Some(Level::Warn),
+        "INFO" => Some(Level::Info),
+        "DEBUG" => Some(Level::Debug),
+        "TRACE" => Some(Level::Trace),
+        _ => None,
+    }
+}
 impl Log for Logger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         let paths = PATHS.read().unwrap();
@@ -28,6 +97,9 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record) {
+        // Console output is ALWAYS produced here (subject only to the existing
+        // level filter); it is never gated by the capture hook below. This
+        // guarantees a log emitted *during* a capture write still reaches stdout.
         if self.enabled(record.metadata()) {
             let now: DateTime<Utc> = Utc::now();
 
@@ -47,7 +119,7 @@ impl Log for Logger {
                 record.target()
             };
 
-            println!(
+            let formatted = format!(
                 "{} ({:>5}) [{}] -- {:}/{:}:{:} {:?}",
                 now.format("%Y-%m-%d %H:%M:%S.%3f"),
                 thread_id::get() % 100000,
@@ -57,6 +129,18 @@ impl Log for Logger {
                 record.line().unwrap(),
                 record.args(),
             );
+            println!("{}", formatted);
+            #[cfg(test)]
+            test_support::record_console(formatted);
+        }
+
+        // Optional capture hook (e.g. persisting logs to storage). It runs
+        // AFTER console output and is fully abstract: this crate knows nothing
+        // about what the sink does. Any reentrancy guarding lives inside the
+        // registered sink, never here, so console output is never suppressed.
+        let sink = LOG_SINK.read().unwrap().clone();
+        if let Some(sink) = sink {
+            sink(LogSnapshot::from_record(record));
         }
     }
 
@@ -109,6 +193,28 @@ impl Logger {
     }
 }
 
+/// Test-only capture of console output, so tests can assert that lines actually
+/// reached the console branch without trying to redirect real stdout. Not
+/// compiled into the library when used as a dependency.
+#[cfg(test)]
+mod test_support {
+    use std::sync::{LazyLock, Mutex};
+
+    static CONSOLE: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+    pub(super) fn record_console(line: String) {
+        CONSOLE.lock().unwrap().push(line);
+    }
+
+    pub(super) fn clear_console() {
+        CONSOLE.lock().unwrap().clear();
+    }
+
+    pub(super) fn captured_console() -> Vec<String> {
+        CONSOLE.lock().unwrap().clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,6 +225,76 @@ mod tests {
     fn it_works() {
         Logger::init("INFO");
         log::info!("Hello, world!");
+    }
+
+    #[test]
+    fn parse_log_level_parses_known_levels_and_rejects_others() {
+        assert_eq!(parse_log_level("warn"), Some(Level::Warn));
+        assert_eq!(parse_log_level(" ERROR "), Some(Level::Error));
+        assert_eq!(parse_log_level("Trace"), Some(Level::Trace));
+        assert_eq!(parse_log_level("OFF"), None);
+        assert_eq!(parse_log_level(""), None);
+        assert_eq!(parse_log_level("bogus"), None);
+    }
+
+    #[test]
+    #[serial]
+    fn sink_receives_owned_snapshot() {
+        use std::sync::Mutex;
+        Logger::init("TRACE");
+        clear_log_sink();
+        test_support::clear_console();
+
+        let captured: Arc<Mutex<Vec<LogSnapshot>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_captured = Arc::clone(&captured);
+        set_log_sink(Arc::new(move |snapshot| {
+            sink_captured.lock().unwrap().push(snapshot);
+        }));
+
+        log::warn!("hello sink");
+        clear_log_sink();
+
+        let snapshots = captured.lock().unwrap();
+        assert!(snapshots
+            .iter()
+            .any(|snap| snap.message == "hello sink" && snap.level == Level::Warn));
+    }
+
+    /// Constraint B: a log emitted *during* the capture hook still reaches the
+    /// console, because the console `println!` is unconditional and runs before
+    /// the (abstract) sink call.
+    #[test]
+    #[serial]
+    fn console_prints_even_when_sink_reenters() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        Logger::init("TRACE");
+        clear_log_sink();
+        test_support::clear_console();
+
+        // The sink simulates "a log happens during a capture write": the first
+        // time it sees the outer message it logs again (once, to stay bounded).
+        let reentered = Arc::new(AtomicBool::new(false));
+        let guard = Arc::clone(&reentered);
+        set_log_sink(Arc::new(move |snapshot: LogSnapshot| {
+            if snapshot.message == "outer-message" && !guard.swap(true, Ordering::SeqCst) {
+                log::error!("inner-during-capture");
+            }
+        }));
+
+        log::warn!("outer-message");
+        let console = test_support::captured_console();
+        clear_log_sink();
+
+        assert!(
+            console.iter().any(|line| line.contains("outer-message")),
+            "outer log must reach console"
+        );
+        assert!(
+            console
+                .iter()
+                .any(|line| line.contains("inner-during-capture")),
+            "a log emitted during a capture write must still reach console (Constraint B)"
+        );
     }
 
     #[test]

--- a/reductstore/src/api/components.rs
+++ b/reductstore/src/api/components.rs
@@ -17,7 +17,7 @@ use crate::lock_file::BoxedLockFile;
 use crate::replication::ManageReplications;
 use crate::storage::engine::StorageEngine;
 use crate::storage::usage::UsageEventAggregator;
-use crate::syslog::LogSystemEvent;
+use crate::syslog::{LogCapture, LogSystemEvent};
 use axum::http::HeaderMap;
 use log::error;
 use reduct_base::error::{ErrorCode, ReductError};
@@ -48,6 +48,11 @@ pub struct Components {
     /// from its own timer — so it is held as the concrete task rather than a
     /// boxed logger.
     pub(crate) usage_stat_logger: AsyncRwLock<Option<UsageEventAggregator>>,
+    /// Log-capture component: owns the consumer task that persists the
+    /// instance's own log messages under `$system/logs/<instance>/messages` and
+    /// the global log-sink registration. `None` when system events are disabled,
+    /// no persist level is configured, or on a replica. Stopped on shutdown.
+    pub(crate) log_capture: AsyncRwLock<Option<LogCapture>>,
 
     pub(crate) cfg: Cfg,
 }
@@ -165,6 +170,10 @@ impl StateKeeper {
             error!("Failed to stop usage statistics task: {}", err);
         }
 
+        if let Err(err) = self.stop_log_capture().await {
+            error!("Failed to stop log capture task: {}", err);
+        }
+
         if let Err(err) = self.sync_storage().await {
             error!("Failed to shutdown storage: {}", err);
         }
@@ -188,6 +197,14 @@ impl StateKeeper {
         let components = self.wait_components().await?.clone();
         if let Some(aggregator) = components.usage_stat_logger.write().await?.as_mut() {
             aggregator.stop().await;
+        }
+        Ok(())
+    }
+
+    async fn stop_log_capture(&self) -> Result<(), ReductError> {
+        let components = self.wait_components().await?.clone();
+        if let Some(capture) = components.log_capture.write().await?.as_mut() {
+            capture.stop().await;
         }
         Ok(())
     }

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -788,6 +788,7 @@ pub(crate) mod tests {
             )
             .expect("Failed to create extension repo"),
             usage_stat_logger: AsyncRwLock::new(None),
+            log_capture: AsyncRwLock::new(None),
             cfg,
             query_link_cache: AsyncRwLock::new(Cache::new(8, Duration::from_secs(60))),
             limits: crate::api::limits::LimitsBuilder::new().build(),
@@ -907,6 +908,7 @@ pub(crate) mod tests {
             )
             .expect("Failed to create extension repo"),
             usage_stat_logger: AsyncRwLock::new(None),
+            log_capture: AsyncRwLock::new(None),
             cfg: Cfg::default(),
             query_link_cache: AsyncRwLock::new(Cache::new(8, Duration::from_secs(60))),
             limits: LimitsBuilder::new().with_config(limits_config).build(),
@@ -1000,6 +1002,7 @@ pub(crate) mod tests {
             .expect("Failed to create extension repo"),
             audit_logger: Arc::new(AsyncRwLock::new(audit_logger)),
             usage_stat_logger: AsyncRwLock::new(None),
+            log_capture: AsyncRwLock::new(None),
             cfg,
             query_link_cache: AsyncRwLock::new(Cache::new(8, Duration::from_secs(60))),
             limits: crate::api::limits::LimitsBuilder::new().build(),

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -34,6 +34,7 @@ use crate::lifecycle::SystemEventSink;
 use crate::lock_file::{BoxedLockFile, LockFileBuilder};
 use crate::storage::usage::UsageCounters;
 use crate::syslog::build_audit_logger;
+use crate::syslog::build_log_capture;
 use crate::syslog::build_replication_system_logger;
 use crate::syslog::build_system_logger;
 use crate::syslog::build_usage_logger;
@@ -461,6 +462,8 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         let usage_stat_logger =
             build_usage_logger(&self.cfg, Arc::clone(&storage), usage_counters).await;
 
+        let log_capture = build_log_capture(&self.cfg, Arc::clone(&storage)).await;
+
         Ok(Components {
             storage: Arc::clone(&storage),
             token_repo: AsyncRwLock::new(token_repo.await),
@@ -484,6 +487,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                 .with_config(self.cfg.limits_config)
                 .build(),
             usage_stat_logger: AsyncRwLock::new(usage_stat_logger),
+            log_capture: AsyncRwLock::new(log_capture),
             cfg: self.cfg.clone(),
         })
     }

--- a/reductstore/src/cfg/system_events.rs
+++ b/reductstore/src/cfg/system_events.rs
@@ -4,6 +4,8 @@
 use crate::cfg::{parse_bool, CfgParser, ExtCfgBounds};
 use crate::core::env::{Env, GetEnv};
 use bytesize::ByteSize;
+use log::Level;
+use reduct_base::logger::parse_log_level;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -14,6 +16,9 @@ const DEFAULT_SYSTEM_EVENTS_REMOTE_TIMEOUT_S: u64 = 5;
 #[derive(Clone, Debug, PartialEq)]
 pub struct SystemEventsConfig {
     pub enabled: bool,
+    /// Minimum level for persisting the instance's own log messages to
+    /// `$system/logs/<instance>`. `None` (unset / `OFF`) disables log capture.
+    pub log_level: Option<Level>,
     pub quota_size: Option<u64>,
     pub remote_verify_ssl: bool,
     pub remote_ca_path: Option<PathBuf>,
@@ -24,6 +29,7 @@ impl Default for SystemEventsConfig {
     fn default() -> Self {
         Self {
             enabled: DEFAULT_SYSTEM_EVENTS_ENABLED,
+            log_level: None,
             quota_size: None,
             remote_verify_ssl: DEFAULT_SYSTEM_EVENTS_REMOTE_VERIFY_SSL,
             remote_ca_path: None,
@@ -42,6 +48,9 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                 env.get_optional::<String>("RS_SYSTEM_EVENTS_ENABLED"),
                 DEFAULT_SYSTEM_EVENTS_ENABLED || has_lifecycles,
             ),
+            log_level: env
+                .get_optional::<String>("RS_SYSTEM_EVENTS_LOG_LEVEL")
+                .and_then(|level| parse_log_level(&level)),
             quota_size: env
                 .get_optional::<ByteSize>("RS_SYSTEM_EVENTS_QUOTA_SIZE")
                 .map(|size| size.as_u64()),
@@ -82,6 +91,10 @@ mod tests {
             .return_const(Ok("true".to_string()));
         env_getter
             .expect_get()
+            .with(eq("RS_SYSTEM_EVENTS_LOG_LEVEL"))
+            .return_const(Ok("WARN".to_string()));
+        env_getter
+            .expect_get()
             .with(eq("RS_SYSTEM_EVENTS_QUOTA_SIZE"))
             .return_const(Ok("10MB".to_string()));
         env_getter
@@ -106,6 +119,7 @@ mod tests {
             config,
             SystemEventsConfig {
                 enabled: true,
+                log_level: Some(Level::Warn),
                 quota_size: Some(10_000_000),
                 remote_verify_ssl: false,
                 remote_ca_path: Some(PathBuf::from("/tmp/system-ca.pem")),
@@ -129,6 +143,7 @@ mod tests {
             config,
             SystemEventsConfig {
                 enabled: true,
+                log_level: None,
                 quota_size: None,
                 remote_verify_ssl: true,
                 remote_ca_path: None,
@@ -150,6 +165,7 @@ mod tests {
             config,
             SystemEventsConfig {
                 enabled: true,
+                log_level: None,
                 quota_size: None,
                 remote_verify_ssl: true,
                 remote_ca_path: None,
@@ -164,6 +180,10 @@ mod tests {
         env_getter
             .expect_get()
             .with(eq("RS_SYSTEM_EVENTS_ENABLED"))
+            .return_const(Err(VarError::NotPresent));
+        env_getter
+            .expect_get()
+            .with(eq("RS_SYSTEM_EVENTS_LOG_LEVEL"))
             .return_const(Err(VarError::NotPresent));
         env_getter
             .expect_get()

--- a/reductstore/src/cfg/system_events.rs
+++ b/reductstore/src/cfg/system_events.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 const DEFAULT_SYSTEM_EVENTS_ENABLED: bool = true;
+const DEFAULT_SYSTEM_EVENTS_LOG_LEVEL: Level = Level::Warn;
 const DEFAULT_SYSTEM_EVENTS_REMOTE_VERIFY_SSL: bool = true;
 const DEFAULT_SYSTEM_EVENTS_REMOTE_TIMEOUT_S: u64 = 5;
 
@@ -17,7 +18,8 @@ const DEFAULT_SYSTEM_EVENTS_REMOTE_TIMEOUT_S: u64 = 5;
 pub struct SystemEventsConfig {
     pub enabled: bool,
     /// Minimum level for persisting the instance's own log messages to
-    /// `$system/logs/<instance>`. `None` (unset / `OFF`) disables log capture.
+    /// `$system/logs/<instance>`. Defaults to `WARN`; set `RS_SYSTEM_EVENTS_LOG_LEVEL`
+    /// to `OFF` (or an invalid value) for `None`, which disables log capture.
     pub log_level: Option<Level>,
     pub quota_size: Option<u64>,
     pub remote_verify_ssl: bool,
@@ -29,7 +31,7 @@ impl Default for SystemEventsConfig {
     fn default() -> Self {
         Self {
             enabled: DEFAULT_SYSTEM_EVENTS_ENABLED,
-            log_level: None,
+            log_level: Some(DEFAULT_SYSTEM_EVENTS_LOG_LEVEL),
             quota_size: None,
             remote_verify_ssl: DEFAULT_SYSTEM_EVENTS_REMOTE_VERIFY_SSL,
             remote_ca_path: None,
@@ -50,7 +52,9 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             ),
             log_level: env
                 .get_optional::<String>("RS_SYSTEM_EVENTS_LOG_LEVEL")
-                .and_then(|level| parse_log_level(&level)),
+                .map_or(Some(DEFAULT_SYSTEM_EVENTS_LOG_LEVEL), |level| {
+                    parse_log_level(&level)
+                }),
             quota_size: env
                 .get_optional::<ByteSize>("RS_SYSTEM_EVENTS_QUOTA_SIZE")
                 .map(|size| size.as_u64()),
@@ -143,7 +147,7 @@ mod tests {
             config,
             SystemEventsConfig {
                 enabled: true,
-                log_level: None,
+                log_level: Some(Level::Warn),
                 quota_size: None,
                 remote_verify_ssl: true,
                 remote_ca_path: None,
@@ -165,7 +169,7 @@ mod tests {
             config,
             SystemEventsConfig {
                 enabled: true,
-                log_level: None,
+                log_level: Some(Level::Warn),
                 quota_size: None,
                 remote_verify_ssl: true,
                 remote_ca_path: None,

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -3,6 +3,8 @@
 
 mod forward_system_logger;
 mod local_system_logger;
+mod log_capture;
+mod log_event_payload;
 
 use crate::cfg::Cfg;
 use crate::core::sync::AsyncRwLock;
@@ -28,6 +30,9 @@ pub(crate) const SYSTEM_AUDIT_ENTRY_PREFIX: &str = "audit";
 pub(crate) const SYSTEM_LIFECYCLE_ENTRY_PREFIX: &str = "lifecycle";
 pub(crate) const SYSTEM_REPLICATION_ENTRY_PREFIX: &str = "replications";
 pub(crate) const SYSTEM_USAGE_ENTRY_PREFIX: &str = "usage";
+pub(crate) const SYSTEM_LOGS_ENTRY_PREFIX: &str = "logs";
+
+pub(crate) use log_capture::LogCapture;
 
 pub(crate) type SystemEventFlushFuture =
     Pin<Box<dyn Future<Output = Result<(), ReductError>> + Send>>;
@@ -227,6 +232,45 @@ pub(crate) async fn build_usage_logger(
         instance_name: cfg.instance_name.clone(),
     };
     Some(UsageEventAggregator::new(sink, storage, counters))
+}
+
+pub(crate) async fn build_logs_system_logger(
+    cfg: &Cfg,
+    storage: Arc<StorageEngine>,
+) -> BoxedSystemLogger {
+    if !cfg.system_events_conf.enabled {
+        return Box::new(DisabledSystemLogger);
+    }
+
+    SystemLoggerBuilder::new(SYSTEM_BUCKET_NAME, system_bucket_settings(cfg))
+        .with_entry_prefix(SYSTEM_LOGS_ENTRY_PREFIX)
+        .build(cfg, storage)
+        .expect("logs system logger must build")
+}
+
+/// Build the log-capture component: it registers a global log sink and owns the
+/// consumer task that writes captured records under `logs/<instance>/messages`.
+/// Returns `None` when system events are disabled, no persist level is
+/// configured, or the instance is a replica (logs are node-local to avoid the
+/// replica forward-failure loop).
+pub(crate) async fn build_log_capture(
+    cfg: &Cfg,
+    storage: Arc<StorageEngine>,
+) -> Option<LogCapture> {
+    if !cfg.system_events_conf.enabled {
+        return None;
+    }
+    let persist_level = cfg.system_events_conf.log_level?;
+    if cfg.role == crate::cfg::InstanceRole::Replica {
+        return None;
+    }
+
+    let inner = build_logs_system_logger(cfg, Arc::clone(&storage)).await;
+    let sink = SystemEventSink {
+        system_logger: Arc::new(AsyncRwLock::new(inner)),
+        instance_name: cfg.instance_name.clone(),
+    };
+    Some(LogCapture::new(sink, persist_level))
 }
 
 fn system_bucket_settings(cfg: &Cfg) -> BucketSettings {

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -270,7 +270,7 @@ pub(crate) async fn build_log_capture(
         system_logger: Arc::new(AsyncRwLock::new(inner)),
         instance_name: cfg.instance_name.clone(),
     };
-    Some(LogCapture::new(sink, persist_level))
+    Some(LogCapture::new(sink, persist_level, &cfg.log_level))
 }
 
 fn system_bucket_settings(cfg: &Cfg) -> BucketSettings {

--- a/reductstore/src/syslog/local_system_logger.rs
+++ b/reductstore/src/syslog/local_system_logger.rs
@@ -42,7 +42,12 @@ impl LocalSystemLogger {
             Some(prefix) => format!("{}/{}/{}", prefix, instance, event.entry_name),
             None => format!("{}/{}", instance, event.entry_name),
         };
-        let labels = Labels::from([("status".to_string(), event.status.to_string())]);
+        let mut labels = Labels::from([("status".to_string(), event.status.to_string())]);
+        // Expose a record's severity as a queryable label when present (log
+        // events carry `level` in their payload).
+        if let Some(level) = event.payload.get("level").and_then(|value| value.as_str()) {
+            labels.insert("level".to_string(), level.to_string());
+        }
         let payload = event.to_flat_json()?;
         let mut writer = match self
             .storage

--- a/reductstore/src/syslog/log_capture.rs
+++ b/reductstore/src/syslog/log_capture.rs
@@ -13,7 +13,7 @@ use crate::lifecycle::SystemEventSink;
 use crate::syslog::log_event_payload::LogSystemEventPayload;
 use crate::syslog::SystemEvent;
 use log::{error, warn, Level};
-use reduct_base::logger::{clear_log_sink, set_log_sink, LogSnapshot};
+use reduct_base::logger::{LogSink, LogSnapshot, Logger};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -32,15 +32,10 @@ tokio::task_local! {
     static IN_CAPTURE_WRITE: bool;
 }
 
-fn level_code(level: Level) -> u16 {
-    match level {
-        Level::Error => 1,
-        Level::Warn => 2,
-        Level::Info => 3,
-        Level::Debug => 4,
-        Level::Trace => 5,
-    }
-}
+/// Status carried by every `log_message` event: the record was persisted
+/// successfully, so it is HTTP OK. Severity is exposed via the `level` payload
+/// field and the per-record `level` label instead.
+const LOG_EVENT_STATUS: u16 = 200;
 
 fn make_event(instance: &str, snapshot: LogSnapshot) -> SystemEvent {
     let LogSnapshot {
@@ -62,7 +57,7 @@ fn make_event(instance: &str, snapshot: LogSnapshot) -> SystemEvent {
         timestamp,
         instance: instance.to_string(),
         entry_name: LOG_ENTRY_NAME.to_string(),
-        status: level_code(level),
+        status: LOG_EVENT_STATUS,
         message,
         payload: payload.to_value(),
     }
@@ -96,11 +91,12 @@ fn enqueue(
     }
 }
 
-/// Owns the log-capture consumer task and the global sink registration.
+/// Owns the log-capture consumer task. The global capture sink is installed in
+/// [`LogCapture::new`] via [`Logger::init_with_sink`].
 ///
 /// Mirrors [`UsageEventAggregator`](crate::storage::usage::UsageEventAggregator):
-/// a bounded channel feeds a worker that drains it. [`stop`](Self::stop)
-/// unregisters the sink and joins the worker.
+/// a bounded channel feeds a worker that drains it. [`stop`](Self::stop) joins
+/// the worker.
 pub(crate) struct LogCapture {
     // Dropping (or `take`-ing in `stop`) closes the channel, signalling the
     // worker to drain the backlog and exit.
@@ -110,16 +106,24 @@ pub(crate) struct LogCapture {
 }
 
 impl LogCapture {
-    pub(crate) fn new(sink: SystemEventSink, persist_level: Level) -> Self {
+    /// `console_log_level` is the console level string (`RS_LOG_LEVEL`): the
+    /// logger is (re)initialized with it via [`Logger::init_with_sink`] so the
+    /// capture sink is installed without a separate accessor.
+    pub(crate) fn new(
+        sink: SystemEventSink,
+        persist_level: Level,
+        console_log_level: &str,
+    ) -> Self {
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
         let (data_tx, data_rx) = mpsc::channel(LOG_CHANNEL_SIZE);
         let dropped = Arc::new(AtomicU64::new(0));
 
         // `data_tx` is the only sender; it is moved into the global sink.
         let sink_dropped = Arc::clone(&dropped);
-        set_log_sink(Arc::new(move |snapshot: LogSnapshot| {
+        let log_sink: LogSink = Arc::new(move |snapshot: LogSnapshot| {
             enqueue(&data_tx, persist_level, &sink_dropped, snapshot);
-        }));
+        });
+        Logger::init_with_sink(console_log_level, log_sink);
 
         let worker_handle = tokio::spawn(Self::run_worker(shutdown_rx, data_rx, sink));
         Self {
@@ -129,10 +133,11 @@ impl LogCapture {
         }
     }
 
-    /// Unregister the sink and stop the worker, draining any buffered records.
-    /// Telemetry must never break shutdown, so a failed join is logged only.
+    /// Stop the worker, draining any buffered records. The installed sink is
+    /// left in place (the channel it feeds is closed once the worker exits, so
+    /// further records are dropped harmlessly). Telemetry must never break
+    /// shutdown, so a failed join is logged only.
     pub(crate) async fn stop(&mut self) {
-        clear_log_sink();
         // Drop the sender so the worker observes shutdown and drains.
         self.shutdown_tx.take();
         if let Some(handle) = self.worker_handle.take() {
@@ -248,7 +253,7 @@ mod tests {
         assert_eq!(event.entry_name, "messages");
         assert_eq!(event.instance, "instance-1");
         assert_eq!(event.timestamp, 1_000);
-        assert_eq!(event.status, 2); // WARN
+        assert_eq!(event.status, 200); // HTTP OK; severity is in `level`
         assert_eq!(event.message, "disk almost full");
         assert_eq!(event.payload["level"], "WARN");
         assert_eq!(event.payload["target"], "reductstore::test");
@@ -368,7 +373,7 @@ mod tests {
     }
 
     /// A captured record lands at `$system/logs/<instance>/messages` with the
-    /// expected flat schema and `status` (level code) label.
+    /// expected flat schema (status 200), plus a `level` severity label.
     #[tokio::test(flavor = "multi_thread")]
     async fn persist_writes_to_logs_entry_path() {
         use crate::cfg::Cfg;
@@ -406,11 +411,16 @@ mod tests {
             .begin_read("logs/instance-1/messages", 1_000)
             .await
             .unwrap();
+        // Severity is exposed as a per-record label for filtering.
+        assert_eq!(
+            reader.meta().labels().get("level").map(String::as_str),
+            Some("WARN")
+        );
         let record = reader.read_chunk().unwrap().unwrap();
         let event: serde_json::Value = serde_json::from_slice(&record).unwrap();
 
         assert_eq!(event["instance"], "instance-1");
-        assert_eq!(event["status"], 2);
+        assert_eq!(event["status"], 200);
         assert_eq!(event["message"], "disk almost full");
         assert_eq!(event["level"], "WARN");
         assert_eq!(event["target"], "reductstore::test");

--- a/reductstore/src/syslog/log_capture.rs
+++ b/reductstore/src/syslog/log_capture.rs
@@ -1,0 +1,419 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+//! Captures the instance's own log messages into `$system/logs/<instance>/messages`.
+//!
+//! A [`reduct_base`] log sink (registered globally) snapshots every log record
+//! and, when it is at or above the configured persist level, forwards it over a
+//! bounded channel to a consumer task that writes it as a `log_message` system
+//! event. The hook is non-blocking (`try_send`, drop-on-overflow) so logging
+//! never blocks the server.
+
+use crate::lifecycle::SystemEventSink;
+use crate::syslog::log_event_payload::LogSystemEventPayload;
+use crate::syslog::SystemEvent;
+use log::{error, warn, Level};
+use reduct_base::logger::{clear_log_sink, set_log_sink, LogSnapshot};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+const LOG_EVENT_TYPE: &str = "log_message";
+const LOG_ENTRY_NAME: &str = "messages";
+const LOG_CHANNEL_SIZE: usize = 1024;
+
+tokio::task_local! {
+    /// Set to `true` while the consumer is writing a captured record to storage.
+    /// The sink checks it and skips re-capturing records emitted *during* that
+    /// write, breaking the otherwise-infinite recursion (a storage write logs).
+    /// It gates ONLY re-capture; console output already happened unconditionally
+    /// upstream in `reduct_base`.
+    static IN_CAPTURE_WRITE: bool;
+}
+
+fn level_code(level: Level) -> u16 {
+    match level {
+        Level::Error => 1,
+        Level::Warn => 2,
+        Level::Info => 3,
+        Level::Debug => 4,
+        Level::Trace => 5,
+    }
+}
+
+fn make_event(instance: &str, snapshot: LogSnapshot) -> SystemEvent {
+    let LogSnapshot {
+        timestamp,
+        level,
+        target,
+        file,
+        line,
+        message,
+    } = snapshot;
+    let payload = LogSystemEventPayload {
+        level: level.to_string(),
+        target,
+        file,
+        line,
+    };
+    SystemEvent {
+        event_type: LOG_EVENT_TYPE.to_string(),
+        timestamp,
+        instance: instance.to_string(),
+        entry_name: LOG_ENTRY_NAME.to_string(),
+        status: level_code(level),
+        message,
+        payload: payload.to_value(),
+    }
+}
+
+/// The non-blocking enqueue path used by the registered sink. Skips records
+/// emitted during a capture write (reentrancy guard) and records below the
+/// persist level, then `try_send`s; on a full channel it counts a drop and
+/// returns immediately rather than blocking.
+fn enqueue(
+    tx: &mpsc::Sender<LogSnapshot>,
+    persist_level: Level,
+    dropped: &AtomicU64,
+    snapshot: LogSnapshot,
+) {
+    // Reentrancy guard: never capture a log emitted while we are writing one.
+    if IN_CAPTURE_WRITE.try_with(|active| *active).unwrap_or(false) {
+        return;
+    }
+    // Persist-level filter: a less severe record (numerically greater `Level`)
+    // is dropped before it reaches the channel.
+    if snapshot.level > persist_level {
+        return;
+    }
+    match tx.try_send(snapshot) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            dropped.fetch_add(1, Ordering::Relaxed);
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {}
+    }
+}
+
+/// Owns the log-capture consumer task and the global sink registration.
+///
+/// Mirrors [`UsageEventAggregator`](crate::storage::usage::UsageEventAggregator):
+/// a bounded channel feeds a worker that drains it. [`stop`](Self::stop)
+/// unregisters the sink and joins the worker.
+pub(crate) struct LogCapture {
+    // Dropping (or `take`-ing in `stop`) closes the channel, signalling the
+    // worker to drain the backlog and exit.
+    shutdown_tx: Option<mpsc::Sender<()>>,
+    worker_handle: Option<JoinHandle<()>>,
+    dropped: Arc<AtomicU64>,
+}
+
+impl LogCapture {
+    pub(crate) fn new(sink: SystemEventSink, persist_level: Level) -> Self {
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (data_tx, data_rx) = mpsc::channel(LOG_CHANNEL_SIZE);
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        // `data_tx` is the only sender; it is moved into the global sink.
+        let sink_dropped = Arc::clone(&dropped);
+        set_log_sink(Arc::new(move |snapshot: LogSnapshot| {
+            enqueue(&data_tx, persist_level, &sink_dropped, snapshot);
+        }));
+
+        let worker_handle = tokio::spawn(Self::run_worker(shutdown_rx, data_rx, sink));
+        Self {
+            shutdown_tx: Some(shutdown_tx),
+            worker_handle: Some(worker_handle),
+            dropped,
+        }
+    }
+
+    /// Unregister the sink and stop the worker, draining any buffered records.
+    /// Telemetry must never break shutdown, so a failed join is logged only.
+    pub(crate) async fn stop(&mut self) {
+        clear_log_sink();
+        // Drop the sender so the worker observes shutdown and drains.
+        self.shutdown_tx.take();
+        if let Some(handle) = self.worker_handle.take() {
+            if let Err(err) = handle.await {
+                error!("Log capture task failed to join: {:?}", err);
+            }
+        }
+
+        let dropped = self.dropped.load(Ordering::Relaxed);
+        if dropped > 0 {
+            warn!(
+                "Log capture dropped {} message(s) because the buffer was full",
+                dropped
+            );
+        }
+    }
+
+    async fn run_worker(
+        mut shutdown_rx: mpsc::Receiver<()>,
+        mut data_rx: mpsc::Receiver<LogSnapshot>,
+        sink: SystemEventSink,
+    ) {
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.recv() => {
+                    // Shutdown signalled: drain whatever is already buffered,
+                    // then stop.
+                    while let Ok(snapshot) = data_rx.try_recv() {
+                        Self::persist(&sink, snapshot).await;
+                    }
+                    break;
+                }
+                maybe_snapshot = data_rx.recv() => {
+                    match maybe_snapshot {
+                        Some(snapshot) => Self::persist(&sink, snapshot).await,
+                        None => break,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Write one captured record. The storage write is wrapped in the
+    /// reentrancy guard so any log it emits is not re-captured; errors are
+    /// swallowed and logged (telemetry must never break the server).
+    async fn persist(sink: &SystemEventSink, snapshot: LogSnapshot) {
+        let event = make_event(&sink.instance_name, snapshot);
+        IN_CAPTURE_WRITE
+            .scope(true, async {
+                let mut logger = match sink.system_logger.write().await {
+                    Ok(logger) => logger,
+                    Err(err) => {
+                        error!("Failed to lock system logger for log capture: {}", err);
+                        return;
+                    }
+                };
+                if let Err(err) = logger.log_event(event).await {
+                    error!("Failed to persist log message: {}", err);
+                }
+            })
+            .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::sync::AsyncRwLock;
+    use crate::syslog::LogSystemEvent;
+    use async_trait::async_trait;
+    use reduct_base::error::ReductError;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    fn snapshot(level: Level, message: &str) -> LogSnapshot {
+        LogSnapshot {
+            timestamp: 1_000,
+            level,
+            target: "reductstore::test".to_string(),
+            file: Some("syslog/log_capture.rs".to_string()),
+            line: Some(42),
+            message: message.to_string(),
+        }
+    }
+
+    fn sink_with(logger: Box<dyn LogSystemEvent + Send + Sync>) -> SystemEventSink {
+        SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(logger)),
+            instance_name: "instance-1".to_string(),
+        }
+    }
+
+    /// A logger whose write path itself re-enters the enqueue path — exactly the
+    /// recursion the guard must stop (a real storage write logs while writing).
+    struct ReentrantLogger {
+        events: Arc<Mutex<Vec<SystemEvent>>>,
+        on_write: Arc<dyn Fn() + Send + Sync>,
+    }
+
+    #[async_trait]
+    impl LogSystemEvent for ReentrantLogger {
+        async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError> {
+            (self.on_write)();
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn make_event_maps_snapshot_fields() {
+        let event = make_event("instance-1", snapshot(Level::Warn, "disk almost full"));
+        assert_eq!(event.event_type, "log_message");
+        assert_eq!(event.entry_name, "messages");
+        assert_eq!(event.instance, "instance-1");
+        assert_eq!(event.timestamp, 1_000);
+        assert_eq!(event.status, 2); // WARN
+        assert_eq!(event.message, "disk almost full");
+        assert_eq!(event.payload["level"], "WARN");
+        assert_eq!(event.payload["target"], "reductstore::test");
+        assert_eq!(event.payload["file"], "syslog/log_capture.rs");
+        assert_eq!(event.payload["line"], 42);
+    }
+
+    #[tokio::test]
+    async fn enqueue_passes_records_at_or_above_persist_level() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let dropped = AtomicU64::new(0);
+        enqueue(&tx, Level::Warn, &dropped, snapshot(Level::Error, "boom"));
+        enqueue(&tx, Level::Warn, &dropped, snapshot(Level::Warn, "warn"));
+        assert!(rx.try_recv().is_ok());
+        assert!(rx.try_recv().is_ok());
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn enqueue_drops_records_below_persist_level() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let dropped = AtomicU64::new(0);
+        enqueue(&tx, Level::Warn, &dropped, snapshot(Level::Info, "chatty"));
+        assert!(rx.try_recv().is_err());
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn enqueue_drops_on_full_channel_and_counts() {
+        let (tx, _rx) = mpsc::channel(1);
+        let dropped = AtomicU64::new(0);
+        // First call fills the single slot; the rest overflow and are counted.
+        for _ in 0..5 {
+            enqueue(&tx, Level::Trace, &dropped, snapshot(Level::Info, "x"));
+        }
+        assert_eq!(dropped.load(Ordering::Relaxed), 4);
+    }
+
+    /// The guard gates ONLY the enqueue (re-capture), nothing else.
+    #[tokio::test]
+    async fn guard_suppresses_reenqueue_during_capture_write() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let dropped = AtomicU64::new(0);
+        // Inside the capture-write scope, an enqueue is skipped...
+        IN_CAPTURE_WRITE
+            .scope(true, async {
+                enqueue(
+                    &tx,
+                    Level::Trace,
+                    &dropped,
+                    snapshot(Level::Error, "during"),
+                );
+            })
+            .await;
+        assert!(
+            rx.try_recv().is_err(),
+            "enqueue during a capture write must be suppressed"
+        );
+        // ...but outside it, enqueue works normally.
+        enqueue(&tx, Level::Trace, &dropped, snapshot(Level::Error, "after"));
+        assert!(
+            rx.try_recv().is_ok(),
+            "enqueue outside a capture write must pass"
+        );
+    }
+
+    /// KEYSTONE: the consumer must not loop when each write emits a log. The
+    /// guard suppresses the re-capture, so exactly the seeded records are
+    /// written and the worker terminates.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn consumer_does_not_loop_when_write_emits_logs() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (data_tx, data_rx) = mpsc::channel::<LogSnapshot>(1024);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        // On every write the logger re-enters the enqueue path (as a storage
+        // write would by logging). Without the guard this loops forever.
+        let reentry_tx = data_tx.clone();
+        let reentry_dropped = Arc::clone(&dropped);
+        let logger = ReentrantLogger {
+            events: Arc::clone(&events),
+            on_write: Arc::new(move || {
+                enqueue(
+                    &reentry_tx,
+                    Level::Trace,
+                    &reentry_dropped,
+                    snapshot(Level::Error, "emitted-during-write"),
+                );
+            }),
+        };
+        let sink = sink_with(Box::new(logger));
+        let worker = tokio::spawn(LogCapture::run_worker(shutdown_rx, data_rx, sink));
+
+        // Seed three records from outside any write scope.
+        for i in 0..3 {
+            enqueue(
+                &data_tx,
+                Level::Trace,
+                &dropped,
+                snapshot(Level::Error, &format!("seed-{i}")),
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        drop(shutdown_tx);
+        tokio::time::timeout(Duration::from_secs(3), worker)
+            .await
+            .expect("consumer must not loop/hang")
+            .unwrap();
+
+        assert_eq!(
+            events.lock().unwrap().len(),
+            3,
+            "exactly the seeds are written — no re-capture amplification"
+        );
+    }
+
+    /// A captured record lands at `$system/logs/<instance>/messages` with the
+    /// expected flat schema and `status` (level code) label.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn persist_writes_to_logs_entry_path() {
+        use crate::cfg::Cfg;
+        use crate::storage::engine::StorageEngine;
+        use crate::syslog::{build_logs_system_logger, SYSTEM_BUCKET_NAME};
+        use reduct_base::io::ReadRecord;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let mut cfg = Cfg {
+            data_path: tmp_dir.keep(),
+            ..Cfg::default()
+        };
+        cfg.system_events_conf.enabled = true;
+        cfg.instance_name = "instance-1".to_string();
+
+        let storage = Arc::new(
+            StorageEngine::builder()
+                .with_data_path(cfg.data_path.clone())
+                .with_cfg(cfg.clone())
+                .build()
+                .await,
+        );
+
+        let logger = build_logs_system_logger(&cfg, Arc::clone(&storage)).await;
+        let sink = sink_with(logger);
+
+        LogCapture::persist(&sink, snapshot(Level::Warn, "disk almost full")).await;
+
+        let bucket = storage
+            .get_bucket(SYSTEM_BUCKET_NAME)
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+        let mut reader = bucket
+            .begin_read("logs/instance-1/messages", 1_000)
+            .await
+            .unwrap();
+        let record = reader.read_chunk().unwrap().unwrap();
+        let event: serde_json::Value = serde_json::from_slice(&record).unwrap();
+
+        assert_eq!(event["instance"], "instance-1");
+        assert_eq!(event["status"], 2);
+        assert_eq!(event["message"], "disk almost full");
+        assert_eq!(event["level"], "WARN");
+        assert_eq!(event["target"], "reductstore::test");
+        assert_eq!(event["line"], 42);
+    }
+}

--- a/reductstore/src/syslog/log_event_payload.rs
+++ b/reductstore/src/syslog/log_event_payload.rs
@@ -1,0 +1,27 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Payload carried by a `log_message` system event. Mirrors the other
+/// `*_event_payload` structs: a flat set of fields that `to_value` renders into
+/// the JSON object flattened by [`SystemEvent::to_flat_json`](crate::syslog::SystemEvent::to_flat_json).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub(crate) struct LogSystemEventPayload {
+    pub level: String,
+    pub target: String,
+    pub file: Option<String>,
+    pub line: Option<u32>,
+}
+
+impl LogSystemEventPayload {
+    pub(crate) fn to_value(&self) -> Value {
+        json!({
+            "level": self.level,
+            "target": self.target,
+            "file": self.file,
+            "line": self.line,
+        })
+    }
+}


### PR DESCRIPTION
Closes #1467.

## Summary
Captures the system's own log messages into `$system/logs/<instance>/messages`, queryable like other `$system` events. Opt-in via `RS_SYSTEM_EVENTS_LOG_LEVEL` (off by default).

## Approach (per our discussion)
- **`reduct-base` stays abstract.** The logger gains a generic sink hook (`LogSnapshot` + `set_log_sink`) with zero knowledge of reductstore types. All `$system` mapping lives in reductstore and registers into the hook, so `reduct-base` keeps no dependency on `reductstore`.
- **Console output is unconditional; only capture is guarded.** A log emitted during a capture write still prints to stdout (a `tokio::task_local!` reentrancy guard suppresses only re-enqueue, not the console `println!`), so logging errors during logging stay visible.
- Node-local only (non-replica), bounded channel with drop-on-overflow so capture never blocks the server.

## For your call
- `status` carries the level code (1=ERROR … 5=TRACE) and level label, reusing the shared flat-schema field. Happy to use a separate field if you'd rather not overload `status`.
- **max_level limitation:** `set_max_level` is still derived from the console level, so a persist level *more verbose* than the console level won't capture the extra records. Left out per our "start simple" plan; the fix is `set_max_level(max(console, persist))` at startup if you want it.

## Tests
- `consumer_does_not_loop_when_write_emits_logs` — reentrancy: a write that emits logs writes exactly its seeds, no amplification, terminates.
- `console_prints_even_when_sink_reenters` — console visibility preserved during capture.
- Plus level filtering, overflow drop+count, round-trip to the entry path, gating, schema mapping.