### PR TITLE
add replication entry prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Emit per-bucket usage statistics as system events under `usage/<instance>/<bucket>` alongside the existing instance total, and add `written_entries`, `read_entries`, and `record_count` fields to usage events, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @DibbayajyotiRoy
-- Add a replication `prefix` setting to write replicated records under a destination entry prefix, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @rohankumardubey
+- Add a replication `dst_prefix` setting to write replicated records under a destination entry prefix, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @rohankumardubey
 
 ## 1.20.6 - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Emit per-bucket usage statistics as system events under `usage/<instance>/<bucket>` alongside the existing instance total, and add `written_entries`, `read_entries`, and `record_count` fields to usage events, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @DibbayajyotiRoy
+- Add a replication `prefix` setting to write replicated records under a destination entry prefix, [PR-NNNN](https://github.com/reductstore/reductstore/pull/NNNN) by @rohankumardubey
 
 ## 1.20.6 - 2026-06-25
 

--- a/reduct_base/src/msg/replication_api.rs
+++ b/reduct_base/src/msg/replication_api.rs
@@ -39,7 +39,7 @@ pub struct ReplicationSettings {
     pub entries: Vec<String>,
     /// Prefix to add to destination entry names
     #[serde(default)]
-    pub prefix: String,
+    pub dst_prefix: String,
     /// Labels to include
     #[serde(default)]
     pub include: Labels,

--- a/reduct_base/src/msg/replication_api.rs
+++ b/reduct_base/src/msg/replication_api.rs
@@ -37,6 +37,9 @@ pub struct ReplicationSettings {
     /// Entries to replicate. If empty, all entries are replicated. Wildcards are supported.
     #[serde(default)]
     pub entries: Vec<String>,
+    /// Prefix to add to destination entry names
+    #[serde(default)]
+    pub prefix: String,
     /// Labels to include
     #[serde(default)]
     pub include: Labels,

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -869,7 +869,7 @@ pub(crate) mod tests {
                     dst_host: "http://localhost:8080".to_string(),
                     dst_token: None,
                     entries: vec![],
-                    prefix: String::new(),
+                    dst_prefix: String::new(),
                     include: Default::default(),
                     exclude: Default::default(),
                     each_n: None,

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -869,6 +869,7 @@ pub(crate) mod tests {
                     dst_host: "http://localhost:8080".to_string(),
                     dst_token: None,
                     entries: vec![],
+                    prefix: String::new(),
                     include: Default::default(),
                     exclude: Default::default(),
                     each_n: None,

--- a/reductstore/src/api/http/replication.rs
+++ b/reductstore/src/api/http/replication.rs
@@ -107,7 +107,7 @@ mod tests {
             dst_host: "http://localhost".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec![],
-            prefix: String::new(),
+            dst_prefix: String::new(),
             include: Labels::default(),
             exclude: Labels::default(),
             each_n: None,
@@ -173,7 +173,7 @@ mod tests {
         async fn test_replication_settings_ok() {
             use crate::api::http::replication::ReplicationSettingsAxum;
 
-            let json = r#"{"src_bucket":"b1","dst_bucket":"b2","dst_host":"http://localhost","prefix":"robot-1"}"#;
+            let json = r#"{"src_bucket":"b1","dst_bucket":"b2","dst_host":"http://localhost","dst_prefix":"robot-1"}"#;
             let req = Request::builder().body(Body::from(json)).unwrap();
 
             let payload = ReplicationSettingsAxum::from_request(req, &())
@@ -181,7 +181,7 @@ mod tests {
                 .expect("parse settings");
             assert_eq!(payload.0.src_bucket, "b1");
             assert_eq!(payload.0.dst_bucket, "b2");
-            assert_eq!(payload.0.prefix, "robot-1");
+            assert_eq!(payload.0.dst_prefix, "robot-1");
         }
 
         #[rstest]

--- a/reductstore/src/api/http/replication.rs
+++ b/reductstore/src/api/http/replication.rs
@@ -107,6 +107,7 @@ mod tests {
             dst_host: "http://localhost".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec![],
+            prefix: String::new(),
             include: Labels::default(),
             exclude: Labels::default(),
             each_n: None,
@@ -172,7 +173,7 @@ mod tests {
         async fn test_replication_settings_ok() {
             use crate::api::http::replication::ReplicationSettingsAxum;
 
-            let json = r#"{"src_bucket":"b1","dst_bucket":"b2","dst_host":"http://localhost"}"#;
+            let json = r#"{"src_bucket":"b1","dst_bucket":"b2","dst_host":"http://localhost","prefix":"robot-1"}"#;
             let req = Request::builder().body(Body::from(json)).unwrap();
 
             let payload = ReplicationSettingsAxum::from_request(req, &())
@@ -180,6 +181,7 @@ mod tests {
                 .expect("parse settings");
             assert_eq!(payload.0.src_bucket, "b1");
             assert_eq!(payload.0.dst_bucket, "b2");
+            assert_eq!(payload.0.prefix, "robot-1");
         }
 
         #[rstest]

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -65,6 +65,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                     dst_host: "http://localhost".to_string(),
                     dst_token: None,
                     entries: vec![],
+                    prefix: String::new(),
                     include: Labels::default(),
                     exclude: Labels::default(),
                     each_n: None,
@@ -127,6 +128,12 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                 env.get_optional::<String>(&format!("RS_REPLICATION_{}_ENTRIES", id))
             {
                 replication.settings.entries = entries.split(",").map(|s| s.to_string()).collect();
+            }
+
+            if let Some(prefix) =
+                env.get_optional::<String>(&format!("RS_REPLICATION_{}_PREFIX", id))
+            {
+                replication.settings.prefix = prefix;
             }
 
             for (key, value) in env.matches(&format!("RS_REPLICATION_{}_INCLUDE_(.*)", id)) {
@@ -246,6 +253,7 @@ mod tests {
         assert_eq!(replication.dst_host, "http://localhost/");
         assert_eq!(replication.dst_token, Some("TOKEN".to_string()));
         assert_eq!(replication.entries, vec!["entry1", "entry2"]);
+        assert_eq!(replication.prefix, "robot-1");
         assert_eq!(replication.each_n, Some(10));
         assert_eq!(replication.each_s, Some(0.5));
         assert_eq!(
@@ -520,6 +528,7 @@ mod tests {
                 dst_host: "http://localhost".to_string(),
                 dst_token: None,
                 entries: vec![],
+                prefix: String::new(),
                 include: Labels::default(),
                 exclude: Labels::default(),
                 each_n: None,
@@ -609,6 +618,7 @@ mod tests {
                 dst_host: "http://localhost".to_string(),
                 dst_token: None,
                 entries: vec![],
+                prefix: String::new(),
                 include: Labels::default(),
                 exclude: Labels::default(),
                 each_n: None,
@@ -693,6 +703,7 @@ mod tests {
                 dst_host: "http://localhost".to_string(),
                 dst_token: None,
                 entries: vec![],
+                prefix: String::new(),
                 include: Labels::default(),
                 exclude: Labels::default(),
                 each_n: None,
@@ -790,6 +801,10 @@ mod tests {
             .expect_get()
             .with(eq("RS_REPLICATION_1_ENTRIES"))
             .return_const(Ok("entry1,entry2".to_string()));
+        mock_getter
+            .expect_get()
+            .with(eq("RS_REPLICATION_1_PREFIX"))
+            .return_const(Ok("robot-1".to_string()));
 
         mock_getter
             .expect_get()

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -65,7 +65,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                     dst_host: "http://localhost".to_string(),
                     dst_token: None,
                     entries: vec![],
-                    prefix: String::new(),
+                    dst_prefix: String::new(),
                     include: Labels::default(),
                     exclude: Labels::default(),
                     each_n: None,
@@ -130,10 +130,10 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                 replication.settings.entries = entries.split(",").map(|s| s.to_string()).collect();
             }
 
-            if let Some(prefix) =
-                env.get_optional::<String>(&format!("RS_REPLICATION_{}_PREFIX", id))
+            if let Some(dst_prefix) =
+                env.get_optional::<String>(&format!("RS_REPLICATION_{}_DST_PREFIX", id))
             {
-                replication.settings.prefix = prefix;
+                replication.settings.dst_prefix = dst_prefix;
             }
 
             for (key, value) in env.matches(&format!("RS_REPLICATION_{}_INCLUDE_(.*)", id)) {
@@ -253,7 +253,7 @@ mod tests {
         assert_eq!(replication.dst_host, "http://localhost/");
         assert_eq!(replication.dst_token, Some("TOKEN".to_string()));
         assert_eq!(replication.entries, vec!["entry1", "entry2"]);
-        assert_eq!(replication.prefix, "robot-1");
+        assert_eq!(replication.dst_prefix, "robot-1");
         assert_eq!(replication.each_n, Some(10));
         assert_eq!(replication.each_s, Some(0.5));
         assert_eq!(
@@ -528,7 +528,7 @@ mod tests {
                 dst_host: "http://localhost".to_string(),
                 dst_token: None,
                 entries: vec![],
-                prefix: String::new(),
+                dst_prefix: String::new(),
                 include: Labels::default(),
                 exclude: Labels::default(),
                 each_n: None,
@@ -618,7 +618,7 @@ mod tests {
                 dst_host: "http://localhost".to_string(),
                 dst_token: None,
                 entries: vec![],
-                prefix: String::new(),
+                dst_prefix: String::new(),
                 include: Labels::default(),
                 exclude: Labels::default(),
                 each_n: None,
@@ -703,7 +703,7 @@ mod tests {
                 dst_host: "http://localhost".to_string(),
                 dst_token: None,
                 entries: vec![],
-                prefix: String::new(),
+                dst_prefix: String::new(),
                 include: Labels::default(),
                 exclude: Labels::default(),
                 each_n: None,
@@ -803,7 +803,7 @@ mod tests {
             .return_const(Ok("entry1,entry2".to_string()));
         mock_getter
             .expect_get()
-            .with(eq("RS_REPLICATION_1_PREFIX"))
+            .with(eq("RS_REPLICATION_1_DST_PREFIX"))
             .return_const(Ok("robot-1".to_string()));
 
         mock_getter

--- a/reductstore/src/proto/replication.proto
+++ b/reductstore/src/proto/replication.proto
@@ -22,6 +22,7 @@ message  ReplicationSettings {
   double each_s = 10;         // replicate each record every N seconds
   optional string when = 11;           // condition to replicate
   ReplicationMode mode = 12;  // replication mode
+  string prefix = 13;         // prefix to add to destination entry names
 }
 
 enum ReplicationMode {

--- a/reductstore/src/proto/replication.proto
+++ b/reductstore/src/proto/replication.proto
@@ -22,7 +22,7 @@ message  ReplicationSettings {
   double each_s = 10;         // replicate each record every N seconds
   optional string when = 11;           // condition to replicate
   ReplicationMode mode = 12;  // replication mode
-  string prefix = 13;         // prefix to add to destination entry names
+  string dst_prefix = 13;     // prefix to add to destination entry names
 }
 
 enum ReplicationMode {

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -44,7 +44,7 @@ impl From<ReplicationSettings> for ProtoReplicationSettings {
             dst_host: settings.dst_host,
             dst_token: settings.dst_token.unwrap_or_default(),
             entries: settings.entries,
-            prefix: settings.prefix,
+            dst_prefix: settings.dst_prefix,
             include: settings
                 .include
                 .into_iter()
@@ -75,7 +75,7 @@ impl From<ProtoReplicationSettings> for ReplicationSettings {
                 Some(settings.dst_token)
             },
             entries: settings.entries,
-            prefix: settings.prefix,
+            dst_prefix: settings.dst_prefix,
             include: settings
                 .include
                 .into_iter()
@@ -729,7 +729,7 @@ mod tests {
             #[future] storage: Arc<StorageEngine>,
             mut settings: ReplicationSettings,
         ) {
-            settings.prefix = "robot-1".to_string();
+            settings.dst_prefix = "robot-1".to_string();
             let storage = storage.await;
             let mut repo =
                 ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
@@ -1512,7 +1512,7 @@ mod tests {
             dst_host: "http://localhost".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec!["entry-1".to_string()],
-            prefix: String::new(),
+            dst_prefix: String::new(),
             include: Labels::default(),
             exclude: Labels::default(),
             each_n: None,

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -44,6 +44,7 @@ impl From<ReplicationSettings> for ProtoReplicationSettings {
             dst_host: settings.dst_host,
             dst_token: settings.dst_token.unwrap_or_default(),
             entries: settings.entries,
+            prefix: settings.prefix,
             include: settings
                 .include
                 .into_iter()
@@ -74,6 +75,7 @@ impl From<ProtoReplicationSettings> for ReplicationSettings {
                 Some(settings.dst_token)
             },
             entries: settings.entries,
+            prefix: settings.prefix,
             include: settings
                 .include
                 .into_iter()
@@ -725,8 +727,9 @@ mod tests {
         #[tokio::test]
         async fn create_and_load_replications(
             #[future] storage: Arc<StorageEngine>,
-            settings: ReplicationSettings,
+            mut settings: ReplicationSettings,
         ) {
+            settings.prefix = "robot-1".to_string();
             let storage = storage.await;
             let mut repo =
                 ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
@@ -1509,6 +1512,7 @@ mod tests {
             dst_host: "http://localhost".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec!["entry-1".to_string()],
+            prefix: String::new(),
             include: Labels::default(),
             exclude: Labels::default(),
             each_n: None,

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -127,7 +127,9 @@ impl ReplicationSender {
                     }
 
                     let batch_size = batch.len() as u64;
-                    match self.bucket.write_batch(entry_name, batch).await {
+                    let dst_entry_name =
+                        Self::destination_entry_name(&self.settings.prefix, entry_name);
+                    match self.bucket.write_batch(&dst_entry_name, batch).await {
                         Ok(map) => {
                             // Bytes successfully replicated are those whose
                             // timestamp is not reported as failed.
@@ -229,6 +231,44 @@ impl ReplicationSender {
             Err(err) => Err(err),
         }
     }
+
+    fn destination_entry_name(prefix: &str, entry_name: &str) -> String {
+        let prefix = prefix.trim_matches('/');
+        if prefix.is_empty() {
+            entry_name.to_string()
+        } else {
+            format!("{}/{}", prefix, entry_name.trim_start_matches('/'))
+        }
+    }
+}
+
+#[cfg(test)]
+mod destination_entry_name_tests {
+    use super::ReplicationSender;
+
+    #[test]
+    fn keeps_entry_name_when_prefix_is_empty() {
+        assert_eq!(
+            ReplicationSender::destination_entry_name("", "camera/front"),
+            "camera/front"
+        );
+    }
+
+    #[test]
+    fn prepends_destination_prefix() {
+        assert_eq!(
+            ReplicationSender::destination_entry_name("robot-1", "camera/front"),
+            "robot-1/camera/front"
+        );
+    }
+
+    #[test]
+    fn avoids_duplicate_slashes() {
+        assert_eq!(
+            ReplicationSender::destination_entry_name("/robot-1/", "/camera/front"),
+            "robot-1/camera/front"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -246,7 +286,7 @@ mod tests {
     use crate::storage::engine::{CHANNEL_BUFFER_SIZE, MAX_IO_BUFFER_SIZE};
     use async_trait::async_trait;
     use bytes::Bytes;
-    use mockall::mock;
+    use mockall::{mock, predicate};
     use reduct_base::error::ErrorCode;
     use reduct_base::error::ReductError;
     use reduct_base::msg::bucket_api::BucketSettings;
@@ -305,6 +345,29 @@ mod tests {
                 .front(1)
                 .await,
             Ok(vec![]),
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_replication_applies_destination_prefix(
+        mut remote_bucket: MockRmBucket,
+        mut settings: ReplicationSettings,
+    ) {
+        settings.prefix = "robot-1".to_string();
+        remote_bucket
+            .expect_write_batch()
+            .with(predicate::eq("robot-1/test"), predicate::always())
+            .returning(|_, _| Ok(ErrorRecordMap::new()));
+        remote_bucket.expect_is_active().return_const(true);
+        let mut sender = build_sender(remote_bucket, settings).await;
+
+        let transaction = Transaction::WriteRecord(10);
+        imitate_write_record(&sender, &transaction, 5).await;
+
+        assert_eq!(
+            sender.run().await.unwrap(),
+            SyncState::SyncedOrRemoved(vec![(Ok(()), 1, 5)])
         );
     }
 
@@ -756,6 +819,7 @@ mod tests {
             dst_host: "http://localhost:8383".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec!["test".to_string()],
+            prefix: String::new(),
             include: Labels::new(),
             exclude: Labels::new(),
             each_n: None,

--- a/reductstore/src/replication/replication_sender.rs
+++ b/reductstore/src/replication/replication_sender.rs
@@ -128,7 +128,7 @@ impl ReplicationSender {
 
                     let batch_size = batch.len() as u64;
                     let dst_entry_name =
-                        Self::destination_entry_name(&self.settings.prefix, entry_name);
+                        Self::destination_entry_name(&self.settings.dst_prefix, entry_name);
                     match self.bucket.write_batch(&dst_entry_name, batch).await {
                         Ok(map) => {
                             // Bytes successfully replicated are those whose
@@ -354,7 +354,7 @@ mod tests {
         mut remote_bucket: MockRmBucket,
         mut settings: ReplicationSettings,
     ) {
-        settings.prefix = "robot-1".to_string();
+        settings.dst_prefix = "robot-1".to_string();
         remote_bucket
             .expect_write_batch()
             .with(predicate::eq("robot-1/test"), predicate::always())
@@ -819,7 +819,7 @@ mod tests {
             dst_host: "http://localhost:8383".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec!["test".to_string()],
-            prefix: String::new(),
+            dst_prefix: String::new(),
             include: Labels::new(),
             exclude: Labels::new(),
             each_n: None,

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -1271,7 +1271,7 @@ mod tests {
             dst_host: "http://localhost:8383".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec!["test1".to_string(), "test2".to_string()],
-            prefix: String::new(),
+            dst_prefix: String::new(),
             include: Labels::new(),
             exclude: Labels::new(),
             each_n: None,

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -1271,6 +1271,7 @@ mod tests {
             dst_host: "http://localhost:8383".to_string(),
             dst_token: Some("token".to_string()),
             entries: vec!["test1".to_string(), "test2".to_string()],
+            prefix: String::new(),
             include: Labels::new(),
             exclude: Labels::new(),
             each_n: None,


### PR DESCRIPTION
Closes #1466

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Added a new replication `prefix` setting on the server side.

The prefix is applied only to destination entry names. For example, source entry `camera/front` with prefix `robot-1` is replicated to destination entry `robot-1/camera/front`.

This change includes:

- `prefix` in the replication HTTP/API settings model
- `prefix` in persisted replication protobuf settings
- loading/saving `prefix` in the replication repository
- destination entry name prefixing in the replication sender
- environment provisioning support via `RS_REPLICATION_<ID>_PREFIX`
- tests for API parsing, provisioning, persistence, and destination entry prefix formatting
- CHANGELOG.md entry

### Related issues

https://github.com/reductstore/reductstore/issues/1466

### Does this PR introduce a breaking change?

No.

Existing replication tasks continue to work without changes because `prefix` defaults to an empty string.

### Other information:

Validated locally:

- `cargo fmt --all -- --check`
- `cargo check --workspace --features "fs-backend,ci"`
- `cargo test -p reductstore --features "fs-backend,ci" api::http::replication`
- `cargo test -p reductstore --features "fs-backend,ci" cfg::provision::replication`
- `cargo test -p reductstore --features "fs-backend,ci" replication::replication_repository::repo`
- `cargo test -p reductstore --features "fs-backend,ci" replication`

Broad replication test result: `178 passed`.