### PR TITLE
support lifecycle entry glob filters (#1524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1524](https://github.com/reductstore/reductstore/issues/1524) by @upuddu
 - Support glob-like entry patterns in replication filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1507](https://github.com/reductstore/reductstore/issues/1507) by @rohankumardubey
 - Support glob-like entry patterns in query entry filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1506](https://github.com/reductstore/reductstore/pull/1506) by @gitcommit90
 - Add CI vulnerability scanning for Rust dependencies and Docker images, gating image publishing on fixed high-severity container findings, [PR-1500](https://github.com/reductstore/reductstore/pull/1500)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1524](https://github.com/reductstore/reductstore/issues/1524) by @upuddu
+- Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1526](https://github.com/reductstore/reductstore/pull/1526) by @upuddu
 - Support glob-like entry patterns in replication filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1507](https://github.com/reductstore/reductstore/issues/1507) by @rohankumardubey
 - Support glob-like entry patterns in query entry filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1506](https://github.com/reductstore/reductstore/pull/1506) by @gitcommit90
 - Add CI vulnerability scanning for Rust dependencies and Docker images, gating image publishing on fixed high-severity container findings, [PR-1500](https://github.com/reductstore/reductstore/pull/1500)

--- a/reduct_base/src/msg/lifecycle_api.rs
+++ b/reduct_base/src/msg/lifecycle_api.rs
@@ -44,8 +44,9 @@ pub struct LifecycleSettings {
     pub lifecycle_type: LifecycleType,
     /// Bucket to apply the lifecycle policy to.
     pub bucket: String,
-    /// Entries to clean. If empty, all removable entries are matched. Prefix wildcards are supported.
-    /// System metadata entries (e.g. `entry/$meta`) are always excluded.
+    /// Entries to clean. If empty, all removable entries are matched. Supports exact names,
+    /// glob-like `*` and `**` wildcards, and `!` exclusion patterns, consistent with query and
+    /// replication entry filters. System metadata entries (e.g. `entry/$meta`) are always excluded.
     #[serde(default)]
     pub entries: Vec<String>,
     /// Records older than this duration, e.g. "30d", "24h", or "3600s".

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -198,6 +198,39 @@ mod tests {
 
     #[tokio::test]
     #[rstest]
+    async fn delete_matches_recursive_wildcards_and_exclusions(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        write(&test_bucket, "a/public/b", 1, b"pub").await.unwrap();
+        write(&test_bucket, "a/private/b", 1, b"priv")
+            .await
+            .unwrap();
+        write(&test_bucket, "other", 1, b"other").await.unwrap();
+
+        settings.mode = LifecycleMode::Enabled;
+        settings.older_than = "0s".to_string();
+        settings.entries = vec!["/a/**".to_string(), "!/a/private/**".to_string()];
+
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 1);
+        assert!(test_bucket.begin_read("a/public/b", 1).await.is_err());
+        assert!(test_bucket.begin_read("a/private/b", 1).await.is_ok());
+        assert!(test_bucket.begin_read("other", 1).await.is_ok());
+    }
+
+    #[tokio::test]
+    #[rstest]
     async fn delete_processes_windowed_data_when_system_events_enabled(
         #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
         action: DeleteLifecycleAction,

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -4,6 +4,7 @@
 use crate::core::duration::parse_duration_to_micros;
 use crate::lifecycle::action::LifecycleContext;
 use crate::storage::engine::StorageEngine;
+use crate::storage::entry::entry_matches_pattern;
 use crate::syslog::{SYSTEM_BUCKET_NAME, SYSTEM_LIFECYCLE_ENTRY_PREFIX};
 use reduct_base::error::ReductError;
 use reduct_base::io::ReadRecord;
@@ -107,7 +108,7 @@ async fn matching_record_window(
 }
 
 fn requested_entries(entries: &[String]) -> Option<&[String]> {
-    if entries.is_empty() || entries.iter().any(|entry| entry == "*") {
+    if entries.is_empty() {
         None
     } else {
         Some(entries)
@@ -120,14 +121,31 @@ fn is_requested_entry(entry_name: &str, requested_entries: &Option<&[String]>) -
         .unwrap_or(true)
 }
 
+/// Match an entry name against glob-like lifecycle patterns, sharing the
+/// semantics of query and replication entry filters: exact names, legacy
+/// prefix wildcards, single-segment `*`, recursive `**`, and `!` exclusions
+/// applied after the includes.
 fn entry_matches_patterns(entry_name: &str, patterns: &[String]) -> bool {
-    patterns.iter().any(|pattern| {
-        if let Some(prefix) = pattern.strip_suffix('*') {
-            entry_name.starts_with(prefix)
-        } else {
-            entry_name == pattern
-        }
-    })
+    let include_patterns: Vec<&str> = patterns
+        .iter()
+        .filter(|pattern| !(pattern.starts_with('!') && pattern.len() > 1))
+        .map(|pattern| pattern.as_str())
+        .collect();
+    let exclude_patterns: Vec<&str> = patterns
+        .iter()
+        .filter_map(|pattern| pattern.strip_prefix('!'))
+        .filter(|pattern| !pattern.is_empty())
+        .collect();
+
+    let included = include_patterns.is_empty()
+        || include_patterns
+            .iter()
+            .any(|pattern| entry_matches_pattern(entry_name, pattern));
+
+    included
+        && !exclude_patterns
+            .iter()
+            .any(|pattern| entry_matches_pattern(entry_name, pattern))
 }
 
 pub(crate) async fn read_progress(
@@ -276,6 +294,35 @@ pub(super) mod tests {
         assert_eq!(window.stop, Some(51));
         assert_eq!(window.last_processed_ts, Some(51));
         assert!(window.reaches_cutoff);
+    }
+
+    #[tokio::test]
+    async fn processing_window_matches_recursive_wildcard_and_exclusions() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let mut settings = settings_fixture();
+        settings.entries = vec!["/a/**".to_string(), "!/a/private/**".to_string()];
+        write(&bucket, "a/public/b", 50, b"pub").await.unwrap();
+        write(&bucket, "a/private/b", 10, b"priv").await.unwrap();
+        write(&bucket, "other", 5, b"other").await.unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, true, "instance-1".to_string()),
+            "policy-1",
+            100,
+        )
+        .await
+        .unwrap();
+
+        // Only `a/public/b` is selected: the excluded and unrelated entries are ignored.
+        assert_eq!(window.start, Some(50));
+        assert_eq!(window.stop, Some(51));
     }
 
     #[tokio::test]

--- a/reductstore/src/storage/bucket/remove_records.rs
+++ b/reductstore/src/storage/bucket/remove_records.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 use crate::storage::bucket::Bucket;
-use crate::storage::entry::RecordQueryStats;
+use crate::storage::entry::{entry_matches_pattern, RecordQueryStats};
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::QueryEntry;
 use std::collections::{BTreeMap, HashMap};
@@ -11,20 +11,37 @@ use std::sync::Arc;
 impl Bucket {
     pub(super) fn requested_entries(entries: &Option<Vec<String>>) -> Option<Vec<String>> {
         match entries {
-            Some(entries) if entries.iter().any(|entry| entry == "*") => None,
-            Some(entries) => Some(entries.clone()),
-            None => None,
+            Some(entries) if !entries.is_empty() => Some(entries.clone()),
+            _ => None,
         }
     }
 
+    /// Check whether an entry name is selected by a set of glob-like patterns.
+    ///
+    /// Patterns share the semantics of query and replication entry filters:
+    /// exact names, legacy prefix wildcards (`cam-*`), single-segment `*`,
+    /// recursive `**`, and `!` exclusions applied after the includes.
     pub(super) fn entry_matches_patterns(entry: &str, patterns: &[String]) -> bool {
-        patterns.iter().any(|pattern| {
-            if let Some(prefix) = pattern.strip_suffix('*') {
-                entry.starts_with(prefix)
-            } else {
-                entry == pattern
-            }
-        })
+        let include_patterns: Vec<&str> = patterns
+            .iter()
+            .filter(|pattern| !(pattern.starts_with('!') && pattern.len() > 1))
+            .map(|pattern| pattern.as_str())
+            .collect();
+        let exclude_patterns: Vec<&str> = patterns
+            .iter()
+            .filter_map(|pattern| pattern.strip_prefix('!'))
+            .filter(|pattern| !pattern.is_empty())
+            .collect();
+
+        let included = include_patterns.is_empty()
+            || include_patterns
+                .iter()
+                .any(|pattern| entry_matches_pattern(entry, pattern));
+
+        included
+            && !exclude_patterns
+                .iter()
+                .any(|pattern| entry_matches_pattern(entry, pattern))
     }
 
     pub(super) fn is_requested_entry(
@@ -163,6 +180,50 @@ mod tests {
     use reduct_base::{conflict, not_found};
     use rstest::rstest;
     use std::collections::HashMap;
+
+    #[rstest]
+    #[case("entry-1", vec!["entry-1".to_string()], true)]
+    #[case("entry-1", vec!["entry-*".to_string()], true)]
+    #[case("other", vec!["entry-*".to_string()], false)]
+    #[case("a/x/b", vec!["/a/*/b".to_string()], true)]
+    #[case("a/x/d/b", vec!["/a/*/b".to_string()], false)]
+    #[case("a/x/b", vec!["/a/**/b".to_string()], true)]
+    #[case("a/x/d/b", vec!["/a/**/b".to_string()], true)]
+    #[case("public", vec!["!secret".to_string()], true)]
+    #[case("secret", vec!["!secret".to_string()], false)]
+    #[case("a/private/x", vec!["/a/**".to_string(), "!/a/private/**".to_string()], false)]
+    #[case("a/public/x", vec!["/a/**".to_string(), "!/a/private/**".to_string()], true)]
+    fn entry_matches_patterns_supports_globs_and_exclusions(
+        #[case] entry: &str,
+        #[case] patterns: Vec<String>,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(Bucket::entry_matches_patterns(entry, &patterns), expected);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn query_remove_records_supports_recursive_and_exclusion(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "a/public/b", 1, b"pub").await.unwrap();
+        write(&bucket, "a/private/b", 1, b"priv").await.unwrap();
+        write(&bucket, "other", 1, b"other").await.unwrap();
+
+        let request = QueryEntry {
+            query_type: QueryType::Remove,
+            entries: Some(vec!["/a/**".into(), "!/a/private/**".into()]),
+            start: Some(1),
+            stop: Some(2),
+            ..Default::default()
+        };
+
+        let removed = bucket.clone().query_remove_records(request).await.unwrap();
+        assert_eq!(removed, 1);
+
+        assert!(bucket.begin_read("a/public/b", 1).await.is_err());
+        assert!(bucket.begin_read("a/private/b", 1).await.is_ok());
+        assert!(bucket.begin_read("other", 1).await.is_ok());
+    }
 
     #[rstest]
     #[tokio::test]


### PR DESCRIPTION
Closes #1524

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Lifecycle task `entries` filters now share the path-aware matching used by query and replication filters:

- exact entry names still work unchanged
- legacy prefix patterns like `entry-*` remain supported
- `*` matches within a single path segment
- `**` matches recursively across path segments
- `!pattern` excludes matching entries after includes are resolved

The shared `entry_matches_pattern` helper is reused for both the delete/compress entry selection and the processing-window computation, so environment-provisioned lifecycles pick up the same rules through the existing action path.

### Related issues

Part of #1508, closes #1524

### Does this PR introduce a breaking change?

No. Existing exact names and prefix-style `*` filters behave as before.
