### PR TITLE
feat: support query entry glob patterns (#1505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support glob-like entry patterns in query entry filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1506](https://github.com/reductstore/reductstore/pull/1506) by @gitcommit90
 - Add CI vulnerability scanning for Rust dependencies and Docker images, gating image publishing on fixed high-severity container findings, [PR-1500](https://github.com/reductstore/reductstore/pull/1500)
 - Emit per-bucket usage statistics as system events under `usage/<instance>/<bucket>` alongside the existing instance total, and add `written_entries`, `read_entries`, and `record_count` fields to usage events, [PR-1474](https://github.com/reductstore/reductstore/pull/1474) by @DibbayajyotiRoy
 - Add a replication `dst_prefix` setting to write replicated records under a destination entry prefix, [PR-1486](https://github.com/reductstore/reductstore/pull/1486) by @rohankumardubey

--- a/reductstore/src/storage/bucket/query.rs
+++ b/reductstore/src/storage/bucket/query.rs
@@ -27,6 +27,69 @@ pub(super) struct MultiEntryQuery {
     last_access: Instant,
 }
 
+fn entry_matches_pattern(entry: &str, pattern: &str) -> bool {
+    let pattern = pattern.trim_start_matches('/');
+
+    if !pattern.contains('*') {
+        return entry == pattern;
+    }
+
+    let entry_parts: Vec<&str> = entry.split('/').collect();
+    let pattern_parts: Vec<&str> = pattern.split('/').collect();
+
+    fn segment_matches(entry: &str, pattern: &str) -> bool {
+        if pattern == "**" {
+            return true;
+        }
+
+        let mut rest = entry;
+        let mut parts = pattern.split('*').peekable();
+
+        if let Some(first) = parts.next() {
+            if !first.is_empty() {
+                let Some(stripped) = rest.strip_prefix(first) else {
+                    return false;
+                };
+                rest = stripped;
+            }
+        }
+
+        while let Some(part) = parts.next() {
+            if part.is_empty() {
+                continue;
+            }
+
+            if parts.peek().is_none() {
+                return rest.ends_with(part);
+            }
+
+            let Some(index) = rest.find(part) else {
+                return false;
+            };
+            rest = &rest[index + part.len()..];
+        }
+
+        pattern.ends_with('*') || rest.is_empty()
+    }
+
+    fn matches_from(entry_parts: &[&str], pattern_parts: &[&str]) -> bool {
+        match pattern_parts.split_first() {
+            None => entry_parts.is_empty(),
+            Some((&"**", tail)) => {
+                matches_from(entry_parts, tail)
+                    || (!entry_parts.is_empty() && matches_from(&entry_parts[1..], pattern_parts))
+            }
+            Some((pattern, tail)) => {
+                !entry_parts.is_empty()
+                    && segment_matches(entry_parts[0], pattern)
+                    && matches_from(&entry_parts[1..], tail)
+            }
+        }
+    }
+
+    matches_from(&entry_parts, &pattern_parts)
+}
+
 impl Bucket {
     /// Initiate a query across multiple entries in the bucket.
     ///
@@ -99,34 +162,53 @@ impl Bucket {
     ) -> Result<Vec<(String, Arc<Entry>)>, ReductError> {
         let entries = self.entries.read().await?;
         let requested_entries = match &request.entries {
-            Some(entries) if entries.iter().any(|entry| entry == "*") => None,
-            Some(entries) => Some(entries.clone()),
-            None => None,
+            Some(entries) => entries,
+            None => {
+                let results = entries
+                    .iter()
+                    .filter(|(_, entry)| entry.is_queryable_by_wildcard())
+                    .map(|(name, entry)| (name.clone(), Arc::clone(entry)))
+                    .collect();
+                return Ok(results);
+            }
         };
 
-        let matches_pattern = |entry: &str, patterns: &[String]| {
-            patterns.iter().any(|pattern| {
-                if let Some(prefix) = pattern.strip_suffix('*') {
-                    entry.starts_with(prefix)
+        let include_patterns: Vec<&str> = requested_entries
+            .iter()
+            .filter_map(|pattern| {
+                if pattern.starts_with('!') && pattern.len() > 1 {
+                    None
                 } else {
-                    entry == pattern
+                    Some(pattern.as_str())
                 }
             })
-        };
+            .collect();
+        let exclude_patterns: Vec<&str> = requested_entries
+            .iter()
+            .filter_map(|pattern| pattern.strip_prefix('!'))
+            .filter(|pattern| !pattern.is_empty())
+            .collect();
 
         let results: Vec<(String, Arc<Entry>)> = entries
             .iter()
             .filter(|(name, entry)| {
-                if requested_entries.is_none() {
-                    return entry.is_queryable_by_wildcard();
-                }
+                let included = if include_patterns.iter().any(|pattern| *pattern == "*") {
+                    entry.is_queryable_by_wildcard()
+                } else if include_patterns.is_empty() {
+                    entry.is_queryable_by_wildcard()
+                } else if include_patterns.iter().any(|pattern| pattern == name) {
+                    true
+                } else {
+                    include_patterns
+                        .iter()
+                        .any(|pattern| entry_matches_pattern(name, pattern))
+                        && entry.is_queryable_by_wildcard()
+                };
 
-                let patterns = requested_entries.as_ref().unwrap();
-                if patterns.iter().any(|pattern| pattern == *name) {
-                    return true;
-                }
-
-                matches_pattern(name, patterns) && entry.is_queryable_by_wildcard()
+                included
+                    && !exclude_patterns
+                        .iter()
+                        .any(|pattern| pattern == name || entry_matches_pattern(name, pattern))
             })
             .map(|(name, entry)| (name.clone(), Arc::clone(entry)))
             .collect();
@@ -419,6 +501,82 @@ mod tests {
         assert_eq!(
             records,
             vec![("acc-a".to_string(), 10), ("acc-b".to_string(), 20)]
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn filters_by_single_segment_wildcard(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "a/x/b", 10, b"a1").await.unwrap();
+        write(&bucket, "a/y/b", 20, b"b1").await.unwrap();
+        write(&bucket, "a/x/d/b", 15, b"c1").await.unwrap();
+
+        let query = QueryEntry {
+            query_type: QueryType::Query,
+            entries: Some(vec!["/a/*/b".into()]),
+            ..Default::default()
+        };
+
+        let id = bucket.query(query).await.unwrap();
+        let (rx, _) = bucket.get_query_receiver(id).await.unwrap();
+
+        let records = collect_records(rx).await;
+
+        assert_eq!(
+            records,
+            vec![("a/x/b".to_string(), 10), ("a/y/b".to_string(), 20)]
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn filters_by_recursive_wildcard(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "a/x/b", 10, b"a1").await.unwrap();
+        write(&bucket, "a/x/d/b", 20, b"b1").await.unwrap();
+        write(&bucket, "a/private/b", 15, b"c1").await.unwrap();
+        write(&bucket, "a/private/x/b", 25, b"d1").await.unwrap();
+
+        let query = QueryEntry {
+            query_type: QueryType::Query,
+            entries: Some(vec!["/a/**/b".into(), "!/a/private/**".into()]),
+            ..Default::default()
+        };
+
+        let id = bucket.query(query).await.unwrap();
+        let (rx, _) = bucket.get_query_receiver(id).await.unwrap();
+
+        let records = collect_records(rx).await;
+
+        assert_eq!(
+            records,
+            vec![("a/x/b".to_string(), 10), ("a/x/d/b".to_string(), 20)]
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn filters_by_exclusion_only(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "a/public/b", 10, b"a1").await.unwrap();
+        write(&bucket, "a/private/b", 20, b"b1").await.unwrap();
+        write(&bucket, "cam-1", 15, b"c1").await.unwrap();
+
+        let query = QueryEntry {
+            query_type: QueryType::Query,
+            entries: Some(vec!["!/a/private/**".into()]),
+            ..Default::default()
+        };
+
+        let id = bucket.query(query).await.unwrap();
+        let (rx, _) = bucket.get_query_receiver(id).await.unwrap();
+
+        let records = collect_records(rx).await;
+
+        assert_eq!(
+            records,
+            vec![("a/public/b".to_string(), 10), ("cam-1".to_string(), 15)]
         );
     }
 

--- a/reductstore/src/storage/bucket/query.rs
+++ b/reductstore/src/storage/bucket/query.rs
@@ -34,6 +34,12 @@ fn entry_matches_pattern(entry: &str, pattern: &str) -> bool {
         return entry == pattern;
     }
 
+    if !pattern.contains('/') {
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            return entry.starts_with(prefix);
+        }
+    }
+
     let entry_parts: Vec<&str> = entry.split('/').collect();
     let pattern_parts: Vec<&str> = pattern.split('/').collect();
 
@@ -480,79 +486,18 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn filters_by_prefix_wildcard(#[future] bucket: Arc<Bucket>) {
-        let bucket = bucket.await;
-        write(&bucket, "acc-a", 10, b"a1").await.unwrap();
-        write(&bucket, "acc-b", 20, b"b1").await.unwrap();
-        write(&bucket, "other", 15, b"c1").await.unwrap();
-
-        let query = QueryEntry {
-            query_type: QueryType::Query,
-            entries: Some(vec!["acc-*".into()]),
-            ..Default::default()
-        };
-
-        let id = bucket.query(query).await.unwrap();
-        let (rx, _) = bucket.get_query_receiver(id).await.unwrap();
-
-        let records = collect_records(rx).await;
-
-        assert_eq!(
-            records,
-            vec![("acc-a".to_string(), 10), ("acc-b".to_string(), 20)]
-        );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn filters_by_single_segment_wildcard(#[future] bucket: Arc<Bucket>) {
-        let bucket = bucket.await;
-        write(&bucket, "a/x/b", 10, b"a1").await.unwrap();
-        write(&bucket, "a/y/b", 20, b"b1").await.unwrap();
-        write(&bucket, "a/x/d/b", 15, b"c1").await.unwrap();
-
-        let query = QueryEntry {
-            query_type: QueryType::Query,
-            entries: Some(vec!["/a/*/b".into()]),
-            ..Default::default()
-        };
-
-        let id = bucket.query(query).await.unwrap();
-        let (rx, _) = bucket.get_query_receiver(id).await.unwrap();
-
-        let records = collect_records(rx).await;
-
-        assert_eq!(
-            records,
-            vec![("a/x/b".to_string(), 10), ("a/y/b".to_string(), 20)]
-        );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn filters_by_recursive_wildcard(#[future] bucket: Arc<Bucket>) {
-        let bucket = bucket.await;
-        write(&bucket, "a/x/b", 10, b"a1").await.unwrap();
-        write(&bucket, "a/x/d/b", 20, b"b1").await.unwrap();
-        write(&bucket, "a/private/b", 15, b"c1").await.unwrap();
-        write(&bucket, "a/private/x/b", 25, b"d1").await.unwrap();
-
-        let query = QueryEntry {
-            query_type: QueryType::Query,
-            entries: Some(vec!["/a/**/b".into(), "!/a/private/**".into()]),
-            ..Default::default()
-        };
-
-        let id = bucket.query(query).await.unwrap();
-        let (rx, _) = bucket.get_query_receiver(id).await.unwrap();
-
-        let records = collect_records(rx).await;
-
-        assert_eq!(
-            records,
-            vec![("a/x/b".to_string(), 10), ("a/x/d/b".to_string(), 20)]
-        );
+    #[case("acc-a", "acc-*", true)]
+    #[case("acc-a/sub-entry", "acc-*", true)]
+    #[case("other", "acc-*", false)]
+    #[case("a/x/b", "/a/*/b", true)]
+    #[case("a/y/b", "/a/*/b", true)]
+    #[case("a/x/d/b", "/a/*/b", false)]
+    #[case("a/x/b", "/a/**/b", true)]
+    #[case("a/x/d/b", "/a/**/b", true)]
+    #[case("a/private/x/b", "/a/private/**", true)]
+    #[case("a/public/x/b", "/a/private/**", false)]
+    fn matches_entry_patterns(#[case] entry: &str, #[case] pattern: &str, #[case] expected: bool) {
+        assert_eq!(entry_matches_pattern(entry, pattern), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #1505

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Adds path-aware query entry pattern matching for `*` single-segment wildcards and `**` recursive wildcards.
- Preserves existing exact-name matching and legacy prefix-style patterns like `cam-*`.
- Adds `!` exclusion patterns that are applied after includes, including exclusion-only filtering.
- Keeps wildcard pattern matches restricted to entries queryable by wildcard.

### Related issues

- #1505

### Does this PR introduce a breaking change?

No. Existing exact entry filters, `*`, and prefix-style wildcard behavior are preserved.

### Other information:

Validation run locally in Docker/Rust 1.91:

```console
cargo fmt --all
cargo test -p reductstore storage::bucket::query --features "fs-backend web-console"
# 13 passed; 0 failed

cargo check --workspace --features "fs-backend web-console"
# Finished dev profile
```
