### PR TITLE
Recover lifecycle entry glob filters for v1.20.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1524](https://github.com/reductstore/reductstore/issues/1524) by @upuddu
+- Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1528](https://github.com/reductstore/reductstore/pull/1528) by @upuddu
 
 ## 1.20.8 - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.20.9 - 2026-07-08
+
+### Added
+
+- Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1524](https://github.com/reductstore/reductstore/issues/1524) by @upuddu
+
 ## 1.20.8 - 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.20.8"
+version = "1.20.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.20.8"
+version = "1.20.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.20.8"
+version = "1.20.9"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.20.8"
+version = "1.20.9"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.91.0"

--- a/reduct_base/src/msg/lifecycle_api.rs
+++ b/reduct_base/src/msg/lifecycle_api.rs
@@ -44,8 +44,9 @@ pub struct LifecycleSettings {
     pub lifecycle_type: LifecycleType,
     /// Bucket to apply the lifecycle policy to.
     pub bucket: String,
-    /// Entries to clean. If empty, all removable entries are matched. Prefix wildcards are supported.
-    /// System metadata entries (e.g. `entry/$meta`) are always excluded.
+    /// Entries to clean. If empty, all removable entries are matched. Supports exact names,
+    /// glob-like `*` and `**` wildcards, and `!` exclusion patterns, consistent with query and
+    /// replication entry filters. System metadata entries (e.g. `entry/$meta`) are always excluded.
     #[serde(default)]
     pub entries: Vec<String>,
     /// Records older than this duration, e.g. "30d", "24h", or "3600s".

--- a/reductstore/src/lifecycle/action/delete.rs
+++ b/reductstore/src/lifecycle/action/delete.rs
@@ -198,6 +198,39 @@ mod tests {
 
     #[tokio::test]
     #[rstest]
+    async fn delete_matches_recursive_wildcards_and_exclusions(
+        #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
+        action: DeleteLifecycleAction,
+        mut settings: LifecycleSettings,
+    ) {
+        let (test_storage, test_bucket) = test_context.await;
+        write(&test_bucket, "a/public/b", 1, b"pub").await.unwrap();
+        write(&test_bucket, "a/private/b", 1, b"priv")
+            .await
+            .unwrap();
+        write(&test_bucket, "other", 1, b"other").await.unwrap();
+
+        settings.mode = LifecycleMode::Enabled;
+        settings.older_than = "0s".to_string();
+        settings.entries = vec!["/a/**".to_string(), "!/a/private/**".to_string()];
+
+        let result = action
+            .run(
+                "test",
+                &settings,
+                LifecycleContext::new(test_storage, false, "unknown".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_records, 1);
+        assert!(test_bucket.begin_read("a/public/b", 1).await.is_err());
+        assert!(test_bucket.begin_read("a/private/b", 1).await.is_ok());
+        assert!(test_bucket.begin_read("other", 1).await.is_ok());
+    }
+
+    #[tokio::test]
+    #[rstest]
     async fn delete_processes_windowed_data_when_system_events_enabled(
         #[future] test_context: (Arc<StorageEngine>, Arc<Bucket>),
         action: DeleteLifecycleAction,

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -4,6 +4,7 @@
 use crate::core::duration::parse_duration_to_micros;
 use crate::lifecycle::action::LifecycleContext;
 use crate::storage::engine::StorageEngine;
+use crate::storage::entry::entry_matches_pattern;
 use crate::syslog::{SYSTEM_BUCKET_NAME, SYSTEM_LIFECYCLE_ENTRY_PREFIX};
 use reduct_base::error::ReductError;
 use reduct_base::io::ReadRecord;
@@ -107,7 +108,7 @@ async fn matching_record_window(
 }
 
 fn requested_entries(entries: &[String]) -> Option<&[String]> {
-    if entries.is_empty() || entries.iter().any(|entry| entry == "*") {
+    if entries.is_empty() {
         None
     } else {
         Some(entries)
@@ -120,14 +121,31 @@ fn is_requested_entry(entry_name: &str, requested_entries: &Option<&[String]>) -
         .unwrap_or(true)
 }
 
+/// Match an entry name against glob-like lifecycle patterns, sharing the
+/// semantics of query and replication entry filters: exact names, legacy
+/// prefix wildcards, single-segment `*`, recursive `**`, and `!` exclusions
+/// applied after the includes.
 fn entry_matches_patterns(entry_name: &str, patterns: &[String]) -> bool {
-    patterns.iter().any(|pattern| {
-        if let Some(prefix) = pattern.strip_suffix('*') {
-            entry_name.starts_with(prefix)
-        } else {
-            entry_name == pattern
-        }
-    })
+    let include_patterns: Vec<&str> = patterns
+        .iter()
+        .filter(|pattern| !(pattern.starts_with('!') && pattern.len() > 1))
+        .map(|pattern| pattern.as_str())
+        .collect();
+    let exclude_patterns: Vec<&str> = patterns
+        .iter()
+        .filter_map(|pattern| pattern.strip_prefix('!'))
+        .filter(|pattern| !pattern.is_empty())
+        .collect();
+
+    let included = include_patterns.is_empty()
+        || include_patterns
+            .iter()
+            .any(|pattern| entry_matches_pattern(entry_name, pattern));
+
+    included
+        && !exclude_patterns
+            .iter()
+            .any(|pattern| entry_matches_pattern(entry_name, pattern))
 }
 
 pub(crate) async fn read_progress(
@@ -276,6 +294,35 @@ pub(super) mod tests {
         assert_eq!(window.stop, Some(51));
         assert_eq!(window.last_processed_ts, Some(51));
         assert!(window.reaches_cutoff);
+    }
+
+    #[tokio::test]
+    async fn processing_window_matches_recursive_wildcard_and_exclusions() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let mut settings = settings_fixture();
+        settings.entries = vec!["/a/**".to_string(), "!/a/private/**".to_string()];
+        write(&bucket, "a/public/b", 50, b"pub").await.unwrap();
+        write(&bucket, "a/private/b", 10, b"priv").await.unwrap();
+        write(&bucket, "other", 5, b"other").await.unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, true, "instance-1".to_string()),
+            "policy-1",
+            100,
+        )
+        .await
+        .unwrap();
+
+        // Only `a/public/b` is selected: the excluded and unrelated entries are ignored.
+        assert_eq!(window.start, Some(50));
+        assert_eq!(window.stop, Some(51));
     }
 
     #[tokio::test]

--- a/reductstore/src/storage/bucket/remove_records.rs
+++ b/reductstore/src/storage/bucket/remove_records.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 use crate::storage::bucket::Bucket;
-use crate::storage::entry::RecordQueryStats;
+use crate::storage::entry::{entry_matches_pattern, RecordQueryStats};
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::QueryEntry;
 use std::collections::{BTreeMap, HashMap};
@@ -11,20 +11,37 @@ use std::sync::Arc;
 impl Bucket {
     pub(super) fn requested_entries(entries: &Option<Vec<String>>) -> Option<Vec<String>> {
         match entries {
-            Some(entries) if entries.iter().any(|entry| entry == "*") => None,
-            Some(entries) => Some(entries.clone()),
-            None => None,
+            Some(entries) if !entries.is_empty() => Some(entries.clone()),
+            _ => None,
         }
     }
 
+    /// Check whether an entry name is selected by a set of glob-like patterns.
+    ///
+    /// Patterns share the semantics of query and replication entry filters:
+    /// exact names, legacy prefix wildcards (`cam-*`), single-segment `*`,
+    /// recursive `**`, and `!` exclusions applied after the includes.
     pub(super) fn entry_matches_patterns(entry: &str, patterns: &[String]) -> bool {
-        patterns.iter().any(|pattern| {
-            if let Some(prefix) = pattern.strip_suffix('*') {
-                entry.starts_with(prefix)
-            } else {
-                entry == pattern
-            }
-        })
+        let include_patterns: Vec<&str> = patterns
+            .iter()
+            .filter(|pattern| !(pattern.starts_with('!') && pattern.len() > 1))
+            .map(|pattern| pattern.as_str())
+            .collect();
+        let exclude_patterns: Vec<&str> = patterns
+            .iter()
+            .filter_map(|pattern| pattern.strip_prefix('!'))
+            .filter(|pattern| !pattern.is_empty())
+            .collect();
+
+        let included = include_patterns.is_empty()
+            || include_patterns
+                .iter()
+                .any(|pattern| entry_matches_pattern(entry, pattern));
+
+        included
+            && !exclude_patterns
+                .iter()
+                .any(|pattern| entry_matches_pattern(entry, pattern))
     }
 
     pub(super) fn is_requested_entry(
@@ -163,6 +180,50 @@ mod tests {
     use reduct_base::{conflict, not_found};
     use rstest::rstest;
     use std::collections::HashMap;
+
+    #[rstest]
+    #[case("entry-1", vec!["entry-1".to_string()], true)]
+    #[case("entry-1", vec!["entry-*".to_string()], true)]
+    #[case("other", vec!["entry-*".to_string()], false)]
+    #[case("a/x/b", vec!["/a/*/b".to_string()], true)]
+    #[case("a/x/d/b", vec!["/a/*/b".to_string()], false)]
+    #[case("a/x/b", vec!["/a/**/b".to_string()], true)]
+    #[case("a/x/d/b", vec!["/a/**/b".to_string()], true)]
+    #[case("public", vec!["!secret".to_string()], true)]
+    #[case("secret", vec!["!secret".to_string()], false)]
+    #[case("a/private/x", vec!["/a/**".to_string(), "!/a/private/**".to_string()], false)]
+    #[case("a/public/x", vec!["/a/**".to_string(), "!/a/private/**".to_string()], true)]
+    fn entry_matches_patterns_supports_globs_and_exclusions(
+        #[case] entry: &str,
+        #[case] patterns: Vec<String>,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(Bucket::entry_matches_patterns(entry, &patterns), expected);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn query_remove_records_supports_recursive_and_exclusion(#[future] bucket: Arc<Bucket>) {
+        let bucket = bucket.await;
+        write(&bucket, "a/public/b", 1, b"pub").await.unwrap();
+        write(&bucket, "a/private/b", 1, b"priv").await.unwrap();
+        write(&bucket, "other", 1, b"other").await.unwrap();
+
+        let request = QueryEntry {
+            query_type: QueryType::Remove,
+            entries: Some(vec!["/a/**".into(), "!/a/private/**".into()]),
+            start: Some(1),
+            stop: Some(2),
+            ..Default::default()
+        };
+
+        let removed = bucket.clone().query_remove_records(request).await.unwrap();
+        assert_eq!(removed, 1);
+
+        assert!(bucket.begin_read("a/public/b", 1).await.is_err());
+        assert!(bucket.begin_read("a/private/b", 1).await.is_ok());
+        assert!(bucket.begin_read("other", 1).await.is_ok());
+    }
 
     #[rstest]
     #[tokio::test]

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -5,6 +5,7 @@ mod builder;
 mod compress;
 mod entry_loader;
 pub(crate) mod io;
+mod pattern;
 mod read_record;
 mod remove_records;
 mod system;
@@ -40,6 +41,7 @@ use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::JoinHandle;
 
 pub(crate) use builder::EntryBuilder;
+pub(crate) use pattern::entry_matches_pattern;
 
 struct QueryHandle {
     rx: Arc<AsyncRwLock<QueryRx>>,

--- a/reductstore/src/storage/entry/pattern.rs
+++ b/reductstore/src/storage/entry/pattern.rs
@@ -1,0 +1,101 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+pub(crate) fn entry_matches_pattern(entry: &str, pattern: &str) -> bool {
+    let pattern = pattern.trim_start_matches('/');
+
+    if !pattern.contains('*') {
+        return entry == pattern;
+    }
+
+    if !pattern.contains('/') {
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            return entry.starts_with(prefix);
+        }
+    }
+
+    let entry_parts: Vec<&str> = entry.split('/').collect();
+    let pattern_parts: Vec<&str> = pattern.split('/').collect();
+
+    fn segment_matches(entry: &str, pattern: &str) -> bool {
+        if pattern == "**" {
+            return true;
+        }
+
+        let mut rest = entry;
+        let mut parts = pattern.split('*').peekable();
+
+        if let Some(first) = parts.next() {
+            if !first.is_empty() {
+                let Some(stripped) = rest.strip_prefix(first) else {
+                    return false;
+                };
+                rest = stripped;
+            }
+        }
+
+        while let Some(part) = parts.next() {
+            if part.is_empty() {
+                continue;
+            }
+
+            if parts.peek().is_none() {
+                return rest.ends_with(part);
+            }
+
+            let Some(index) = rest.find(part) else {
+                return false;
+            };
+            rest = &rest[index + part.len()..];
+        }
+
+        pattern.ends_with('*') || rest.is_empty()
+    }
+
+    fn matches_from(entry_parts: &[&str], pattern_parts: &[&str]) -> bool {
+        match pattern_parts.split_first() {
+            None => entry_parts.is_empty(),
+            Some((&"**", tail)) => {
+                matches_from(entry_parts, tail)
+                    || (!entry_parts.is_empty() && matches_from(&entry_parts[1..], pattern_parts))
+            }
+            Some((pattern, tail)) => {
+                !entry_parts.is_empty()
+                    && segment_matches(entry_parts[0], pattern)
+                    && matches_from(&entry_parts[1..], tail)
+            }
+        }
+    }
+
+    matches_from(&entry_parts, &pattern_parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("acc-a", "acc-*", true)]
+    #[case("acc-a/sub-entry", "acc-*", true)]
+    #[case("other", "acc-*", false)]
+    #[case("a/x/b", "/a/*/b", true)]
+    #[case("a/y/b", "/a/*/b", true)]
+    #[case("a/x/d/b", "/a/*/b", false)]
+    #[case("a/x/b", "/a/**/b", true)]
+    #[case("a/x/d/b", "/a/**/b", true)]
+    #[case("a/b", "/a/**", true)]
+    #[case("a/private/x/b", "/a/private/**", true)]
+    #[case("a/public/x/b", "/a/private/**", false)]
+    #[case("a/x/b", "/**/**/", false)]
+    #[case("sensor-alpha-temp/b", "/camera-*/b", false)]
+    #[case("sensor-alpha-temp", "sensor-*temp", true)]
+    #[case("sensor-alpha-temp", "sensor-*humidity", false)]
+    #[case("a/sensor-alpha-temp/b", "/a/sensor-*alpha-*/b", true)]
+    #[case("a/sensor-alpha-temp/b", "/a/sensor-*beta-*/b", false)]
+    #[case("sensor-alpha-temp", "sensor-*", true)]
+    #[case("a/sensor-alpha-temp/b", "/a/*alpha*/b", true)]
+    fn matches_entry_patterns(#[case] entry: &str, #[case] pattern: &str, #[case] expected: bool) {
+        assert_eq!(entry_matches_pattern(entry, pattern), expected);
+    }
+}


### PR DESCRIPTION
Closes #1524

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature backport / stable release preparation

### What was changed?

Recover lifecycle `entries` glob filtering for the `stable` branch and prepare `v1.20.9`:

- bump the workspace package version from `1.20.8` to `1.20.9`
- add a `1.20.9` changelog section
- support lifecycle exact entry names, legacy prefix wildcards, path-aware `*`, recursive `**`, and `!` exclusion patterns
- apply the same matching rules to lifecycle delete actions, query-remove selection, and lifecycle processing-window calculation
- add the shared entry-pattern matcher needed by the stable branch
- add coverage for recursive wildcard and exclusion behavior

### Related issues

Backports the implementation from #1526 for #1524 onto `stable`.

### Does this PR introduce a breaking change?

No. Existing exact entry names and prefix-style wildcard filters continue to work.

### Other information:

Validated locally with:

- `cargo fmt --check`
- `cargo test -p reductstore recursive`
- `cargo test -p reductstore entry_matches_patterns_supports_globs_and_exclusions`
- `cargo test -p reductstore matches_entry_patterns`
- `cargo check --workspace --all-targets`
