### PR TITLE
add block descriptor version recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Distinguish stale block indexes from corrupted descriptors by persisting block descriptor versions and corruption flags, [PR-1495](https://github.com/reductstore/reductstore/pull/1495)
 - Persist corrupted blocks in the storage index and skip them during active lifecycle, query, read, write, and compression operations, [PR-1494](https://github.com/reductstore/reductstore/pull/1494)
 - Keep read-only replica buckets visible when transient cached block state prevents entry restore or reads, [PR-1492](https://github.com/reductstore/reductstore/pull/1492)
 - Remove redundant `error_code` and `error_message` fields from newly written `lifecycle_run` diagnostics and keep top-level `status` / `message` as the canonical failure metadata, [PR-1491](https://github.com/reductstore/reductstore/pull/1491)

--- a/reductstore/src/proto/storage.proto
+++ b/reductstore/src/proto/storage.proto
@@ -58,6 +58,8 @@ message Block {
   // bool invalid = 5;                               // DEPRECATED: mark block as invalid if some IO happened
   uint64 record_count = 6;                       // number of records in the block
   uint64 metadata_size = 7;                       // size of metadata in bytes
+  optional uint64 version = 8;                    // logical version counter, incremented on every save
+  optional bool corrupted = 9;                    // block data/descriptor is damaged
 }
 
 // Represents a minimal block of records with no records
@@ -69,6 +71,8 @@ message MinimalBlock {
   // bool invalid = 5;                               // DEPRECATED: mark block as invalid if some IO happened
   uint64 record_count = 6;                       // number of records in the block
   uint64 metadata_size = 7;                       // size of metadata in bytes
+  optional uint64 version = 8;                    // logical version counter, incremented on every save
+  optional bool corrupted = 9;                    // block data/descriptor is damaged
 }
 
 // Represents a block index for an entry
@@ -87,6 +91,7 @@ message BlockIndex {
     optional uint64 crc64 = 6;  // integrity check for a block
     optional CompressionAlgorithm compression = 7;  // compression algorithm for data and descriptor files
     optional bool corrupted = 8;  // block data/descriptor is damaged
+    optional uint64 version = 9;  // version counter from descriptor
   }
 
   repeated Block blocks = 1;

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -218,13 +218,52 @@ impl BlockManager {
                             ));
                         }
 
-                        error!("Block descriptor {:?} is corrupted: index CRC {} mismatch with calculated CRC {}", path, block_crc, crc.sum64());
+                        match BlockProto::decode(Bytes::from(buf.clone())) {
+                            Ok(decoded) => {
+                                let desc_version = decoded.version.unwrap_or(0);
+                                let index_version = block.version.unwrap_or(0);
 
-                        self.mark_block_corrupted(block_id).await?;
-                        return Err(internal_server_error!(
-                            "Block descriptor {:?} is corrupted",
-                            path
-                        ));
+                                if desc_version > index_version {
+                                    warn!(
+                                        "Block descriptor {:?} is newer than index (v{} > v{}). Updating index",
+                                        path, desc_version, index_version
+                                    );
+
+                                    self.block_index
+                                        .insert_or_update_with_crc(decoded.clone(), crc.sum64());
+                                    self.block_index.save().await?;
+                                } else {
+                                    error!(
+                                        "Block descriptor {:?} is corrupted: index CRC {} mismatch with calculated CRC {}, version {} <= {}",
+                                        path,
+                                        block_crc,
+                                        crc.sum64(),
+                                        desc_version,
+                                        index_version
+                                    );
+
+                                    self.mark_block_corrupted(block_id).await?;
+                                    return Err(internal_server_error!(
+                                        "Block descriptor {:?} is corrupted",
+                                        path
+                                    ));
+                                }
+                            }
+                            Err(err) => {
+                                error!(
+                                    "Block descriptor {:?} is corrupted: index CRC {} mismatch with calculated CRC {} and descriptor can't be decoded: {}",
+                                    path,
+                                    block_crc,
+                                    crc.sum64(),
+                                    err
+                                );
+                                self.mark_block_corrupted(block_id).await?;
+                                return Err(internal_server_error!(
+                                    "Block descriptor {:?} is corrupted",
+                                    path
+                                ));
+                            }
+                        }
                     }
                 }
             } else {
@@ -415,6 +454,29 @@ impl BlockManager {
 
         self.block_index.mark_corrupted(block_id);
         self.block_cache.remove(&block_id);
+
+        let path = self.path_to_desc(block_id);
+        let descriptor = if let Ok(mut file) = FILE_CACHE.read(&path, SeekFrom::Start(0)).await {
+            let mut buf = Vec::new();
+            if file.read_to_end(&mut buf).is_ok() {
+                BlockProto::decode(Bytes::from(buf)).ok()
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(mut proto) = descriptor {
+            proto.corrupted = Some(true);
+            let new_buf = proto.encode_to_vec();
+            if let Ok(mut writer) = FILE_CACHE.write_or_create(&path, SeekFrom::Start(0)).await {
+                let _ = writer.set_len(new_buf.len() as u64);
+                let _ = writer.write_all(&new_buf);
+                let _ = writer.flush_local().await;
+            }
+        }
+
         self.block_index.save().await?;
 
         error!(
@@ -856,6 +918,14 @@ impl BlockManager {
         let mut buf = BytesMut::new();
 
         let mut proto = BlockProto::from(block_snapshot);
+        let version = self
+            .block_index
+            .get_block(block_id)
+            .and_then(|block| block.version)
+            .unwrap_or(0)
+            + 1;
+        proto.version = Some(version);
+        proto.corrupted = None;
         proto.encode(&mut buf).map_err(|e| {
             internal_server_error!("Failed to encode block descriptor {:?}: {}", path, e)
         })?;
@@ -987,6 +1057,47 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
+        async fn test_save_meta_stores_version_in_descriptor() {
+            let path = tempdir().unwrap().keep().join("bucket").join("entry");
+            FILE_CACHE.create_dir_all(&path).await.unwrap();
+            let mut block_manager = BlockManager::build(
+                path.clone(),
+                BlockIndex::new(path.join(BLOCK_INDEX_FILE)),
+                "bucket".to_string(),
+                "entry".to_string(),
+                Cfg::default().into(),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+            let block_id = 1;
+            let block_ref = block_manager.start_new_block(block_id, 1024).await.unwrap();
+            block_manager
+                .save_meta_on_disk(block_ref.clone())
+                .await
+                .unwrap();
+
+            let block_proto = BlockProto::decode(
+                std::fs::read(block_manager.path_to_desc(block_id))
+                    .unwrap()
+                    .as_slice(),
+            )
+            .unwrap();
+            assert_eq!(block_proto.version, Some(1));
+
+            block_manager.save_meta_on_disk(block_ref).await.unwrap();
+
+            let block_proto = BlockProto::decode(
+                std::fs::read(block_manager.path_to_desc(block_id))
+                    .unwrap()
+                    .as_slice(),
+            )
+            .unwrap();
+            assert_eq!(block_proto.version, Some(2));
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_save_cache_metadata_skips_blocks_without_wal() {
             let path = tempdir().unwrap().keep().join("bucket").join("entry");
             let mut block_manager = BlockManager::build(
@@ -1079,6 +1190,58 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
+        async fn test_load_block_stale_index_self_heals(#[future] block_manager: BlockManager) {
+            let mut block_manager = block_manager.await;
+            let block_id = 1;
+
+            let block_ref = block_manager.load_block(block_id).await.unwrap();
+            block_manager.save_meta_on_disk(block_ref).await.unwrap();
+            block_manager.block_cache.remove(&block_id);
+            let desc_version = BlockProto::decode(
+                std::fs::read(block_manager.path_to_desc(block_id))
+                    .unwrap()
+                    .as_slice(),
+            )
+            .unwrap()
+            .version
+            .unwrap();
+
+            let index_block = block_manager.index_mut().get_block_mut(block_id).unwrap();
+            index_block.version = Some(desc_version - 1);
+            index_block.crc64 = Some(0);
+            block_manager.index_mut().save().await.unwrap();
+
+            let loaded = block_manager.load_block(block_id).await;
+
+            assert!(loaded.is_ok());
+            let index_block = block_manager.index().get_block(block_id).unwrap();
+            assert_eq!(index_block.version, Some(desc_version));
+            assert_ne!(index_block.crc64, Some(0));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_load_block_corrupted_descriptor_detected(
+            #[future] block_manager: BlockManager,
+        ) {
+            let mut block_manager = block_manager.await;
+            let block_id = 1;
+            block_manager.block_cache.remove(&block_id);
+
+            let path = block_manager.path_to_desc(block_id);
+            let mut block_proto =
+                BlockProto::decode(std::fs::read(&path).unwrap().as_slice()).unwrap();
+            block_proto.record_count += 1;
+            std::fs::write(&path, block_proto.encode_to_vec()).unwrap();
+
+            let err = block_manager.load_block(block_id).await.err().unwrap();
+
+            assert_eq!(err.status(), ErrorCode::InternalServerError);
+            assert!(block_manager.is_block_corrupted(block_id));
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_mark_block_corrupted_removes_cache(
             #[future] block_manager: BlockManager,
             block_id: u64,
@@ -1091,6 +1254,25 @@ mod tests {
 
             assert!(block_manager.is_block_corrupted(block_id));
             assert!(block_manager.block_cache.get_read(&block_id).is_none());
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_mark_block_corrupted_persists_in_descriptor(
+            #[future] block_manager: BlockManager,
+            block_id: u64,
+        ) {
+            let mut block_manager = block_manager.await;
+
+            block_manager.mark_block_corrupted(block_id).await.unwrap();
+
+            let block_proto = BlockProto::decode(
+                std::fs::read(block_manager.path_to_desc(block_id))
+                    .unwrap()
+                    .as_slice(),
+            )
+            .unwrap();
+            assert_eq!(block_proto.corrupted, Some(true));
         }
 
         #[rstest]
@@ -1304,7 +1486,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 index.get_block(block_id).unwrap().metadata_size,
-                25,
+                27,
                 "index not updated"
             );
 
@@ -1329,7 +1511,7 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                block_index_proto.blocks[0].metadata_size, 39,
+                block_index_proto.blocks[0].metadata_size, 41,
                 "index updated"
             );
         }

--- a/reductstore/src/storage/block_manager/block.rs
+++ b/reductstore/src/storage/block_manager/block.rs
@@ -50,6 +50,8 @@ impl From<Block> for BlockProto {
             record_count: block.record_count,
             metadata_size: block.metadata_size,
             records,
+            version: None,
+            corrupted: None,
         }
     }
 }
@@ -255,6 +257,8 @@ mod tests {
             record_count: 1,
             metadata_size: 4,
             records: vec![record],
+            version: None,
+            corrupted: None,
         }
     }
 }

--- a/reductstore/src/storage/block_manager/block_index.rs
+++ b/reductstore/src/storage/block_manager/block_index.rs
@@ -35,7 +35,8 @@ impl Into<BlockEntry> for MinimalBlock {
             latest_record_time: self.latest_record_time,
             crc64: None,
             compression: None,
-            corrupted: None,
+            corrupted: self.corrupted,
+            version: self.version,
         }
     }
 }
@@ -50,7 +51,8 @@ impl Into<BlockEntry> for BlockProto {
             latest_record_time: self.latest_record_time,
             crc64: None,
             compression: None,
-            corrupted: None,
+            corrupted: self.corrupted,
+            version: self.version,
         }
     }
 }
@@ -66,6 +68,7 @@ impl Into<BlockEntry> for Block {
             crc64: None,
             compression: None,
             corrupted: None,
+            version: None,
         }
     }
 }
@@ -224,6 +227,10 @@ impl BlockIndex {
                 crc.write(&(corrupted as u8).to_be_bytes());
             }
 
+            if let Some(version) = block.version {
+                crc.write(&version.to_be_bytes());
+            }
+
             block_index.index.insert(block.block_id);
             block_index.index_info.insert(block.block_id, block);
         });
