### PR TITLE
Isolate corrupted blocks during lifecycle cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Persist corrupted blocks in the storage index and skip them during active lifecycle, query, read, write, and compression operations, [PR-1494](https://github.com/reductstore/reductstore/pull/1494)
 - Keep read-only replica buckets visible when transient cached block state prevents entry restore or reads, [PR-1492](https://github.com/reductstore/reductstore/pull/1492)
 - Remove redundant `error_code` and `error_message` fields from newly written `lifecycle_run` diagnostics and keep top-level `status` / `message` as the canonical failure metadata, [PR-1491](https://github.com/reductstore/reductstore/pull/1491)
 

--- a/reductstore/src/proto/storage.proto
+++ b/reductstore/src/proto/storage.proto
@@ -86,6 +86,7 @@ message BlockIndex {
     google.protobuf.Timestamp latest_record_time = 5;  // the timestamp of the latest record
     optional uint64 crc64 = 6;  // integrity check for a block
     optional CompressionAlgorithm compression = 7;  // compression algorithm for data and descriptor files
+    optional bool corrupted = 8;  // block data/descriptor is damaged
   }
 
   repeated Block blocks = 1;

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -23,7 +23,7 @@ use crate::storage::proto::{record, ts_to_us, us_to_ts, Block as BlockProto, Rec
 use crate::storage::usage::UsageCounters;
 use block_index::BlockIndex;
 use crc64fast::Digest;
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, trace, warn};
 use prost::bytes::{Bytes, BytesMut};
 use prost::Message;
 use reduct_base::error::ReductError;
@@ -137,30 +137,27 @@ impl BlockManager {
     }
 
     pub async fn find_block(&mut self, start: u64) -> Result<BlockRef, ReductError> {
-        let start_block_id = self.block_index.tree().range(start..).next();
-        let id = if start_block_id.is_some() && start >= *start_block_id.unwrap() {
-            start_block_id.unwrap().clone()
-        } else {
-            if let Some(block_id) = self.block_index.tree().range(..start).rev().next() {
-                block_id.clone()
-            } else {
-                return Err(ReductError::not_found(&format!(
-                    "Record {} not found in entry {}/{}",
-                    start, self.bucket, self.entry
-                )));
-            }
-        };
-
+        let id = self.find_block_id(start)?;
         self.load_block(id).await
     }
 
-    pub fn find_cached_block(&self, start: u64) -> Option<BlockRef> {
-        let start_block_id = self.block_index.tree().range(start..).next();
-        let id = if start_block_id.is_some() && start >= *start_block_id.unwrap() {
-            *start_block_id.unwrap()
+    fn find_block_id(&self, start: u64) -> Result<u64, ReductError> {
+        let active_tree = self.block_index.active_tree();
+        let start_block_id = active_tree.range(start..).next();
+        if start_block_id.is_some() && start >= *start_block_id.unwrap() {
+            Ok(*start_block_id.unwrap())
+        } else if let Some(block_id) = active_tree.range(..start).rev().next() {
+            Ok(*block_id)
         } else {
-            *self.block_index.tree().range(..start).rev().next()?
-        };
+            Err(ReductError::not_found(&format!(
+                "Record {} not found in entry {}/{}",
+                start, self.bucket, self.entry
+            )))
+        }
+    }
+
+    pub fn find_cached_block(&self, start: u64) -> Option<BlockRef> {
+        let id = self.find_block_id(start).ok()?;
 
         self.block_cache.get_read(&id)
     }
@@ -191,16 +188,9 @@ impl BlockManager {
                     }
 
                     // here we can't read the block descriptor, it might be corrupted or not exist
-                    // we should remove it from the index
                     let err_msg = format!("Block descriptor {:?} can't be read: {}", path, err);
                     error!("{}", &err_msg);
-                    info!(
-                        "Remove block {} from the index. The block {} must be removed manually",
-                        block_id,
-                        self.path_to_data(block_id).display()
-                    );
-                    self.block_index.remove_block(block_id);
-                    self.block_index.save().await?;
+                    self.mark_block_corrupted(block_id).await?;
                     return Err(internal_server_error!(&err_msg));
                 }
             };
@@ -228,10 +218,9 @@ impl BlockManager {
                             ));
                         }
 
