### PR TITLE
support replication entry glob filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support glob-like entry patterns in replication filters, including path-aware `*` and `**` wildcards and exclusion patterns, [Issue-1507](https://github.com/reductstore/reductstore/issues/1507) by @rohankumardubey
 - Support glob-like entry patterns in query entry filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1506](https://github.com/reductstore/reductstore/pull/1506) by @gitcommit90
 - Add CI vulnerability scanning for Rust dependencies and Docker images, gating image publishing on fixed high-severity container findings, [PR-1500](https://github.com/reductstore/reductstore/pull/1500)
 - Emit per-bucket usage statistics as system events under `usage/<instance>/<bucket>` alongside the existing instance total, and add `written_entries`, `read_entries`, and `record_count` fields to usage events, [PR-1474](https://github.com/reductstore/reductstore/pull/1474) by @DibbayajyotiRoy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support glob-like entry patterns in replication filters, including path-aware `*` and `**` wildcards and exclusion patterns, [Issue-1507](https://github.com/reductstore/reductstore/issues/1507) by @rohankumardubey
+- Support glob-like entry patterns in replication filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1507](https://github.com/reductstore/reductstore/issues/1507) by @rohankumardubey
 - Support glob-like entry patterns in query entry filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1506](https://github.com/reductstore/reductstore/pull/1506) by @gitcommit90
 - Add CI vulnerability scanning for Rust dependencies and Docker images, gating image publishing on fixed high-severity container findings, [PR-1500](https://github.com/reductstore/reductstore/pull/1500)
 - Emit per-bucket usage statistics as system events under `usage/<instance>/<bucket>` alongside the existing instance total, and add `written_entries`, `read_entries`, and `record_count` fields to usage events, [PR-1474](https://github.com/reductstore/reductstore/pull/1474) by @DibbayajyotiRoy

--- a/reduct_base/src/msg/replication_api.rs
+++ b/reduct_base/src/msg/replication_api.rs
@@ -34,7 +34,8 @@ pub struct ReplicationSettings {
     pub dst_host: String,
     /// Destination access token
     pub dst_token: Option<String>,
-    /// Entries to replicate. If empty, all entries are replicated. Wildcards are supported.
+    /// Entries to replicate. If empty, all entries are replicated. Supports exact names,
+    /// glob-like `*` and `**` wildcards, and `!` exclusion patterns.
     #[serde(default)]
     pub entries: Vec<String>,
     /// Prefix to add to destination entry names

--- a/reductstore/src/replication/transaction_filter.rs
+++ b/reductstore/src/replication/transaction_filter.rs
@@ -3,12 +3,8 @@
 
 use crate::cfg::io::IoConfig;
 use crate::replication::TransactionNotification;
-use crate::storage::entry::{is_system_meta_entry, meta_entry_parent};
+use crate::storage::entry::{entry_matches_pattern, is_system_meta_entry, meta_entry_parent};
 use crate::storage::query::condition::Parser;
-// use crate::storage::query::filters::{
-//     apply_filters_recursively, EachNFilter, EachSecondFilter, ExcludeLabelFilter, FilterRecord,
-//     IncludeLabelFilter, RecordFilter, WhenFilter,
-// };
 use crate::storage::query::filters::{
     apply_filters_recursively, EachNFilter, ExcludeLabelFilter, FilterRecord, IncludeLabelFilter,
     RecordFilter, WhenFilter,
@@ -119,17 +115,8 @@ impl TransactionFilter {
             return vec![];
         }
 
-        if !self.entries.is_empty() {
-            let mut found = false;
-            for entry in self.entries.iter() {
-                if Self::entry_matches(entry, &notification.entry) {
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                return vec![];
-            }
+        if !Self::entry_is_selected(&self.entries, &notification.entry) {
+            return vec![];
         }
 
         if is_system_meta_entry(&notification.entry) {
@@ -160,13 +147,44 @@ impl TransactionFilter {
         notifications
     }
 
-    fn entry_matches(entry_filter: &str, entry_name: &str) -> bool {
-        if entry_filter.contains('*') {
-            let prefix = entry_filter.replace('*', "");
-            return entry_name.starts_with(&prefix);
+    fn entry_is_selected(entries: &[String], entry_name: &str) -> bool {
+        if entries.is_empty() {
+            return true;
         }
 
-        entry_name == entry_filter || meta_entry_parent(entry_name) == Some(entry_filter)
+        let include_patterns: Vec<&str> = entries
+            .iter()
+            .filter_map(|pattern| {
+                if pattern.starts_with('!') && pattern.len() > 1 {
+                    None
+                } else {
+                    Some(pattern.as_str())
+                }
+            })
+            .collect();
+        let exclude_patterns: Vec<&str> = entries
+            .iter()
+            .filter_map(|pattern| pattern.strip_prefix('!'))
+            .filter(|pattern| !pattern.is_empty())
+            .collect();
+
+        let included = include_patterns.is_empty()
+            || include_patterns
+                .iter()
+                .any(|pattern| Self::entry_matches(pattern, entry_name));
+
+        included
+            && !exclude_patterns
+                .iter()
+                .any(|pattern| Self::entry_matches(pattern, entry_name))
+    }
+
+    fn entry_matches(entry_filter: &str, entry_name: &str) -> bool {
+        let entry_filter = entry_filter.trim_start_matches('/');
+
+        entry_matches_pattern(entry_name, entry_filter)
+            || meta_entry_parent(entry_name)
+                .is_some_and(|parent| entry_matches_pattern(parent, entry_filter))
     }
 }
 
@@ -208,16 +226,29 @@ mod tests {
     }
 
     #[rstest]
-    #[case(vec ! ["entry".to_string()], true)]
-    #[case(vec ! ["other".to_string(), "entry".to_string()], true)]
-    #[case(vec ! ["ent*".to_string()], true)]
-    #[case(vec ! ["other".to_string()], false)]
-    #[case(vec ! ["oth*".to_string()], false)]
+    #[case("entry", vec ! ["entry".to_string()], true)]
+    #[case("entry", vec ! ["other".to_string(), "entry".to_string()], true)]
+    #[case("entry", vec ! ["ent*".to_string()], true)]
+    #[case("entry", vec ! ["*".to_string()], true)]
+    #[case("entry", vec ! ["other".to_string()], false)]
+    #[case("entry", vec ! ["oth*".to_string()], false)]
+    #[case("cam-1", vec ! ["cam-*".to_string()], true)]
+    #[case("cam-1/nested", vec ! ["cam-*".to_string()], true)]
+    #[case("a/x/b", vec ! ["/a/*/b".to_string()], true)]
+    #[case("a/x/d/b", vec ! ["/a/*/b".to_string()], false)]
+    #[case("a/x/b", vec ! ["/a/**/b".to_string()], true)]
+    #[case("a/x/d/b", vec ! ["/a/**/b".to_string()], true)]
+    #[case("a/private/x/b", vec ! ["!/a/private/**".to_string()], false)]
+    #[case("a/public/x/b", vec ! ["!/a/private/**".to_string()], true)]
+    #[case("a/private/x/b", vec ! ["/a/**/b".to_string(), "!/a/private/**".to_string()], false)]
+    #[case("a/public/x/b", vec ! ["/a/**/b".to_string(), "!/a/private/**".to_string()], true)]
     fn test_transaction_filter_entries(
+        #[case] entry: String,
         #[case] entries: Vec<String>,
         #[case] expected: bool,
-        notification: TransactionNotification,
+        mut notification: TransactionNotification,
     ) {
+        notification.entry = entry;
         let mut filter = TransactionFilter::try_new(
             "test",
             ReplicationSettings {
@@ -251,6 +282,32 @@ mod tests {
         .unwrap();
 
         assert_eq!(filter.filter(notification).len(), 1);
+    }
+
+    #[rstest]
+    #[case("a/x/$meta", vec ! ["/a/*".to_string()], true)]
+    #[case("a/private/$meta", vec ! ["/a/**".to_string(), "!/a/private".to_string()], false)]
+    fn test_transaction_filter_entries_match_meta_parent(
+        #[case] entry: String,
+        #[case] entries: Vec<String>,
+        #[case] expected: bool,
+        mut notification: TransactionNotification,
+    ) {
+        notification.entry = entry;
+
+        let mut filter = TransactionFilter::try_new(
+            "test",
+            ReplicationSettings {
+                src_bucket: "bucket".to_string(),
+                entries,
+                include: HashMap::from([("must".to_string(), "match".to_string())]),
+                ..ReplicationSettings::default()
+            },
+            IoConfig::default(),
+        )
+        .unwrap();
+
+        assert_eq!(filter.filter(notification).is_empty(), !expected);
     }
 
     #[rstest]

--- a/reductstore/src/storage/bucket/query.rs
+++ b/reductstore/src/storage/bucket/query.rs
@@ -5,7 +5,7 @@ use crate::cfg::io::IoConfig;
 use crate::core::sync::AsyncRwLock;
 use crate::core::weak::Weak;
 use crate::storage::bucket::Bucket;
-use crate::storage::entry::{Entry, RecordReader};
+use crate::storage::entry::{entry_matches_pattern, Entry, RecordReader};
 use crate::storage::query::base::QueryOptions;
 use crate::storage::query::{next_query_id, QueryRx};
 use log::debug;
@@ -25,75 +25,6 @@ pub(super) struct MultiEntryQuery {
     io_settings: IoConfig,
     options: QueryOptions,
     last_access: Instant,
-}
-
-fn entry_matches_pattern(entry: &str, pattern: &str) -> bool {
-    let pattern = pattern.trim_start_matches('/');
-
-    if !pattern.contains('*') {
-        return entry == pattern;
-    }
-
-    if !pattern.contains('/') {
-        if let Some(prefix) = pattern.strip_suffix('*') {
-            return entry.starts_with(prefix);
-        }
-    }
-
-    let entry_parts: Vec<&str> = entry.split('/').collect();
-    let pattern_parts: Vec<&str> = pattern.split('/').collect();
-
-    fn segment_matches(entry: &str, pattern: &str) -> bool {
-        if pattern == "**" {
-            return true;
-        }
-
-        let mut rest = entry;
-        let mut parts = pattern.split('*').peekable();
-
-        if let Some(first) = parts.next() {
-            if !first.is_empty() {
-                let Some(stripped) = rest.strip_prefix(first) else {
-                    return false;
-                };
-                rest = stripped;
-            }
-        }
-
-        while let Some(part) = parts.next() {
-            if part.is_empty() {
-                continue;
-            }
-
-            if parts.peek().is_none() {
-                return rest.ends_with(part);
-            }
-
-            let Some(index) = rest.find(part) else {
-                return false;
-            };
-            rest = &rest[index + part.len()..];
-        }
-
-        pattern.ends_with('*') || rest.is_empty()
-    }
-
-    fn matches_from(entry_parts: &[&str], pattern_parts: &[&str]) -> bool {
-        match pattern_parts.split_first() {
-            None => entry_parts.is_empty(),
-            Some((&"**", tail)) => {
-                matches_from(entry_parts, tail)
-                    || (!entry_parts.is_empty() && matches_from(&entry_parts[1..], pattern_parts))
-            }
-            Some((pattern, tail)) => {
-                !entry_parts.is_empty()
-                    && segment_matches(entry_parts[0], pattern)
-                    && matches_from(&entry_parts[1..], tail)
-            }
-        }
-    }
-
-    matches_from(&entry_parts, &pattern_parts)
 }
 
 impl Bucket {

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -5,6 +5,7 @@ mod builder;
 mod compress;
 mod entry_loader;
 pub(crate) mod io;
+mod pattern;
 mod read_record;
 mod remove_records;
 mod system;
@@ -40,6 +41,7 @@ use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::JoinHandle;
 
 pub(crate) use builder::EntryBuilder;
+pub(crate) use pattern::entry_matches_pattern;
 
 struct QueryHandle {
     rx: Arc<AsyncRwLock<QueryRx>>,

--- a/reductstore/src/storage/entry/pattern.rs
+++ b/reductstore/src/storage/entry/pattern.rs
@@ -1,0 +1,93 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+pub(crate) fn entry_matches_pattern(entry: &str, pattern: &str) -> bool {
+    let pattern = pattern.trim_start_matches('/');
+
+    if !pattern.contains('*') {
+        return entry == pattern;
+    }
+
+    if !pattern.contains('/') {
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            return entry.starts_with(prefix);
+        }
+    }
+
+    let entry_parts: Vec<&str> = entry.split('/').collect();
+    let pattern_parts: Vec<&str> = pattern.split('/').collect();
+
+    fn segment_matches(entry: &str, pattern: &str) -> bool {
+        if pattern == "**" {
+            return true;
+        }
+
+        let mut rest = entry;
+        let mut parts = pattern.split('*').peekable();
+
+        if let Some(first) = parts.next() {
+            if !first.is_empty() {
+                let Some(stripped) = rest.strip_prefix(first) else {
+                    return false;
+                };
+                rest = stripped;
+            }
+        }
+
+        while let Some(part) = parts.next() {
+            if part.is_empty() {
+                continue;
+            }
+
+            if parts.peek().is_none() {
+                return rest.ends_with(part);
+            }
+
+            let Some(index) = rest.find(part) else {
+                return false;
+            };
+            rest = &rest[index + part.len()..];
+        }
+
+        pattern.ends_with('*') || rest.is_empty()
+    }
+
+    fn matches_from(entry_parts: &[&str], pattern_parts: &[&str]) -> bool {
+        match pattern_parts.split_first() {
+            None => entry_parts.is_empty(),
+            Some((&"**", tail)) => {
+                matches_from(entry_parts, tail)
+                    || (!entry_parts.is_empty() && matches_from(&entry_parts[1..], pattern_parts))
+            }
+            Some((pattern, tail)) => {
+                !entry_parts.is_empty()
+                    && segment_matches(entry_parts[0], pattern)
+                    && matches_from(&entry_parts[1..], tail)
+            }
+        }
+    }
+
+    matches_from(&entry_parts, &pattern_parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("acc-a", "acc-*", true)]
+    #[case("acc-a/sub-entry", "acc-*", true)]
+    #[case("other", "acc-*", false)]
+    #[case("a/x/b", "/a/*/b", true)]
+    #[case("a/y/b", "/a/*/b", true)]
+    #[case("a/x/d/b", "/a/*/b", false)]
+    #[case("a/x/b", "/a/**/b", true)]
+    #[case("a/x/d/b", "/a/**/b", true)]
+    #[case("a/private/x/b", "/a/private/**", true)]
+    #[case("a/public/x/b", "/a/private/**", false)]
+    #[case("a/x/b", "/**/**/", false)]
+    fn matches_entry_patterns(#[case] entry: &str, #[case] pattern: &str, #[case] expected: bool) {
+        assert_eq!(entry_matches_pattern(entry, pattern), expected);
+    }
+}

--- a/reductstore/src/storage/entry/pattern.rs
+++ b/reductstore/src/storage/entry/pattern.rs
@@ -87,6 +87,13 @@ mod tests {
     #[case("a/private/x/b", "/a/private/**", true)]
     #[case("a/public/x/b", "/a/private/**", false)]
     #[case("a/x/b", "/**/**/", false)]
+    #[case("sensor-alpha-temp/b", "/camera-*/b", false)]
+    #[case("sensor-alpha-temp", "sensor-*temp", true)]
+    #[case("sensor-alpha-temp", "sensor-*humidity", false)]
+    #[case("a/sensor-alpha-temp/b", "/a/sensor-*alpha-*/b", true)]
+    #[case("a/sensor-alpha-temp/b", "/a/sensor-*beta-*/b", false)]
+    #[case("sensor-alpha-temp", "sensor-*", true)]
+    #[case("a/sensor-alpha-temp/b", "/a/*alpha*/b", true)]
     fn matches_entry_patterns(#[case] entry: &str, #[case] pattern: &str, #[case] expected: bool) {
         assert_eq!(entry_matches_pattern(entry, pattern), expected);
     }

--- a/reductstore/src/storage/entry/pattern.rs
+++ b/reductstore/src/storage/entry/pattern.rs
@@ -84,6 +84,7 @@ mod tests {
     #[case("a/x/d/b", "/a/*/b", false)]
     #[case("a/x/b", "/a/**/b", true)]
     #[case("a/x/d/b", "/a/**/b", true)]
+    #[case("a/b", "/a/**", true)]
     #[case("a/private/x/b", "/a/private/**", true)]
     #[case("a/public/x/b", "/a/private/**", false)]
     #[case("a/x/b", "/**/**/", false)]


### PR DESCRIPTION
Closes #1507

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Extended replication `settings.entries` filtering to support glob-like entry patterns:

- exact entry names still work unchanged
- legacy prefix patterns like `cam-*` remain supported
- `*` matches within a single path segment
- `**` matches recursively across path segments
- `!pattern` excludes matching entries after includes are resolved

The matcher from the query entry filter implementation was moved into shared entry pattern logic and reused by replication.

### Related issues

#1507

### Does this PR introduce a breaking change?

No.

### Other information:

Validated locally with:

```bash
cargo fmt --all -- --check
cargo check --workspace --features "fs-backend,ci"
cargo test -p reductstore --features "fs-backend,ci" replication
cargo test -p reductstore --features "fs-backend,ci" storage::bucket::query
cargo test -p reductstore --features "fs-backend,ci" storage::entry::pattern