### PR TITLE
docs: refine contributor onboarding and add contributor credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refresh contributor onboarding docs to validate branch builds locally and add `@gitcommit90` to the README contributor wall, [PR-1511](https://github.com/reductstore/reductstore/pull/1511)
 - Unify `$system` event handling under `syslog`: move all event production (audit, usage, lifecycle, replication, logs) into the module behind a single system event logger with one shared writer and sink (no change to the stored record format), [PR-1496](https://github.com/reductstore/reductstore/pull/1496) by @DibbayajyotiRoy
 
 ## 1.20.7 - 2026-06-30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,18 +29,29 @@ If possible, start the branch name with the issue ID, for example `1469-docs-con
 
 If your change affects runtime behavior, start a real ReductStore instance and test it yourself when possible.
 
-Please validate the changed path against a live server, not only with unit tests. For most changes, one of these is enough:
+Please validate the changed path against a live server, not only with unit tests.
+Contributors should run the code from their branch, not only the published Docker image, so the instance actually includes their changes.
+
+For most changes, build and run ReductStore locally:
+
+```bash
+cargo run -p reductstore --features "fs-backend web-console" -- --data-path ./data
+```
+
+If you prefer building a binary first:
+
+```bash
+cargo build -p reductstore --features "fs-backend web-console"
+mkdir -p ./data
+./target/debug/reductstore --data-path ./data
+```
+
+Use the published Docker image only for dependency-free smoke checks or to compare released behavior:
 
 ```bash
 mkdir -p ./data
 sudo chown -R 10001:10001 ./data
 docker run -p 8383:8383 -v ${PWD}/data:/data reduct/store:latest
-```
-
-or
-
-```bash
-RS_DATA_PATH=./data cargo run -p reductstore --features "fs-backend web-console"
 ```
 
 Then exercise the API, replication flow, query behavior, lifecycle policy, or UI path that your change touches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ Contributors should run the code from their branch, not only the published Docke
 For most changes, build and run ReductStore locally:
 
 ```bash
-cargo run -p reductstore --features "fs-backend web-console" -- --data-path ./data
+mkdir -p ./data
+RS_DATA_PATH=./data cargo run -p reductstore --features "fs-backend web-console"
 ```
 
 If you prefer building a binary first:
@@ -43,7 +44,7 @@ If you prefer building a binary first:
 ```bash
 cargo build -p reductstore --features "fs-backend web-console"
 mkdir -p ./data
-./target/debug/reductstore --data-path ./data
+RS_DATA_PATH=./data ./target/debug/reductstore
 ```
 
 Use the published Docker image only for dependency-free smoke checks or to compare released behavior:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Thanks to everyone who has contributed to ReductStore.
   <a href="https://github.com/rtadepalli"><img src="https://avatars.githubusercontent.com/u/105760760?v=4" width="48" height="48" alt="@rtadepalli" /></a>
   <a href="https://github.com/rohankumardubey"><img src="https://avatars.githubusercontent.com/u/82864904?v=4" width="48" height="48" alt="@rohankumardubey" /></a>
   <a href="https://github.com/tuanhungngyn"><img src="https://avatars.githubusercontent.com/u/165829382?v=4" width="48" height="48" alt="@tuanhungngyn" /></a>
+  <a href="https://github.com/gitcommit90"><img src="https://avatars.githubusercontent.com/u/294273268?v=4" width="48" height="48" alt="@gitcommit90" /></a>
   <a href="https://github.com/vbmade2000"><img src="https://avatars.githubusercontent.com/u/1904995?v=4" width="48" height="48" alt="@vbmade2000" /></a>
   <a href="https://github.com/mambaz"><img src="https://avatars.githubusercontent.com/u/3928782?v=4" width="48" height="48" alt="@mambaz" /></a>
   <a href="https://github.com/victor1234"><img src="https://avatars.githubusercontent.com/u/1102205?v=4" width="48" height="48" alt="@victor1234" /></a>


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

docs update

### What was changed?

- add `@gitcommit90` to the README contributor wall after the merge of PR #1506
- clarify the contributing guide so contributors validate their own branch build locally instead of relying on the published Docker image
- fix the local run examples to use `RS_DATA_PATH`, which matches the existing ReductStore docs and runtime configuration
- keep Docker in the guide only as an optional released-image smoke check

### Related issues

- PR #1506 added the new contributor work that prompted the README credit update
- follows the recent contributor onboarding refresh in PR #1509

### Does this PR introduce a breaking change?

No.

### Other information:

- docs-only change
- no tests run
