### PR TITLE
auto-create missing replication destination buckets

### DIFF
--- a/.github/actions/replication-test/action.yml
+++ b/.github/actions/replication-test/action.yml
@@ -48,7 +48,6 @@ runs:
           --env RS_LOG_LEVEL=DEBUG \
           --env RS_API_TOKEN=${{ inputs.rs_api_token }} \
           --env RS_BUCKET_1_NAME=src \
-          --env RS_BUCKET_2_NAME=dest \
           --env RS_REPLICATION_1_NAME=replication \
           --env RS_REPLICATION_1_SRC_BUCKET=src \
           --env RS_REPLICATION_1_DST_BUCKET=dest \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey
+
 - Configure server-wide default bucket settings with `RS_DEFAULTS_BUCKET_*` environment variables, [PR-1535](https://github.com/reductstore/reductstore/pull/1535) by @rohankumardubey
 - Reject record writes before writing when the data folder filesystem has insufficient free disk space, in addition to the existing quota check, [PR-1525](https://github.com/reductstore/reductstore/pull/1525)
 - Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1526](https://github.com/reductstore/reductstore/pull/1526) by @upuddu

--- a/reductstore/src/replication/remote_bucket.rs
+++ b/reductstore/src/replication/remote_bucket.rs
@@ -151,6 +151,8 @@ pub(super) mod tests {
         impl ReductClientApi for ReductClientApi {
             async fn get_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError>;
 
+            async fn create_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError>;
+
             fn url(&self) -> &str;
         }
     }

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -23,6 +23,8 @@ use std::str::FromStr;
 pub(super) trait ReductClientApi {
     async fn get_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError>;
 
+    async fn create_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError>;
+
     fn url(&self) -> &str;
 }
 
@@ -218,6 +220,22 @@ impl ReductClientApi for ReductClient {
     async fn get_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError> {
         let request = self.client_api.client().request(
             Method::GET,
+            &format!("{}{}/b/{}", self.server_url, API_PATH, bucket_name),
+        );
+
+        let resp = request.send().await;
+        check_response(resp)?;
+
+        Ok(Box::new(BucketWrapper {
+            server_url: self.server_url.clone(),
+            bucket_name: bucket_name.to_string(),
+            client: self.client_api.client().clone(),
+        }))
+    }
+
+    async fn create_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError> {
+        let request = self.client_api.client().request(
+            Method::POST,
             &format!("{}{}/b/{}", self.server_url, API_PATH, bucket_name),
         );
 

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -25,6 +25,22 @@ pub(super) trait ReductClientApi {
 
     async fn create_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError>;
 
+    async fn get_or_create_bucket(&self, bucket_name: &str) -> Result<BoxedBucketApi, ReductError> {
+        match self.get_bucket(bucket_name).await {
+            Ok(bucket) => Ok(bucket),
+            Err(err) if err.status() == ErrorCode::NotFound => {
+                match self.create_bucket(bucket_name).await {
+                    Ok(bucket) => Ok(bucket),
+                    Err(err) if err.status() == ErrorCode::Conflict => {
+                        self.get_bucket(bucket_name).await
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     fn url(&self) -> &str;
 }
 

--- a/reductstore/src/replication/remote_bucket/states.rs
+++ b/reductstore/src/replication/remote_bucket/states.rs
@@ -5,12 +5,32 @@ mod bucket_available;
 mod bucket_unavailable;
 mod initial_state;
 
+use crate::replication::remote_bucket::client_wrapper::{BoxedBucketApi, BoxedClientApi};
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::replication::Transaction;
 use async_trait::async_trait;
 pub(super) use initial_state::InitialState;
-use reduct_base::error::ReductError;
+use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::io::BoxedReadRecord;
+
+async fn get_or_create_bucket(
+    client: &BoxedClientApi,
+    bucket_name: &str,
+) -> Result<BoxedBucketApi, ReductError> {
+    match client.get_bucket(bucket_name).await {
+        Ok(bucket) => Ok(bucket),
+        Err(err) if err.status() == ErrorCode::NotFound => {
+            match client.create_bucket(bucket_name).await {
+                Ok(bucket) => Ok(bucket),
+                Err(err) if err.status() == ErrorCode::Conflict => {
+                    client.get_bucket(bucket_name).await
+                }
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
 
 /// A state of the remote bucket.
 

--- a/reductstore/src/replication/remote_bucket/states.rs
+++ b/reductstore/src/replication/remote_bucket/states.rs
@@ -5,32 +5,13 @@ mod bucket_available;
 mod bucket_unavailable;
 mod initial_state;
 
-use crate::replication::remote_bucket::client_wrapper::{BoxedBucketApi, BoxedClientApi};
+use crate::replication::remote_bucket::client_wrapper::BoxedClientApi;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::replication::Transaction;
 use async_trait::async_trait;
 pub(super) use initial_state::InitialState;
-use reduct_base::error::{ErrorCode, ReductError};
+use reduct_base::error::ReductError;
 use reduct_base::io::BoxedReadRecord;
-
-async fn get_or_create_bucket(
-    client: &BoxedClientApi,
-    bucket_name: &str,
-) -> Result<BoxedBucketApi, ReductError> {
-    match client.get_bucket(bucket_name).await {
-        Ok(bucket) => Ok(bucket),
-        Err(err) if err.status() == ErrorCode::NotFound => {
-            match client.create_bucket(bucket_name).await {
-                Ok(bucket) => Ok(bucket),
-                Err(err) if err.status() == ErrorCode::Conflict => {
-                    client.get_bucket(bucket_name).await
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err),
-    }
-}
 
 /// A state of the remote bucket.
 

--- a/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
@@ -3,6 +3,7 @@
 
 use crate::replication::remote_bucket::client_wrapper::BoxedClientApi;
 use crate::replication::remote_bucket::states::bucket_available::BucketAvailableState;
+use crate::replication::remote_bucket::states::get_or_create_bucket;
 use crate::replication::remote_bucket::states::RemoteBucketState;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::replication::Transaction;
@@ -28,8 +29,7 @@ impl RemoteBucketState for BucketUnavailableState {
         records: Vec<(BoxedReadRecord, Transaction)>,
     ) -> Box<dyn RemoteBucketState + Sync + Send> {
         if self.init_time.elapsed() > self.timeout {
-            let bucket = self.client.get_bucket(&self.bucket_name).await;
-            return match bucket {
+            return match get_or_create_bucket(&self.client, &self.bucket_name).await {
                 Ok(bucket) => {
                     let new_state = Box::new(BucketAvailableState::new(self.client, bucket));
                     new_state.write_batch(entry, records).await
@@ -56,7 +56,7 @@ impl RemoteBucketState for BucketUnavailableState {
     }
 
     async fn probe(self: Box<Self>) -> Box<dyn RemoteBucketState + Sync + Send> {
-        match self.client.get_bucket(&self.bucket_name).await {
+        match get_or_create_bucket(&self.client, &self.bucket_name).await {
             Ok(bucket) => Box::new(BucketAvailableState::new(self.client, bucket)),
             Err(err) => Box::new(BucketUnavailableState::new(
                 self.client,
@@ -93,7 +93,7 @@ mod tests {
     use crate::replication::remote_bucket::tests::{
         bucket, client, MockReductBucketApi, MockReductClientApi,
     };
-    use mockall::predicate;
+    use mockall::{predicate, Sequence};
     use reduct_base::error::{ErrorCode, ReductError};
     use rstest::rstest;
 
@@ -122,12 +122,95 @@ mod tests {
         client
             .expect_get_bucket()
             .with(predicate::eq("test_bucket"))
-            .return_once(move |_| Err(ReductError::not_found("")));
+            .return_once(move |_| Err(ReductError::bad_request("test error")));
+        client.expect_create_bucket().times(0);
 
         let state = state_without_timeout(client);
         let state = state.write_batch("test_entry", vec![]).await;
-        assert_eq!(state.last_result(), &Err(ReductError::not_found("")));
+        assert_eq!(
+            state.last_result(),
+            &Err(ReductError::bad_request("test error"))
+        );
         assert!(!state.is_available());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_bucket_missing_created(
+        mut client: MockReductClientApi,
+        mut bucket: MockReductBucketApi,
+    ) {
+        bucket
+            .expect_write_batch()
+            .with(predicate::eq("test_entry"), predicate::always())
+            .return_once(|_, _| Ok(ErrorRecordMap::new()));
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Err(ReductError::not_found("bucket not found")));
+        client
+            .expect_create_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Ok(Box::new(bucket)));
+
+        let state = state_without_timeout(client);
+        let state = state.write_batch("test_entry", vec![]).await;
+        assert!(state.last_result().is_ok());
+        assert!(state.is_available());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_bucket_missing_create_fails(mut client: MockReductClientApi) {
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Err(ReductError::not_found("bucket not found")));
+        client
+            .expect_create_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Err(ReductError::forbidden("denied")));
+
+        let state = state_without_timeout(client);
+        let state = state.write_batch("test_entry", vec![]).await;
+        assert_eq!(state.last_result(), &Err(ReductError::forbidden("denied")));
+        assert!(!state.is_available());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_bucket_created_concurrently(
+        mut client: MockReductClientApi,
+        mut bucket: MockReductBucketApi,
+    ) {
+        bucket
+            .expect_write_batch()
+            .with(predicate::eq("test_entry"), predicate::always())
+            .return_once(|_, _| Ok(ErrorRecordMap::new()));
+        let mut sequence = Sequence::new();
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Err(ReductError::not_found("bucket not found")));
+        client
+            .expect_create_bucket()
+            .with(predicate::eq("test_bucket"))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Err(ReductError::new(ErrorCode::Conflict, "already exists")));
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Ok(Box::new(bucket)));
+
+        let state = state_without_timeout(client);
+        let state = state.write_batch("test_entry", vec![]).await;
+        assert!(state.last_result().is_ok());
+        assert!(state.is_available());
     }
 
     #[rstest]
@@ -170,7 +253,8 @@ mod tests {
         client
             .expect_get_bucket()
             .with(predicate::eq("test_bucket"))
-            .return_once(move |_| Err(ReductError::not_found("")));
+            .return_once(move |_| Err(ReductError::bad_request("test error")));
+        client.expect_create_bucket().times(0);
 
         let state = state_without_timeout(client);
         let state = state.probe().await;

--- a/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
+++ b/reductstore/src/replication/remote_bucket/states/bucket_unavailable.rs
@@ -3,7 +3,6 @@
 
 use crate::replication::remote_bucket::client_wrapper::BoxedClientApi;
 use crate::replication::remote_bucket::states::bucket_available::BucketAvailableState;
-use crate::replication::remote_bucket::states::get_or_create_bucket;
 use crate::replication::remote_bucket::states::RemoteBucketState;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::replication::Transaction;
@@ -29,7 +28,7 @@ impl RemoteBucketState for BucketUnavailableState {
         records: Vec<(BoxedReadRecord, Transaction)>,
     ) -> Box<dyn RemoteBucketState + Sync + Send> {
         if self.init_time.elapsed() > self.timeout {
-            return match get_or_create_bucket(&self.client, &self.bucket_name).await {
+            return match self.client.get_or_create_bucket(&self.bucket_name).await {
                 Ok(bucket) => {
                     let new_state = Box::new(BucketAvailableState::new(self.client, bucket));
                     new_state.write_batch(entry, records).await
@@ -56,7 +55,7 @@ impl RemoteBucketState for BucketUnavailableState {
     }
 
     async fn probe(self: Box<Self>) -> Box<dyn RemoteBucketState + Sync + Send> {
-        match get_or_create_bucket(&self.client, &self.bucket_name).await {
+        match self.client.get_or_create_bucket(&self.bucket_name).await {
             Ok(bucket) => Box::new(BucketAvailableState::new(self.client, bucket)),
             Err(err) => Box::new(BucketUnavailableState::new(
                 self.client,

--- a/reductstore/src/replication/remote_bucket/states/initial_state.rs
+++ b/reductstore/src/replication/remote_bucket/states/initial_state.rs
@@ -4,7 +4,6 @@
 use crate::replication::remote_bucket::client_wrapper::{create_client, BoxedClientApi};
 use crate::replication::remote_bucket::states::bucket_available::BucketAvailableState;
 use crate::replication::remote_bucket::states::bucket_unavailable::BucketUnavailableState;
-use crate::replication::remote_bucket::states::get_or_create_bucket;
 use crate::replication::remote_bucket::states::RemoteBucketState;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::replication::remote_bucket::RemoteBucketConfig;
@@ -38,7 +37,7 @@ impl RemoteBucketState for InitialState {
         entry: &str,
         records: Vec<(BoxedReadRecord, Transaction)>,
     ) -> Box<dyn RemoteBucketState + Sync + Send> {
-        match get_or_create_bucket(&self.client, &self.bucket_name).await {
+        match self.client.get_or_create_bucket(&self.bucket_name).await {
             Ok(bucket) => {
                 // Bucket is available, transition to the available state and write the record.
                 let new_state = Box::new(BucketAvailableState::new(self.client, bucket));
@@ -62,7 +61,7 @@ impl RemoteBucketState for InitialState {
     }
 
     async fn probe(self: Box<Self>) -> Box<dyn RemoteBucketState + Sync + Send> {
-        match get_or_create_bucket(&self.client, &self.bucket_name).await {
+        match self.client.get_or_create_bucket(&self.bucket_name).await {
             Ok(bucket) => Box::new(BucketAvailableState::new(self.client, bucket)),
             Err(err) => Box::new(BucketUnavailableState::new(
                 self.client,

--- a/reductstore/src/replication/remote_bucket/states/initial_state.rs
+++ b/reductstore/src/replication/remote_bucket/states/initial_state.rs
@@ -4,6 +4,7 @@
 use crate::replication::remote_bucket::client_wrapper::{create_client, BoxedClientApi};
 use crate::replication::remote_bucket::states::bucket_available::BucketAvailableState;
 use crate::replication::remote_bucket::states::bucket_unavailable::BucketUnavailableState;
+use crate::replication::remote_bucket::states::get_or_create_bucket;
 use crate::replication::remote_bucket::states::RemoteBucketState;
 use crate::replication::remote_bucket::ErrorRecordMap;
 use crate::replication::remote_bucket::RemoteBucketConfig;
@@ -37,9 +38,7 @@ impl RemoteBucketState for InitialState {
         entry: &str,
         records: Vec<(BoxedReadRecord, Transaction)>,
     ) -> Box<dyn RemoteBucketState + Sync + Send> {
-        // Try to get the bucket.
-        let bucket = self.client.get_bucket(&self.bucket_name).await;
-        match bucket {
+        match get_or_create_bucket(&self.client, &self.bucket_name).await {
             Ok(bucket) => {
                 // Bucket is available, transition to the available state and write the record.
                 let new_state = Box::new(BucketAvailableState::new(self.client, bucket));
@@ -63,7 +62,7 @@ impl RemoteBucketState for InitialState {
     }
 
     async fn probe(self: Box<Self>) -> Box<dyn RemoteBucketState + Sync + Send> {
-        match self.client.get_bucket(&self.bucket_name).await {
+        match get_or_create_bucket(&self.client, &self.bucket_name).await {
             Ok(bucket) => Box::new(BucketAvailableState::new(self.client, bucket)),
             Err(err) => Box::new(BucketUnavailableState::new(
                 self.client,
@@ -87,8 +86,8 @@ mod tests {
     use crate::replication::remote_bucket::tests::{
         bucket, client, MockReductBucketApi, MockReductClientApi,
     };
-    use mockall::predicate;
-    use reduct_base::error::ReductError;
+    use mockall::{predicate, Sequence};
+    use reduct_base::error::{ErrorCode, ReductError};
     use rstest::rstest;
 
     #[rstest]
@@ -135,10 +134,108 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    async fn test_bucket_missing_created(
+        mut client: MockReductClientApi,
+        mut bucket: MockReductBucketApi,
+    ) {
+        bucket
+            .expect_write_batch()
+            .with(predicate::eq("test_entry"), predicate::always())
+            .return_once(|_, _| Ok(ErrorRecordMap::new()));
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Err(ReductError::not_found("bucket not found")));
+        client
+            .expect_create_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Ok(Box::new(bucket)));
+
+        let state = Box::new(InitialState {
+            client: Box::new(client),
+            bucket_name: "test_bucket".to_string(),
+            last_result: Ok(ErrorRecordMap::new()),
+        });
+
+        let state = state.write_batch("test_entry", vec![]).await;
+
+        assert_eq!(state.last_result(), &Ok(ErrorRecordMap::new()));
+        assert!(state.is_available());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_bucket_created_concurrently(
+        mut client: MockReductClientApi,
+        mut bucket: MockReductBucketApi,
+    ) {
+        bucket
+            .expect_write_batch()
+            .with(predicate::eq("test_entry"), predicate::always())
+            .return_once(|_, _| Ok(ErrorRecordMap::new()));
+        let mut sequence = Sequence::new();
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Err(ReductError::not_found("bucket not found")));
+        client
+            .expect_create_bucket()
+            .with(predicate::eq("test_bucket"))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Err(ReductError::new(ErrorCode::Conflict, "already exists")));
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(move |_| Ok(Box::new(bucket)));
+
+        let state = Box::new(InitialState {
+            client: Box::new(client),
+            bucket_name: "test_bucket".to_string(),
+            last_result: Ok(ErrorRecordMap::new()),
+        });
+
+        let state = state.write_batch("test_entry", vec![]).await;
+
+        assert_eq!(state.last_result(), &Ok(ErrorRecordMap::new()));
+        assert!(state.is_available());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_bucket_missing_create_fails(mut client: MockReductClientApi) {
+        client
+            .expect_get_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Err(ReductError::not_found("bucket not found")));
+        client
+            .expect_create_bucket()
+            .with(predicate::eq("test_bucket"))
+            .return_once(move |_| Err(ReductError::forbidden("denied")));
+
+        let state = Box::new(InitialState {
+            client: Box::new(client),
+            bucket_name: "test_bucket".to_string(),
+            last_result: Ok(ErrorRecordMap::new()),
+        });
+
+        let state = state.write_batch("test_entry", vec![]).await;
+
+        assert_eq!(state.last_result(), &Err(ReductError::forbidden("denied")));
+        assert!(!state.is_available());
+    }
+
+    #[rstest]
+    #[tokio::test]
     async fn test_bucket_unavailable(mut client: MockReductClientApi) {
         client
             .expect_get_bucket()
             .return_once(move |_| Err(ReductError::bad_request("test error")));
+        client.expect_create_bucket().times(0);
 
         let state = Box::new(InitialState {
             client: Box::new(client),
@@ -178,6 +275,7 @@ mod tests {
         client
             .expect_get_bucket()
             .return_once(move |_| Err(ReductError::bad_request("test error")));
+        client.expect_create_bucket().times(0);
 
         let state = Box::new(InitialState {
             client: Box::new(client),


### PR DESCRIPTION
Closes #1537

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not required)
- [ ] CHANGELOG.md has been updated (will be added after the PR number is available)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Replication now creates a missing destination bucket before failing.

When the destination bucket lookup returns `404 Not Found`, ReductStore creates the bucket using only its name and continues replication. If another process creates the bucket at the same time, a `409 Conflict` triggers a retry of the bucket lookup.

Added unit coverage for successful creation, concurrent creation, and creation failures. Updated the replication test setup so the destination bucket is not pre-created.

### Related issues

https://github.com/reductstore/reductstore/issues/1537

### Does this PR introduce a breaking change?

No.

### Other information:

The destination bucket is created without copying source bucket settings. Users who need specific bucket settings should provision the destination bucket in advance.