### PR TITLE
fix(audit): resolve client_ip from multi-hop RFC 7239 Forwarded header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Resolve client IP from multi-hop RFC 7239 `Forwarded` headers so token IP allowlists compare against the real client instead of the proxy, [PR-1546](https://github.com/reductstore/reductstore/pull/1546) by @LordAizen1
 - Normalize bucket history timestamps when only attachment metadata entries contain records, [PR-1534](https://github.com/reductstore/reductstore/pull/1534)
 
 ## 1.20.9 - 2026-07-08

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Thanks to everyone who has contributed to ReductStore.
   <a href="https://github.com/victor1234"><img src="https://avatars.githubusercontent.com/u/1102205?v=4" width="48" height="48" alt="@victor1234" /></a>
   <a href="https://github.com/aschenbecherwespe"><img src="https://avatars.githubusercontent.com/u/94011659?v=4" width="48" height="48" alt="@aschenbecherwespe" /></a>
   <a href="https://github.com/renghen"><img src="https://avatars.githubusercontent.com/u/271285?v=4" width="48" height="48" alt="@renghen" /></a>
+  <a href="https://github.com/LordAizen1"><img src="https://avatars.githubusercontent.com/u/119096690?v=4" width="48" height="48" alt="@LordAizen1" /></a>
 </p>
 
 Your support fuels our passion and drives us to keep improving.

--- a/reductstore/src/api/http/middleware.rs
+++ b/reductstore/src/api/http/middleware.rs
@@ -220,6 +220,7 @@ mod tests {
     #[case("for=_hidden", None)]
     #[case("for=192.0.2.43, for=198.51.100.17", Some("192.0.2.43"))]
     #[case("for=192.0.2.43, for=198.51.100.17;proto=http", Some("192.0.2.43"))]
+    #[case("for=_hidden, for=198.51.100.17;proto=http", Some("198.51.100.17"))]
     fn parses_forwarded_header(#[case] input: &str, #[case] expected: Option<&str>) {
         assert_eq!(
             parse_forwarded_for(input).map(|ip| ip.to_string()),

--- a/reductstore/src/api/http/middleware.rs
+++ b/reductstore/src/api/http/middleware.rs
@@ -218,6 +218,8 @@ mod tests {
     #[case("for=\"[2001:db8:cafe::17]\"", Some("2001:db8:cafe::17"))]
     #[case("by=203.0.113.60;proto=http", None)]
     #[case("for=_hidden", None)]
+    #[case("for=192.0.2.43, for=198.51.100.17", Some("192.0.2.43"))]
+    #[case("for=192.0.2.43, for=198.51.100.17;proto=http", Some("192.0.2.43"))]
     fn parses_forwarded_header(#[case] input: &str, #[case] expected: Option<&str>) {
         assert_eq!(
             parse_forwarded_for(input).map(|ip| ip.to_string()),

--- a/reductstore/src/api/http/middleware/client_ip.rs
+++ b/reductstore/src/api/http/middleware/client_ip.rs
@@ -56,7 +56,16 @@ pub(super) fn parse_x_forwarded_for(value: &str) -> Option<IpAddr> {
 }
 
 pub(super) fn parse_forwarded_for(value: &str) -> Option<IpAddr> {
-    for part in value.split(';') {
+    // RFC 7239 allows several proxy hops separated by commas, with the
+    // originating client listed first. Within a hop the parameters are
+    // separated by semicolons. Return the first hop that carries a usable
+    // `for=` address, matching how `parse_x_forwarded_for` takes the first
+    // comma-separated element.
+    value.split(',').find_map(parse_forwarded_hop)
+}
+
+fn parse_forwarded_hop(hop: &str) -> Option<IpAddr> {
+    for part in hop.split(';') {
         let mut kv = part.splitn(2, '=');
         let key = kv.next()?.trim();
         let val = kv.next()?.trim();


### PR DESCRIPTION
Fixes #1545.

`parse_forwarded_for` only splits the `Forwarded` header on `;`, never on `,`.
RFC 7239 uses commas between proxy hops, so something like

    Forwarded: for=192.0.2.43, for=198.51.100.17

ends up shoving `192.0.2.43, for=198.51.100.17` into the first `for=` value.
That doesn't parse as an IP, so the function just returns `None`.

The annoying part is what happens next. Behind a trusted proxy that sends
`Forwarded` but no `X-Forwarded-For`, `client_ip_from_request` falls back to the
proxy's own IP. So if a token has an IP allowlist, it gets checked against the
proxy IP instead of the real client and the request is rejected with
`Token is not allowed for client IP <proxy-ip>`. It fails closed, so it's not a
bypass, just a valid client getting locked out. Same thing as #1288, which was
fixed for `X-Forwarded-For` in #1296. The `Forwarded` path never got the same
treatment.

To be fair this is fairly narrow. Most proxies send `X-Forwarded-For` too and
the code falls through to that, so you only hit it with a spec-compliant
`Forwarded` header and no XFF.

The fix splits on `,` first and runs the existing per-hop parsing on each piece,
taking the first hop with a real `for=` IP. That's the same thing
`parse_x_forwarded_for` already does with its first element. I just pulled the
per-hop logic into a helper, didn't change it.

Added two cases to the existing `parses_forwarded_header` rstest for the
multi-hop header (one with a trailing `;proto=http` on the second hop). The old
single-hop cases have no comma, so nothing changes for them.
