### PR TITLE
Restore ReductError conversion compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.20.9 - 2026-07-08
+
 ### Fixed
 
 - Restore plain type conversions for `ReductError` to keep downstream `Result<_, ReductError>` APIs compatible, [PR-1529](https://github.com/reductstore/reductstore/pull/1529)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Restore plain `url::ParseError` conversion for `ReductError` to keep downstream `Result<_, ReductError>` APIs compatible.
+- Restore plain type conversions for `ReductError` to keep downstream `Result<_, ReductError>` APIs compatible, [PR-1529](https://github.com/reductstore/reductstore/pull/1529)
 
 ## 1.20.8 - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore plain `url::ParseError` conversion for `ReductError` to keep downstream `Result<_, ReductError>` APIs compatible.
+
 ## 1.20.8 - 2026-07-07
 
 ### Fixed
 
 - Add source field to `ReductError` and improve error handling in `BlockManager::remove_records` to detect and mark corrupted blocks, [PR-1519](https://github.com/reductstore/reductstore/pull/1519)
 - Fix read-only replica block reads when compressed index state arrives before compressed block files and make replica cache invalidation for block variants fault-tolerant, [PR-1523](https://github.com/reductstore/reductstore/pull/1523)
-
 
 ## 1.20.7 - 2026-06-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-base"
-version = "1.20.8"
+version = "1.20.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "reduct-macros"
-version = "1.20.8"
+version = "1.20.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "reductstore"
-version = "1.20.8"
+version = "1.20.9"
 dependencies = [
  "aes-siv",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.20.8"
+version = "1.20.9"
 authors = ["Alexey Timin <atimin@reduct.store>", "ReductSoftware UG <info@reduct.store>"]
 edition = "2021"
 rust-version = "1.91.0"

--- a/reduct_base/Cargo.toml
+++ b/reduct_base/Cargo.toml
@@ -34,7 +34,7 @@ url = "2.5.4"
 http = "1.4.1"
 bytes = "1.11.0"
 async-trait = { version =  "0.1.89" , optional = true }
-tokio = { version = "1.51.1", optional = true, features = ["default", "rt", "time"] }
+tokio = { version = "1.51.1", optional = true, features = ["default", "rt", "sync", "time"] }
 log = "0.4.28"
 thread-id = "5.1.0"
 futures = "0.3.31"

--- a/reduct_base/src/error.rs
+++ b/reduct_base/src/error.rs
@@ -126,6 +126,28 @@ impl From<std::io::Error> for ReductError {
     }
 }
 
+impl From<ParseError> for ReductError {
+    fn from(err: ParseError) -> Self {
+        // Keep the plain conversion for downstream APIs returning Result<_, ReductError>.
+        ReductError {
+            status: ErrorCode::UrlParseError,
+            message: err.to_string(),
+            source: None,
+        }
+    }
+}
+
+impl From<SystemTimeError> for ReductError {
+    fn from(err: SystemTimeError) -> Self {
+        // Keep the plain conversion for downstream APIs returning Result<_, ReductError>.
+        ReductError {
+            status: ErrorCode::InternalServerError,
+            message: err.to_string(),
+            source: None,
+        }
+    }
+}
+
 impl From<SystemTimeError> for ReductError<SystemTimeError> {
     fn from(err: SystemTimeError) -> Self {
         // A system time error is an internal reductstore error
@@ -148,6 +170,17 @@ impl From<ParseError> for ReductError<ParseError> {
     }
 }
 
+impl<T> From<PoisonError<T>> for ReductError {
+    fn from(_: PoisonError<T>) -> Self {
+        // Keep the plain conversion for downstream APIs returning Result<_, ReductError>.
+        ReductError {
+            status: ErrorCode::InternalServerError,
+            message: "Poison error".to_string(),
+            source: None,
+        }
+    }
+}
+
 impl<T> From<PoisonError<T>> for ReductError<PoisonError<T>> {
     fn from(err: PoisonError<T>) -> Self {
         // A poison error is an internal reductstore error
@@ -155,6 +188,29 @@ impl<T> From<PoisonError<T>> for ReductError<PoisonError<T>> {
             status: ErrorCode::InternalServerError,
             message: "Poison error".to_string(),
             source: Some(err),
+        }
+    }
+}
+
+impl From<Box<dyn std::any::Any + Send>> for ReductError {
+    fn from(err: Box<dyn std::any::Any + Send>) -> Self {
+        // Keep the plain conversion for downstream APIs returning Result<_, ReductError>.
+        ReductError {
+            status: ErrorCode::InternalServerError,
+            message: format!("{:?}", err),
+            source: None,
+        }
+    }
+}
+
+#[cfg(feature = "io")]
+impl<T> From<SendError<T>> for ReductError {
+    fn from(err: SendError<T>) -> Self {
+        // Keep the plain conversion for downstream APIs returning Result<_, ReductError>.
+        ReductError {
+            status: ErrorCode::InternalServerError,
+            message: err.to_string(),
+            source: None,
         }
     }
 }
@@ -442,25 +498,63 @@ mod tests {
     #[test]
     fn converts_system_time_error_to_reduct_error() {
         let system_time_error = UNIX_EPOCH.duration_since(SystemTime::now()).unwrap_err();
-        let error: ReductError<_> = system_time_error.into();
+        let error: ReductError = system_time_error.into();
         assert_eq!(error.status, ErrorCode::InternalServerError);
         assert_eq!(error.message, "second time provided was later than self");
+        assert_eq!(error.source, None);
+    }
+
+    #[test]
+    fn converts_system_time_error_to_typed_reduct_error() {
+        let system_time_error = UNIX_EPOCH.duration_since(SystemTime::now()).unwrap_err();
+        let error: ReductError<SystemTimeError> = system_time_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "second time provided was later than self");
+        assert!(error.source.is_some());
     }
 
     #[test]
     fn converts_url_parse_error_to_reduct_error() {
         let parse_error = ParseError::EmptyHost;
-        let error: ReductError<_> = parse_error.into();
+        let error: ReductError = parse_error.into();
         assert_eq!(error.status, ErrorCode::UrlParseError);
         assert_eq!(error.message, "empty host");
+        assert_eq!(error.source, None);
+    }
+
+    #[test]
+    fn converts_url_parse_error_to_typed_reduct_error() {
+        let parse_error = ParseError::EmptyHost;
+        let error: ReductError<ParseError> = parse_error.into();
+        assert_eq!(error.status, ErrorCode::UrlParseError);
+        assert_eq!(error.message, "empty host");
+        assert_eq!(error.source, Some(ParseError::EmptyHost));
     }
 
     #[test]
     fn converts_poison_error_to_reduct_error() {
         let poison_error: PoisonError<()> = PoisonError::new(());
-        let error: ReductError<_> = poison_error.into();
+        let error: ReductError = poison_error.into();
         assert_eq!(error.status, ErrorCode::InternalServerError);
         assert_eq!(error.message, "Poison error");
+        assert_eq!(error.source, None);
+    }
+
+    #[test]
+    fn converts_poison_error_to_typed_reduct_error() {
+        let poison_error: PoisonError<()> = PoisonError::new(());
+        let error: ReductError<PoisonError<()>> = poison_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "Poison error");
+        assert!(error.source.is_some());
+    }
+
+    #[test]
+    fn converts_boxed_any_to_reduct_error() {
+        let boxed_error: Box<dyn std::any::Any + Send> = Box::new("panic payload");
+        let error: ReductError = boxed_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.source, None);
     }
 
     #[test]
@@ -495,9 +589,20 @@ mod tests {
     #[test]
     fn converts_send_error_to_reduct_error() {
         let send_error: SendError<()> = SendError(());
-        let error: ReductError<_> = send_error.into();
+        let error: ReductError = send_error.into();
         assert_eq!(error.status, ErrorCode::InternalServerError);
         assert_eq!(error.message, "channel closed");
+        assert_eq!(error.source, None);
+    }
+
+    #[cfg(feature = "io")]
+    #[test]
+    fn converts_send_error_to_typed_reduct_error() {
+        let send_error: SendError<()> = SendError(());
+        let error: ReductError<SendError<()>> = send_error.into();
+        assert_eq!(error.status, ErrorCode::InternalServerError);
+        assert_eq!(error.message, "channel closed");
+        assert!(error.source.is_some());
     }
 
     mod macros {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Restored plain `ReductError` conversions for `url::ParseError`, `SystemTimeError`, `PoisonError<T>`, boxed panic payloads, and `tokio::sync::mpsc::error::SendError<T>` so downstream `Result<_, ReductError>` APIs can keep using `?`.
- Kept the typed/source-preserving `ReductError<T>` conversions added in PR #1519.
- Enabled Tokio's `sync` feature for `reduct-base` when the `io` feature is used so the `SendError` compatibility path builds.
- Added tests covering both plain and typed conversions.

### Related issues

Fixes compatibility regressions introduced by #1519 and observed in the website pipeline: https://github.com/reductstore/website/actions/runs/28929235480/job/85824014478?pr=358

### Does this PR introduce a breaking change?

No. This restores source compatibility for downstream users affected by the `ReductError` conversion changes in PR #1519.

### Other information:

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p reduct-base`
- `cargo test -p reduct-base --features io`
- `cargo check --workspace`
