### PR TITLE
Check data folder free disk space before writing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Reject record writes before writing when the data folder filesystem has insufficient free disk space, in addition to the existing quota check, [PR-1522](https://github.com/reductstore/reductstore/issues/1522)
 - Support glob-like entry patterns in replication filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1507](https://github.com/reductstore/reductstore/issues/1507) by @rohankumardubey
 - Support glob-like entry patterns in query entry filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1506](https://github.com/reductstore/reductstore/pull/1506) by @gitcommit90
 - Add CI vulnerability scanning for Rust dependencies and Docker images, gating image publishing on fixed high-severity container findings, [PR-1500](https://github.com/reductstore/reductstore/pull/1500)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Reject record writes before writing when the data folder filesystem has insufficient free disk space, in addition to the existing quota check, [PR-1522](https://github.com/reductstore/reductstore/issues/1522)
+- Reject record writes before writing when the data folder filesystem has insufficient free disk space, in addition to the existing quota check, [PR-1525](https://github.com/reductstore/reductstore/pull/1525)
 - Support glob-like entry patterns in replication filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1507](https://github.com/reductstore/reductstore/issues/1507) by @rohankumardubey
 - Support glob-like entry patterns in query entry filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1506](https://github.com/reductstore/reductstore/pull/1506) by @gitcommit90
 - Add CI vulnerability scanning for Rust dependencies and Docker images, gating image publishing on fixed high-severity container findings, [PR-1500](https://github.com/reductstore/reductstore/pull/1500)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +2996,7 @@ dependencies = [
  "crossbeam-channel",
  "dlopen2",
  "flate2",
+ "fs4",
  "futures",
  "futures-util",
  "hex",

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -75,6 +75,7 @@ uuid = { version = "1.21.0", features = ["v4"] }
 parking_lot="0.12.5"
 zenoh = { version = "1.9.0", optional = true }
 zstd = "0.13.3"
+fs4 = "1.1"
 
 
 [build-dependencies]

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -45,6 +45,18 @@ fn normalize_entry_name(path: &std::path::Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
+/// A function that returns the number of bytes available for writing on the
+/// filesystem that contains the given path.
+///
+/// It is injectable so the write-admission logic can be tested deterministically
+/// without depending on the real free space of the host filesystem.
+pub(crate) type FreeSpaceFn = Arc<dyn Fn(&std::path::Path) -> std::io::Result<u64> + Send + Sync>;
+
+/// Default free-space provider backed by the host filesystem containing the data folder.
+pub(crate) fn default_free_space_fn() -> FreeSpaceFn {
+    Arc::new(|path| fs4::available_space(path))
+}
+
 fn settings_for_entry(entry_name: &str, settings: &BucketSettings) -> EntrySettings {
     EntrySettings {
         max_block_size: if is_system_meta_entry(entry_name) {
@@ -70,6 +82,7 @@ pub(crate) struct Bucket {
     queries: AsyncRwLock<HashMap<u64, MultiEntryQuery>>,
     io_limiter: InFlightIoLimiter,
     usage_counters: Arc<UsageCounters>,
+    free_space_fn: FreeSpaceFn,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -216,6 +229,7 @@ impl Bucket {
 
         let get_entry = async || {
             self.keep_quota_for(content_size).await?;
+            self.check_free_disk_space(content_size).await?;
             self.get_or_create_entry(name).await?.upgrade()
         };
 

--- a/reductstore/src/storage/bucket/builder.rs
+++ b/reductstore/src/storage/bucket/builder.rs
@@ -1,7 +1,10 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use super::{normalize_entry_name, settings_for_entry, Bucket, MultiEntryQuery};
+use super::{
+    default_free_space_fn, normalize_entry_name, settings_for_entry, Bucket, FreeSpaceFn,
+    MultiEntryQuery,
+};
 use crate::cfg::Cfg;
 use crate::core::file_cache::FILE_CACHE;
 use crate::core::sync::AsyncRwLock;
@@ -33,6 +36,7 @@ pub(crate) struct BucketBuilder {
     cfg: Option<Cfg>,
     io_limiter: Option<InFlightIoLimiter>,
     usage_counters: Option<Arc<UsageCounters>>,
+    free_space_fn: Option<FreeSpaceFn>,
 }
 
 impl BucketBuilder {
@@ -71,6 +75,14 @@ impl BucketBuilder {
         self
     }
 
+    /// Override the free-space provider. Used in tests to simulate a filesystem
+    /// with a limited amount of free disk space.
+    #[cfg(test)]
+    pub(crate) fn free_space_fn(mut self, free_space_fn: FreeSpaceFn) -> Self {
+        self.free_space_fn = Some(free_space_fn);
+        self
+    }
+
     pub(crate) async fn build(self) -> Result<Bucket, ReductError> {
         let name = self.name.expect("Bucket name must be set");
         let data_path = self.data_path.expect("Bucket data path must be set");
@@ -97,6 +109,7 @@ impl BucketBuilder {
             queries: AsyncRwLock::new(HashMap::<u64, MultiEntryQuery>::new()),
             io_limiter,
             usage_counters,
+            free_space_fn: self.free_space_fn.unwrap_or_else(default_free_space_fn),
         };
 
         bucket.save_settings().await?;
@@ -178,6 +191,7 @@ impl BucketBuilder {
             queries: AsyncRwLock::new(HashMap::<u64, MultiEntryQuery>::new()),
             io_limiter,
             usage_counters,
+            free_space_fn: self.free_space_fn.unwrap_or_else(default_free_space_fn),
         })
     }
 }

--- a/reductstore/src/storage/bucket/quotas.rs
+++ b/reductstore/src/storage/bucket/quotas.rs
@@ -4,12 +4,43 @@
 use crate::storage::bucket::Bucket;
 use crate::storage::entry::Entry;
 use log::debug;
-use reduct_base::error::ReductError;
+use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::bucket_api::QuotaType;
 use reduct_base::{bad_request, internal_server_error};
 use std::sync::Arc;
 
 impl Bucket {
+    /// Ensure the filesystem that holds the data folder has enough free space to
+    /// store an incoming record of `content_size` bytes.
+    ///
+    /// This complements the configured quota: even when the bucket is within its
+    /// quota, the write is rejected early if the underlying filesystem cannot fit
+    /// the record. The check runs before any data is written.
+    pub(super) async fn check_free_disk_space(&self, content_size: u64) -> Result<(), ReductError> {
+        let path = self.path.clone();
+        let free_space_fn = self.free_space_fn.clone();
+
+        // `available_space` may perform a blocking syscall, so keep it off the async reactor.
+        let available = tokio::task::spawn_blocking(move || free_space_fn(&path))
+            .await
+            .map_err(|e| internal_server_error!("Failed to query free disk space: {}", e))?
+            .map_err(|e| {
+                internal_server_error!("Failed to query free disk space for the data folder: {}", e)
+            })?;
+
+        if content_size > available {
+            return Err(ReductError::new(
+                ErrorCode::InsufficientStorage,
+                &format!(
+                    "Not enough free disk space in the data folder to write a record of {} bytes: only {} bytes available",
+                    content_size, available
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
     pub(super) async fn keep_quota_for(
         self: &Arc<Self>,
         content_size: u64,
@@ -105,11 +136,37 @@ impl Bucket {
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::bucket::tests::{bucket, path, write, write_meta};
-    use reduct_base::error::ReductError;
+    use crate::cfg::Cfg;
+    use crate::core::file_cache::FILE_CACHE;
+    use crate::storage::bucket::tests::{bucket, path, read, write, write_meta};
+    use crate::storage::bucket::{Bucket, FreeSpaceFn};
+    use reduct_base::error::{ErrorCode, ReductError};
     use reduct_base::msg::bucket_api::{BucketSettings, QuotaType};
     use rstest::rstest;
     use std::path::PathBuf;
+    use std::sync::Arc;
+
+    /// Build a bucket whose free-space provider reports a fixed number of
+    /// available bytes, so the disk-space gate can be exercised deterministically.
+    async fn bucket_with_free_space(
+        settings: BucketSettings,
+        path: PathBuf,
+        free_space_fn: FreeSpaceFn,
+    ) -> Arc<Bucket> {
+        FILE_CACHE.create_dir_all(&path.join("test")).await.unwrap();
+        Arc::new(
+            Bucket::builder()
+                .name("test")
+                .data_path(path)
+                .settings(settings)
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .free_space_fn(free_space_fn)
+                .build()
+                .await
+                .unwrap(),
+        )
+    }
 
     #[rstest]
     #[tokio::test]
@@ -224,5 +281,73 @@ mod tests {
                 "Failed to keep quota of 'test'"
             ))
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_write_rejected_when_disk_full(path: PathBuf) {
+        // Simulate a filesystem that only has 10 bytes of free space left.
+        let bucket = bucket_with_free_space(
+            BucketSettings {
+                quota_type: Some(QuotaType::NONE),
+                ..BucketSettings::default()
+            },
+            path,
+            Arc::new(|_| Ok(10)),
+        )
+        .await;
+
+        let blob: &[u8] = &[0u8; 40];
+        let err = write(&bucket, "test-1", 0, blob).await.err().unwrap();
+
+        assert_eq!(err.status, ErrorCode::InsufficientStorage);
+        assert_eq!(
+            err.message,
+            "Not enough free disk space in the data folder to write a record of 40 bytes: only 10 bytes available"
+        );
+
+        // The write must be rejected before any data is stored.
+        assert!(
+            read(&bucket, "test-1", 0).await.is_err(),
+            "no record should have been written when the disk is full"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_write_allowed_when_disk_has_space(path: PathBuf) {
+        // Plenty of free disk space: the write must succeed as before.
+        let bucket = bucket_with_free_space(
+            BucketSettings {
+                quota_type: Some(QuotaType::NONE),
+                ..BucketSettings::default()
+            },
+            path,
+            Arc::new(|_| Ok(1_000_000)),
+        )
+        .await;
+
+        let blob: &[u8] = &[0u8; 40];
+        write(&bucket, "test-1", 0, blob).await.unwrap();
+        assert!(read(&bucket, "test-1", 0).await.is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_disk_full_error_surfaces_provider_failure(path: PathBuf) {
+        // A failure while querying free space is reported as an internal error.
+        let bucket = bucket_with_free_space(
+            BucketSettings {
+                quota_type: Some(QuotaType::NONE),
+                ..BucketSettings::default()
+            },
+            path,
+            Arc::new(|_| Err(std::io::Error::other("boom"))),
+        )
+        .await;
+
+        let blob: &[u8] = &[0u8; 40];
+        let err = write(&bucket, "test-1", 0, blob).await.err().unwrap();
+        assert_eq!(err.status, ErrorCode::InternalServerError);
     }
 }


### PR DESCRIPTION
Closes #1522

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Before accepting a record write, ReductStore checked the configured quota but could still proceed when the data folder's filesystem had run out of free space. This adds a free-space check to the write path:

- `Bucket::begin_write` now rejects a write with `507 Insufficient Storage` when the incoming record doesn't fit in the space available on the filesystem holding the data folder. The check runs right after the existing quota check, so FIFO eviction still gets a chance to free space first.
- Free space is queried with `fs4::available_space` for cross-platform support (the in-tree `nix`/`libc` are Unix-only, and CI covers Windows).
- Existing quota behavior (NONE / FIFO / HARD) is unchanged.

### Related issues

#1522

### Does this PR introduce a breaking change?

No. Writes that previously succeeded still succeed; only writes that wouldn't fit on disk are now rejected up front instead of failing mid-write.
