### PR TITLE
fix replica read race for compressed block paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add source field to `ReductError` and improve error handling in `BlockManager::remove_records` to detect and mark corrupted blocks, [PR-1519](https://github.com/reductstore/reductstore/pull/1519)
+- Fix read-only replica block reads when compressed index state arrives before compressed block files and make replica cache invalidation for block variants fault-tolerant, [PR-1523](https://github.com/reductstore/reductstore/pull/1523)
 
 
 ## 1.20.7 - 2026-06-30

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -815,38 +815,62 @@ impl BlockManager {
     }
 
     async fn resolve_desc_path(&self, block_id: u64) -> Result<PathBuf, ReductError> {
-        if self.block_is_compressed(block_id) {
-            let compressed_desc_path = self.path_to_compressed_desc(block_id);
-            if FILE_CACHE.try_exists(&compressed_desc_path).await? {
-                self.decompress_cache
-                    .get_or_decompress(
-                        &self.path,
-                        block_id,
-                        DecompressedFileType::Descriptor,
-                        &compressed_desc_path,
-                    )
-                    .await
-            } else {
-                Ok(self.path_to_desc(block_id))
-            }
-        } else {
-            Ok(self.path_to_desc(block_id))
-        }
+        self.resolve_block_file_path(
+            block_id,
+            DecompressedFileType::Descriptor,
+            self.path_to_compressed_desc(block_id),
+            self.path_to_desc(block_id),
+            false,
+            "descriptor",
+        )
+        .await
     }
 
     async fn resolve_data_path(&self, block_id: u64) -> Result<PathBuf, ReductError> {
-        if self.block_is_compressed(block_id) {
-            self.decompress_cache
-                .get_or_decompress(
-                    &self.path,
-                    block_id,
-                    DecompressedFileType::Data,
-                    &self.path_to_compressed_data(block_id),
-                )
-                .await
-        } else {
-            Ok(self.path_to_data(block_id))
+        self.resolve_block_file_path(
+            block_id,
+            DecompressedFileType::Data,
+            self.path_to_compressed_data(block_id),
+            self.path_to_data(block_id),
+            true,
+            "data",
+        )
+        .await
+    }
+
+    async fn resolve_block_file_path(
+        &self,
+        block_id: u64,
+        file_type: DecompressedFileType,
+        compressed_path: PathBuf,
+        uncompressed_path: PathBuf,
+        return_too_early_if_missing_on_replica: bool,
+        file_kind: &'static str,
+    ) -> Result<PathBuf, ReductError> {
+        if !self.block_is_compressed(block_id) {
+            return Ok(uncompressed_path);
         }
+
+        if FILE_CACHE.try_exists(&compressed_path).await? {
+            return self
+                .decompress_cache
+                .get_or_decompress(&self.path, block_id, file_type, &compressed_path)
+                .await;
+        }
+
+        if FILE_CACHE.try_exists(&uncompressed_path).await? {
+            return Ok(uncompressed_path);
+        }
+
+        if return_too_early_if_missing_on_replica && self.cfg.role == InstanceRole::Replica {
+            return Err(too_early!(
+                "Compressed {} block {:?} is not available on replica yet. Reload index and retry",
+                file_kind,
+                compressed_path
+            ));
+        }
+
+        Ok(uncompressed_path)
     }
 
     pub(in crate::storage) fn block_is_compressed(&self, block_id: u64) -> bool {
@@ -874,13 +898,32 @@ impl BlockManager {
     }
 
     async fn invalidate_replica_block_cache(&self, block_id: u64) -> Result<(), ReductError> {
-        FILE_CACHE
-            .invalidate_local_cache_file(&self.path_to_desc(block_id))
-            .await?;
-        FILE_CACHE
-            .invalidate_local_cache_file(&self.path_to_data(block_id))
-            .await?;
-        Ok(())
+        let paths = [
+            self.path_to_desc(block_id),
+            self.path_to_data(block_id),
+            self.path_to_compressed_desc(block_id),
+            self.path_to_compressed_data(block_id),
+        ];
+
+        let mut first_err = None;
+        for path in paths {
+            if let Err(err) = FILE_CACHE.invalidate_local_cache_file(&path).await {
+                warn!(
+                    "Failed to invalidate replica cache file {:?} for {}/{}: {}",
+                    path, self.bucket, self.entry, err
+                );
+                if first_err.is_none() {
+                    first_err = Some(err);
+                }
+            }
+        }
+
+        self.decompress_cache.invalidate(&self.path, block_id).await;
+        if let Some(err) = first_err {
+            Err(err)
+        } else {
+            Ok(())
+        }
     }
 
     pub(in crate::storage) fn is_block_in_write_cache(&self, block_id: u64) -> bool {
@@ -1046,6 +1089,66 @@ mod tests {
             .await
             .unwrap();
             block_manager.sync_data_block(999).await.unwrap();
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_resolve_data_path_falls_back_to_uncompressed_on_replica() {
+            let path = tempdir().unwrap().keep().join("bucket").join("entry");
+            FILE_CACHE.create_dir_all(&path).await.unwrap();
+
+            let mut cfg = Cfg::default();
+            cfg.role = InstanceRole::Replica;
+
+            let mut index = BlockIndex::new(path.join(BLOCK_INDEX_FILE));
+            index.insert_or_update(Block::new(1));
+            index.get_block_mut(1).unwrap().compression =
+                Some(i32::from(CompressionAlgorithm::Zstd));
+
+            std::fs::write(path.join("1.blk"), b"data").unwrap();
+
+            let block_manager = BlockManager::build(
+                path.clone(),
+                index,
+                "bucket".to_string(),
+                "entry".to_string(),
+                Arc::new(cfg),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+            let data_path = block_manager.resolve_data_path(1).await.unwrap();
+            assert_eq!(data_path, path.join("1.blk"));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_resolve_data_path_replica_returns_too_early_when_missing() {
+            let path = tempdir().unwrap().keep().join("bucket").join("entry");
+            FILE_CACHE.create_dir_all(&path).await.unwrap();
+
+            let mut cfg = Cfg::default();
+            cfg.role = InstanceRole::Replica;
+
+            let mut index = BlockIndex::new(path.join(BLOCK_INDEX_FILE));
+            index.insert_or_update(Block::new(1));
+            index.get_block_mut(1).unwrap().compression =
+                Some(i32::from(CompressionAlgorithm::Zstd));
+
+            let block_manager = BlockManager::build(
+                path,
+                index,
+                "bucket".to_string(),
+                "entry".to_string(),
+                Arc::new(cfg),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+            let err = block_manager.resolve_data_path(1).await.err().unwrap();
+            assert_eq!(err.status(), ErrorCode::TooEarly);
         }
 
         #[rstest]

--- a/reductstore/src/storage/block_manager/read_only.rs
+++ b/reductstore/src/storage/block_manager/read_only.rs
@@ -5,9 +5,11 @@ use crate::cfg::InstanceRole;
 use crate::core::file_cache::FILE_CACHE;
 use crate::storage::block_manager::block_index::BlockIndex;
 use crate::storage::block_manager::{
-    BlockManager, BLOCK_INDEX_FILE, DATA_FILE_EXT, DESCRIPTOR_FILE_EXT,
+    BlockManager, BLOCK_INDEX_FILE, COMPRESSED_DATA_FILE_EXT, COMPRESSED_DESCRIPTOR_FILE_EXT,
+    DATA_FILE_EXT, DESCRIPTOR_FILE_EXT,
 };
 use crate::storage::proto::block_index::Block as BlockEntry;
+use log::warn;
 use reduct_base::error::ReductError;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -27,28 +29,39 @@ impl ReplicaIndexReload {
 
         let updated_index = BlockIndex::try_load(self.index_path.clone()).await?;
 
+        let mut first_err = None;
+
         for (block_id, new_block_info) in updated_index.info().iter() {
             if let Some(previous_block_info) = self.previous_state.get(block_id) {
                 if previous_block_info.crc64 != new_block_info.crc64 {
-                    FILE_CACHE
-                        .invalidate_local_cache_file(
-                            &self
-                                .entry_path
-                                .join(format!("{}{}", block_id, DESCRIPTOR_FILE_EXT)),
-                        )
-                        .await?;
-                    FILE_CACHE
-                        .invalidate_local_cache_file(
-                            &self
-                                .entry_path
-                                .join(format!("{}{}", block_id, DATA_FILE_EXT)),
-                        )
-                        .await?;
+                    let extensions = [
+                        DESCRIPTOR_FILE_EXT,
+                        DATA_FILE_EXT,
+                        COMPRESSED_DESCRIPTOR_FILE_EXT,
+                        COMPRESSED_DATA_FILE_EXT,
+                    ];
+
+                    for ext in extensions {
+                        let path = self.entry_path.join(format!("{}{}", block_id, ext));
+                        if let Err(err) = FILE_CACHE.invalidate_local_cache_file(&path).await {
+                            warn!(
+                                "Failed to invalidate replica cache file {:?}: {}",
+                                path, err
+                            );
+                            if first_err.is_none() {
+                                first_err = Some(err);
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        Ok(updated_index)
+        if let Some(err) = first_err {
+            Err(err)
+        } else {
+            Ok(updated_index)
+        }
     }
 }
 
@@ -224,6 +237,82 @@ mod tests {
             block_manager.block_index.info().get(&1).unwrap().crc64,
             Some(2)
         );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_reload_if_readonly_discards_compressed_cache_on_crc_change(
+        #[future] path: PathBuf,
+    ) {
+        let path = path.await;
+        let entry_path = path.join("bucket").join("entry");
+
+        let cfg = Cfg {
+            role: InstanceRole::Replica,
+            data_path: path.clone(),
+            engine_config: StorageEngineConfig {
+                replica_update_interval: Duration::from_millis(50),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let index_path = entry_path.join(BLOCK_INDEX_FILE);
+        let mut index = BlockIndex::new(index_path.clone());
+        index.insert_or_update_with_crc(Block::new(1), 1);
+        index.save().await.unwrap();
+
+        std::fs::write(entry_path.join("1.meta.zst"), b"old-meta").unwrap();
+        std::fs::write(entry_path.join("1.blk.zst"), b"old-data").unwrap();
+
+        FILE_CACHE
+            .read(&entry_path.join("1.meta.zst"), std::io::SeekFrom::Start(0))
+            .await
+            .unwrap();
+        FILE_CACHE
+            .read(&entry_path.join("1.blk.zst"), std::io::SeekFrom::Start(0))
+            .await
+            .unwrap();
+
+        let mut block_manager = BlockManager::build(
+            entry_path.clone(),
+            index,
+            "bucket".to_string(),
+            "entry".to_string(),
+            Arc::new(cfg),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+        let mut updated_index = BlockIndex::new(index_path.clone());
+        updated_index.insert_or_update_with_crc(Block::new(1), 2);
+        updated_index.save().await.unwrap();
+
+        std::fs::write(entry_path.join("1.meta.zst"), b"new-meta").unwrap();
+        std::fs::write(entry_path.join("1.blk.zst"), b"new-data").unwrap();
+
+        let reload = block_manager.prepare_replica_index_reload().unwrap();
+        let updated_index = reload.load_updated_index().await.unwrap();
+        block_manager.apply_replica_index_reload(updated_index);
+
+        let mut meta = FILE_CACHE
+            .read(&entry_path.join("1.meta.zst"), std::io::SeekFrom::Start(0))
+            .await
+            .unwrap();
+        let mut meta_content = vec![];
+        use std::io::Read;
+        meta.read_to_end(&mut meta_content).unwrap();
+
+        let mut data = FILE_CACHE
+            .read(&entry_path.join("1.blk.zst"), std::io::SeekFrom::Start(0))
+            .await
+            .unwrap();
+        let mut data_content = vec![];
+        data.read_to_end(&mut data_content).unwrap();
+
+        assert_eq!(meta_content, b"new-meta");
+        assert_eq!(data_content, b"new-data");
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #1517

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Fixed replica read path behavior when index marks a block as compressed before the corresponding `.blk.zst` is available.
- Added fallback logic to read uncompressed `.blk` / `.meta` files when compressed files are missing.
- Return `TooEarly` for replica reads when compressed data is not available yet instead of surfacing an internal error.
- Refactored duplicated descriptor/data path resolution into a shared helper.
- Made replica cache invalidation fault-tolerant and loop-based, so all related files are attempted even if one invalidation fails.
- Extended cache invalidation to include compressed artifacts (`.meta.zst`, `.blk.zst`) during replica index reload.
- Added regression tests for fallback behavior, `TooEarly` behavior, and compressed cache invalidation after CRC/index changes.

### Related issues

- https://github.com/reductstore/reductstore/issues/1517

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with targeted tests:
- `cargo test -p reductstore test_resolve_data_path_falls_back_to_uncompressed_on_replica`
- `cargo test -p reductstore test_resolve_data_path_replica_returns_too_early_when_missing`
- `cargo test -p reductstore test_reload_if_readonly_discards_compressed_cache_on_crc_change`
