### PR TITLE
docs: add contributing guide and refresh onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ Human judgment is required. "The AI wrote it" is not enough.
 When you open the PR:
 
 - Link the issue it resolves.
+- Use the repository pull request template.
 - Explain the user or maintainer problem you fixed.
 - List the validation you ran, including manual runtime checks when applicable.
 - Mention config or environment changes such as new `RS_*` variables or feature flags.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,12 @@ Open a pull request only for an existing issue.
 
 Before you start coding:
 
-1. Update your local `main` branch from `origin/main`.
+1. Sync your fork with the latest `upstream/main` (or update your local `main` from `origin/main` if you work directly in the repository).
 2. Create a fresh branch from the latest `main`.
 3. Keep the branch focused on one issue.
 
 This repository expects every PR to be based on the newest default branch commit.
+If possible, start the branch name with the issue ID, for example `1469-docs-contributing-guide`. It helps keep PRs easier to organize and review.
 
 ## Run ReductStore Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to ReductStore
+
+Thanks for contributing.
+
+This guide is intentionally practical. It reflects how work is reviewed in this repository today, including recent community PRs and the repository workflow notes in `AGENTS.md`.
+
+## Start with an Issue
+
+Open a pull request only for an existing issue.
+
+- If you want to work on an issue, say so in the comments first and wait to be assigned before you start coding.
+- If you want to fix a reported bug, comment on the issue first so maintainers know you are working on it.
+- If you have a new idea, do not open a surprise PR. Start with a GitHub issue or a thread on the [ReductStore community forum](https://community.reduct.store) to discuss scope first.
+- If you want a small first task, start with [good first issue](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or [help wanted](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).
+
+## Prepare Your Branch
+
+Before you start coding:
+
+1. Update your local `main` branch from `origin/main`.
+2. Create a fresh branch from the latest `main`.
+3. Keep the branch focused on one issue.
+
+This repository expects every PR to be based on the newest default branch commit.
+
+## Run ReductStore Locally
+
+If your change affects runtime behavior, start a real ReductStore instance and test it yourself when possible.
+
+The maintainers expect contributors to validate the changed path against a live server, not only with unit tests. For most changes, one of these is enough:
+
+```bash
+mkdir -p ./data
+sudo chown -R 10001:10001 ./data
+docker run -p 8383:8383 -v ${PWD}/data:/data reduct/store:latest
+```
+
+or
+
+```bash
+RS_DATA_PATH=./data cargo run -p reductstore --features "fs-backend web-console"
+```
+
+Then exercise the API, replication flow, query behavior, lifecycle policy, or UI path that your change touches.
+
+## Build and Test
+
+Run the smallest relevant set locally before opening a PR:
+
+```bash
+cargo fmt --all
+cargo check --workspace
+cargo test --workspace
+```
+
+Useful follow-ups when they apply:
+
+- `cargo test --workspace --features "s3-backend,fs-backend,ci"`
+- `pip install -r integration_tests/api/requirements.txt`
+- `STORAGE_URL=http://127.0.0.1:8383 pytest integration_tests/api`
+
+If you skip a test, explain why in the PR.
+
+## AI-Assisted Changes
+
+Generated code is allowed.
+
+But the contributor submitting the PR is responsible for it:
+
+- Read and understand every generated change before you submit it.
+- Remove dead code, vague comments, and accidental scope creep.
+- Re-run tests and manual checks yourself.
+- Be ready to explain the design and tradeoffs in review.
+
+Human judgment is required. "The AI wrote it" is not enough.
+
+## Open the Pull Request
+
+When you open the PR:
+
+- Link the issue it resolves.
+- Explain the user or maintainer problem you fixed.
+- List the validation you ran, including manual runtime checks when applicable.
+- Mention config or environment changes such as new `RS_*` variables or feature flags.
+- Keep screenshots, logs, or request examples when they help reviewers verify behavior quickly.
+
+## Review Expectations
+
+Recent contributor PRs in this repository show a consistent pattern:
+
+- Well-scoped PRs tied to an issue move faster.
+- Changes that come with local validation are easier to review.
+- Ambiguous feature additions usually need issue discussion before code review starts.
+- Maintainers may ask for behavior changes, test updates, or smaller scope before merge.
+
+Treat review as collaboration, not a formality.
+
+## Need Help?
+
+- Ask on the [community forum](https://community.reduct.store)
+- Comment on the issue you want to work on
+- Open a draft PR early if you want feedback on direction

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,18 @@ When you open the PR:
 - Explain the user or maintainer problem you fixed.
 - List the validation you ran, including manual runtime checks when applicable.
 - Mention config or environment changes such as new `RS_*` variables or feature flags.
+- Update `CHANGELOG.md` when the change affects users, operators, or client-visible behavior.
 - Keep screenshots, logs, or request examples when they help reviewers verify behavior quickly.
+
+## Update the Changelog
+
+If your PR changes behavior that users may notice, add an entry to `CHANGELOG.md`.
+
+- Add the entry in the relevant unreleased section.
+- Keep it short and factual.
+- Focus on what changed for users or operators, not on internal refactoring details.
+- Include the pull request number if the surrounding entries already follow that style.
+- Skip changelog noise for purely internal changes with no user-facing effect.
 
 ## Review Expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 Thanks for contributing.
 
-This guide is intentionally practical. It reflects how work is reviewed in this repository today, including recent community PRs and the repository workflow notes in `AGENTS.md`.
+We want ReductStore to be easy to contribute to, especially for people joining the project for the first time.
+This guide keeps the workflow clear so you can spend more time building and less time guessing what reviewers expect.
 
 ## Start with an Issue
 
@@ -27,7 +28,7 @@ This repository expects every PR to be based on the newest default branch commit
 
 If your change affects runtime behavior, start a real ReductStore instance and test it yourself when possible.
 
-The maintainers expect contributors to validate the changed path against a live server, not only with unit tests. For most changes, one of these is enough:
+Please validate the changed path against a live server, not only with unit tests. For most changes, one of these is enough:
 
 ```bash
 mkdir -p ./data
@@ -93,7 +94,7 @@ Recent contributor PRs in this repository show a consistent pattern:
 - Ambiguous feature additions usually need issue discussion before code review starts.
 - Maintainers may ask for behavior changes, test updates, or smaller scope before merge.
 
-Treat review as collaboration, not a formality.
+Treat review as collaboration. The goal is to help each other land solid changes with as little friction as possible.
 
 ## Need Help?
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you've found a bug, have ideas, built something with ReductStore, or want to 
 - **Questions and Ideas**: Join our [**Discourse community**](https://community.reduct.store) to ask questions, share ideas, and collaborate with fellow ReductStore users.
 - **Bug Reports**: Open an issue on our **[GitHub repository](https://github.com/reductstore/reductstore/issues)**. Please provide as much detail as possible so we can address it effectively.
 - **First Contributions**: Pick a task from [**good first issues**](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or [**help wanted**](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).
-- **Pull Requests**: Open PRs only for an existing issue. Comment on the issue and get assigned before you start work. If you want to propose a new feature or workflow, open an issue first or start the discussion on the [**community forum**](https://community.reduct.store) before writing code.
+- **Pull Requests**: Open PRs only for an existing issue. Comment on the issue and get assigned before you start work. Use the repository pull request template when you open the PR. If you want to propose a new feature or workflow, open an issue first or start the discussion on the [**community forum**](https://community.reduct.store) before writing code.
 - **Show Your Work**: Share your projects, benchmarks, and lessons learned on our [**Discourse community**](https://community.reduct.store).
 - **Support the Project**: If ReductStore is useful to you, give us a ⭐ on GitHub.
 

--- a/README.md
+++ b/README.md
@@ -76,16 +76,6 @@ mkdir -p ./data
 RS_DATA_PATH=./data ./reductstore
 ```
 
-If you prefer to build from source:
-
-```bash
-# Install Rust via the official rustup instructions:
-# https://www.rust-lang.org/tools/install
-apt install protobuf-compiler
-cargo install --locked reductstore
-RS_DATA_PATH=./data reductstore
-```
-
 For a more in-depth guide, visit the **[Getting Started](https://reduct.store/docs/)** and **[Download](https://www.reduct.store/download)** sections.
 
 After initializing the instance, you can start writing and querying data immediately. Here's a Python sample:

--- a/README.md
+++ b/README.md
@@ -59,13 +59,7 @@ In such scenarios, ReductStore can help you manage and transfer your data effici
 
 ## Get Started
 
-The quickest way to get up and running is with our Docker image:
-
-```
-docker run -p 8383:8383 -v reduct-data:/data reduct/store:latest
-```
-
-If you prefer a bind mount instead of a Docker volume:
+The quickest way to get up and running is with Docker:
 
 ```bash
 mkdir -p ./data
@@ -73,7 +67,16 @@ sudo chown -R 10001:10001 ./data
 docker run -p 8383:8383 -v ${PWD}/data:/data reduct/store:latest
 ```
 
-Alternatively, you can opt for Cargo:
+Or download a Linux binary directly from the latest release:
+
+```bash
+curl -LO https://github.com/reductstore/reductstore/releases/latest/download/reductstore.x86_64-unknown-linux-gnu.tar.gz
+tar -xzf reductstore.x86_64-unknown-linux-gnu.tar.gz
+mkdir -p ./data
+RS_DATA_PATH=./data ./reductstore
+```
+
+If you prefer to build from source:
 
 ```bash
 # Install Rust via the official rustup instructions:
@@ -120,6 +123,7 @@ Learn more and pick the next piece you need:
 
 - **[Documentation](https://www.reduct.store/docs/)**
 - **[Download](https://www.reduct.store/download)**
+- **[Contributing Guide](./CONTRIBUTING.md)**
 - **[Community Forum](https://community.reduct.store)**
 - **[Good First Issues](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)**
 
@@ -138,6 +142,7 @@ If you've found a bug, have ideas, built something with ReductStore, or want to 
 - **Questions and Ideas**: Join our [**Discourse community**](https://community.reduct.store) to ask questions, share ideas, and collaborate with fellow ReductStore users.
 - **Bug Reports**: Open an issue on our **[GitHub repository](https://github.com/reductstore/reductstore/issues)**. Please provide as much detail as possible so we can address it effectively.
 - **First Contributions**: Pick a task from [**good first issues**](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or [**help wanted**](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).
+- **Pull Requests**: Open PRs only for an existing issue. Comment on the issue and get assigned before you start work. If you want to propose a new feature or workflow, open an issue first or start the discussion on the [**community forum**](https://community.reduct.store) before writing code.
 - **Show Your Work**: Share your projects, benchmarks, and lessons learned on our [**Discourse community**](https://community.reduct.store).
 - **Support the Project**: If ReductStore is useful to you, give us a ⭐ on GitHub.
 
@@ -147,14 +152,13 @@ Thanks to everyone who has contributed to ReductStore.
 
 <p align="center">
   <a href="https://github.com/atimin"><img src="https://avatars.githubusercontent.com/u/67068?v=4" width="48" height="48" alt="@atimin" /></a>
-  <a href="https://github.com/apps/dependabot"><img src="https://avatars.githubusercontent.com/in/29110?v=4" width="48" height="48" alt="@dependabot[bot]" /></a>
   <a href="https://github.com/mother-6000"><img src="https://avatars.githubusercontent.com/u/270019311?v=4" width="48" height="48" alt="@mother-6000" /></a>
   <a href="https://github.com/AnthonyCvn"><img src="https://avatars.githubusercontent.com/u/26444489?v=4" width="48" height="48" alt="@AnthonyCvn" /></a>
   <a href="https://github.com/DibbayajyotiRoy"><img src="https://avatars.githubusercontent.com/u/125145390?v=4" width="48" height="48" alt="@DibbayajyotiRoy" /></a>
   <a href="https://github.com/rtadepalli"><img src="https://avatars.githubusercontent.com/u/105760760?v=4" width="48" height="48" alt="@rtadepalli" /></a>
   <a href="https://github.com/rohankumardubey"><img src="https://avatars.githubusercontent.com/u/82864904?v=4" width="48" height="48" alt="@rohankumardubey" /></a>
   <a href="https://github.com/tuanhungngyn"><img src="https://avatars.githubusercontent.com/u/165829382?v=4" width="48" height="48" alt="@tuanhungngyn" /></a>
-  <a href="https://github.com/apps/copilot-swe-agent"><img src="https://avatars.githubusercontent.com/in/1143301?v=4" width="48" height="48" alt="@Copilot" /></a>
+  <a href="https://github.com/vbmade2000"><img src="https://avatars.githubusercontent.com/u/1904995?v=4" width="48" height="48" alt="@vbmade2000" /></a>
   <a href="https://github.com/mambaz"><img src="https://avatars.githubusercontent.com/u/3928782?v=4" width="48" height="48" alt="@mambaz" /></a>
   <a href="https://github.com/victor1234"><img src="https://avatars.githubusercontent.com/u/1102205?v=4" width="48" height="48" alt="@victor1234" /></a>
   <a href="https://github.com/aschenbecherwespe"><img src="https://avatars.githubusercontent.com/u/94011659?v=4" width="48" height="48" alt="@aschenbecherwespe" /></a>

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you've found a bug, have ideas, built something with ReductStore, or want to 
 - **Questions and Ideas**: Join our [**Discourse community**](https://community.reduct.store) to ask questions, share ideas, and collaborate with fellow ReductStore users.
 - **Bug Reports**: Open an issue on our **[GitHub repository](https://github.com/reductstore/reductstore/issues)**. Please provide as much detail as possible so we can address it effectively.
 - **First Contributions**: Pick a task from [**good first issues**](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or [**help wanted**](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).
-- **Pull Requests**: Open PRs only for an existing issue. Comment on the issue and get assigned before you start work. Use the repository pull request template when you open the PR. If you want to propose a new feature or workflow, open an issue first or start the discussion on the [**community forum**](https://community.reduct.store) before writing code.
+- **Pull Requests**: Open PRs only for an existing issue. Comment on the issue and get assigned before you start work. Use the repository pull request template when you open the PR, and update `CHANGELOG.md` for user-visible changes. If you want to propose a new feature or workflow, open an issue first or start the discussion on the [**community forum**](https://community.reduct.store) before writing code.
 - **Show Your Work**: Share your projects, benchmarks, and lessons learned on our [**Discourse community**](https://community.reduct.store).
 - **Support the Project**: If ReductStore is useful to you, give us a ⭐ on GitHub.
 


### PR DESCRIPTION
Refs #1469

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update.

### What was changed?

- simplify the README installation flow around the Docker bind-mount setup
- add a direct Linux binary download example from the latest release
- add a repository-level `CONTRIBUTING.md`
- document contribution expectations drawn from current workflow: work only from an existing issue, comment and get assigned before starting, discuss new ideas in an issue or the forum first, AI-assisted code requires human review, and runtime changes should be manually validated against a live ReductStore instance when possible
- refresh the README contributor list by removing bot accounts and adding recent human contributors

This is a partial step for `#1469` focused on `reductstore/reductstore` documentation. It does not yet cover the CI changes or the other repositories listed in the issue.

### Related issues

- https://github.com/reductstore/reductstore/issues/1469

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed for this docs-only change:

- `git diff --check`
- manual review of the rendered Markdown snippets and links
