### PR TITLE
fix CI for fork pull requests

### DIFF
--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -1,9 +1,6 @@
 name: 'Build Binaries'
 description: 'Builds binaries for a specific target and uploads them as artifacts.'
 inputs:
-  action_github_token:
-    description: 'GitHub token for setup-protoc.'
-    required: true
   target:
     description: 'Target triple.'
     required: true
@@ -23,11 +20,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: reductstore/setup-protoc@ac76da16b8e70736e159368a4bc962934d1f825a # master
-      with:
-        version: '26.x'
-        repo-token: ${{ inputs.action_github_token }}
-
     - name: Install Rust
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       with:

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -7,9 +7,6 @@ inputs:
   target:
     description: 'Target triple.'
     required: true
-  action_github_token:
-    description: 'GitHub token for authentication.'
-    required: true
 runs:
   using: 'composite'
   steps:
@@ -22,11 +19,6 @@ runs:
 
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
-
-    - uses: reductstore/setup-protoc@ac76da16b8e70736e159368a4bc962934d1f825a # master
-      with:
-        version: '26.x'
-        repo-token: ${{ inputs.action_github_token }}
 
     - name: AWS Credentials and Cargo Cache
       uses: ./.github/actions/aws-cargo-cache

--- a/.github/actions/migration-test/action.yml
+++ b/.github/actions/migration-test/action.yml
@@ -9,10 +9,12 @@ inputs:
     required: true
   docker_user:
     description: 'Docker username.'
-    required: true
+    required: false
+    default: ''
   docker_token:
     description: 'Docker token.'
-    required: true
+    required: false
+    default: ''
   repository:
     description: 'GitHub repository.'
     required: true
@@ -30,10 +32,14 @@ runs:
         echo "DATA_VOLUME=$DATA_VOLUME" >> "$GITHUB_ENV"
         docker volume create "$DATA_VOLUME"
 
+    - name: Login Docker
+      if: ${{ inputs.docker_user != '' && inputs.docker_token != '' }}
+      shell: bash
+      run: docker login -u "${{ inputs.docker_user }}" -p "${{ inputs.docker_token }}"
+
     - name: Run latest stable ReductStore
       shell: bash
       run: |
-        docker login -u ${{ inputs.docker_user }} -p ${{ inputs.docker_token }}
         docker run --network=host -v "${DATA_VOLUME}:/data" --env RS_API_TOKEN=${{ inputs.rs_api_token }} --name latest -d reduct/store:${{ inputs.version }}
         sleep 5
         docker logs latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/build-binaries
         with:
-          action_github_token: ${{ secrets.ACTION_GITHUB_TOKEN }}
           target: ${{ matrix.target }}
           os: ${{ matrix.os }}
           compiler: ${{ matrix.compiler }}
@@ -140,7 +139,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
           target: ${{ matrix.target }}
-          action_github_token: ${{ secrets.ACTION_GITHUB_TOKEN }}
 
       - name: Upload coverage to Codecov
         continue-on-error: true
@@ -693,10 +691,6 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: ${{ vars.MINIMAL_RUST_VERSION }}
-      - uses: reductstore/setup-protoc@ac76da16b8e70736e159368a4bc962934d1f825a # master
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.ACTION_GITHUB_TOKEN }}
       - name: Login
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,11 +214,14 @@ jobs:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       MINIO_BUCKET: test
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login Docker
-        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
+        if: ${{ env.DOCKER_USER != '' && env.DOCKER_TOKEN != '' }}
+        run: docker login -u "$DOCKER_USER" -p "$DOCKER_TOKEN"
 
       - uses: ./.github/actions/api/http-tests
         with:
@@ -245,11 +248,15 @@ jobs:
             auth_dictionary: ""
             tls_root_ca: "use-misc-cert"
     timeout-minutes: 5
