### PR TITLE
Add source field to ReductError and improve error handling in record deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add source field to `ReductError` and improve error handling in `BlockManager::remove_records` to detect and mark corrupted blocks, [PR-1519](https://github.com/reductstore/reductstore/pull/1519)
+
 
 ## 1.20.7 - 2026-06-30
 

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -69,15 +69,37 @@ pub enum ErrorCode {
 
 /// An HTTP error, we use it for error handling.
 #[derive(PartialEq, Debug, Clone)]
-pub struct ReductError {
+pub struct ReductError<Original = ()> {
     /// The HTTP status code.
     pub status: ErrorCode,
 
     /// The human-readable message.
     pub message: String,
+
+    /// The original err
+    pub source: Option<Original>,
 }
 
-impl Display for ReductError {
+impl<Original> ReductError<Original> {
+    /// Convert to a plain `ReductError` by dropping the original source type.
+    pub fn without_source(self) -> ReductError {
+        ReductError {
+            status: self.status,
+            message: self.message,
+            source: None,
+        }
+    }
+
+    pub fn with_source<T>(self, source: T) -> ReductError<T> {
+        ReductError {
+            status: self.status,
+            message: self.message,
+            source: Some(source),
+        }
+    }
+}
+
+impl<Original> Display for ReductError<Original> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         write!(f, "[{:?}] {}", self.status, self.message)
     }
@@ -99,57 +121,64 @@ impl From<std::io::Error> for ReductError {
         ReductError {
             status,
             message: err.to_string(),
+            source: None,
         }
     }
 }
 
-impl From<SystemTimeError> for ReductError {
+impl From<SystemTimeError> for ReductError<SystemTimeError> {
     fn from(err: SystemTimeError) -> Self {
         // A system time error is an internal reductstore error
         ReductError {
             status: ErrorCode::InternalServerError,
             message: err.to_string(),
+            source: Some(err),
         }
     }
 }
 
-impl From<ParseError> for ReductError {
+impl From<ParseError> for ReductError<ParseError> {
     fn from(err: ParseError) -> Self {
         // A parse error is an internal reductstore error
         ReductError {
             status: ErrorCode::UrlParseError,
             message: err.to_string(),
+            source: Some(err),
         }
     }
 }
 
-impl<T> From<PoisonError<T>> for ReductError {
-    fn from(_: PoisonError<T>) -> Self {
+impl<T> From<PoisonError<T>> for ReductError<PoisonError<T>> {
+    fn from(err: PoisonError<T>) -> Self {
         // A poison error is an internal reductstore error
         ReductError {
             status: ErrorCode::InternalServerError,
             message: "Poison error".to_string(),
+            source: Some(err),
         }
     }
 }
 
-impl From<Box<dyn std::any::Any + Send>> for ReductError {
-    fn from(err: Box<dyn std::any::Any + Send>) -> Self {
+type BoxedAny = Box<dyn std::any::Any + Send>;
+impl From<BoxedAny> for ReductError<BoxedAny> {
+    fn from(err: BoxedAny) -> Self {
         // A box error is an internal reductstore error
         ReductError {
             status: ErrorCode::InternalServerError,
             message: format!("{:?}", err),
+            source: Some(err),
         }
     }
 }
 
 #[cfg(feature = "io")]
-impl<T> From<SendError<T>> for ReductError {
+impl<T> From<SendError<T>> for ReductError<SendError<T>> {
     fn from(err: SendError<T>) -> Self {
         // A send error is an internal reductstore error
         ReductError {
             status: ErrorCode::InternalServerError,
             message: err.to_string(),
+            source: Some(err),
         }
     }
 }
@@ -165,6 +194,7 @@ impl ReductError {
         ReductError {
             status,
             message: message.to_string(),
+            source: None,
         }
     }
 
@@ -180,6 +210,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::OK,
             message: "".to_string(),
+            source: None,
         }
     }
 
@@ -187,6 +218,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::Timeout,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -195,6 +227,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::NoContent,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -203,6 +236,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::NotFound,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -211,6 +245,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::Conflict,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -219,6 +254,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::BadRequest,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -227,6 +263,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::Unauthorized,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -235,6 +272,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::Forbidden,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -243,6 +281,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::UnprocessableEntity,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -251,6 +290,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::TooEarly,
             message: msg.to_string(),
+            source: None,
         }
     }
 
@@ -259,6 +299,7 @@ impl ReductError {
         ReductError {
             status: ErrorCode::InternalServerError,
             message: msg.to_string(),
+            source: None,
         }
     }
 }
@@ -377,7 +418,17 @@ macro_rules! service_unavailable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Debug)]
+    struct CustomSource;
+
+    impl fmt::Display for CustomSource {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "custom source")
+        }
+    }
 
     #[test]
     fn creates_internal_server_error() {
@@ -397,7 +448,7 @@ mod tests {
     #[test]
     fn converts_system_time_error_to_reduct_error() {
         let system_time_error = UNIX_EPOCH.duration_since(SystemTime::now()).unwrap_err();
-        let error: ReductError = system_time_error.into();
+        let error: ReductError<_> = system_time_error.into();
         assert_eq!(error.status, ErrorCode::InternalServerError);
         assert_eq!(error.message, "second time provided was later than self");
     }
@@ -405,7 +456,7 @@ mod tests {
     #[test]
     fn converts_url_parse_error_to_reduct_error() {
         let parse_error = ParseError::EmptyHost;
-        let error: ReductError = parse_error.into();
+        let error: ReductError<_> = parse_error.into();
         assert_eq!(error.status, ErrorCode::UrlParseError);
         assert_eq!(error.message, "empty host");
     }
@@ -413,16 +464,44 @@ mod tests {
     #[test]
     fn converts_poison_error_to_reduct_error() {
         let poison_error: PoisonError<()> = PoisonError::new(());
-        let error: ReductError = poison_error.into();
+        let error: ReductError<_> = poison_error.into();
         assert_eq!(error.status, ErrorCode::InternalServerError);
         assert_eq!(error.message, "Poison error");
+    }
+
+    #[test]
+    fn drops_source_from_typed_reduct_error() {
+        let error_with_source = ReductError {
+            status: ErrorCode::BadRequest,
+            message: "bad input".to_string(),
+            source: Some(CustomSource),
+        };
+
+        let error = error_with_source.without_source();
+        assert_eq!(error.status, ErrorCode::BadRequest);
+        assert_eq!(error.message, "bad input");
+        assert_eq!(error.source, None);
+    }
+
+    #[test]
+    fn converts_io_reduct_error_into_plain_error() {
+        let error_with_source = ReductError {
+            status: ErrorCode::InternalServerError,
+            message: "io typed error".to_string(),
+            source: Some(std::io::Error::other("boom")),
+        };
+
+        let error: ReductError = error_with_source.without_source();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "io typed error");
+        assert_eq!(error.source, None);
     }
 
     #[cfg(feature = "io")]
     #[test]
     fn converts_send_error_to_reduct_error() {
         let send_error: SendError<()> = SendError(());
-        let error: ReductError = send_error.into();
+        let error: ReductError<_> = send_error.into();
         assert_eq!(error.status, ErrorCode::InternalServerError);
         assert_eq!(error.message, "channel closed");
     }

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -159,18 +159,6 @@ impl<T> From<PoisonError<T>> for ReductError<PoisonError<T>> {
     }
 }
 
-type BoxedAny = Box<dyn std::any::Any + Send>;
-impl From<BoxedAny> for ReductError<BoxedAny> {
-    fn from(err: BoxedAny) -> Self {
-        // A box error is an internal reductstore error
-        ReductError {
-            status: ErrorCode::InternalServerError,
-            message: format!("{:?}", err),
-            source: Some(err),
-        }
-    }
-}
-
 #[cfg(feature = "io")]
 impl<T> From<SendError<T>> for ReductError<SendError<T>> {
     fn from(err: SendError<T>) -> Self {
@@ -305,6 +293,12 @@ impl ReductError {
 }
 
 // Macros for creating errors with a message.
+#[macro_export]
+macro_rules! ok {
+    () => {
+        ReductError::ok()
+    };
+}
 
 #[macro_export]
 macro_rules! timeout {
@@ -508,6 +502,13 @@ mod tests {
 
     mod macros {
         use super::*;
+
+        #[test]
+        fn test_ok_macro() {
+            let error = ok!();
+            assert_eq!(error.status, ErrorCode::OK);
+            assert_eq!(error.message, "");
+        }
 
         #[test]
         fn test_timeout_macro() {

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -427,7 +427,7 @@ pub(crate) mod tests {
             assert!(debug.contains("BadRequest"));
             assert_eq!(
                 format!("{err}"),
-                "ReductError { status: BadRequest, message: \"boom\" }"
+                "ReductError { status: BadRequest, message: \"boom\", source: None }"
             );
             assert!(StdError::source(&err).is_none());
         }

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -1797,6 +1797,39 @@ mod tests {
             assert_eq!(block.record_count(), 1);
             assert!(block.get_record(1).is_some());
         }
+
+        #[rstest]
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_remove_records_marks_corrupted_on_eof(
+            #[future] block_manager: BlockManager,
+            #[future] block: BlockRef,
+            block_id: u64,
+        ) {
+            let block_manager = block_manager.await;
+            let block = block.await;
+            let block_manager = Arc::new(AsyncRwLock::new(block_manager));
+            write_record(1, 10, &block_manager, block.clone()).await;
+
+            {
+                let bm = block_manager.write().await.unwrap();
+                let data_path = bm.path_to_data(block_id);
+                FILE_CACHE.remove(&data_path).await.unwrap();
+
+                // Write a truncated record to simulate EOF during read
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&data_path)
+                    .unwrap();
+                file.write_all(&vec![0; 100]).unwrap(); // Write a small record to simulate truncation
+            }
+
+            let mut bm = block_manager.write().await.unwrap();
+            let _ = bm.remove_records(block_id, vec![0]).await;
+
+            assert!(bm.is_block_corrupted(block_id));
+        }
     }
 
     async fn write_record(

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -30,6 +30,7 @@ use reduct_base::error::ReductError;
 use reduct_base::internal_server_error;
 use reduct_base::too_early;
 use std::fs::OpenOptions;
+use std::io::ErrorKind::UnexpectedEof;
 use std::io::{Read, SeekFrom, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -620,8 +621,31 @@ impl BlockManager {
         for (record_time, begin, record_size) in record_info {
             let mut read_bytes = 0;
             while read_bytes < record_size {
-                let (buf, read) =
-                    read_in_chunks(&src_block_path, begin, record_size, read_bytes).await?;
+                let (buf, read) = match read_in_chunks(
+                    &src_block_path,
+                    begin,
+                    record_size,
+                    read_bytes,
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(e) => {
+                        let _ = std::fs::remove_file(&temp_block_path);
+                        if let Some(source) = &e.source {
+                            if source.kind() == UnexpectedEof {
+                                warn!(
+                                        "Unexpected EOF while reading record {}/{} from block {}. Marking block as corrupted.",
+                                        block_id,
+                                        record_time,
+                                        src_block_path.display()
+                                    );
+                                self.mark_block_corrupted(block_id).await?;
+                            }
+                        }
+                        return Err(e.without_source());
+                    }
+                };
 
                 read_bytes += read as u64;
                 temp_block.write_all(&buf)?;

--- a/reductstore/src/storage/entry/io/record_reader.rs
+++ b/reductstore/src/storage/entry/io/record_reader.rs
@@ -230,23 +230,33 @@ pub(in crate::storage) async fn read_in_chunks(
     offset: u64,
     content_size: u64,
     read_bytes: u64,
-) -> Result<(Vec<u8>, usize), ReductError> {
+) -> Result<(Vec<u8>, usize), ReductError<io::Error>> {
     let chunk_size = min(content_size - read_bytes, MAX_IO_BUFFER_SIZE as u64);
     let mut buf = vec![0; chunk_size as usize];
 
     let mut file = FILE_CACHE
         .read(&file_path, SeekFrom::Start(offset + read_bytes))
-        .await?;
+        .await
+        .map_err(|e| e.with_source(io::Error::new(io::ErrorKind::Deadlock, "")))?;
 
     let read = match file.read(&mut buf) {
         Ok(read) => read,
         Err(e) => {
-            return Err(internal_server_error!("Failed to read record chunk: {}", e));
+            return Err(internal_server_error!(
+                "Failed to read record chunk from {:?}: {}",
+                file_path,
+                e
+            )
+            .with_source(e));
         }
     };
 
     if read == 0 {
-        return Err(internal_server_error!("Failed to read record chunk: EOF"));
+        return Err(internal_server_error!(
+            "Failed to read record chunk from {:?}: EOF",
+            file_path
+        )
+        .with_source(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF")));
     }
 
     Ok((buf, read))
@@ -293,8 +303,11 @@ pub(crate) mod tests {
                 .err()
                 .unwrap();
             assert_eq!(
-                err,
-                internal_server_error!("Failed to read record chunk: EOF")
+                err.to_string(),
+                format!(
+                    "[InternalServerError] Failed to read record chunk from {:?}: EOF",
+                    file_to_read
+                ),
             );
         }
 

--- a/reductstore/src/storage/query/continuous.rs
+++ b/reductstore/src/storage/query/continuous.rs
@@ -10,6 +10,7 @@ use crate::storage::query::historical::HistoricalQuery;
 use async_trait::async_trait;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::ReadRecord;
+use reduct_base::no_content;
 use std::sync::Arc;
 
 pub struct ContinuousQuery {
@@ -72,10 +73,7 @@ impl Query for ContinuousQuery {
                     self.options.clone(),
                     self.io_defaults.clone(),
                 )?;
-                Err(ReductError {
-                    status: ErrorCode::NoContent,
-                    message: "No content".to_string(),
-                })
+                Err(no_content!("No content"))
             }
             Err(err) => Err(err),
         }
@@ -90,10 +88,9 @@ impl Query for ContinuousQuery {
 mod tests {
     use super::*;
 
-    use reduct_base::error::ErrorCode;
-    use rstest::rstest;
-
     use crate::storage::query::base::tests::block_manager;
+    use reduct_base::no_content;
+    use rstest::rstest;
 
     #[rstest]
     #[tokio::test]
@@ -116,17 +113,11 @@ mod tests {
         }
         assert_eq!(
             query.next(block_manager.clone()).await.err(),
-            Some(ReductError {
-                status: ErrorCode::NoContent,
-                message: "No content".to_string(),
-            })
+            Some(no_content!("No content"))
         );
         assert_eq!(
             query.next(block_manager).await.err(),
-            Some(ReductError {
-                status: ErrorCode::NoContent,
-                message: "No content".to_string(),
-            })
+            Some(no_content!("No content"))
         );
     }
 }

--- a/reductstore/src/storage/query/limited.rs
+++ b/reductstore/src/storage/query/limited.rs
@@ -56,7 +56,6 @@ impl Query for LimitedQuery {
 mod tests {
     use super::*;
     use crate::storage::query::base::tests::block_manager;
-    use reduct_base::error::ErrorCode;
     use reduct_base::io::ReadRecord;
     use rstest::rstest;
 
@@ -81,10 +80,7 @@ mod tests {
 
         assert_eq!(
             query.next(block_manager).await.err(),
-            Some(ReductError {
-                status: ErrorCode::NoContent,
-                message: "No content".to_string(),
-            })
+            Some(no_content!("No content"))
         );
     }
 }


### PR DESCRIPTION
Closes #1502

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix and enhancement

### What was changed?

- Added a `source` field to `ReductError` to preserve original error information
- Updated `BlockManager::remove_records` to handle `UnexpectedEof` errors and mark blocks as corrupted
- Enhanced error handling in `read_in_chunks` to include file paths and original errors
- Added `without_source` and `with_source` methods to `ReductError` for type-safe error conversion
- Updated all error conversion implementations to include the original error as the source

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

No. This PR enhances error handling but maintains backward compatibility.

### Other information:
