### PR TITLE
fix(cfg): default RS_SYSTEM_EVENTS_QUOTA_SIZE to 10 GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Default `RS_SYSTEM_EVENTS_QUOTA_SIZE` to 10 GB when it is not set, [Issue-1551](https://github.com/reductstore/reductstore/issues/1551) by @LordAizen1
 - Allow fork pull request CI to run without protobuf setup tokens or Docker Hub credentials by vendoring `protoc` and making Docker login optional, [PR-1532](https://github.com/reductstore/reductstore/pull/1532)
 - Pipelined replication batch sending to overlap preparing the next batch with sending the current one, [PR-1527](https://github.com/reductstore/reductstore/pull/1527) by @DibbayajyotiRoy (based on [PR-1415](https://github.com/reductstore/reductstore/pull/1415) by @FirasCh3)
 - Split block manager storage logic into smaller modules by responsibility, [PR-1503](https://github.com/reductstore/reductstore/pull/1503) by @rohankumardubey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Default `RS_SYSTEM_EVENTS_QUOTA_SIZE` to 10 GB when it is not set, [Issue-1551](https://github.com/reductstore/reductstore/issues/1551) by @LordAizen1
+- Default `RS_SYSTEM_EVENTS_QUOTA_SIZE` to 10 GB when it is not set, [PR-1556](https://github.com/reductstore/reductstore/pull/1556) by @LordAizen1
 - Allow fork pull request CI to run without protobuf setup tokens or Docker Hub credentials by vendoring `protoc` and making Docker login optional, [PR-1532](https://github.com/reductstore/reductstore/pull/1532)
 - Pipelined replication batch sending to overlap preparing the next batch with sending the current one, [PR-1527](https://github.com/reductstore/reductstore/pull/1527) by @DibbayajyotiRoy (based on [PR-1415](https://github.com/reductstore/reductstore/pull/1415) by @FirasCh3)
 - Split block manager storage logic into smaller modules by responsibility, [PR-1503](https://github.com/reductstore/reductstore/pull/1503) by @rohankumardubey

--- a/reductstore/src/cfg/system_events.rs
+++ b/reductstore/src/cfg/system_events.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 
 const DEFAULT_SYSTEM_EVENTS_ENABLED: bool = true;
 const DEFAULT_SYSTEM_EVENTS_LOG_LEVEL: Level = Level::Warn;
+/// 10 GB in SI notation, matching how the other size settings are expressed.
+const DEFAULT_SYSTEM_EVENTS_QUOTA_SIZE: u64 = 10_000_000_000;
 const DEFAULT_SYSTEM_EVENTS_REMOTE_VERIFY_SSL: bool = true;
 const DEFAULT_SYSTEM_EVENTS_REMOTE_TIMEOUT_S: u64 = 5;
 
@@ -32,7 +34,7 @@ impl Default for SystemEventsConfig {
         Self {
             enabled: DEFAULT_SYSTEM_EVENTS_ENABLED,
             log_level: Some(DEFAULT_SYSTEM_EVENTS_LOG_LEVEL),
-            quota_size: None,
+            quota_size: Some(DEFAULT_SYSTEM_EVENTS_QUOTA_SIZE),
             remote_verify_ssl: DEFAULT_SYSTEM_EVENTS_REMOTE_VERIFY_SSL,
             remote_ca_path: None,
             remote_timeout: Duration::from_secs(DEFAULT_SYSTEM_EVENTS_REMOTE_TIMEOUT_S),
@@ -55,9 +57,10 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
                 .map_or(Some(DEFAULT_SYSTEM_EVENTS_LOG_LEVEL), |level| {
                     parse_log_level(&level)
                 }),
-            quota_size: env
-                .get_optional::<ByteSize>("RS_SYSTEM_EVENTS_QUOTA_SIZE")
-                .map(|size| size.as_u64()),
+            quota_size: Some(
+                env.get_optional::<ByteSize>("RS_SYSTEM_EVENTS_QUOTA_SIZE")
+                    .map_or(DEFAULT_SYSTEM_EVENTS_QUOTA_SIZE, |size| size.as_u64()),
+            ),
             remote_verify_ssl: env
                 .get_optional("RS_SYSTEM_EVENTS_REMOTE_VERIFY_SSL")
                 .unwrap_or(DEFAULT_SYSTEM_EVENTS_REMOTE_VERIFY_SSL),
@@ -148,7 +151,7 @@ mod tests {
             SystemEventsConfig {
                 enabled: true,
                 log_level: Some(Level::Warn),
-                quota_size: None,
+                quota_size: Some(10_000_000_000),
                 remote_verify_ssl: true,
                 remote_ca_path: None,
                 remote_timeout: Duration::from_secs(5),
@@ -170,7 +173,7 @@ mod tests {
             SystemEventsConfig {
                 enabled: true,
                 log_level: Some(Level::Warn),
-                quota_size: None,
+                quota_size: Some(10_000_000_000),
                 remote_verify_ssl: true,
                 remote_ca_path: None,
                 remote_timeout: Duration::from_secs(5),


### PR DESCRIPTION
Fixes #1551.

The `$system` bucket had no default quota, so leaving `RS_SYSTEM_EVENTS_QUOTA_SIZE` unset meant system events were stored without any quota. Every other setting in this module already has a `DEFAULT_SYSTEM_EVENTS_*` constant, this one was just missing.

Went with 10 GB in SI notation (10,000,000,000) as you said in the issue. That also matches how the rest of the code reads sizes: the bucket provisioning test asserts 1GB as `1_000_000_000`, and this module's own test asserts 10MB as `10_000_000`.

### Checked on a live server

Built and ran from this branch, no Docker image:

```
RS_DATA_PATH=./data cargo run -p reductstore --features "fs-backend"
```

With `RS_SYSTEM_EVENTS_QUOTA_SIZE` unset, `GET /api/v1/b/$system`:

```json
"settings": { "quota_type": "FIFO", "quota_size": 10000000000, ... }
```

Then restarted with `RS_SYSTEM_EVENTS_QUOTA_SIZE=5GB` to make sure an explicit value still wins:

```json
"settings": { "quota_type": "FIFO", "quota_size": 5000000000, ... }
```

### Tests

The two default tests were asserting `quota_size: None`, so they now assert the new default. `cargo test -p reductstore --lib cfg::` passes (125 tests).

Kept this to the default value only, #1550 stays separate as you suggested. I'll pick that one up next.
