### PR TITLE
Add per-run limits to lifecycle policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey
 - Add a replication `compression` setting (`none`, `zstd`, `gzip`, default `none`) that compresses batch payloads during transfer using HTTP `Content-Encoding`, [Issue-1348](https://github.com/reductstore/reductstore/issues/1348) by @DibbayajyotiRoy
+- Add a `processing_interval` setting to lifecycle policies that bounds how much data time a single run processes (defaults to `24 * interval` when unset), configurable via the API and `RS_LIFECYCLE_<ID>_PROCESSING_INTERVAL`, [PR-1549](https://github.com/reductstore/reductstore/pull/1549) by @Harshal875
 - Configure server-wide default bucket settings with `RS_DEFAULTS_BUCKET_*` environment variables, [PR-1535](https://github.com/reductstore/reductstore/pull/1535) by @rohankumardubey
 - Reject record writes before writing when the data folder filesystem has insufficient free disk space, in addition to the existing quota check, [PR-1525](https://github.com/reductstore/reductstore/pull/1525)
 - Support glob-like entry patterns in lifecycle task filters, including path-aware `*` and `**` wildcards and exclusion patterns, [PR-1526](https://github.com/reductstore/reductstore/pull/1526) by @upuddu

--- a/reduct_base/src/msg/lifecycle_api.rs
+++ b/reduct_base/src/msg/lifecycle_api.rs
@@ -57,6 +57,10 @@ pub struct LifecycleSettings {
     /// When condition.
     #[serde(default)]
     pub when: Option<Value>,
+    /// Maximum timestamp range processed in one run, e.g. "12h" or "1d".
+    /// If not set, the run window defaults to 24 times the interval.
+    #[serde(default)]
+    pub processing_interval: Option<String>,
     /// Lifecycle mode.
     #[serde(default)]
     pub mode: LifecycleMode,
@@ -71,6 +75,7 @@ impl Default for LifecycleSettings {
             older_than: String::default(),
             interval: default_lifecycle_interval(),
             when: Option::default(),
+            processing_interval: Option::default(),
             mode: LifecycleMode::default(),
         }
     }
@@ -174,6 +179,39 @@ mod tests {
         .unwrap();
 
         assert_eq!(settings.mode, LifecycleMode::Enabled);
+    }
+
+    #[test]
+    fn lifecycle_settings_processing_interval_defaults_to_none() {
+        let settings: LifecycleSettings = serde_json::from_str(
+            r#"{
+                "type": "delete",
+                "bucket": "bucket-1",
+                "older_than": "1d"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(settings.processing_interval, None);
+    }
+
+    #[test]
+    fn lifecycle_settings_processing_interval_roundtrip() {
+        let settings: LifecycleSettings = serde_json::from_str(
+            r#"{
+                "type": "delete",
+                "bucket": "bucket-1",
+                "older_than": "1d",
+                "processing_interval": "12h"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(settings.processing_interval, Some("12h".to_string()));
+
+        let serialized = serde_json::to_string(&settings).unwrap();
+        let deserialized: LifecycleSettings = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, settings);
     }
 
     #[test]

--- a/reductstore/src/api/http/lifecycle.rs
+++ b/reductstore/src/api/http/lifecycle.rs
@@ -151,6 +151,24 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
+        async fn test_settings_with_processing_interval() {
+            let json = r#"{"type":"delete","bucket":"bucket-1","older_than":"30d","processing_interval":"6h"}"#;
+            let req = Request::builder().body(Body::from(json)).unwrap();
+            let body = LifecycleSettingsAxum::from_request(req, &()).await.unwrap();
+            assert_eq!(body.0.processing_interval, Some("6h".to_string()));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_settings_processing_interval_defaults_to_none() {
+            let json = r#"{"type":"delete","bucket":"bucket-1","older_than":"30d"}"#;
+            let req = Request::builder().body(Body::from(json)).unwrap();
+            let body = LifecycleSettingsAxum::from_request(req, &()).await.unwrap();
+            assert_eq!(body.0.processing_interval, None);
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_settings_invalid_json() {
             let req = Request::builder().body(Body::from("{bad")).unwrap();
             let err = LifecycleSettingsAxum::from_request(req, &())

--- a/reductstore/src/cfg/provision/lifecycle.rs
+++ b/reductstore/src/cfg/provision/lifecycle.rs
@@ -119,6 +119,12 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                 lifecycle.settings.interval = interval;
             }
 
+            if let Some(processing_interval) =
+                env.get_optional::<String>(&format!("RS_LIFECYCLE_{}_PROCESSING_INTERVAL", id))
+            {
+                lifecycle.settings.processing_interval = Some(processing_interval);
+            }
+
             if let Some(entries) =
                 env.get_optional::<String>(&format!("RS_LIFECYCLE_{}_ENTRIES", id))
             {
@@ -287,6 +293,26 @@ mod tests {
             settings.when,
             Some(serde_json::json!({"$eq": ["&label", "true"]}))
         );
+        assert_eq!(settings.processing_interval, None);
+    }
+
+    #[rstest]
+    fn parse_lifecycles_parses_processing_interval() {
+        let getter = TestEnvGetter::new(&[
+            ("RS_LIFECYCLE_A_NAME", "purge-sensors-30d"),
+            ("RS_LIFECYCLE_A_TYPE", "delete"),
+            ("RS_LIFECYCLE_A_BUCKET", "telemetry"),
+            ("RS_LIFECYCLE_A_OLDER_THAN", "30d"),
+            ("RS_LIFECYCLE_A_PROCESSING_INTERVAL", "6h"),
+        ]);
+        let mut env = Env::new(getter);
+        let lifecycles = CfgParser::<TestEnvGetter>::parse_lifecycles(&mut env);
+
+        let lifecycle = lifecycles.get("purge-sensors-30d").unwrap();
+        assert_eq!(
+            lifecycle.settings.processing_interval,
+            Some("6h".to_string())
+        );
     }
 
     #[rstest]
@@ -454,6 +480,7 @@ mod tests {
                 older_than: "1d".to_string(),
                 interval: "1h".to_string(),
                 when: None,
+                processing_interval: None,
                 mode: LifecycleMode::Enabled,
             },
         )
@@ -500,6 +527,7 @@ mod tests {
                 older_than: "1d".to_string(),
                 interval: "1h".to_string(),
                 when: None,
+                processing_interval: None,
                 mode: LifecycleMode::Enabled,
             },
         )

--- a/reductstore/src/lifecycle/README.md
+++ b/reductstore/src/lifecycle/README.md
@@ -28,7 +28,8 @@ The module is built around three layers:
 The repository owns all configured lifecycle policies.
 
 Each policy becomes a `LifecycleTask` with:
-- immutable policy settings for bucket, entries, interval, and `older_than`
+- immutable policy settings for bucket, entries, interval, `older_than`, and
+  an optional `processing_interval`
 - a concrete action implementation selected by lifecycle type
 - a shared storage handle
 - optional system-event sink
@@ -88,6 +89,9 @@ When system events are disabled, actions process the full eligible data range:
 - `start = oldest matching record`
 - `stop = min(latest matching record + 1, now - older_than + 1)`
 
+If `processing_interval` is set, `stop` is additionally clamped to
+`start + processing_interval`.
+
 When system events are enabled, lifecycle uses persisted progress from the latest lifecycle stats event:
 - progress source: `$system/lifecycle/<instance>/<policy>`
 - stored field: `last_processed_ts`
@@ -97,11 +101,11 @@ The shared window calculation works like this:
 2. Find the latest matching record across selected entries.
 3. Compute `effective_cutoff_stop = min(latest_matching_record + 1, now - older_than + 1)`.
 4. Load `last_processed_ts`; if absent, start from the oldest matching record.
-5. Advance by a bounded data window: `24 * interval`.
+5. Advance by a bounded data window: `processing_interval` if set, otherwise `24 * interval`.
 
 Effective range for one run:
 - `start = oldest matching record`, clamped so `start <= stop`
-- `stop = min(last_processed_ts + 24 * interval, effective_cutoff_stop)`
+- `stop = min(last_processed_ts + data_window, effective_cutoff_stop)`
 
 Important behavior:
 - tasks always scan from the oldest matching record
@@ -109,6 +113,19 @@ Important behavior:
 - this allows old data to be re-processed if later mutations make it eligible again
   for example: label updates after delete rules, or decompressed blocks after compress rules
 - `caught_up` means the current run reached the effective stop for the currently visible data
+
+## Processing Interval
+
+An optional `processing_interval` setting bounds how much data time a single
+run processes:
+
+- `processing_interval`: maximum span of data time per run (e.g. `6h`). When
+  set, it replaces the default `24 * interval` data window and also bounds the
+  full-range window used when system events are disabled.
+
+Bounding each run keeps individual runs cheap on buckets with a large backlog;
+successive scheduled runs advance the window until they reach the current
+cutoff.
 
 ## Why Tasks Always Start From The Oldest Record
 
@@ -161,6 +178,7 @@ The same event stream is also used as the source of persisted lifecycle progress
 The repository is responsible for:
 - validating lifecycle settings
 - enforcing minimum `older_than` and interval limits
+- validating `processing_interval`: it must be a positive duration
 - persisting lifecycle definitions in `.lifecycles`
 - starting and stopping tasks
 - switching task mode at runtime

--- a/reductstore/src/lifecycle/action/progress.rs
+++ b/reductstore/src/lifecycle/action/progress.rs
@@ -27,8 +27,23 @@ pub(crate) async fn processing_window(
     let (first_record_start, effective_cutoff_stop) =
         matching_record_window(settings, context, cutoff_stop).await?;
 
+    let processing_interval_us = settings
+        .processing_interval
+        .as_ref()
+        .map(|interval| parse_duration_to_micros(interval))
+        .transpose()?
+        .map(|interval| interval.max(0) as u64);
+
     if !context.system_events_enabled {
-        let stop = effective_cutoff_stop;
+        // Without persisted progress, the processing interval still bounds
+        // each run: processed data becomes ineligible, so the window
+        // advances anyway.
+        let stop = match processing_interval_us {
+            Some(interval) => first_record_start
+                .saturating_add(interval)
+                .min(effective_cutoff_stop),
+            None => effective_cutoff_stop,
+        };
         return Ok(ProcessingWindow {
             start: Some(first_record_start.min(stop)),
             stop: Some(stop),
@@ -38,7 +53,7 @@ pub(crate) async fn processing_window(
     }
 
     let interval_us = parse_duration_to_micros(&settings.interval)?.max(0) as u64;
-    let data_window = interval_us.saturating_mul(24);
+    let data_window = processing_interval_us.unwrap_or_else(|| interval_us.saturating_mul(24));
     let last_processed = read_progress(
         &context.storage,
         &context.system_event_instance,
@@ -411,6 +426,73 @@ pub(super) mod tests {
         assert_eq!(window.stop, Some(101));
         assert_eq!(window.last_processed_ts, Some(101));
         assert!(window.reaches_cutoff);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn processing_window_uses_processing_interval_instead_of_default_window() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let mut settings = settings_fixture();
+        settings.interval = "1s".to_string();
+        settings.processing_interval = Some("2s".to_string());
+        write_lifecycle_stats(&storage, "instance-1", "policy-1", 1_000_000)
+            .await
+            .unwrap();
+        write(&bucket, "entry-1", 50, b"old").await.unwrap();
+        write(&bucket, "entry-1", 50_000_000, b"newer")
+            .await
+            .unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, true, "instance-1".to_string()),
+            "policy-1",
+            u64::MAX,
+        )
+        .await
+        .unwrap();
+
+        // The window advances by processing_interval (2s), not 24 * interval (24s).
+        assert_eq!(window.start, Some(50));
+        assert_eq!(window.stop, Some(3_000_000));
+        assert_eq!(window.last_processed_ts, Some(3_000_000));
+        assert!(!window.reaches_cutoff);
+    }
+
+    #[tokio::test]
+    async fn processing_window_clamps_full_range_to_processing_interval_without_system_events() {
+        let storage = storage().await;
+        let bucket = storage
+            .get_bucket("bucket-1")
+            .await
+            .unwrap()
+            .upgrade()
+            .unwrap();
+        let mut settings = settings_fixture();
+        settings.processing_interval = Some("2s".to_string());
+        write(&bucket, "entry-1", 50, b"old").await.unwrap();
+        write(&bucket, "entry-1", 50_000_000, b"newer")
+            .await
+            .unwrap();
+
+        let window = processing_window(
+            &settings,
+            &LifecycleContext::new(storage, false, "unknown".to_string()),
+            "policy-1",
+            u64::MAX,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(window.start, Some(50));
+        assert_eq!(window.stop, Some(2_000_050));
+        assert_eq!(window.last_processed_ts, None);
+        assert!(!window.reaches_cutoff);
     }
 
     pub(crate) async fn write_lifecycle_stats(

--- a/reductstore/src/lifecycle/lifecycle_repository/repo.rs
+++ b/reductstore/src/lifecycle/lifecycle_repository/repo.rs
@@ -309,6 +309,23 @@ impl LifecycleRepository {
             ));
         }
 
+        if let Some(processing_interval) = &settings.processing_interval {
+            let processing_interval_us =
+                parse_duration_to_micros(processing_interval).map_err(|err| {
+                    unprocessable_entity!(
+                        "Invalid lifecycle processing_interval '{}': {}",
+                        processing_interval,
+                        err
+                    )
+                })?;
+            if processing_interval_us <= 0 {
+                return Err(unprocessable_entity!(
+                    "Lifecycle processing_interval '{}' must be positive",
+                    processing_interval
+                ));
+            }
+        }
+
         if settings.lifecycle_type == LifecycleType::Compress && settings.when.is_some() {
             return Err(unprocessable_entity!(
                 "Lifecycle type 'compress' does not support 'when' condition"
@@ -611,6 +628,22 @@ mod tests {
         },
         unprocessable_entity!("Lifecycle type 'compress' does not support 'when' condition")
     )]
+    #[case::bad_processing_interval(
+        LifecycleSettings {
+            processing_interval: Some("6hours".to_string()),
+            ..settings_fixture()
+        },
+        unprocessable_entity!(
+            "Invalid lifecycle processing_interval '6hours': [UnprocessableEntity] Invalid duration unit: hours"
+        )
+    )]
+    #[case::zero_processing_interval(
+        LifecycleSettings {
+            processing_interval: Some("0s".to_string()),
+            ..settings_fixture()
+        },
+        unprocessable_entity!("Lifecycle processing_interval '0s' must be positive")
+    )]
     #[tokio::test]
     async fn rejects_invalid_settings(
         #[future] mut repo: LifecycleRepository,
@@ -629,6 +662,44 @@ mod tests {
         let settings = LifecycleSettings {
             lifecycle_type: LifecycleType::Compress,
             when: None,
+            ..settings_fixture()
+        };
+
+        repo.create_lifecycle("test", settings.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(repo.get_lifecycle_settings("test").await.unwrap(), settings);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn creates_delete_lifecycle_with_processing_interval(
+        #[future] mut repo: LifecycleRepository,
+    ) {
+        let mut repo = repo.await;
+        let settings = LifecycleSettings {
+            processing_interval: Some("6h".to_string()),
+            ..settings_fixture()
+        };
+
+        repo.create_lifecycle("test", settings.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(repo.get_lifecycle_settings("test").await.unwrap(), settings);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn creates_compress_lifecycle_with_processing_interval(
+        #[future] mut repo: LifecycleRepository,
+    ) {
+        let mut repo = repo.await;
+        let settings = LifecycleSettings {
+            lifecycle_type: LifecycleType::Compress,
+            when: None,
+            processing_interval: Some("6h".to_string()),
             ..settings_fixture()
         };
 

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -666,6 +666,7 @@ pub(super) mod tests {
             older_than: "1d".to_string(),
             interval: "100ms".to_string(),
             when: None,
+            processing_interval: None,
             mode,
         };
 
@@ -711,6 +712,7 @@ pub(super) mod tests {
             older_than: "1h".to_string(),
             interval: "1h".to_string(),
             when: None,
+            processing_interval: None,
             mode: LifecycleMode::Enabled,
         }
     }


### PR DESCRIPTION
Lifecycle policies previously used a fixed per-run data-time window of `24 * interval` when persisted lifecycle progress was available, and processed the full eligible range when system events were disabled. Large backlogs could therefore make a single run too expensive.

This PR adds one optional setting:

- `processing_interval`: maximum span of data time processed by one lifecycle run, for example `6h`, `12h`, or `1d`.

Behavior:

- If unset, existing behavior is preserved: lifecycle uses the default `24 * interval` data window.
- If set, `processing_interval` replaces the default data window when lifecycle progress is available.
- If system events are disabled, `processing_interval` still clamps the full-range processing window.
- The value is validated as a positive duration.
- The setting is available through the lifecycle API as `processing_interval`.
- The setting is available through provisioning as `RS_LIFECYCLE_<ID>_PROCESSING_INTERVAL`.
- The setting applies to both delete and compress lifecycle policies.

Follow-up SDK and public documentation task: #1577

Closes #1463