### PR TITLE
fix replication meta test transient reads

### DIFF
--- a/integration_tests/data_check/replication_meta_test.py
+++ b/integration_tests/data_check/replication_meta_test.py
@@ -37,8 +37,12 @@ async def wait_until(
 ):
     deadline = time.time() + timeout_s
     while time.time() < deadline:
-        if await predicate():
-            return
+        try:
+            if await predicate():
+                return
+        except ReductError as err:
+            if err.status_code not in (404, 409, 425):
+                raise
         await asyncio.sleep(step_s)
     raise AssertionError(f"Timed out waiting for {label}")
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The replication metadata integration test now treats transient read errors the same way as the read-only replica test while polling.

When a replicated `$meta` record is visible but still being written, ReductStore returns `425 Too Early`. Previously `replication_meta_test.py` let that error escape from the polling loop, which made the test fail intermittently instead of waiting for the next poll interval.

The wait loop now ignores temporary `404`, `409`, and `425` statuses while polling, matching `integration_tests/deployment/read_only_replica_test.py`.

### Related issues

Observed in PR #1539:
https://github.com/reductstore/reductstore/actions/runs/29152768348/job/86545849124?pr=1539

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `python3 -m py_compile integration_tests/data_check/replication_meta_test.py`

`black` was not available in the local environment (`No module named black`), but the edit follows the existing formatting.

No changelog entry is included because this is a test-only CI stability fix.