-                        error!("Block descriptor {:?} is corrupted: index CRC {} mismatch with calculated CRC {}.\
-                     Remove it and its data block, then restart the database", path, block_crc, crc.sum64());
+                        error!("Block descriptor {:?} is corrupted: index CRC {} mismatch with calculated CRC {}", path, block_crc, crc.sum64());
 
-                        self.block_index.remove_block(block_id);
+                        self.mark_block_corrupted(block_id).await?;
                         return Err(internal_server_error!(
                             "Block descriptor {:?} is corrupted",
                             path
@@ -246,9 +235,17 @@ impl BlockManager {
             }
 
             // parse the block descriptor
-            let mut block_from_disk = BlockProto::decode(Bytes::from(buf)).map_err(|e| {
-                internal_server_error!("Failed to decode block descriptor {:?}: {}", path, e)
-            })?;
+            let mut block_from_disk = match BlockProto::decode(Bytes::from(buf)) {
+                Ok(block) => block,
+                Err(e) => {
+                    self.mark_block_corrupted(block_id).await?;
+                    return Err(internal_server_error!(
+                        "Failed to decode block descriptor {:?}: {}",
+                        path,
+                        e
+                    ));
+                }
+            };
 
             if block_from_disk.begin_time.is_none() {
                 warn!(
@@ -409,6 +406,27 @@ impl BlockManager {
 
         self.wal.remove(block_id).await?;
         Ok(())
+    }
+
+    pub async fn mark_block_corrupted(&mut self, block_id: u64) -> Result<(), ReductError> {
+        if self.cfg.role == InstanceRole::Replica {
+            return Ok(());
+        }
+
+        self.block_index.mark_corrupted(block_id);
+        self.block_cache.remove(&block_id);
+        self.block_index.save().await?;
+
+        error!(
+            "Marked block {}/{}/{} as corrupted",
+            self.bucket, self.entry, block_id
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn is_block_corrupted(&self, block_id: u64) -> bool {
+        self.block_index.is_corrupted(block_id)
     }
 
     /// Check if a block exists on disk.
@@ -1055,6 +1073,24 @@ mod tests {
             let err = block_manager.load_block(block_id).await.err().unwrap();
             assert_eq!(err.status(), ErrorCode::InternalServerError);
             assert!(err.to_string().contains("corrupted"));
+            assert!(block_manager.index().get_block(block_id).is_some());
+            assert!(block_manager.is_block_corrupted(block_id));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_mark_block_corrupted_removes_cache(
+            #[future] block_manager: BlockManager,
+            block_id: u64,
+        ) {
+            let mut block_manager = block_manager.await;
+            block_manager.load_block(block_id).await.unwrap();
+            assert!(block_manager.block_cache.get_read(&block_id).is_some());
+
+            block_manager.mark_block_corrupted(block_id).await.unwrap();
+
+            assert!(block_manager.is_block_corrupted(block_id));
+            assert!(block_manager.block_cache.get_read(&block_id).is_none());
         }
 
         #[rstest]
@@ -1398,9 +1434,10 @@ mod tests {
                 ErrorCode::InternalServerError
             );
             assert!(
-                block_manager.index().get_block(block_id).is_none(),
-                "we removed the block descriptor file"
+                block_manager.index().get_block(block_id).is_some(),
+                "corrupted blocks remain in the index for quota cleanup"
             );
+            assert!(block_manager.is_block_corrupted(block_id));
         }
     }
 

--- a/reductstore/src/storage/block_manager/block_index.rs
+++ b/reductstore/src/storage/block_manager/block_index.rs
@@ -35,6 +35,7 @@ impl Into<BlockEntry> for MinimalBlock {
             latest_record_time: self.latest_record_time,
             crc64: None,
             compression: None,
+            corrupted: None,
         }
     }
 }
@@ -49,6 +50,7 @@ impl Into<BlockEntry> for BlockProto {
             latest_record_time: self.latest_record_time,
             crc64: None,
             compression: None,
+            corrupted: None,
         }
     }
 }
@@ -63,6 +65,7 @@ impl Into<BlockEntry> for Block {
             latest_record_time: Some(us_to_ts(&self.latest_record_time())),
             crc64: None,
             compression: None,
+            corrupted: None,
         }
     }
 }
@@ -122,6 +125,38 @@ impl BlockIndex {
         self.index.remove(&block_id);
 
         block
+    }
+
+    pub fn is_corrupted(&self, block_id: u64) -> bool {
+        self.index_info
+            .get(&block_id)
+            .is_some_and(|block| block.corrupted == Some(true))
+    }
+
+    pub fn mark_corrupted(&mut self, block_id: u64) {
+        if let Some(block) = self.index_info.get_mut(&block_id) {
+            block.corrupted = Some(true);
+        }
+    }
+
+    pub fn corrupted_block_count(&self) -> usize {
+        self.corrupted_block_ids().len()
+    }
+
+    pub fn corrupted_block_ids(&self) -> Vec<u64> {
+        self.index
+            .iter()
+            .copied()
+            .filter(|block_id| self.is_corrupted(*block_id))
+            .collect()
+    }
+
+    pub fn active_tree(&self) -> BTreeSet<u64> {
+        self.index
+            .iter()
+            .copied()
+            .filter(|block_id| !self.is_corrupted(*block_id))
+            .collect()
     }
 
     pub async fn try_load(path: PathBuf) -> Result<Self, ReductError> {
@@ -185,6 +220,10 @@ impl BlockIndex {
                 crc.write(&crc64.to_be_bytes());
             }
 
+            if let Some(corrupted) = block.corrupted {
+                crc.write(&(corrupted as u8).to_be_bytes());
+            }
+
             block_index.index.insert(block.block_id);
             block_index.index_info.insert(block.block_id, block);
         });
@@ -217,6 +256,7 @@ impl BlockIndex {
                 block_entry.latest_record_time = block.latest_record_time;
                 block_entry.crc64 = block.crc64;
                 block_entry.compression = block.compression;
+                block_entry.corrupted = block.corrupted;
                 block_entry
             })
             .collect();
@@ -231,6 +271,10 @@ impl BlockIndex {
 
             if let Some(crc64) = block.crc64 {
                 crc.write(&crc64.to_be_bytes());
+            }
+
+            if let Some(corrupted) = block.corrupted {
+                crc.write(&(corrupted as u8).to_be_bytes());
             }
         });
 
@@ -313,6 +357,7 @@ mod tests {
                     latest_record_time: Some(Timestamp::default()),
                     crc64: None,
                     compression: None,
+                    corrupted: None,
                 }],
                 crc64: 294433432134063049,
             };
@@ -350,6 +395,7 @@ mod tests {
                     latest_record_time: Some(Timestamp::default()),
                     crc64: None,
                     compression: None,
+                    corrupted: None,
                 }],
                 crc64: 0,
             };
@@ -390,6 +436,7 @@ mod tests {
                 latest_record_time: Some(Timestamp::default()),
                 crc64: None,
                 compression: None,
+                corrupted: None,
             });
 
             block_index.save().await.unwrap();
@@ -398,6 +445,36 @@ mod tests {
             assert_eq!(block_index_proto.size(), 2);
             assert_eq!(block_index_proto.record_count(), 1);
             assert_eq!(block_index_proto.tree().len(), 1);
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_corrupted_round_trip() {
+            let path = tempdir().unwrap().keep().join(BLOCK_INDEX_FILE);
+
+            let mut block_index = BlockIndex::new(path.clone());
+            block_index.insert_or_update(BlockEntry {
+                block_id: 1,
+                size: 1,
+                record_count: 1,
+                metadata_size: 1,
+                latest_record_time: Some(Timestamp::default()),
+                crc64: None,
+                compression: None,
+                corrupted: None,
+            });
+            block_index.mark_corrupted(1);
+
+            assert!(block_index.is_corrupted(1));
+            assert_eq!(block_index.corrupted_block_count(), 1);
+            assert_eq!(block_index.corrupted_block_ids(), vec![1]);
+
+            block_index.save().await.unwrap();
+
+            let block_index = BlockIndex::try_load(path).await.unwrap();
+            assert!(block_index.is_corrupted(1));
+            assert_eq!(block_index.corrupted_block_count(), 1);
+            assert_eq!(block_index.corrupted_block_ids(), vec![1]);
         }
     }
 }