@@ -257,6 +264,7 @@ impl BlockIndex {
                 block_entry.crc64 = block.crc64;
                 block_entry.compression = block.compression;
                 block_entry.corrupted = block.corrupted;
+                block_entry.version = block.version;
                 block_entry
             })
             .collect();
@@ -275,6 +283,10 @@ impl BlockIndex {
 
             if let Some(corrupted) = block.corrupted {
                 crc.write(&(corrupted as u8).to_be_bytes());
+            }
+
+            if let Some(version) = block.version {
+                crc.write(&version.to_be_bytes());
             }
         });
 
@@ -358,6 +370,7 @@ mod tests {
                     crc64: None,
                     compression: None,
                     corrupted: None,
+                    version: None,
                 }],
                 crc64: 294433432134063049,
             };
@@ -396,6 +409,7 @@ mod tests {
                     crc64: None,
                     compression: None,
                     corrupted: None,
+                    version: None,
                 }],
                 crc64: 0,
             };
@@ -437,6 +451,7 @@ mod tests {
                 crc64: None,
                 compression: None,
                 corrupted: None,
+                version: None,
             });
 
             block_index.save().await.unwrap();
@@ -462,6 +477,7 @@ mod tests {
                 crc64: None,
                 compression: None,
                 corrupted: None,
+                version: None,
             });
             block_index.mark_corrupted(1);
 

--- a/reductstore/src/storage/block_manager/compress.rs
+++ b/reductstore/src/storage/block_manager/compress.rs
@@ -9,7 +9,9 @@ use crate::storage::block_manager::{
 };
 use crate::storage::engine::MAX_IO_BUFFER_SIZE;
 use crate::storage::proto::block_index::CompressionAlgorithm as ProtoCompressionAlgorithm;
+use crate::storage::proto::Block as BlockProto;
 use crc64fast::Digest;
+use prost::Message;
 use reduct_base::error::ReductError;
 use reduct_base::{conflict, internal_server_error, not_found};
 use std::cmp::min;
@@ -171,6 +173,9 @@ impl BlockManager {
         let desc_size = desc.len() as u64;
         let mut crc = Digest::new();
         crc.write(&desc);
+        let desc_proto = BlockProto::decode(desc.as_slice()).map_err(|err| {
+            internal_server_error!("Failed to decode descriptor file {:?}: {}", desc_path, err)
+        })?;
 
         let block = self.block_index.get_block_mut(block_id).ok_or_else(|| {
             not_found!(
@@ -184,6 +189,8 @@ impl BlockManager {
         block.size = data_size;
         block.metadata_size = desc_size;
         block.crc64 = Some(crc.sum64());
+        block.version = desc_proto.version;
+        block.corrupted = desc_proto.corrupted;
         self.block_index.save().await?;
 
         self.decompress_cache.invalidate(&self.path, block_id).await;

--- a/reductstore/src/storage/bucket/quotas.rs
+++ b/reductstore/src/storage/bucket/quotas.rs
@@ -215,7 +215,7 @@ mod tests {
 
         write(&bucket, "test-1", 0, b"test").await.unwrap();
         bucket.sync_fs().await.unwrap(); // we need to sync to get the correct size
-        assert_eq!(bucket.clone().info().await.unwrap().info.size, 22);
+        assert_eq!(bucket.clone().info().await.unwrap().info.size, 24);
 
         let result = write(&bucket, "test-2", 1, b"0123456789___").await;
         assert_eq!(

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -902,7 +902,7 @@ mod tests {
                 ServerInfo {
                     version: env!("CARGO_PKG_VERSION").to_string(),
                     bucket_count: 1,
-                    usage: 142,
+                    usage: 146,
                     uptime: 0,
                     oldest_record: 1000,
                     latest_record: 5000,

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -619,7 +619,7 @@ mod tests {
             let info = entry.info().await.unwrap();
             assert_eq!(info.name, "entry");
             assert_eq!(info.record_count, 2);
-            assert_eq!(info.size, 88);
+            assert_eq!(info.size, 90);
         }
     }
 
@@ -1002,7 +1002,7 @@ mod tests {
 
             assert_eq!(entry.info().await.unwrap().block_count, 2);
             assert_eq!(entry.info().await.unwrap().record_count, 4);
-            assert_eq!(entry.info().await.unwrap().size, 138);
+            assert_eq!(entry.info().await.unwrap().size, 140);
 
             entry.try_remove_oldest_block().await.unwrap();
             assert_eq!(entry.info().await.unwrap().block_count, 1);

--- a/reductstore/src/storage/entry/entry_loader.rs
+++ b/reductstore/src/storage/entry/entry_loader.rs
@@ -556,7 +556,7 @@ impl EntryLoader {
 mod tests {
     use crate::storage::block_manager::wal::{create_wal, WalEntry};
     use crate::storage::entry::tests::{entry, entry_settings, path, write_stub_record};
-    use crate::storage::proto::{record, us_to_ts, BlockIndex as BlockIndexProto, Record};
+    use crate::storage::proto::{record, us_to_ts, Block, BlockIndex as BlockIndexProto, Record};
     use std::fs;
     use std::io::SeekFrom;
 
@@ -622,7 +622,7 @@ mod tests {
         let info = entry.info().await.unwrap();
         assert_eq!(entry.name, "entry");
         assert_eq!(info.record_count, 2);
-        assert_eq!(info.size, 88);
+        assert_eq!(info.size, 90);
 
         let mut rec = entry.begin_read(1).await.unwrap();
         assert_eq!(rec.meta().timestamp(), 1);
@@ -936,10 +936,57 @@ mod tests {
             BlockIndexProto::decode(Bytes::from(fs::read(block_index_path).unwrap())).unwrap();
 
         assert_eq!(block_index.blocks.len(), 1);
-        assert_eq!(block_index.crc64, 4579043244124502122);
+        assert_eq!(block_index.crc64, 14511237322380062442);
         assert_eq!(block_index.blocks[0].block_id, 1);
         assert_eq!(block_index.blocks[0].size, 20);
         assert_eq!(block_index.blocks[0].record_count, 2);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_restore_carries_descriptor_version_and_corrupted_flag(
+        path: PathBuf,
+        entry_settings: EntrySettings,
+    ) {
+        let entry = entry(entry_settings.clone(), path.clone()).await;
+        write_stub_record(&entry, 1).await;
+        entry
+            .block_manager
+            .write()
+            .await
+            .unwrap()
+            .save_cache_on_disk()
+            .await
+            .unwrap();
+
+        let entry_path = path.join(entry.name());
+        FILE_CACHE
+            .remove(&entry_path.join(BLOCK_INDEX_FILE))
+            .await
+            .unwrap();
+
+        let meta_path = entry_path.join("1.meta");
+        let mut block = Block::decode(Bytes::from(fs::read(&meta_path).unwrap())).unwrap();
+        block.version = Some(5);
+        block.corrupted = Some(true);
+        fs::write(&meta_path, block.encode_to_vec()).unwrap();
+
+        EntryLoader::restore_entry(
+            entry_path.clone(),
+            entry_settings,
+            Cfg::default().into(),
+            Default::default(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let block_index = BlockIndexProto::decode(Bytes::from(
+            fs::read(entry_path.join(BLOCK_INDEX_FILE)).unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(block_index.blocks[0].version, Some(5));
+        assert_eq!(block_index.blocks[0].corrupted, Some(true));
     }
 
     #[rstest]
@@ -1123,6 +1170,8 @@ mod tests {
             size: 1,
             record_count: 1,
             metadata_size: 0,
+            version: None,
+            corrupted: None,
         };
         fs::write(entry_path.join("1.meta"), block.encode_to_vec()).unwrap();
         fs::write(entry_path.join("1.blk"), b"a").unwrap();


### PR DESCRIPTION
Closes #1388

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / storage recovery improvement

### What was changed?

- Added optional `version` and `corrupted` fields to block descriptors and persisted descriptor version in the block index.
- Increment descriptor versions on metadata saves so CRC mismatches can distinguish stale indexes from descriptor corruption.
- Self-heal stale block indexes when a descriptor has a newer version than the index.
- Persist corrupted block state back to descriptors and carry descriptor version/corruption state during index rebuilds and decompression.
- Updated affected storage accounting expectations and added regression tests for version persistence, stale-index recovery, corrupted descriptor detection, and restore carryover.

### Related issues

#1388

### Does this PR introduce a breaking change?

No. New protobuf fields are optional, and legacy descriptors/indexes continue to decode with missing values treated as version `0` / not corrupted.

### Other information:

Validation performed:

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p reductstore storage::block_manager::tests`
- `cargo test -p reductstore storage::entry::entry_loader::tests`
- `cargo test -p reductstore storage::block_manager::block_index::tests`
- Targeted storage regression tests for quota, engine recovery, entry restore, and oldest-block removal

`cargo test --workspace` was also run; the only unrelated failures were launcher HTTP/HTTPS tests caused by local port `8383` already being in use.