### PR TITLE
Remove duplicate lifecycle error fields from lifecycle_run diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove redundant `error_code` and `error_message` fields from newly written `lifecycle_run` diagnostics and keep top-level `status` / `message` as the canonical failure metadata
+
 ## 1.20.6 - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove redundant `error_code` and `error_message` fields from newly written `lifecycle_run` diagnostics and keep top-level `status` / `message` as the canonical failure metadata
+- Remove redundant `error_code` and `error_message` fields from newly written `lifecycle_run` diagnostics and keep top-level `status` / `message` as the canonical failure metadata, [PR-1491](https://github.com/reductstore/reductstore/pull/1491)
 
 ## 1.20.6 - 2026-06-25
 

--- a/reductstore/src/lifecycle/README.md
+++ b/reductstore/src/lifecycle/README.md
@@ -150,8 +150,9 @@ Error payload fields:
 - `processed_records = 0`
 - `processed_blocks = 0`
 - `caught_up = false`
-- `error_code`
-- `error_message`
+
+Failure details live in the shared top-level `SystemEvent.status` and `SystemEvent.message`
+fields, which are the canonical error metadata for lifecycle diagnostics.
 
 The same event stream is also used as the source of persisted lifecycle progress.
 

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -256,8 +256,6 @@ impl LifecycleTask {
                     &format!("{:?}", action_type).to_lowercase(),
                     bucket,
                     duration,
-                    err.status as u16,
-                    &err.message,
                 )
                 .to_value(),
             ),
@@ -652,8 +650,8 @@ pub(super) mod tests {
         assert_eq!(event.payload["processed_records"], 0);
         assert_eq!(event.payload["processed_blocks"], 0);
         assert_eq!(event.payload["caught_up"], false);
-        assert_eq!(event.payload["error_code"], 422);
-        assert_eq!(event.payload["error_message"], "failed to run");
+        assert!(event.payload.get("error_code").is_none());
+        assert!(event.payload.get("error_message").is_none());
     }
 
     async fn new_task(

--- a/reductstore/src/lifecycle/system_event_payload.rs
+++ b/reductstore/src/lifecycle/system_event_payload.rs
@@ -14,9 +14,6 @@ pub(crate) struct LifecycleSystemEventPayload {
     pub processed_blocks: u64,
     pub last_processed_ts: Option<u64>,
     pub caught_up: bool,
-    pub error_code: Option<u16>,
-    #[serde(default)]
-    pub error_message: Option<String>,
 }
 
 impl LifecycleSystemEventPayload {
@@ -39,19 +36,10 @@ impl LifecycleSystemEventPayload {
             processed_blocks: processed_blocks.unwrap_or(0),
             last_processed_ts,
             caught_up,
-            error_code: None,
-            error_message: None,
         }
     }
 
-    pub(crate) fn error(
-        policy_name: &str,
-        action_type: &str,
-        bucket: &str,
-        duration: f64,
-        error_code: u16,
-        error_message: &str,
-    ) -> Self {
+    pub(crate) fn error(policy_name: &str, action_type: &str, bucket: &str, duration: f64) -> Self {
         Self {
             policy_name: policy_name.to_string(),
             action_type: action_type.to_string(),
@@ -61,8 +49,6 @@ impl LifecycleSystemEventPayload {
             processed_blocks: 0,
             last_processed_ts: None,
             caught_up: false,
-            error_code: Some(error_code),
-            error_message: Some(error_message.to_string()),
         }
     }
 
@@ -77,16 +63,8 @@ impl LifecycleSystemEventPayload {
             "caught_up": self.caught_up,
         });
 
-        if let Some(error_code) = self.error_code {
-            payload["error_code"] = json!(error_code);
-        }
-
         if let Some(last_processed_ts) = self.last_processed_ts {
             payload["last_processed_ts"] = json!(last_processed_ts);
-        }
-
-        if let Some(error_message) = &self.error_message {
-            payload["error_message"] = json!(error_message);
         }
 
         payload


### PR DESCRIPTION
Closes #1483

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- remove the redundant `error_code` and `error_message` fields from newly written `lifecycle_run` payloads
- keep the top-level `status` and `message` fields as the canonical lifecycle failure metadata
- update lifecycle event tests to assert the duplicate fields are no longer emitted
- clarify the lifecycle README and changelog entry so consumers know which fields are authoritative

### Related issues

- Issue: https://github.com/reductstore/reductstore/issues/1483
- Approved plan: https://github.com/reductstore/reductstore/issues/1483#issuecomment-4829463508

CC @reductstore/maintainers

### Does this PR introduce a breaking change?

No public API routes or config changed, but consumers of newly written `$system` `lifecycle_run` diagnostics should read the already-existing top-level `status` / `message` fields instead of the removed duplicate payload aliases.

### Other information:

Validated locally on the `stable`-targeted branch with:
- `cargo test --workspace --locked lifecycle_task::tests::log_system_event -- --nocapture`
- `cargo fmt --all --check`
- `cargo check --workspace --locked`