--- a/reductstore/src/storage/block_manager/compress.rs
+++ b/reductstore/src/storage/block_manager/compress.rs
@@ -129,8 +129,30 @@ impl BlockManager {
         let data_path = self.path_to_data(block_id);
         let desc_path = self.path_to_desc(block_id);
 
-        decompress_file_zstd(&compressed_data_path, &data_path).await?;
-        decompress_file_zstd(&compressed_desc_path, &desc_path).await?;
+        if let Err(err) = decompress_file_zstd(&compressed_data_path, &data_path).await {
+            if let Err(mark_err) = self.mark_block_corrupted(block_id).await {
+                log::error!(
+                    "Failed to mark block {}/{}/{} as corrupted after decompression error: {}",
+                    self.bucket_name(),
+                    self.entry_name(),
+                    block_id,
+                    mark_err
+                );
+            }
+            return Err(err);
+        }
+        if let Err(err) = decompress_file_zstd(&compressed_desc_path, &desc_path).await {
+            if let Err(mark_err) = self.mark_block_corrupted(block_id).await {
+                log::error!(
+                    "Failed to mark block {}/{}/{} as corrupted after decompression error: {}",
+                    self.bucket_name(),
+                    self.entry_name(),
+                    block_id,
+                    mark_err
+                );
+            }
+            return Err(err);
+        }
 
         FILE_CACHE.remove(&compressed_data_path).await?;
         FILE_CACHE.remove(&compressed_desc_path).await?;

--- a/reductstore/src/storage/block_manager/compress.rs
+++ b/reductstore/src/storage/block_manager/compress.rs
@@ -699,7 +699,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[serial]
-    async fn test_decompress_block_missing_compressed_file() {
+    async fn test_decompress_block_missing_compressed_data_marks_corrupted() {
         let (mut block_manager, block_id, _, _) =
             block_manager_with_data(b"missing file".to_vec()).await;
 
@@ -708,7 +708,10 @@ mod tests {
             .await
             .unwrap();
 
-        std::fs::remove_file(block_manager.path_to_compressed_data(block_id)).unwrap();
+        FILE_CACHE
+            .remove(&block_manager.path_to_compressed_data(block_id))
+            .await
+            .unwrap();
 
         let err = block_manager
             .decompress_block(block_id)
@@ -716,6 +719,35 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err.status(), ErrorCode::InternalServerError);
+        assert!(block_manager.is_block_corrupted(block_id));
+        assert!(!block_manager.index().active_tree().contains(&block_id));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[serial]
+    async fn test_decompress_block_missing_compressed_descriptor_marks_corrupted() {
+        let (mut block_manager, block_id, _, _) =
+            block_manager_with_data(b"missing descriptor".to_vec()).await;
+
+        block_manager
+            .compress_block(block_id, CompressionAlgorithm::Zstd)
+            .await
+            .unwrap();
+
+        FILE_CACHE
+            .remove(&block_manager.path_to_compressed_desc(block_id))
+            .await
+            .unwrap();
+
+        let err = block_manager
+            .decompress_block(block_id)
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(err.status(), ErrorCode::InternalServerError);
+        assert!(block_manager.is_block_corrupted(block_id));
+        assert!(!block_manager.index().active_tree().contains(&block_id));
     }
 
     #[rstest]

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -216,16 +216,15 @@ impl Entry {
 
         let bm = self.block_manager.read().await?;
         let index = bm.index();
-        let oldest_record = index
-            .tree()
+        let active_tree = index.active_tree();
+        let oldest_record = active_tree
             .iter()
             .find_map(|block_id| {
                 let block = index.get_block(*block_id)?;
                 (block.record_count > 0).then_some(*block_id)
             })
             .unwrap_or(0);
-        let latest_record = index
-            .tree()
+        let latest_record = active_tree
             .iter()
             .rev()
             .find_map(|block_id| {

--- a/reductstore/src/storage/entry/compress.rs
+++ b/reductstore/src/storage/entry/compress.rs
@@ -33,8 +33,9 @@ impl Entry {
         let blocks = {
             let bm = self.block_manager.read().await?;
             let index = bm.index();
+            let active_tree = index.active_tree();
 
-            let range = block_id_range(index.tree(), start, stop);
+            let range = block_id_range(&active_tree, start, stop);
 
             range
                 .filter(|&&block_id| {
@@ -94,8 +95,9 @@ impl Entry {
     ) -> Result<CompressionStats, ReductError> {
         let bm = self.block_manager.read().await?;
         let index = bm.index();
+        let active_tree = index.active_tree();
 
-        let range = block_id_range(index.tree(), start, stop);
+        let range = block_id_range(&active_tree, start, stop);
 
         let stats = range
             .filter(|&&block_id| {
@@ -238,6 +240,36 @@ mod tests {
             entry.compress_blocks(None, None).await.unwrap(),
             CompressionStats::default()
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[serial]
+    async fn test_compress_blocks_skips_corrupted(path: PathBuf) {
+        let entry = entry(multi_block_settings(), path.clone()).await;
+        write_blocks(&entry, &[1_000_000, 2_000_000, 3_000_000]).await;
+        let entry = restore_flushed_entry(&entry, multi_block_settings(), path).await;
+
+        entry
+            .block_manager
+            .write()
+            .await
+            .unwrap()
+            .mark_block_corrupted(2_000_000)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            entry.compress_blocks(None, None).await.unwrap(),
+            CompressionStats {
+                blocks: 2,
+                records: 2
+            }
+        );
+
+        assert_compressed(&entry, 1_000_000, true).await;
+        assert_compressed(&entry, 2_000_000, false).await;
+        assert_compressed(&entry, 3_000_000, true).await;
     }
 
     #[rstest]

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -151,6 +151,17 @@ impl EntryLoader {
 
         {
             let bm = entry.block_manager.read().await?;
+            let corrupted_blocks = bm.index().corrupted_block_ids();
+            if !corrupted_blocks.is_empty() {
+                warn!(
+                    "Entry `{}/{}` has {} corrupted block(s): {:?}. Run diagnostics or allow FIFO quota to reclaim space.",
+                    entry.bucket_name,
+                    entry.name,
+                    bm.index().corrupted_block_count(),
+                    corrupted_blocks
+                );
+            }
+
             debug!(
                 "Restored entry `{}` in {}ms: size={}, records={}",
                 entry.name,

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -6,9 +6,7 @@ use crate::core::sync::AsyncRwLock;
 use crate::storage::block_manager::{BlockManager, BlockRef};
 use crate::storage::engine::MAX_IO_BUFFER_SIZE;
 use crate::storage::proto::Record;
-use async_trait::async_trait;
 use bytes::Bytes;
-use log::error;
 use reduct_base::error::ReductError;
 use reduct_base::io::{ReadChunk, ReadRecord, RecordMeta};
 use reduct_base::{internal_server_error, not_found, too_early};
@@ -27,8 +25,6 @@ pub(crate) struct RecordReader {
     offset: u64,
     content_size: u64,
     pos: u64,
-    block_manager: Option<Arc<AsyncRwLock<BlockManager>>>,
-    block_id: Option<u64>,
     _permit: Option<OwnedSemaphorePermit>,
 }
 
@@ -57,7 +53,6 @@ impl RecordReader {
         let bm = block_manager.read().await?;
         let block = block_ref.read().await?;
 
-        let block_id = block.block_id();
         let (file_path, offset) = bm.begin_read_record(&block, record_timestamp).await?;
 
         let record = block.get_record(record_timestamp).unwrap();
@@ -99,8 +94,6 @@ impl RecordReader {
             offset,
             content_size,
             pos: 0,
-            block_manager: Some(Arc::clone(&block_manager)),
-            block_id: Some(block_id),
             _permit: permit,
         })
     }
@@ -127,30 +120,7 @@ impl RecordReader {
             offset: 0,
             content_size: 0,
             pos: 0,
-            block_manager: None,
-            block_id: None,
             _permit: None,
-        }
-    }
-
-    fn mark_current_block_corrupted(&self) {
-        let (Some(block_manager), Some(block_id)) = (&self.block_manager, self.block_id) else {
-            return;
-        };
-
-        let block_manager = Arc::clone(block_manager);
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async move {
-                block_manager
-                    .write()
-                    .await?
-                    .mark_block_corrupted(block_id)
-                    .await
-            })
-        });
-
-        if let Err(err) = result {
-            error!("Failed to mark block {} as corrupted: {}", block_id, err);
         }
     }
 
@@ -211,7 +181,6 @@ impl Seek for RecordReader {
     }
 }
 
-#[async_trait]
 impl ReadRecord for RecordReader {
     fn read_chunk(&mut self) -> ReadChunk {
         let mut buf =
@@ -221,23 +190,17 @@ impl ReadRecord for RecordReader {
         }
 
         match self.read(&mut buf) {
-            Ok(0) => {
-                self.mark_current_block_corrupted();
-                Some(Err(internal_server_error!(
-                    "Failed to read record chunk: EOF"
-                )))
-            }
+            Ok(0) => Some(Err(internal_server_error!(
+                "Failed to read record chunk: EOF"
+            ))),
             Ok(n) => {
                 buf.truncate(n);
                 Some(Ok(Bytes::from(buf)))
             }
-            Err(e) => {
-                self.mark_current_block_corrupted();
-                Some(Err(internal_server_error!(
-                    "Failed to read record chunk: {}",
-                    e
-                )))
-            }
+            Err(e) => Some(Err(internal_server_error!(
+                "Failed to read record chunk: {}",
+                e
+            ))),
         }
     }
 
@@ -295,6 +258,7 @@ pub(crate) mod tests {
 
     use crate::storage::engine::MAX_IO_BUFFER_SIZE;
     use crate::storage::entry::tests::{entry, write_record, write_stub_record};
+    use async_trait::async_trait;
     use mockall::mock;
     use rstest::{fixture, rstest};
 

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -8,6 +8,7 @@ use crate::storage::engine::MAX_IO_BUFFER_SIZE;
 use crate::storage::proto::Record;
 use async_trait::async_trait;
 use bytes::Bytes;
+use log::error;
 use reduct_base::error::ReductError;
 use reduct_base::io::{ReadChunk, ReadRecord, RecordMeta};
 use reduct_base::{internal_server_error, not_found, too_early};
@@ -26,6 +27,8 @@ pub(crate) struct RecordReader {
     offset: u64,
     content_size: u64,
     pos: u64,
+    block_manager: Option<Arc<AsyncRwLock<BlockManager>>>,
+    block_id: Option<u64>,
     _permit: Option<OwnedSemaphorePermit>,
 }
 
@@ -54,6 +57,7 @@ impl RecordReader {
         let bm = block_manager.read().await?;
         let block = block_ref.read().await?;
 
+        let block_id = block.block_id();
         let (file_path, offset) = bm.begin_read_record(&block, record_timestamp).await?;
 
         let record = block.get_record(record_timestamp).unwrap();
@@ -95,6 +99,8 @@ impl RecordReader {
             offset,
             content_size,
             pos: 0,
+            block_manager: Some(Arc::clone(&block_manager)),
+            block_id: Some(block_id),
             _permit: permit,
         })
     }
@@ -121,7 +127,30 @@ impl RecordReader {
             offset: 0,
             content_size: 0,
             pos: 0,
+            block_manager: None,
+            block_id: None,
             _permit: None,
+        }
+    }
+
+    fn mark_current_block_corrupted(&self) {
+        let (Some(block_manager), Some(block_id)) = (&self.block_manager, self.block_id) else {
+            return;
+        };
+
+        let block_manager = Arc::clone(block_manager);
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                block_manager
+                    .write()
+                    .await?
+                    .mark_block_corrupted(block_id)
+                    .await
+            })
+        });
+
+        if let Err(err) = result {
+            error!("Failed to mark block {} as corrupted: {}", block_id, err);
         }
     }
 
@@ -192,17 +221,23 @@ impl ReadRecord for RecordReader {
         }
 
         match self.read(&mut buf) {
-            Ok(0) => Some(Err(internal_server_error!(
-                "Failed to read record chunk: EOF"
-            ))),
+            Ok(0) => {
+                self.mark_current_block_corrupted();
+                Some(Err(internal_server_error!(
+                    "Failed to read record chunk: EOF"
+                )))
+            }
             Ok(n) => {
                 buf.truncate(n);
                 Some(Ok(Bytes::from(buf)))
             }
-            Err(e) => Some(Err(internal_server_error!(
-                "Failed to read record chunk: {}",
-                e
-            ))),
+            Err(e) => {
+                self.mark_current_block_corrupted();
+                Some(Err(internal_server_error!(
+                    "Failed to read record chunk: {}",
+                    e
+                )))
+            }
         }
     }
 

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -325,7 +325,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_read_chunk_marks_block_corrupted_on_eof(#[future] entry: Arc<Entry>) {
+    async fn test_read_chunk_eof_does_not_mark_block_corrupted(#[future] entry: Arc<Entry>) {
         let entry = entry.await;
         write_stub_record(&entry, 1000000).await;
         let mut reader = entry.begin_read(1000000).await.unwrap();
@@ -346,7 +346,7 @@ mod tests {
             err.status(),
             reduct_base::error::ErrorCode::InternalServerError
         );
-        assert!(entry
+        assert!(!entry
             .block_manager
             .read()
             .await

--- a/reductstore/src/storage/entry/read_record.rs
+++ b/reductstore/src/storage/entry/read_record.rs
@@ -1,8 +1,9 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
+use crate::storage::block_manager::BlockRef;
 use crate::storage::entry::{Entry, RecordReader};
-use crate::storage::proto::record;
+use crate::storage::proto::{record, Record};
 use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::{internal_server_error, not_found, too_early};
@@ -34,40 +35,10 @@ impl Entry {
                 drop(block);
                 (block_ref, record)
             } else {
-                let mut bm = self.block_manager.write().await?;
-                let block_ref = bm.find_block(time).await?;
-                let block = block_ref.read().await?;
-                let record = block
-                    .get_record(time)
-                    .ok_or_else(|| {
-                        not_found!(
-                            "Record {} not found in block {}/{}/{}",
-                            time,
-                            self.bucket_name,
-                            self.name,
-                            block.block_id(),
-                        )
-                    })?
-                    .clone();
-                (block_ref.clone(), record)
+                self.find_record_for_read(time).await?
             }
         } else {
-            let mut bm = self.block_manager.write().await?;
-            let block_ref = bm.find_block(time).await?;
-            let block = block_ref.read().await?;
-            let record = block
-                .get_record(time)
-                .ok_or_else(|| {
-                    not_found!(
-                        "Record {} not found in block {}/{}/{}",
-                        time,
-                        self.bucket_name,
-                        self.name,
-                        block.block_id(),
-                    )
-                })?
-                .clone();
-            (block_ref.clone(), record)
+            self.find_record_for_read(time).await?
         };
 
         if record.state == record::State::Started as i32 {
@@ -89,6 +60,27 @@ impl Entry {
         }
 
         RecordReader::try_new(self.block_manager.clone(), block_ref, time, None, None).await
+    }
+
+    async fn find_record_for_read(&self, time: u64) -> Result<(BlockRef, Record), ReductError> {
+        let mut bm = self.block_manager.write().await?;
+        let block_ref = bm.find_block(time).await?;
+        let block = block_ref.read().await?;
+        let record = block
+            .get_record(time)
+            .ok_or_else(|| {
+                not_found!(
+                    "Record {} not found in block {}/{}/{}",
+                    time,
+                    self.bucket_name,
+                    self.name,
+                    block.block_id(),
+                )
+            })?
+            .clone();
+
+        drop(block);
+        Ok((block_ref, record))
     }
 }
 
@@ -252,6 +244,28 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_begin_read_ignores_already_corrupted_block(#[future] entry: Arc<Entry>) {
+        let entry = entry.await;
+        write_stub_record(&entry, 1000000).await;
+
+        entry
+            .block_manager
+            .write()
+            .await
+            .unwrap()
+            .mark_block_corrupted(1000000)
+            .await
+            .unwrap();
+
+        let reader = entry.begin_read(1000000).await;
+        assert_eq!(
+            reader.err(),
+            Some(not_found!("Record 1000000 not found in entry bucket/entry"))
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_begin_read_missing_data_file_on_replica_returns_too_early(
         entry_settings: EntrySettings,
         path: PathBuf,
@@ -307,6 +321,37 @@ mod tests {
         write_stub_record(&entry, 1000000).await;
         let mut reader = entry.begin_read(1000000).await.unwrap();
         assert_eq!(reader.read_chunk().unwrap(), Ok(Bytes::from("0123456789")));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_read_chunk_marks_block_corrupted_on_eof(#[future] entry: Arc<Entry>) {
+        let entry = entry.await;
+        write_stub_record(&entry, 1000000).await;
+        let mut reader = entry.begin_read(1000000).await.unwrap();
+
+        let data_path = {
+            let bm = entry.block_manager.read().await.unwrap();
+            bm.path().join(format!("1000000{}", DATA_FILE_EXT))
+        };
+        FILE_CACHE
+            .write_or_create(&data_path, std::io::SeekFrom::Start(0))
+            .await
+            .unwrap()
+            .set_len(0)
+            .unwrap();
+
+        let err = reader.read_chunk().unwrap().err().unwrap();
+        assert_eq!(
+            err.status(),
+            reduct_base::error::ErrorCode::InternalServerError
+        );
+        assert!(entry
+            .block_manager
+            .read()
+            .await
+            .unwrap()
+            .is_block_corrupted(1000000));
     }
 
     #[rstest]

--- a/reductstore/src/storage/entry/write_record.rs
+++ b/reductstore/src/storage/entry/write_record.rs
@@ -75,10 +75,11 @@ impl Entry {
             let mut bm = self.block_manager.write().await?;
             // When we write, the likely case is that we are writing the latest record
             // in the entry. In this case, we can just append to the latest block.
-            let block_ref = if bm.index().tree().is_empty() {
+            let active_index_tree = bm.index().active_tree();
+            let block_ref = if active_index_tree.is_empty() {
                 bm.start_new_block(time, settings.max_block_size).await?
             } else {
-                let block_id = *bm.index().tree().last().unwrap();
+                let block_id = *active_index_tree.last().unwrap();
                 if bm.block_is_compressed(block_id) {
                     bm.decompress_block(block_id).await?;
                 }
@@ -99,7 +100,7 @@ impl Entry {
                 );
                 // The timestamp is belated. We need to find the proper block to write to.
                 let mut bm = self.block_manager.write().await?;
-                let index_tree = bm.index().tree();
+                let index_tree = bm.index().active_tree();
                 let record_type = if *index_tree.first().unwrap() > time {
                     // The timestamp is the earliest. We need to create a new block.
                     debug!(

--- a/reductstore/src/storage/query/historical.rs
+++ b/reductstore/src/storage/query/historical.rs
@@ -164,7 +164,7 @@ impl Query for HistoricalQuery {
                     Vec::new()
                 } else {
                     bm.index()
-                        .tree()
+                        .active_tree()
                         .range(first_block..self.stop_time)
                         .map(|k| *k)
                         .collect::<Vec<u64>>()
@@ -449,6 +449,27 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].0.meta().timestamp(), 0);
         assert_eq!(records[1].0.meta().timestamp(), 5);
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_query_skips_corrupted_block(
+        #[future] block_manager: Arc<AsyncRwLock<BlockManager>>,
+    ) {
+        let block_manager = block_manager.await;
+        block_manager
+            .write()
+            .await
+            .unwrap()
+            .mark_block_corrupted(0)
+            .await
+            .unwrap();
+
+        let mut query = build_query(0, 1001, QueryOptions::default()).unwrap();
+        let records = read_to_vector(&mut query, block_manager).await;
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0.meta().timestamp(), 1000);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #1482

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Persist corrupted block state in the block index and filter corrupted blocks from active reads, writes, queries, compression, and lifecycle operations while keeping them in the full index for accounting and quota cleanup.

Corruption detection is isolated to the block manager and record reader paths that actually observe descriptor, compressed data, or chunk-read failures. Corrupted blocks are marked instead of being removed from the index so sparse lifecycle delete and other active operations can continue past damaged blocks on subsequent runs.

### Related issues

https://github.com/reductstore/reductstore/issues/1482

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed locally:

- `cargo fmt --all`
- `cargo test -p reductstore corrupted -- --test-threads=1`
- `cargo check --workspace`
