### PR TITLE
normalize empty bucket history timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refresh contributor onboarding docs to validate branch builds locally and add `@gitcommit90` to the README contributor wall, [PR-1511](https://github.com/reductstore/reductstore/pull/1511)
 - Unify `$system` event handling under `syslog`: move all event production (audit, usage, lifecycle, replication, logs) into the module behind a single system event logger with one shared writer and sink (no change to the stored record format), [PR-1496](https://github.com/reductstore/reductstore/pull/1496) by @DibbayajyotiRoy
 
+### Fixed
+
+- Normalize bucket history timestamps when only attachment metadata entries contain records, [PR-1534](https://github.com/reductstore/reductstore/pull/1534)
+
 ## 1.20.9 - 2026-07-08
 
 ### Fixed

--- a/reductstore/src/storage/bucket.rs
+++ b/reductstore/src/storage/bucket.rs
@@ -159,6 +159,10 @@ impl Bucket {
             }
         }
 
+        if oldest_record == u64::MAX {
+            oldest_record = 0;
+        }
+
         Ok(FullBucketInfo {
             info: BucketInfo {
                 name: self.name.clone(),
@@ -532,6 +536,25 @@ pub(crate) mod tests {
             assert_eq!(entries["filled"].record_count, 2);
             assert_eq!(entries["filled"].oldest_record, 1);
             assert_eq!(entries["filled"].latest_record, 2);
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_bucket_info_normalizes_history_when_only_meta_entries_have_records(
+            #[future] bucket: Arc<Bucket>,
+        ) {
+            let bucket = bucket.await;
+            write_meta(&bucket, "entry/$meta", 1, b"meta")
+                .await
+                .unwrap();
+
+            let info = bucket.info().await.unwrap();
+            assert_eq!(info.info.oldest_record, 0);
+            assert_eq!(info.info.latest_record, 0);
+            assert_eq!(info.info.entry_count, 1);
+            assert_eq!(info.entries.len(), 1);
+            assert_eq!(info.entries[0].name, "entry");
+            assert_eq!(info.entries[0].record_count, 0);
         }
 
         #[rstest]


### PR DESCRIPTION
Closes #1533

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Normalize bucket history timestamps when all visible entries are empty, including the case where only hidden attachment metadata entries contain records. This prevents `oldest_record` from leaking the internal `u64::MAX` sentinel to API clients and being rendered as a huge history duration in the web console.

A regression test covers an attachment-only bucket entry where the visible parent entry has zero records.

### Related issues

https://github.com/reductstore/reductstore/issues/1533

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo fmt --all`
- `cargo test -p reductstore test_bucket_info_normalizes_history_when_only_meta_entries_have_records`