+    env:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login Docker
-        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
+        if: ${{ env.DOCKER_USER != '' && env.DOCKER_TOKEN != '' }}
+        run: docker login -u "$DOCKER_USER" -p "$DOCKER_TOKEN"
 
       - name: Read TLS cert if needed
         id: tls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow fork pull request CI to run without protobuf setup tokens or Docker Hub credentials by vendoring `protoc` and making Docker login optional, [PR-1532](https://github.com/reductstore/reductstore/pull/1532)
 - Split block manager storage logic into smaller modules by responsibility, [PR-1503](https://github.com/reductstore/reductstore/pull/1503) by @rohankumardubey
 - Refresh contributor onboarding docs to validate branch builds locally and add `@gitcommit90` to the README contributor wall, [PR-1511](https://github.com/reductstore/reductstore/pull/1511)
 - Unify `$system` event handling under `syslog`: move all event production (audit, usage, lifecycle, replication, logs) into the module behind a single system event logger with one shared writer and sink (no change to the stored record format), [PR-1496](https://github.com/reductstore/reductstore/pull/1496) by @DibbayajyotiRoy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Open a pull request only for an existing issue.
 - If you want to work on an issue, say so in the comments first and wait to be assigned before you start coding.
 - If you want to fix a reported bug, comment on the issue first so maintainers know you are working on it.
 - If you have a new idea, do not open a surprise PR. Start with a GitHub issue or a thread on the [ReductStore community forum](https://community.reduct.store) to discuss scope first.
-- If you want a small first task, start with [good first issue](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or [help wanted](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).
+- If you want a small first task, start with [good first issue](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22).
 
 ## Prepare Your Branch
 
@@ -37,22 +37,6 @@ For most changes, build and run ReductStore locally:
 ```bash
 mkdir -p ./data
 RS_DATA_PATH=./data cargo run -p reductstore --features "fs-backend web-console"
-```
-
-If you prefer building a binary first:
-
-```bash
-cargo build -p reductstore --features "fs-backend web-console"
-mkdir -p ./data
-RS_DATA_PATH=./data ./target/debug/reductstore
-```
-
-Use the published Docker image only for dependency-free smoke checks or to compare released behavior:
-
-```bash
-mkdir -p ./data
-sudo chown -R 10001:10001 ./data
-docker run -p 8383:8383 -v ${PWD}/data:/data reduct/store:latest
 ```
 
 Then exercise the API, replication flow, query behavior, lifecycle policy, or UI path that your change touches.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,6 +3073,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-wkt-types",
+ "protoc-bin-vendored",
  "rand 0.10.2",
  "reduct-base",
  "reduct-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2034,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2143,28 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -2723,6 +2817,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
+dependencies = [
+ "logos 0.16.1",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2877,7 @@ dependencies = [
  "prost-types",
  "prost-wkt",
  "prost-wkt-build",
+ "protox",
  "regex",
  "serde",
  "serde_derive",
@@ -2842,6 +2949,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos 0.15.1",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +3001,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "fastbloom",
  "getrandom 0.4.3",
@@ -3078,7 +3213,8 @@ dependencies = [
  "reduct-base",
  "reduct-macros",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "ring",
  "rstest",
  "rustls",
@@ -3192,6 +3328,45 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4459,6 +4634,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Learn more and pick the next piece you need:
 - **[Community Forum](https://community.reduct.store)**
 - **[Good First Issues](https://github.com/reductstore/reductstore/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)**
 
+## Build From Source
+
+ReductStore uses a vendored `protoc` binary through Cargo, so contributors do not need to install Protocol Buffers manually. To check the workspace locally, run:
+
+```bash
+cargo check --workspace
+```
+
 ## When You Should Not Use It
 
 ReductStore is not the best fit for every data storage problem. You should consider another solution when:

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -38,7 +38,7 @@ chrono-tz = "0.10.4"
 zip = "8.1.0"
 tempfile = "3.27.0"
 hex = "0.4.3"
-prost-wkt-types = "0.7.0"
+prost-wkt-types = { version = "0.7.0", features = ["vendored-protox"] }
 rand = "0.10.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
@@ -81,7 +81,7 @@ fs4 = "1.1"
 [build-dependencies]
 prost-build = "0.14.1"
 protoc-bin-vendored = "3"
-reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls", "blocking", "json"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "blocking", "json"] }
 chrono = "0.4.41"
 serde_json = "1.0.150"
 

--- a/reductstore/Cargo.toml
+++ b/reductstore/Cargo.toml
@@ -80,6 +80,7 @@ fs4 = "1.1"
 
 [build-dependencies]
 prost-build = "0.14.1"
+protoc-bin-vendored = "3"
 reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls", "blocking", "json"] }
 chrono = "0.4.41"
 serde_json = "1.0.150"

--- a/reductstore/build.rs
+++ b/reductstore/build.rs
@@ -8,8 +8,12 @@ use std::time::SystemTime;
 use std::{env, fs};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+
     // build protos
-    prost_build::Config::new()
+    let mut config = prost_build::Config::new();
+    config
+        .protoc_executable(protoc)
         .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute(".reduct.proto.auth", "#[serde(default)]")


### PR DESCRIPTION
Closes #1469

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / CI update

### What was changed?

- Vendor `protoc` through Cargo with `protoc-bin-vendored` and remove the `reductstore/setup-protoc` GitHub action from CI.
- Remove the now-unused GitHub token plumbing for protobuf setup.
- Make Docker Hub login optional in PR-running integration jobs so fork PRs can continue with anonymous pulls when Docker secrets are unavailable.
- Document that source builds do not require a manual Protocol Buffers installation.

### Related issues

#1469

### Does this PR introduce a breaking change?

No. This only changes CI setup and build-time protobuf compiler sourcing.

### Other information:
