### PR TITLE
Fix read-only replica restores with transient cached blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep read-only replica buckets visible when transient cached block state prevents entry restore or reads, [PR-1492](https://github.com/reductstore/reductstore/pull/1492)
 - Remove redundant `error_code` and `error_message` fields from newly written `lifecycle_run` diagnostics and keep top-level `status` / `message` as the canonical failure metadata, [PR-1491](https://github.com/reductstore/reductstore/pull/1491)
 
 ## 1.20.6 - 2026-06-25

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -638,15 +638,16 @@ mod tests {
                 .create_dir_all(&path.join(&settings.src_bucket))
                 .await
                 .unwrap();
-            Bucket::try_build(
-                &settings.src_bucket,
-                &path,
-                BucketSettings::default(),
-                Cfg::default(),
-                Default::default(),
-            )
-            .await
-            .unwrap();
+            Bucket::builder()
+                .name(&settings.src_bucket)
+                .data_path(path.clone())
+                .settings(BucketSettings::default())
+                .cfg(Cfg::default())
+                .io_limiter(Default::default())
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap();
 
             fs::create_dir_all(log_path.parent().unwrap()).unwrap();
             let mut log_file = fs::File::create(&log_path).unwrap();

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -764,6 +764,10 @@ impl BlockManager {
         &self.usage_counters
     }
 
+    pub(in crate::storage) fn is_replica(&self) -> bool {
+        self.cfg.role == InstanceRole::Replica
+    }
+
     pub(in crate::storage) fn is_block_in_write_cache(&self, block_id: u64) -> bool {
         self.block_cache.get_write(&block_id).is_some()
     }

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -220,6 +220,7 @@ impl BlockManager {
                                 block_crc,
                                 crc.sum64()
                             );
+                            self.invalidate_replica_block_cache(block_id).await?;
                             self.block_index.remove_block(block_id);
                             return Err(too_early!(
                                 "Block descriptor {:?} CRC mismatch on replica. Reload index and retry",
@@ -766,6 +767,16 @@ impl BlockManager {
 
     pub(in crate::storage) fn is_replica(&self) -> bool {
         self.cfg.role == InstanceRole::Replica
+    }
+
+    async fn invalidate_replica_block_cache(&self, block_id: u64) -> Result<(), ReductError> {
+        FILE_CACHE
+            .invalidate_local_cache_file(&self.path_to_desc(block_id))
+            .await?;
+        FILE_CACHE
+            .invalidate_local_cache_file(&self.path_to_data(block_id))
+            .await?;
+        Ok(())
     }
 
     pub(in crate::storage) fn is_block_in_write_cache(&self, block_id: u64) -> bool {

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -210,12 +210,21 @@ impl Bucket {
                 Arc::clone(&usage_counters),
             );
 
-            task_set.push(handler);
+            task_set.push((entry_name, handler));
         }
 
-        for task in task_set {
-            if let Some(entry) = task.await? {
-                entries.insert(entry.name().to_string(), entry);
+        for (entry_name, task) in task_set {
+            match task.await {
+                Ok(Some(entry)) => {
+                    entries.insert(entry.name().to_string(), entry);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    error!(
+                        "Failed to restore entry '{}' in bucket '{}': {}",
+                        entry_name, bucket_name, err
+                    );
+                }
             }
         }
 

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -485,15 +485,15 @@ pub(crate) mod tests {
             let bucket = bucket.await;
             let settings = bucket.settings().await.unwrap();
             let empty_entry = Arc::new(
-                Entry::try_build(
-                    "empty",
-                    bucket.path.clone(),
-                    settings_for_entry("empty", &settings),
-                    bucket.cfg.clone(),
-                    Default::default(),
-                )
-                .await
-                .unwrap(),
+                Entry::builder()
+                    .name("empty")
+                    .bucket_path(bucket.path.clone())
+                    .settings(settings_for_entry("empty", &settings))
+                    .cfg(bucket.cfg.clone())
+                    .usage_counters(Default::default())
+                    .build()
+                    .await
+                    .unwrap(),
             );
             bucket
                 .entries

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
+mod builder;
 mod compress_blocks;
 mod get_entry;
 mod query;
@@ -19,30 +20,26 @@ use crate::core::weak::Weak;
 pub use crate::storage::block_manager::RecordRx;
 pub use crate::storage::block_manager::RecordTx;
 use crate::storage::bucket::query::MultiEntryQuery;
-use crate::storage::bucket::settings::{
-    DEFAULT_MAX_BLOCK_SIZE, DEFAULT_MAX_RECORDS, SETTINGS_NAME,
-};
+use crate::storage::bucket::settings::{DEFAULT_MAX_BLOCK_SIZE, DEFAULT_MAX_RECORDS};
 use crate::storage::entry::{
     is_system_meta_entry, Entry, EntrySettings, META_ENTRY_MAX_BLOCK_SIZE,
 };
 use crate::storage::folder_keeper::FolderKeeper;
 use crate::storage::in_flight::InFlightIoLimiter;
-use crate::storage::proto::BucketSettings as ProtoBucketSettings;
 use crate::storage::usage::UsageCounters;
 use log::{debug, error};
-use prost::bytes::Bytes;
-use prost::Message;
 use reduct_base::error::ReductError;
 use reduct_base::io::WriteRecord;
 use reduct_base::msg::bucket_api::{BucketInfo, BucketSettings, FullBucketInfo};
 use reduct_base::msg::status::ResourceStatus;
-use reduct_base::{conflict, forbidden, internal_server_error, Labels};
+use reduct_base::{conflict, forbidden, Labels};
 use std::collections::{BTreeMap, HashMap};
-use std::io::{Read, SeekFrom};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+
+pub(crate) use builder::BucketBuilder;
 
 fn normalize_entry_name(path: &std::path::Path) -> String {
     path.to_string_lossy().replace('\\', "/")
@@ -82,6 +79,10 @@ enum EntryMaintenanceMode {
 }
 
 impl Bucket {
+    pub(crate) fn builder() -> BucketBuilder {
+        BucketBuilder::default()
+    }
+
     #[cfg(test)]
     pub(crate) fn cfg(&self) -> &Cfg {
         &self.cfg
@@ -95,154 +96,6 @@ impl Bucket {
         }
 
         Ok(())
-    }
-
-    /// Create a new Bucket
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the bucket
-    /// * `path` - The path to folder with buckets
-    /// * `settings` - The settings for the bucket
-    /// * `repl_agent_builder` - The replica agent builder
-    ///
-    /// # Returns
-    ///
-    /// * `Bucket` - The bucket or an HTTPError
-    #[allow(dead_code)]
-    pub(crate) async fn try_build(
-        name: &str,
-        path: &PathBuf,
-        settings: BucketSettings,
-        cfg: Cfg,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Bucket, ReductError> {
-        let io_limiter = InFlightIoLimiter::from_cfg(&cfg);
-        Self::try_build_with_limiter(name, path, settings, cfg, io_limiter, usage_counters).await
-    }
-
-    pub(crate) async fn try_build_with_limiter(
-        name: &str,
-        path: &PathBuf,
-        settings: BucketSettings,
-        cfg: Cfg,
-        io_limiter: InFlightIoLimiter,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Bucket, ReductError> {
-        let path = path.join(name);
-        let settings = Self::fill_settings(settings, Self::defaults());
-        let folder_keeper = FolderKeeper::new(path.clone(), &cfg).await;
-
-        let bucket = Bucket {
-            name: name.to_string(),
-            path,
-            entries: Arc::new(AsyncRwLock::new(BTreeMap::new())),
-            settings: AsyncRwLock::new(settings),
-            is_provisioned: AtomicBool::new(false),
-            status: AsyncRwLock::new(ResourceStatus::Ready),
-            cfg: Arc::new(cfg),
-            folder_keeper: Arc::new(folder_keeper),
-            queries: AsyncRwLock::new(HashMap::new()),
-            io_limiter,
-            usage_counters,
-        };
-
-        bucket.save_settings().await?;
-        Ok(bucket)
-    }
-
-    /// Restore a Bucket from disk
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path to the bucket
-    /// * `cfg` - The global configuration
-    ///
-    /// # Returns
-    ///
-    /// * `Bucket` - The bucket or an HTTPError
-    #[allow(dead_code)]
-    pub async fn restore(
-        path: PathBuf,
-        cfg: Cfg,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Bucket, ReductError> {
-        let io_limiter = InFlightIoLimiter::from_cfg(&cfg);
-        Self::restore_with_limiter(path, cfg, io_limiter, usage_counters).await
-    }
-
-    pub async fn restore_with_limiter(
-        path: PathBuf,
-        cfg: Cfg,
-        io_limiter: InFlightIoLimiter,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Bucket, ReductError> {
-        let mut file = FILE_CACHE
-            .read(&path.join(SETTINGS_NAME), SeekFrom::Start(0))
-            .await?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf)?;
-
-        let cfg = Arc::new(cfg);
-        let settings = ProtoBucketSettings::decode(&mut Bytes::from(buf))
-            .map_err(|e| internal_server_error!("Failed to decode settings: {}", e))?;
-
-        let settings = Self::fill_settings(settings.into(), Self::defaults());
-        let bucket_name = path.file_name().unwrap().to_str().unwrap().to_string();
-
-        let mut entries = BTreeMap::new();
-        let mut task_set = Vec::new();
-        let folder_keeper = FolderKeeper::new(path.clone(), cfg.as_ref()).await;
-
-        for entry_path in folder_keeper.list_folders().await? {
-            let entry_name = normalize_entry_name(
-                entry_path
-                    .strip_prefix(&path)
-                    .unwrap_or(entry_path.as_path()),
-            );
-            let handler = Entry::restore_with_limiter(
-                entry_path,
-                entry_name.clone(),
-                bucket_name.clone(),
-                settings_for_entry(&entry_name, &settings),
-                cfg.clone(),
-                io_limiter.clone(),
-                Arc::clone(&usage_counters),
-            );
-
-            task_set.push((entry_name, handler));
-        }
-
-        for (entry_name, task) in task_set {
-            match task.await {
-                Ok(Some(entry)) => {
-                    entries.insert(entry.name().to_string(), entry);
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    error!(
-                        "Failed to restore entry '{}' in bucket '{}': {}",
-                        entry_name, bucket_name, err
-                    );
-                }
-            }
-        }
-
-        Ok(Bucket {
-            name: bucket_name,
-            path,
-            entries: Arc::new(AsyncRwLock::new(
-                entries.into_iter().map(|(k, v)| (k, Arc::new(v))).collect(),
-            )),
-            settings: AsyncRwLock::new(settings),
-            is_provisioned: AtomicBool::new(false),
-            status: AsyncRwLock::new(ResourceStatus::Ready),
-            cfg,
-            folder_keeper: Arc::new(folder_keeper),
-            queries: AsyncRwLock::new(HashMap::new()),
-            io_limiter,
-            usage_counters,
-        })
     }
 
     /// Get an entry in the bucket
@@ -561,10 +414,11 @@ impl Bucket {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use reduct_base::conflict;
+    use bytes::Bytes;
     use reduct_base::io::ReadRecord;
     use reduct_base::msg::bucket_api::QuotaType;
     use reduct_base::msg::status::ResourceStatus;
+    use reduct_base::{conflict, internal_server_error};
     use rstest::{fixture, rstest};
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -830,7 +684,11 @@ pub(crate) mod tests {
             write(&bucket, "entry/a", 1, b"test").await.unwrap();
             bucket.sync_fs().await.unwrap();
 
-            let bucket = Bucket::restore(bucket.path.clone(), Cfg::default(), Default::default())
+            let bucket = Bucket::builder()
+                .path(bucket.path.clone())
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .restore()
                 .await
                 .unwrap();
             let mut reader = bucket.begin_read("entry/a", 1).await.unwrap();
@@ -846,7 +704,11 @@ pub(crate) mod tests {
                 .unwrap();
             bucket.sync_fs().await.unwrap();
 
-            let bucket = Bucket::restore(bucket.path.clone(), Cfg::default(), Default::default())
+            let bucket = Bucket::builder()
+                .path(bucket.path.clone())
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .restore()
                 .await
                 .unwrap();
             let entry = bucket
@@ -964,7 +826,13 @@ pub(crate) mod tests {
     pub async fn bucket(settings: BucketSettings, path: PathBuf) -> Arc<Bucket> {
         FILE_CACHE.create_dir_all(&path.join("test")).await.unwrap();
         Arc::new(
-            Bucket::try_build("test", &path, settings, Cfg::default(), Default::default())
+            Bucket::builder()
+                .name("test")
+                .data_path(path)
+                .settings(settings)
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .build()
                 .await
                 .unwrap(),
         )
@@ -973,7 +841,13 @@ pub(crate) mod tests {
     #[fixture]
     pub async fn provisioned_bucket(settings: BucketSettings, path: PathBuf) -> Arc<Bucket> {
         FILE_CACHE.create_dir_all(&path.join("test")).await.unwrap();
-        let bucket = Bucket::try_build("test", &path, settings, Cfg::default(), Default::default())
+        let bucket = Bucket::builder()
+            .name("test")
+            .data_path(path)
+            .settings(settings)
+            .cfg(Cfg::default())
+            .usage_counters(Default::default())
+            .build()
             .await
             .unwrap();
         bucket.set_provisioned(true);

--- a/reductstore/src/storage/bucket/builder.rs
+++ b/reductstore/src/storage/bucket/builder.rs
@@ -136,15 +136,15 @@ impl BucketBuilder {
                     .strip_prefix(&path)
                     .unwrap_or(entry_path.as_path()),
             );
-            let handler = Entry::restore_with_limiter(
-                entry_path,
-                entry_name.clone(),
-                bucket_name.clone(),
-                settings_for_entry(&entry_name, &settings),
-                cfg.clone(),
-                io_limiter.clone(),
-                Arc::clone(&usage_counters),
-            );
+            let handler = Entry::builder()
+                .path(entry_path)
+                .name(entry_name.clone())
+                .bucket_name(bucket_name.clone())
+                .settings(settings_for_entry(&entry_name, &settings))
+                .cfg(cfg.clone())
+                .io_limiter(io_limiter.clone())
+                .usage_counters(Arc::clone(&usage_counters))
+                .restore();
 
             task_set.push((entry_name, handler));
         }

--- a/reductstore/src/storage/bucket/builder.rs
+++ b/reductstore/src/storage/bucket/builder.rs
@@ -1,0 +1,183 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use super::{normalize_entry_name, settings_for_entry, Bucket, MultiEntryQuery};
+use crate::cfg::Cfg;
+use crate::core::file_cache::FILE_CACHE;
+use crate::core::sync::AsyncRwLock;
+use crate::storage::bucket::settings::SETTINGS_NAME;
+use crate::storage::entry::Entry;
+use crate::storage::folder_keeper::FolderKeeper;
+use crate::storage::in_flight::InFlightIoLimiter;
+use crate::storage::proto::BucketSettings as ProtoBucketSettings;
+use crate::storage::usage::UsageCounters;
+use log::error;
+use prost::bytes::Bytes;
+use prost::Message;
+use reduct_base::error::ReductError;
+use reduct_base::internal_server_error;
+use reduct_base::msg::bucket_api::BucketSettings;
+use reduct_base::msg::status::ResourceStatus;
+use std::collections::{BTreeMap, HashMap};
+use std::io::{Read, SeekFrom};
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+#[derive(Default)]
+pub(crate) struct BucketBuilder {
+    name: Option<String>,
+    path: Option<PathBuf>,
+    data_path: Option<PathBuf>,
+    settings: Option<BucketSettings>,
+    cfg: Option<Cfg>,
+    io_limiter: Option<InFlightIoLimiter>,
+    usage_counters: Option<Arc<UsageCounters>>,
+}
+
+impl BucketBuilder {
+    pub(crate) fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub(crate) fn path(mut self, path: PathBuf) -> Self {
+        self.path = Some(path);
+        self
+    }
+
+    pub(crate) fn data_path(mut self, data_path: PathBuf) -> Self {
+        self.data_path = Some(data_path);
+        self
+    }
+
+    pub(crate) fn settings(mut self, settings: BucketSettings) -> Self {
+        self.settings = Some(settings);
+        self
+    }
+
+    pub(crate) fn cfg(mut self, cfg: Cfg) -> Self {
+        self.cfg = Some(cfg);
+        self
+    }
+
+    pub(crate) fn io_limiter(mut self, io_limiter: InFlightIoLimiter) -> Self {
+        self.io_limiter = Some(io_limiter);
+        self
+    }
+
+    pub(crate) fn usage_counters(mut self, usage_counters: Arc<UsageCounters>) -> Self {
+        self.usage_counters = Some(usage_counters);
+        self
+    }
+
+    pub(crate) async fn build(self) -> Result<Bucket, ReductError> {
+        let name = self.name.expect("Bucket name must be set");
+        let data_path = self.data_path.expect("Bucket data path must be set");
+        let cfg = self.cfg.expect("Config must be set");
+        let io_limiter = self
+            .io_limiter
+            .unwrap_or_else(|| InFlightIoLimiter::from_cfg(&cfg));
+        let usage_counters = self
+            .usage_counters
+            .unwrap_or_else(|| Arc::new(UsageCounters::default()));
+        let settings = Bucket::fill_settings(self.settings.unwrap_or_default(), Bucket::defaults());
+        let path = data_path.join(&name);
+        let folder_keeper = FolderKeeper::new(path.clone(), &cfg).await;
+
+        let bucket = Bucket {
+            name,
+            path,
+            entries: Arc::new(AsyncRwLock::new(BTreeMap::new())),
+            settings: AsyncRwLock::new(settings),
+            is_provisioned: AtomicBool::new(false),
+            status: AsyncRwLock::new(ResourceStatus::Ready),
+            cfg: Arc::new(cfg),
+            folder_keeper: Arc::new(folder_keeper),
+            queries: AsyncRwLock::new(HashMap::<u64, MultiEntryQuery>::new()),
+            io_limiter,
+            usage_counters,
+        };
+
+        bucket.save_settings().await?;
+        Ok(bucket)
+    }
+
+    pub(crate) async fn restore(self) -> Result<Bucket, ReductError> {
+        let path = self.path.expect("Bucket path must be set");
+        let cfg = self.cfg.expect("Config must be set");
+        let io_limiter = self
+            .io_limiter
+            .unwrap_or_else(|| InFlightIoLimiter::from_cfg(&cfg));
+        let usage_counters = self
+            .usage_counters
+            .unwrap_or_else(|| Arc::new(UsageCounters::default()));
+
+        let mut file = FILE_CACHE
+            .read(&path.join(SETTINGS_NAME), SeekFrom::Start(0))
+            .await?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+
+        let cfg = Arc::new(cfg);
+        let settings = ProtoBucketSettings::decode(&mut Bytes::from(buf))
+            .map_err(|e| internal_server_error!("Failed to decode settings: {}", e))?;
+
+        let settings = Bucket::fill_settings(settings.into(), Bucket::defaults());
+        let bucket_name = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        let mut entries = BTreeMap::new();
+        let mut task_set = Vec::new();
+        let folder_keeper = FolderKeeper::new(path.clone(), cfg.as_ref()).await;
+
+        for entry_path in folder_keeper.list_folders().await? {
+            let entry_name = normalize_entry_name(
+                entry_path
+                    .strip_prefix(&path)
+                    .unwrap_or(entry_path.as_path()),
+            );
+            let handler = Entry::restore_with_limiter(
+                entry_path,
+                entry_name.clone(),
+                bucket_name.clone(),
+                settings_for_entry(&entry_name, &settings),
+                cfg.clone(),
+                io_limiter.clone(),
+                Arc::clone(&usage_counters),
+            );
+
+            task_set.push((entry_name, handler));
+        }
+
+        for (entry_name, task) in task_set {
+            match task.await {
+                Ok(Some(entry)) => {
+                    entries.insert(entry.name().to_string(), entry);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    error!(
+                        "Failed to restore entry '{}' in bucket '{}': {}",
+                        entry_name, bucket_name, err
+                    );
+                }
+            }
+        }
+
+        Ok(Bucket {
+            name: bucket_name,
+            path,
+            entries: Arc::new(AsyncRwLock::new(
+                entries.into_iter().map(|(k, v)| (k, Arc::new(v))).collect(),
+            )),
+            settings: AsyncRwLock::new(settings),
+            is_provisioned: AtomicBool::new(false),
+            status: AsyncRwLock::new(ResourceStatus::Ready),
+            cfg,
+            folder_keeper: Arc::new(folder_keeper),
+            queries: AsyncRwLock::new(HashMap::<u64, MultiEntryQuery>::new()),
+            io_limiter,
+            usage_counters,
+        })
+    }
+}

--- a/reductstore/src/storage/bucket/compress_blocks.rs
+++ b/reductstore/src/storage/bucket/compress_blocks.rs
@@ -84,7 +84,11 @@ mod tests {
         write(&bucket, "entry-c", 3, b"c1").await.unwrap();
         bucket.sync_fs().await.unwrap();
         let bucket = Arc::new(
-            Bucket::restore(bucket.path.clone(), Cfg::default(), Default::default())
+            Bucket::builder()
+                .path(bucket.path.clone())
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .restore()
                 .await
                 .unwrap(),
         );
@@ -136,7 +140,11 @@ mod tests {
             .unwrap();
         bucket.sync_fs().await.unwrap();
         let bucket = Arc::new(
-            Bucket::restore(bucket.path.clone(), Cfg::default(), Default::default())
+            Bucket::builder()
+                .path(bucket.path.clone())
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .restore()
                 .await
                 .unwrap(),
         );

--- a/reductstore/src/storage/bucket/get_entry.rs
+++ b/reductstore/src/storage/bucket/get_entry.rs
@@ -40,15 +40,15 @@ impl Bucket {
             } else {
                 self.folder_keeper.add_folder(&prefix).await?;
                 let entry = Arc::new(
-                    Entry::try_build_with_limiter(
-                        &prefix,
-                        self.path.clone(),
-                        settings_for_entry(&prefix, &settings),
-                        self.cfg.clone(),
-                        self.io_limiter.clone(),
-                        Arc::clone(&self.usage_counters),
-                    )
-                    .await?,
+                    Entry::builder()
+                        .name(&prefix)
+                        .bucket_path(self.path.clone())
+                        .settings(settings_for_entry(&prefix, &settings))
+                        .cfg(self.cfg.clone())
+                        .io_limiter(self.io_limiter.clone())
+                        .usage_counters(Arc::clone(&self.usage_counters))
+                        .build()
+                        .await?,
                 );
                 let mut entries = self.entries.write().await?;
                 entries

--- a/reductstore/src/storage/bucket/get_entry.rs
+++ b/reductstore/src/storage/bucket/get_entry.rs
@@ -216,7 +216,13 @@ mod tests {
     pub async fn bucket(settings: BucketSettings, path: PathBuf) -> Arc<Bucket> {
         FILE_CACHE.create_dir_all(&path.join("test")).await.unwrap();
         Arc::new(
-            Bucket::try_build("test", &path, settings, Cfg::default(), Default::default())
+            Bucket::builder()
+                .name("test")
+                .data_path(path)
+                .settings(settings)
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .build()
                 .await
                 .unwrap(),
         )

--- a/reductstore/src/storage/bucket/read_only.rs
+++ b/reductstore/src/storage/bucket/read_only.rs
@@ -55,13 +55,24 @@ impl Bucket {
                 Arc::clone(&self.usage_counters),
             );
 
-            task_set.push(handler);
+            task_set.push((entry_name, handler));
         }
 
         let mut new_entries = BTreeMap::new();
-        for task in task_set {
-            if let Some(entry) = task.await? {
-                new_entries.insert(entry.name().to_string(), Arc::new(entry));
+        for (entry_name, task) in task_set {
+            match task.await {
+                Ok(Some(entry)) => {
+                    new_entries.insert(entry.name().to_string(), Arc::new(entry));
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    error!(
+                        "Failed to restore entry '{}' in bucket '{}': {}",
+                        entry_name,
+                        self.name(),
+                        err
+                    );
+                }
             }
         }
 
@@ -94,6 +105,8 @@ mod tests {
     use crate::cfg::storage_engine::StorageEngineConfig;
     use crate::cfg::Cfg;
     use crate::cfg::InstanceRole;
+    use crate::storage::block_manager::block_index::BlockIndex;
+    use crate::storage::block_manager::BLOCK_INDEX_FILE;
     use crate::storage::bucket::tests::write;
     use crate::storage::bucket::FILE_CACHE;
     use reduct_base::msg::bucket_api::BucketSettings;
@@ -242,6 +255,83 @@ mod tests {
             .find(|entry| entry.name == "test-1")
             .unwrap();
         assert_eq!(entry.record_count, 2);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_restore_skips_failed_replica_entry(#[future] primary_bucket: Arc<Bucket>) {
+        let primary_bucket = primary_bucket.await;
+        create_entry_with_broken_wal(primary_bucket.path().join("broken-entry")).await;
+
+        let mut cfg = primary_bucket.cfg().clone();
+        cfg.role = InstanceRole::Replica;
+        let read_only_bucket = Bucket::restore(
+            primary_bucket.path().clone(),
+            cfg.clone(),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+        let entries = read_only_bucket.entries.read().await.unwrap();
+        assert!(entries.contains_key("test-1"));
+        assert!(!entries.contains_key("broken-entry"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_restore_skips_failed_primary_entry(#[future] primary_bucket: Arc<Bucket>) {
+        let primary_bucket = primary_bucket.await;
+        create_entry_with_broken_wal(primary_bucket.path().join("broken-entry")).await;
+
+        let read_write_bucket = Bucket::restore(
+            primary_bucket.path().clone(),
+            primary_bucket.cfg().clone(),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+        let entries = read_write_bucket.entries.read().await.unwrap();
+        assert!(entries.contains_key("test-1"));
+        assert!(!entries.contains_key("broken-entry"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_reload_skips_failed_replica_entry(#[future] primary_bucket: Arc<Bucket>) {
+        let primary_bucket = primary_bucket.await;
+        let mut cfg = primary_bucket.cfg().clone();
+        cfg.role = InstanceRole::Replica;
+        let read_only_bucket = Arc::new(
+            Bucket::restore(
+                primary_bucket.path().clone(),
+                cfg.clone(),
+                Default::default(),
+            )
+            .await
+            .unwrap(),
+        );
+
+        create_entry_with_broken_wal(primary_bucket.path().join("broken-entry")).await;
+        read_only_bucket.reload_entries().await.unwrap();
+
+        let entries = read_only_bucket.entries.read().await.unwrap();
+        assert!(entries.contains_key("test-1"));
+        assert!(!entries.contains_key("broken-entry"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_reload_skips_failed_primary_entry(#[future] primary_bucket: Arc<Bucket>) {
+        let primary_bucket = primary_bucket.await;
+        create_entry_with_broken_wal(primary_bucket.path().join("broken-entry")).await;
+
+        primary_bucket.reload_entries().await.unwrap();
+
+        let entries = primary_bucket.entries.read().await.unwrap();
+        assert!(entries.contains_key("test-1"));
+        assert!(!entries.contains_key("broken-entry"));
     }
 
     mod forbidden {
@@ -419,5 +509,14 @@ mod tests {
         write(&bucket, "test-1", 1, b"test data").await.unwrap();
         bucket.sync_fs().await.unwrap();
         bucket
+    }
+
+    async fn create_entry_with_broken_wal(entry_path: std::path::PathBuf) {
+        FILE_CACHE.create_dir_all(&entry_path).await.unwrap();
+        BlockIndex::new(entry_path.join(BLOCK_INDEX_FILE))
+            .save()
+            .await
+            .unwrap();
+        std::fs::write(entry_path.join(".wal"), b"not a directory").unwrap();
     }
 }

--- a/reductstore/src/storage/bucket/read_only.rs
+++ b/reductstore/src/storage/bucket/read_only.rs
@@ -121,13 +121,13 @@ mod tests {
         let mut cfg = primary_bucket.cfg().clone();
         cfg.role = InstanceRole::Replica;
         let read_only_bucket = Arc::new(
-            Bucket::restore(
-                primary_bucket.path().clone(),
-                cfg.clone(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+            Bucket::builder()
+                .path(primary_bucket.path().clone())
+                .cfg(cfg.clone())
+                .usage_counters(Default::default())
+                .restore()
+                .await
+                .unwrap(),
         );
         // Initially, read-only bucket has one entry
         {
@@ -170,13 +170,13 @@ mod tests {
         let mut cfg = primary_bucket.cfg().clone();
         cfg.role = InstanceRole::Replica;
         let read_only_bucket = Arc::new(
-            Bucket::restore(
-                primary_bucket.path().clone(),
-                cfg.clone(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+            Bucket::builder()
+                .path(primary_bucket.path().clone())
+                .cfg(cfg.clone())
+                .usage_counters(Default::default())
+                .restore()
+                .await
+                .unwrap(),
         );
         // Initially, read-only bucket has one entry
         {
@@ -224,13 +224,13 @@ mod tests {
         let mut cfg = primary_bucket.cfg().clone();
         cfg.role = InstanceRole::Replica;
         let read_only_bucket = Arc::new(
-            Bucket::restore(
-                primary_bucket.path().clone(),
-                cfg.clone(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+            Bucket::builder()
+                .path(primary_bucket.path().clone())
+                .cfg(cfg.clone())
+                .usage_counters(Default::default())
+                .restore()
+                .await
+                .unwrap(),
         );
 
         write(&primary_bucket, "test-1", 2, b"new data")
@@ -265,13 +265,13 @@ mod tests {
 
         let mut cfg = primary_bucket.cfg().clone();
         cfg.role = InstanceRole::Replica;
-        let read_only_bucket = Bucket::restore(
-            primary_bucket.path().clone(),
-            cfg.clone(),
-            Default::default(),
-        )
-        .await
-        .unwrap();
+        let read_only_bucket = Bucket::builder()
+            .path(primary_bucket.path().clone())
+            .cfg(cfg.clone())
+            .usage_counters(Default::default())
+            .restore()
+            .await
+            .unwrap();
 
         let entries = read_only_bucket.entries.read().await.unwrap();
         assert!(entries.contains_key("test-1"));
@@ -284,13 +284,13 @@ mod tests {
         let primary_bucket = primary_bucket.await;
         create_entry_with_broken_wal(primary_bucket.path().join("broken-entry")).await;
 
-        let read_write_bucket = Bucket::restore(
-            primary_bucket.path().clone(),
-            primary_bucket.cfg().clone(),
-            Default::default(),
-        )
-        .await
-        .unwrap();
+        let read_write_bucket = Bucket::builder()
+            .path(primary_bucket.path().clone())
+            .cfg(primary_bucket.cfg().clone())
+            .usage_counters(Default::default())
+            .restore()
+            .await
+            .unwrap();
 
         let entries = read_write_bucket.entries.read().await.unwrap();
         assert!(entries.contains_key("test-1"));
@@ -304,13 +304,13 @@ mod tests {
         let mut cfg = primary_bucket.cfg().clone();
         cfg.role = InstanceRole::Replica;
         let read_only_bucket = Arc::new(
-            Bucket::restore(
-                primary_bucket.path().clone(),
-                cfg.clone(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+            Bucket::builder()
+                .path(primary_bucket.path().clone())
+                .cfg(cfg.clone())
+                .usage_counters(Default::default())
+                .restore()
+                .await
+                .unwrap(),
         );
 
         create_entry_with_broken_wal(primary_bucket.path().join("broken-entry")).await;
@@ -349,13 +349,13 @@ mod tests {
             let mut cfg = primary_bucket.cfg().clone();
             cfg.role = InstanceRole::Replica;
             let read_only_bucket = Arc::new(
-                Bucket::restore(
-                    primary_bucket.path().clone(),
-                    cfg.clone(),
-                    Default::default(),
-                )
-                .await
-                .unwrap(),
+                Bucket::builder()
+                    .path(primary_bucket.path().clone())
+                    .cfg(cfg.clone())
+                    .usage_counters(Default::default())
+                    .restore()
+                    .await
+                    .unwrap(),
             );
 
             let err = forbidden!("Cannot perform this operation in read-only mode");
@@ -380,13 +380,13 @@ mod tests {
             let mut cfg = primary_bucket.cfg().clone();
             cfg.role = InstanceRole::Replica;
             let read_only_bucket = Arc::new(
-                Bucket::restore(
-                    primary_bucket.path().clone(),
-                    cfg.clone(),
-                    Default::default(),
-                )
-                .await
-                .unwrap(),
+                Bucket::builder()
+                    .path(primary_bucket.path().clone())
+                    .cfg(cfg.clone())
+                    .usage_counters(Default::default())
+                    .restore()
+                    .await
+                    .unwrap(),
             );
 
             read_only_bucket.compact().await.unwrap();
@@ -405,13 +405,13 @@ mod tests {
             let mut cfg = primary_bucket.cfg().clone();
             cfg.role = InstanceRole::Replica;
             let read_only_bucket = Arc::new(
-                Bucket::restore(
-                    primary_bucket.path().clone(),
-                    cfg.clone(),
-                    Default::default(),
-                )
-                .await
-                .unwrap(),
+                Bucket::builder()
+                    .path(primary_bucket.path().clone())
+                    .cfg(cfg.clone())
+                    .usage_counters(Default::default())
+                    .restore()
+                    .await
+                    .unwrap(),
             );
 
             {
@@ -445,13 +445,13 @@ mod tests {
             let mut cfg = primary_bucket.cfg().clone();
             cfg.role = InstanceRole::Replica;
             let read_only_bucket = Arc::new(
-                Bucket::restore(
-                    primary_bucket.path().clone(),
-                    cfg.clone(),
-                    Default::default(),
-                )
-                .await
-                .unwrap(),
+                Bucket::builder()
+                    .path(primary_bucket.path().clone())
+                    .cfg(cfg.clone())
+                    .usage_counters(Default::default())
+                    .restore()
+                    .await
+                    .unwrap(),
             );
 
             write(&primary_bucket, "test-2", 1, b"test data")
@@ -496,15 +496,15 @@ mod tests {
             .await
             .unwrap();
         let bucket = Arc::new(
-            Bucket::try_build(
-                "bucket",
-                &cfg.data_path.clone(),
-                BucketSettings::default(),
-                cfg,
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+            Bucket::builder()
+                .name("bucket")
+                .data_path(cfg.data_path.clone())
+                .settings(BucketSettings::default())
+                .cfg(cfg)
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap(),
         );
         write(&bucket, "test-1", 1, b"test data").await.unwrap();
         bucket.sync_fs().await.unwrap();

--- a/reductstore/src/storage/bucket/read_only.rs
+++ b/reductstore/src/storage/bucket/read_only.rs
@@ -45,15 +45,15 @@ impl Bucket {
                     .strip_prefix(self.path())
                     .unwrap_or(entry_path.as_path()),
             );
-            let handler = Entry::restore_with_limiter(
-                entry_path,
-                entry_name.clone(),
-                self.name().to_string(),
-                settings_for_entry(&entry_name, &settings),
-                self.cfg.clone(),
-                self.io_limiter.clone(),
-                Arc::clone(&self.usage_counters),
-            );
+            let handler = Entry::builder()
+                .path(entry_path)
+                .name(entry_name.clone())
+                .bucket_name(self.name().to_string())
+                .settings(settings_for_entry(&entry_name, &settings))
+                .cfg(self.cfg.clone())
+                .io_limiter(self.io_limiter.clone())
+                .usage_counters(Arc::clone(&self.usage_counters))
+                .restore();
 
             task_set.push((entry_name, handler));
         }

--- a/reductstore/src/storage/bucket/remove_entry.rs
+++ b/reductstore/src/storage/bucket/remove_entry.rs
@@ -856,7 +856,13 @@ mod tests {
     pub async fn bucket(settings: BucketSettings, path: PathBuf) -> Arc<Bucket> {
         FILE_CACHE.create_dir_all(&path.join("test")).await.unwrap();
         Arc::new(
-            Bucket::try_build("test", &path, settings, Cfg::default(), Default::default())
+            Bucket::builder()
+                .name("test")
+                .data_path(path)
+                .settings(settings)
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .build()
                 .await
                 .unwrap(),
         )

--- a/reductstore/src/storage/bucket/remove_entry.rs
+++ b/reductstore/src/storage/bucket/remove_entry.rs
@@ -286,16 +286,16 @@ impl Bucket {
     ) {
         let recovered_entry = match entry.settings().await {
             Ok(settings) => {
-                Entry::restore_with_limiter(
-                    path,
-                    entry_name.to_string(),
-                    bucket_name.to_string(),
-                    settings,
-                    cfg,
-                    io_limiter,
-                    usage_counters,
-                )
-                .await
+                Entry::builder()
+                    .path(path)
+                    .name(entry_name)
+                    .bucket_name(bucket_name)
+                    .settings(settings)
+                    .cfg(cfg)
+                    .io_limiter(io_limiter)
+                    .usage_counters(usage_counters)
+                    .restore()
+                    .await
             }
             Err(err) => Err(err),
         };

--- a/reductstore/src/storage/bucket/rename_entry.rs
+++ b/reductstore/src/storage/bucket/rename_entry.rs
@@ -25,15 +25,17 @@ impl Bucket {
                     .strip_prefix(&self.path)
                     .unwrap_or(entry_path.as_path()),
             );
-            task_set.push(Entry::restore_with_limiter(
-                entry_path,
-                entry_name.clone(),
-                self.name.clone(),
-                settings_for_entry(&entry_name, settings),
-                self.cfg.clone(),
-                self.io_limiter.clone(),
-                Arc::clone(&self.usage_counters),
-            ));
+            task_set.push(
+                Entry::builder()
+                    .path(entry_path)
+                    .name(entry_name.clone())
+                    .bucket_name(self.name.clone())
+                    .settings(settings_for_entry(&entry_name, settings))
+                    .cfg(self.cfg.clone())
+                    .io_limiter(self.io_limiter.clone())
+                    .usage_counters(Arc::clone(&self.usage_counters))
+                    .restore(),
+            );
         }
 
         for task in task_set {

--- a/reductstore/src/storage/bucket/rename_entry.rs
+++ b/reductstore/src/storage/bucket/rename_entry.rs
@@ -391,7 +391,11 @@ mod tests {
         bucket.sync_fs().await.unwrap();
         bucket.rename_entry("test-1", "test-2").await.unwrap();
 
-        let bucket = Bucket::restore(bucket.path.clone(), Cfg::default(), Default::default())
+        let bucket = Bucket::builder()
+            .path(bucket.path.clone())
+            .cfg(Cfg::default())
+            .usage_counters(Default::default())
+            .restore()
             .await
             .unwrap();
         assert_eq!(
@@ -476,7 +480,13 @@ mod tests {
     pub async fn bucket(settings: BucketSettings, path: PathBuf) -> Arc<Bucket> {
         FILE_CACHE.create_dir_all(&path.join("test")).await.unwrap();
         Arc::new(
-            Bucket::try_build("test", &path, settings, Cfg::default(), Default::default())
+            Bucket::builder()
+                .name("test")
+                .data_path(path)
+                .settings(settings)
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .build()
                 .await
                 .unwrap(),
         )

--- a/reductstore/src/storage/bucket/settings.rs
+++ b/reductstore/src/storage/bucket/settings.rs
@@ -153,7 +153,11 @@ mod tests {
         let bucket = bucket.await;
         assert_eq!(bucket.settings().await.unwrap(), settings);
 
-        let bucket = Bucket::restore(bucket.path.clone(), Cfg::default(), Default::default())
+        let bucket = Bucket::builder()
+            .path(bucket.path.clone())
+            .cfg(Cfg::default())
+            .usage_counters(Default::default())
+            .restore()
             .await
             .unwrap();
         assert_eq!(bucket.name(), "test");
@@ -264,7 +268,11 @@ mod tests {
             .await
             .unwrap();
         bucket.set_settings(Bucket::defaults()).await.unwrap();
-        let bucket = Bucket::restore(bucket.path.clone(), Cfg::default(), Default::default())
+        let bucket = Bucket::builder()
+            .path(bucket.path.clone())
+            .cfg(Cfg::default())
+            .usage_counters(Default::default())
+            .restore()
             .await
             .unwrap();
         assert_eq!(bucket.settings().await.unwrap(), Bucket::defaults());

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -82,13 +82,13 @@ impl StorageEngineBuilder {
             .await
             .expect("Failed to list folders")
         {
-            match Bucket::restore_with_limiter(
-                path.clone(),
-                cfg.clone(),
-                io_limiter.clone(),
-                Arc::clone(&usage_counters),
-            )
-            .await
+            match Bucket::builder()
+                .path(path.clone())
+                .cfg(cfg.clone())
+                .io_limiter(io_limiter.clone())
+                .usage_counters(Arc::clone(&usage_counters))
+                .restore()
+                .await
             {
                 Ok(bucket) => {
                     let bucket = Arc::new(bucket);
@@ -324,15 +324,15 @@ impl StorageEngine {
 
         self.folder_keeper.add_folder(name).await?;
         let bucket = Arc::new(
-            Bucket::try_build_with_limiter(
-                name,
-                &self.data_path,
-                settings,
-                self.cfg.clone(),
-                self.io_limiter.clone(),
-                Arc::clone(&self.usage_counters),
-            )
-            .await?,
+            Bucket::builder()
+                .name(name)
+                .data_path(self.data_path.clone())
+                .settings(settings)
+                .cfg(self.cfg.clone())
+                .io_limiter(self.io_limiter.clone())
+                .usage_counters(Arc::clone(&self.usage_counters))
+                .build()
+                .await?,
         );
         buckets.insert(name.to_string(), Arc::clone(&bucket));
 
@@ -452,13 +452,13 @@ impl StorageEngine {
         folder_keeper.rename_folder(&old_name, &new_name).await?;
 
         buckets.remove(&old_name);
-        let bucket = Bucket::restore_with_limiter(
-            new_path,
-            cfg,
-            self.io_limiter.clone(),
-            Arc::clone(&self.usage_counters),
-        )
-        .await?;
+        let bucket = Bucket::builder()
+            .path(new_path)
+            .cfg(cfg)
+            .io_limiter(self.io_limiter.clone())
+            .usage_counters(Arc::clone(&self.usage_counters))
+            .restore()
+            .await?;
         buckets.insert(new_name.to_string(), Arc::new(bucket));
         debug!("Bucket '{}' is renamed to '{}'", old_name, new_name);
         Ok(())

--- a/reductstore/src/storage/engine/read_only.rs
+++ b/reductstore/src/storage/engine/read_only.rs
@@ -38,13 +38,13 @@ impl StorageEngine {
             }
 
             // Restore new bucket
-            match Bucket::restore_with_limiter(
-                path.clone(),
-                self.cfg.clone(),
-                self.io_limiter.clone(),
-                Arc::clone(&self.usage_counters),
-            )
-            .await
+            match Bucket::builder()
+                .path(path.clone())
+                .cfg(self.cfg.clone())
+                .io_limiter(self.io_limiter.clone())
+                .usage_counters(Arc::clone(&self.usage_counters))
+                .restore()
+                .await
             {
                 Ok(bucket) => {
                     let bucket = Arc::new(bucket);

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
+mod builder;
 mod compress;
 mod entry_loader;
 pub(crate) mod io;
@@ -15,14 +16,11 @@ use crate::cfg::Cfg;
 use crate::core::file_cache::FILE_CACHE;
 use crate::core::sync::AsyncRwLock;
 use crate::core::weak::Weak;
-use crate::storage::block_manager::block_index::BlockIndex;
-use crate::storage::block_manager::{BlockManager, BLOCK_INDEX_FILE};
-use crate::storage::entry::entry_loader::EntryLoader;
+use crate::storage::block_manager::BlockManager;
 use crate::storage::in_flight::InFlightIoLimiter;
 use crate::storage::proto::ts_to_us;
 use crate::storage::query::base::QueryOptions;
 use crate::storage::query::{build_query, next_query_id, spawn_query_task, QueryRx};
-use crate::storage::usage::UsageCounters;
 pub(crate) use io::record_reader::RecordReader;
 pub(crate) use io::record_writer::{RecordDrainer, RecordWriter};
 use log::{debug, error};
@@ -40,6 +38,8 @@ pub(crate) use system::{
 };
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::JoinHandle;
+
+pub(crate) use builder::EntryBuilder;
 
 struct QueryHandle {
     rx: Arc<AsyncRwLock<QueryRx>>,
@@ -94,103 +94,8 @@ pub(crate) struct RecordQueryStats {
 }
 
 impl Entry {
-    #[allow(dead_code)]
-    pub async fn try_build(
-        name: &str,
-        path: PathBuf,
-        settings: EntrySettings,
-        cfg: Arc<Cfg>,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Self, ReductError> {
-        let io_limiter = InFlightIoLimiter::from_cfg(cfg.as_ref());
-        Self::try_build_with_limiter(name, path, settings, cfg, io_limiter, usage_counters).await
-    }
-
-    pub(crate) async fn try_build_with_limiter(
-        name: &str,
-        path: PathBuf,
-        settings: EntrySettings,
-        cfg: Arc<Cfg>,
-        io_limiter: InFlightIoLimiter,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Self, ReductError> {
-        let bucket_name = path.file_name().unwrap().to_str().unwrap().to_string();
-        let path = path.join(name);
-        let block_index_path = path.join(BLOCK_INDEX_FILE);
-        let block_index = BlockIndex::new(block_index_path.clone());
-
-        // create block index file if it doesn't exist.
-        if !FILE_CACHE.try_exists(&block_index_path).await? {
-            FILE_CACHE.create_dir_all(&path).await?;
-            block_index.save().await?;
-        }
-
-        Ok(Self {
-            name: name.to_string(),
-            bucket_name: bucket_name.clone(),
-            settings: AsyncRwLock::new(settings),
-            block_manager: Arc::new(AsyncRwLock::new(
-                BlockManager::build(
-                    path.clone(),
-                    block_index,
-                    bucket_name.clone(),
-                    name.to_string(),
-                    cfg.clone(),
-                    usage_counters,
-                )
-                .await?,
-            )),
-            system_behavior: strategy_for_entry(name),
-            queries: Arc::new(AsyncRwLock::new(HashMap::new())),
-            status: AsyncRwLock::new(ResourceStatus::Ready),
-            path,
-            cfg,
-            io_limiter,
-        })
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn restore(
-        path: PathBuf,
-        entry_name: String,
-        bucket_name: String,
-        options: EntrySettings,
-        cfg: Arc<Cfg>,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Option<Entry>, ReductError> {
-        let io_limiter = InFlightIoLimiter::from_cfg(cfg.as_ref());
-        Self::restore_with_limiter(
-            path,
-            entry_name,
-            bucket_name,
-            options,
-            cfg,
-            io_limiter,
-            usage_counters,
-        )
-        .await
-    }
-
-    pub(crate) async fn restore_with_limiter(
-        path: PathBuf,
-        entry_name: String,
-        bucket_name: String,
-        options: EntrySettings,
-        cfg: Arc<Cfg>,
-        io_limiter: InFlightIoLimiter,
-        usage_counters: Arc<UsageCounters>,
-    ) -> Result<Option<Entry>, ReductError> {
-        let entry = EntryLoader::restore_entry_with_names(
-            path,
-            entry_name,
-            bucket_name,
-            options,
-            cfg,
-            io_limiter,
-            usage_counters,
-        )
-        .await?;
-        Ok(entry)
+    pub(crate) fn builder() -> EntryBuilder {
+        EntryBuilder::default()
     }
 
     pub(crate) async fn acquire_writer_slot(
@@ -701,17 +606,17 @@ mod tests {
             );
 
             bm.save_cache_on_disk().await.unwrap();
-            let entry = Entry::restore(
-                path.join(entry.name()),
-                "entry".to_string(),
-                "bucket".to_string(),
-                entry_settings,
-                Cfg::default().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap()
-            .unwrap();
+            let entry = Entry::builder()
+                .path(path.join(entry.name()))
+                .name("entry")
+                .bucket_name("bucket")
+                .settings(entry_settings)
+                .cfg(Cfg::default().into())
+                .usage_counters(Default::default())
+                .restore()
+                .await
+                .unwrap()
+                .unwrap();
             let info = entry.info().await.unwrap();
             assert_eq!(info.name, "entry");
             assert_eq!(info.record_count, 2);
@@ -981,18 +886,18 @@ mod tests {
         use reduct_base::io::ReadRecord;
 
         let entry = Arc::new(
-            Entry::try_build(
-                "x/y/z",
-                path.clone(),
-                EntrySettings {
+            Entry::builder()
+                .name("x/y/z")
+                .bucket_path(path.clone())
+                .settings(EntrySettings {
                     max_block_size: 10000,
                     max_block_records: 10000,
-                },
-                Cfg::default().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+                })
+                .cfg(Cfg::default().into())
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap(),
         );
 
         write_stub_record(&entry, 1000000).await;
@@ -1077,18 +982,18 @@ mod tests {
         #[tokio::test]
         async fn test_size_counting(path: PathBuf) {
             let entry = Arc::new(
-                Entry::try_build(
-                    "entry",
-                    path.clone(),
-                    EntrySettings {
+                Entry::builder()
+                    .name("entry")
+                    .bucket_path(path.clone())
+                    .settings(EntrySettings {
                         max_block_size: 100000,
                         max_block_records: 2,
-                    },
-                    Cfg::default().into(),
-                    Default::default(),
-                )
-                .await
-                .unwrap(),
+                    })
+                    .cfg(Cfg::default().into())
+                    .usage_counters(Default::default())
+                    .build()
+                    .await
+                    .unwrap(),
             );
 
             write_stub_record(&entry, 1000000).await;
@@ -1123,15 +1028,15 @@ mod tests {
     #[fixture]
     pub(super) async fn entry(entry_settings: EntrySettings, path: PathBuf) -> Arc<Entry> {
         Arc::new(
-            Entry::try_build(
-                "entry",
-                path.clone(),
-                entry_settings,
-                Cfg::default().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+            Entry::builder()
+                .name("entry")
+                .bucket_path(path.clone())
+                .settings(entry_settings)
+                .cfg(Cfg::default().into())
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap(),
         )
     }
 

--- a/reductstore/src/storage/entry/builder.rs
+++ b/reductstore/src/storage/entry/builder.rs
@@ -1,0 +1,156 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use super::{strategy_for_entry, Entry, EntrySettings};
+use crate::cfg::Cfg;
+use crate::core::file_cache::FILE_CACHE;
+use crate::core::sync::AsyncRwLock;
+use crate::storage::block_manager::block_index::BlockIndex;
+use crate::storage::block_manager::{BlockManager, BLOCK_INDEX_FILE};
+use crate::storage::entry::entry_loader::EntryLoader;
+use crate::storage::in_flight::InFlightIoLimiter;
+use crate::storage::usage::UsageCounters;
+use reduct_base::error::ReductError;
+use reduct_base::msg::status::ResourceStatus;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Default)]
+pub(crate) struct EntryBuilder {
+    name: Option<String>,
+    bucket_name: Option<String>,
+    bucket_path: Option<PathBuf>,
+    path: Option<PathBuf>,
+    settings: Option<EntrySettings>,
+    cfg: Option<Arc<Cfg>>,
+    io_limiter: Option<InFlightIoLimiter>,
+    usage_counters: Option<Arc<UsageCounters>>,
+}
+
+impl EntryBuilder {
+    pub(crate) fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub(crate) fn bucket_name(mut self, bucket_name: impl Into<String>) -> Self {
+        self.bucket_name = Some(bucket_name.into());
+        self
+    }
+
+    pub(crate) fn bucket_path(mut self, bucket_path: PathBuf) -> Self {
+        self.bucket_path = Some(bucket_path);
+        self
+    }
+
+    pub(crate) fn path(mut self, path: PathBuf) -> Self {
+        self.path = Some(path);
+        self
+    }
+
+    pub(crate) fn settings(mut self, settings: EntrySettings) -> Self {
+        self.settings = Some(settings);
+        self
+    }
+
+    pub(crate) fn cfg(mut self, cfg: Arc<Cfg>) -> Self {
+        self.cfg = Some(cfg);
+        self
+    }
+
+    pub(crate) fn io_limiter(mut self, io_limiter: InFlightIoLimiter) -> Self {
+        self.io_limiter = Some(io_limiter);
+        self
+    }
+
+    pub(crate) fn usage_counters(mut self, usage_counters: Arc<UsageCounters>) -> Self {
+        self.usage_counters = Some(usage_counters);
+        self
+    }
+
+    pub(crate) async fn build(self) -> Result<Entry, ReductError> {
+        let name = self.name.expect("Entry name must be set");
+        let bucket_path = self.bucket_path.expect("Bucket path must be set");
+        let bucket_name = bucket_path
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let path = bucket_path.join(&name);
+        let settings = self.settings.expect("Entry settings must be set");
+        let cfg = self.cfg.expect("Config must be set");
+        let io_limiter = self
+            .io_limiter
+            .unwrap_or_else(|| InFlightIoLimiter::from_cfg(cfg.as_ref()));
+        let usage_counters = self
+            .usage_counters
+            .unwrap_or_else(|| Arc::new(UsageCounters::default()));
+        let block_index_path = path.join(BLOCK_INDEX_FILE);
+        let block_index = BlockIndex::new(block_index_path.clone());
+
+        if !FILE_CACHE.try_exists(&block_index_path).await? {
+            FILE_CACHE.create_dir_all(&path).await?;
+            block_index.save().await?;
+        }
+
+        Ok(Entry {
+            name: name.clone(),
+            bucket_name: bucket_name.clone(),
+            settings: AsyncRwLock::new(settings),
+            block_manager: Arc::new(AsyncRwLock::new(
+                BlockManager::build(
+                    path.clone(),
+                    block_index,
+                    bucket_name,
+                    name.clone(),
+                    cfg.clone(),
+                    usage_counters,
+                )
+                .await?,
+            )),
+            system_behavior: strategy_for_entry(&name),
+            queries: Arc::new(AsyncRwLock::new(HashMap::new())),
+            status: AsyncRwLock::new(ResourceStatus::Ready),
+            path,
+            cfg,
+            io_limiter,
+        })
+    }
+
+    pub(crate) async fn restore(self) -> Result<Option<Entry>, ReductError> {
+        let path = self.path.expect("Entry path must be set");
+        let entry_name = self
+            .name
+            .unwrap_or_else(|| path.file_name().unwrap().to_str().unwrap().to_string());
+        let bucket_name = self.bucket_name.unwrap_or_else(|| {
+            path.parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        });
+        let settings = self.settings.expect("Entry settings must be set");
+        let cfg = self.cfg.expect("Config must be set");
+        let io_limiter = self
+            .io_limiter
+            .unwrap_or_else(|| InFlightIoLimiter::from_cfg(cfg.as_ref()));
+        let usage_counters = self
+            .usage_counters
+            .unwrap_or_else(|| Arc::new(UsageCounters::default()));
+
+        EntryLoader::restore_entry_with_names(
+            path,
+            entry_name,
+            bucket_name,
+            settings,
+            cfg,
+            io_limiter,
+            usage_counters,
+        )
+        .await
+    }
+}

--- a/reductstore/src/storage/entry/compress.rs
+++ b/reductstore/src/storage/entry/compress.rs
@@ -446,15 +446,15 @@ mod tests {
 
     async fn entry(settings: EntrySettings, path: PathBuf) -> Arc<Entry> {
         Arc::new(
-            Entry::try_build(
-                "entry",
-                path.clone(),
-                settings,
-                Cfg::default().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+            Entry::builder()
+                .name("entry")
+                .bucket_path(path.clone())
+                .settings(settings)
+                .cfg(Cfg::default().into())
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap(),
         )
     }
 
@@ -499,17 +499,17 @@ mod tests {
             .await
             .unwrap();
 
-        Entry::restore(
-            bucket_path.join(entry.name()),
-            entry.name().to_string(),
-            entry.bucket_name().to_string(),
-            settings,
-            Cfg::default().into(),
-            Default::default(),
-        )
-        .await
-        .unwrap()
-        .unwrap()
+        Entry::builder()
+            .path(bucket_path.join(entry.name()))
+            .name(entry.name())
+            .bucket_name(entry.bucket_name())
+            .settings(settings)
+            .cfg(Cfg::default().into())
+            .usage_counters(Default::default())
+            .restore()
+            .await
+            .unwrap()
+            .unwrap()
     }
 
     async fn assert_compressed(entry: &Entry, block_id: u64, expected: bool) {

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -90,6 +90,10 @@ impl EntryLoader {
             Ok(entry) => entry,
             Err(err) => {
                 if cfg.role == Replica {
+                    error!(
+                        "Failed to restore replica entry from block index {:?}: {}",
+                        path, err.message
+                    );
                     return Ok(None);
                 }
 
@@ -111,9 +115,11 @@ impl EntryLoader {
             }
         };
 
-        Self::restore_uncommitted_changes(path.clone(), &mut entry).await?;
+        if cfg.role != Replica {
+            Self::restore_uncommitted_changes(path.clone(), &mut entry).await?;
+        }
 
-        if cfg.engine_config.enable_integrity_checks {
+        if cfg.role != Replica && cfg.engine_config.enable_integrity_checks {
             let needs_rebuild = {
                 let file_list = FILE_CACHE
                     .read_dir(&path)
@@ -537,7 +543,7 @@ impl EntryLoader {
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::block_manager::wal::WalEntry;
+    use crate::storage::block_manager::wal::{create_wal, WalEntry};
     use crate::storage::entry::tests::{entry, entry_settings, path, write_stub_record};
     use crate::storage::proto::{record, us_to_ts, BlockIndex as BlockIndexProto, Record};
     use std::fs;
@@ -626,6 +632,107 @@ mod tests {
             rec.read_chunk().unwrap().unwrap(),
             Bytes::from_static(b"0123456789")
         );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_restore_replica_skips_wal_recovery(entry_settings: EntrySettings, path: PathBuf) {
+        let entry = entry(entry_settings.clone(), path.clone()).await;
+        write_stub_record(&entry, 1).await;
+        entry
+            .block_manager
+            .write()
+            .await
+            .unwrap()
+            .save_cache_on_disk()
+            .await
+            .unwrap();
+
+        let entry_path = path.join(entry.name());
+        let mut wal = create_wal(entry_path.clone()).await.unwrap();
+        wal.append(
+            1,
+            WalEntry::WriteRecord(Record {
+                timestamp: Some(us_to_ts(&2)),
+                begin: 10,
+                end: 20,
+                content_type: "text/plain".to_string(),
+                state: record::State::Finished as i32,
+                labels: vec![],
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(wal.list().await.unwrap(), vec![1]);
+
+        let mut cfg = Cfg {
+            role: Replica,
+            ..Default::default()
+        };
+        cfg.engine_config.enable_integrity_checks = true;
+
+        let entry = EntryLoader::restore_entry(
+            entry_path.clone(),
+            entry_settings,
+            Arc::new(cfg),
+            Default::default(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let info = entry.info().await.unwrap();
+        assert_eq!(info.record_count, 1);
+        assert!(entry.begin_read(2).await.is_err());
+
+        let wal = create_wal(entry_path).await.unwrap();
+        assert_eq!(wal.list().await.unwrap(), vec![1]);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_restore_replica_ignores_entry_when_index_fails(
+        entry_settings: EntrySettings,
+        path: PathBuf,
+    ) {
+        let entry = entry(entry_settings.clone(), path.clone()).await;
+        write_stub_record(&entry, 1).await;
+        entry
+            .block_manager
+            .write()
+            .await
+            .unwrap()
+            .save_cache_on_disk()
+            .await
+            .unwrap();
+
+        let entry_path = path.join(entry.name());
+        {
+            let mut block_file_index = FILE_CACHE
+                .write_or_create(&entry_path.join(BLOCK_INDEX_FILE), SeekFrom::Start(0))
+                .await
+                .unwrap();
+            block_file_index.set_len(0).unwrap();
+            block_file_index.write_all(b"bad index").unwrap();
+            block_file_index.sync_all().await.unwrap();
+        }
+
+        let mut cfg = Cfg {
+            role: Replica,
+            ..Default::default()
+        };
+        cfg.engine_config.enable_integrity_checks = true;
+
+        let entry = EntryLoader::restore_entry(
+            entry_path,
+            entry_settings,
+            Arc::new(cfg),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+        assert!(entry.is_none());
     }
 
     #[rstest]

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use reduct_base::error::ReductError;
 use reduct_base::io::{ReadChunk, ReadRecord, RecordMeta};
-use reduct_base::{internal_server_error, not_found};
+use reduct_base::{internal_server_error, not_found, too_early};
 use std::cmp::min;
 use std::io;
 use std::io::Read;
@@ -73,6 +73,13 @@ impl RecordReader {
 
         let file_path = if content_size > 0 {
             if !FILE_CACHE.try_exists(&file_path).await? {
+                if bm.is_replica() {
+                    return Err(too_early!(
+                        "Data block {} is not available on replica yet",
+                        file_path.display()
+                    ));
+                }
+
                 return Err(not_found!("Data block {} not found", file_path.display()));
             }
             Some(file_path)

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -95,6 +95,7 @@ impl Entry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cfg::{Cfg, InstanceRole};
     use crate::core::file_cache::FILE_CACHE;
     use crate::storage::block_manager::DATA_FILE_EXT;
     use crate::storage::engine::MAX_IO_BUFFER_SIZE;
@@ -246,6 +247,56 @@ mod tests {
         assert_eq!(
             reader.err(),
             Some(not_found!("Data block {} not found", data_path.display()))
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_begin_read_missing_data_file_on_replica_returns_too_early(
+        entry_settings: EntrySettings,
+        path: PathBuf,
+    ) {
+        let entry = entry(entry_settings.clone(), path.clone()).await;
+        write_stub_record(&entry, 1000000).await;
+        entry
+            .block_manager
+            .write()
+            .await
+            .unwrap()
+            .save_cache_on_disk()
+            .await
+            .unwrap();
+
+        let data_path = {
+            let bm = entry.block_manager.read().await.unwrap();
+            let block_id = *bm.index().tree().first().unwrap();
+            bm.path().join(format!("{}{}", block_id, DATA_FILE_EXT))
+        };
+        FILE_CACHE.remove(&data_path).await.unwrap();
+
+        let cfg = Cfg {
+            role: InstanceRole::Replica,
+            ..Default::default()
+        };
+        let replica_entry = Entry::restore(
+            path.join("entry"),
+            "entry".to_string(),
+            "bucket".to_string(),
+            entry_settings,
+            Arc::new(cfg),
+            Default::default(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let reader = replica_entry.begin_read(1000000).await;
+        assert_eq!(
+            reader.err(),
+            Some(too_early!(
+                "Data block {} is not available on replica yet",
+                data_path.display()
+            ))
         );
     }
 

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -278,17 +278,17 @@ mod tests {
             role: InstanceRole::Replica,
             ..Default::default()
         };
-        let replica_entry = Entry::restore(
-            path.join("entry"),
-            "entry".to_string(),
-            "bucket".to_string(),
-            entry_settings,
-            Arc::new(cfg),
-            Default::default(),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let replica_entry = Entry::builder()
+            .path(path.join("entry"))
+            .name("entry")
+            .bucket_name("bucket")
+            .settings(entry_settings)
+            .cfg(Arc::new(cfg))
+            .usage_counters(Default::default())
+            .restore()
+            .await
+            .unwrap()
+            .unwrap();
 
         let reader = replica_entry.begin_read(1000000).await;
         assert_eq!(

--- a/reductstore/src/storage/entry/system.rs
+++ b/reductstore/src/storage/entry/system.rs
@@ -186,18 +186,18 @@ mod tests {
 
     async fn build_entry(name: &str) -> Entry {
         let path = tempdir().unwrap().keep();
-        Entry::try_build(
-            name,
-            path,
-            EntrySettings {
+        Entry::builder()
+            .name(name)
+            .bucket_path(path)
+            .settings(EntrySettings {
                 max_block_size: 1024 * 1024,
                 max_block_records: 1024,
-            },
-            Cfg::default().into(),
-            Default::default(),
-        )
-        .await
-        .unwrap()
+            })
+            .cfg(Cfg::default().into())
+            .usage_counters(Default::default())
+            .build()
+            .await
+            .unwrap()
     }
 
     async fn write_record(entry: &Entry, ts: u64, labels: Labels) {

--- a/reductstore/src/storage/entry/write_record.rs
+++ b/reductstore/src/storage/entry/write_record.rs
@@ -668,18 +668,18 @@ mod tests {
     #[tokio::test]
     async fn test_meta_entry_requires_key_label(path: PathBuf) {
         let entry = Arc::new(
-            Entry::try_build(
-                "entry/$meta",
-                path,
-                EntrySettings {
+            Entry::builder()
+                .name("entry/$meta")
+                .bucket_path(path)
+                .settings(EntrySettings {
                     max_block_size: 10000,
                     max_block_records: 10000,
-                },
-                Cfg::default().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+                })
+                .cfg(Cfg::default().into())
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap(),
         );
 
         let err = entry
@@ -700,18 +700,18 @@ mod tests {
     #[tokio::test]
     async fn test_meta_entry_replaces_previous_record_with_same_key(path: PathBuf) {
         let entry = Arc::new(
-            Entry::try_build(
-                "entry/$meta",
-                path,
-                EntrySettings {
+            Entry::builder()
+                .name("entry/$meta")
+                .bucket_path(path)
+                .settings(EntrySettings {
                     max_block_size: 10000,
                     max_block_records: 10000,
-                },
-                Cfg::default().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+                })
+                .cfg(Cfg::default().into())
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap(),
         );
 
         let mut sender = entry
@@ -753,18 +753,18 @@ mod tests {
     #[tokio::test]
     async fn test_meta_entry_remove_true_is_rejected(path: PathBuf) {
         let entry = Arc::new(
-            Entry::try_build(
-                "entry/$meta",
-                path,
-                EntrySettings {
+            Entry::builder()
+                .name("entry/$meta")
+                .bucket_path(path)
+                .settings(EntrySettings {
                     max_block_size: 10000,
                     max_block_records: 10000,
-                },
-                Cfg::default().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap(),
+                })
+                .cfg(Cfg::default().into())
+                .usage_counters(Default::default())
+                .build()
+                .await
+                .unwrap(),
         );
 
         let mut sender = entry


### PR DESCRIPTION
Closes #1488

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix and refactoring.

### What was changed?

- Restore read-only replica entries from persisted block indexes without WAL recovery or integrity rebuilds, so transient cached block state does not make buckets disappear.
- Return `425 Too Early` when replica reads see an index/descriptor before the corresponding data block is available, while preserving `404 Not Found` for primary buckets.
- Invalidate stale cached replica block metadata/data when descriptor CRC validation fails.
- Keep bucket restore and entry reload visible by logging and skipping entries that fail to restore.
- Move bucket and entry creation/restoration to builder APIs with `build()` and `restore()`.

### Related issues

- #1488

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed locally:

- `cargo fmt --all`
- `cargo check -p reductstore`
- `cargo test -p reductstore storage::entry::tests::restore`
- `cargo test -p reductstore storage::entry::read_record::tests::test_begin_read_missing_data_file`
- `cargo test -p reductstore storage::bucket::tests::restore`
- `cargo test -p reductstore storage::bucket::read_only`
- `cargo test -p reductstore storage::entry::write_record::tests::test_meta_entry_requires_key_label`
- `cargo test -p reductstore storage::entry::system`
