### PR TITLE
fix(syslog): make $system a provisioned bucket and reapply its quota on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [Issue-1550](https://github.com/reductstore/reductstore/issues/1550) by @LordAizen1
 - Resolve client IP from multi-hop RFC 7239 `Forwarded` headers so token IP allowlists compare against the real client instead of the proxy, [PR-1546](https://github.com/reductstore/reductstore/pull/1546) by @LordAizen1
 - Normalize bucket history timestamps when only attachment metadata entries contain records, [PR-1534](https://github.com/reductstore/reductstore/pull/1534)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [Issue-1550](https://github.com/reductstore/reductstore/issues/1550) by @LordAizen1
+- Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [PR-1557](https://github.com/reductstore/reductstore/pull/1557) by @LordAizen1
 - Resolve client IP from multi-hop RFC 7239 `Forwarded` headers so token IP allowlists compare against the real client instead of the proxy, [PR-1546](https://github.com/reductstore/reductstore/pull/1546) by @LordAizen1
 - Normalize bucket history timestamps when only attachment metadata entries contain records, [PR-1534](https://github.com/reductstore/reductstore/pull/1534)
 

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -18,6 +18,7 @@ use crate::storage::engine::StorageEngine;
 use crate::storage::usage::UsageCounters;
 use aggregate::audit::BoxedSystemEventAggregator;
 use async_trait::async_trait;
+use log::error;
 use reduct_base::error::ReductError;
 use reduct_base::msg::bucket_api::{BucketSettings, QuotaType};
 use std::sync::Arc;
@@ -116,6 +117,44 @@ pub(crate) async fn build_logs_system_logger(
     SystemEventLoggerBuilder::new(SYSTEM_BUCKET_NAME, system_bucket_settings(cfg))
         .build(cfg, storage)
         .expect("logs system logger must build")
+}
+
+/// Reapply the configured settings to `$system` and mark it provisioned.
+///
+/// `$system` is created lazily by the local writer on the first event, so at
+/// startup it only exists on a restart. Two things have to happen there:
+///
+/// * `is_provisioned` lives in memory, so it is false again on every boot and
+///   has to be re-armed, otherwise the bucket can be removed through the API.
+/// * the settings are reapplied, so a changed `RS_SYSTEM_EVENTS_QUOTA_SIZE`
+///   takes effect on restart instead of only at first creation.
+///
+/// A replica forwards its events and keeps no local `$system`, so there is
+/// nothing to provision there.
+async fn provision_system_bucket(cfg: &Cfg, storage: &StorageEngine) {
+    if cfg.role == crate::cfg::InstanceRole::Replica {
+        return;
+    }
+
+    // Not created yet: the local writer provisions it when it writes the first
+    // event.
+    let Ok(bucket) = storage.get_bucket(SYSTEM_BUCKET_NAME).await else {
+        return;
+    };
+    let Ok(bucket) = bucket.upgrade() else {
+        return;
+    };
+
+    // `set_settings` refuses on a provisioned bucket, so step around the flag
+    // the same way `provision_buckets` does for user buckets.
+    bucket.set_provisioned(false);
+    if let Err(err) = bucket.set_settings(system_bucket_settings(cfg)).await {
+        error!(
+            "Failed to provision bucket '{}': {}",
+            SYSTEM_BUCKET_NAME, err
+        );
+    }
+    bucket.set_provisioned(true);
 }
 
 fn system_bucket_settings(cfg: &Cfg) -> BucketSettings {
@@ -250,6 +289,8 @@ pub(crate) async fn build_system_event_logger(
             instance_name: cfg.instance_name.clone(),
         });
     }
+
+    provision_system_bucket(cfg, &storage).await;
 
     let instance_name = cfg.instance_name.clone();
     // One shared writer for every family; the audit aggregator's flush handler
@@ -716,6 +757,73 @@ mod tests {
         assert!(!object.contains_key("error_code"));
         assert!(!object.contains_key("error_message"));
         assert!(!object.contains_key("last_processed_ts"));
+    }
+
+    /// Regression test for #1550: `$system` must behave as a provisioned bucket.
+    ///
+    /// Two guarantees, one per changed file:
+    ///
+    /// * On lazy creation the local writer marks `$system` provisioned, so it
+    ///   cannot be removed or reconfigured through the API.
+    /// * On restart `provision_system_bucket` re-arms that flag — it lives in
+    ///   memory and is lost on reload — and reapplies the configured quota, so a
+    ///   changed `RS_SYSTEM_EVENTS_QUOTA_SIZE` takes effect instead of staying
+    ///   pinned to the value from first creation.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn provisions_and_reapplies_quota_on_restart() {
+        let tmp_dir = tempdir().unwrap();
+        let mut cfg = Cfg {
+            data_path: tmp_dir.keep(),
+            ..Cfg::default()
+        };
+        cfg.system_events_conf.enabled = true;
+        cfg.system_events_conf.quota_size = Some(1_000_000_000);
+
+        let storage = Arc::new(
+            StorageEngine::builder()
+                .with_data_path(cfg.data_path.clone())
+                .with_cfg(cfg.clone())
+                .build()
+                .await,
+        );
+
+        // Lazy creation: writing the first event creates `$system`.
+        let mut repo = build_audit_logger(&cfg, Arc::clone(&storage)).await;
+        repo.log_event(make_event()).await.unwrap();
+        sleep(Duration::from_secs(AGGREGATION_WINDOW_SECS * 2)).await;
+
+        let bucket = storage
+            .get_bucket(SYSTEM_BUCKET_NAME)
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+        assert!(
+            bucket.is_provisioned(),
+            "the local writer must provision $system on creation"
+        );
+        assert_eq!(
+            bucket.settings().await.unwrap().quota_size,
+            Some(1_000_000_000)
+        );
+
+        // Mimic a restart: the provisioned flag lives in memory, so a reloaded
+        // engine sees it false again while the old quota still persists on disk.
+        // A second engine on the same path would block on the instance lock, so
+        // resetting the flag in place reproduces the post-reload state exactly.
+        bucket.set_provisioned(false);
+        cfg.system_events_conf.quota_size = Some(2_000_000_000);
+
+        provision_system_bucket(&cfg, &storage).await;
+
+        assert!(
+            bucket.is_provisioned(),
+            "restart must re-arm the provisioned flag"
+        );
+        assert_eq!(
+            bucket.settings().await.unwrap().quota_size,
+            Some(2_000_000_000),
+            "restart must reapply the configured system-events quota"
+        );
     }
 
     mod routing {

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -137,22 +137,17 @@ async fn provision_system_bucket(cfg: &Cfg, storage: &StorageEngine) {
     }
 
     // Not created yet: the local writer provisions it when it writes the first
-    // event.
+    // event, so on a fresh start there is nothing to reapply.
     let Ok(bucket) = storage.get_bucket(SYSTEM_BUCKET_NAME).await else {
         return;
     };
-    let Ok(bucket) = bucket.upgrade() else {
-        return;
-    };
+    let bucket = bucket.upgrade().unwrap();
 
     // `set_settings` refuses on a provisioned bucket, so step around the flag
     // the same way `provision_buckets` does for user buckets.
     bucket.set_provisioned(false);
     if let Err(err) = bucket.set_settings(system_bucket_settings(cfg)).await {
-        error!(
-            "Failed to provision bucket '{}': {}",
-            SYSTEM_BUCKET_NAME, err
-        );
+        error!("Failed to provision bucket '{SYSTEM_BUCKET_NAME}': {err}");
     }
     bucket.set_provisioned(true);
 }
@@ -824,6 +819,45 @@ mod tests {
             Some(2_000_000_000),
             "restart must reapply the configured system-events quota"
         );
+    }
+
+    /// A replica keeps no local `$system`, so provisioning must leave it alone.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn provision_skips_replica() {
+        let (storage, mut cfg) = enabled_storage().await;
+
+        // Create `$system`, then drop the flag so we can tell whether a replica
+        // provision touches it.
+        let mut repo = build_audit_logger(&cfg, Arc::clone(&storage)).await;
+        repo.log_event(make_event()).await.unwrap();
+        sleep(Duration::from_secs(AGGREGATION_WINDOW_SECS * 2)).await;
+        let bucket = storage
+            .get_bucket(SYSTEM_BUCKET_NAME)
+            .await
+            .unwrap()
+            .upgrade_and_unwrap();
+        bucket.set_provisioned(false);
+
+        cfg.role = crate::cfg::InstanceRole::Replica;
+        provision_system_bucket(&cfg, &storage).await;
+
+        assert!(
+            !bucket.is_provisioned(),
+            "a replica must not provision $system"
+        );
+    }
+
+    /// On a fresh start `$system` does not exist yet, so provisioning is a no-op
+    /// and must not panic.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn provision_noop_when_system_bucket_absent() {
+        let (storage, cfg) = enabled_storage().await;
+        // No event has been written, so `$system` is not created yet.
+        assert!(storage.get_bucket(SYSTEM_BUCKET_NAME).await.is_err());
+
+        provision_system_bucket(&cfg, &storage).await;
+
+        assert!(storage.get_bucket(SYSTEM_BUCKET_NAME).await.is_err());
     }
 
     mod routing {

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -47,9 +47,15 @@ impl LocalSystemLogger {
         {
             Ok(writer) => writer,
             Err(err) if err.status == ErrorCode::NotFound => {
-                self.storage
+                let bucket = self
+                    .storage
                     .create_system_bucket(self.bucket_name, self.bucket_settings.clone())
                     .await?;
+                // The server owns this bucket, so protect it from being removed,
+                // renamed or reconfigured through the API.
+                if let Ok(bucket) = bucket.upgrade() {
+                    bucket.set_provisioned(true);
+                }
                 self.storage
                     .begin_write(
                         self.bucket_name,


### PR DESCRIPTION
## Problem

Closes #1550.

Right now the `$system` bucket only picks up `RS_SYSTEM_EVENTS_QUOTA_SIZE` when
it's first created, and after that it acts like any normal bucket. That leaves
two problems:

- Anyone can delete `$system` through the API, so the server's own telemetry
  bucket isn't really protected.
- If you change `RS_SYSTEM_EVENTS_QUOTA_SIZE` and restart, nothing happens. The
  bucket just keeps whatever quota it had when it was first made.

## What this does

- `local_writer.rs`: when the writer creates `$system` on the first event, it
  now marks it provisioned, so it can't be removed, renamed or reconfigured
  through the API.
- `syslog.rs`: adds `provision_system_bucket`, which runs on startup. It re-arms
  the provisioned flag (that flag lives in memory, so it's gone after a reload)
  and re-applies the settings, so a changed quota actually takes effect.
  Replicas don't keep a local `$system`, so they get skipped.

## How I tested it

I ran a real server built from this branch with data on disk, then restarted it
with `RS_SYSTEM_EVENTS_QUOTA_SIZE` changed from 1GB to 2GB:

| | `is_provisioned` after restart | quota after restart | `DELETE /b/$system` |
|---|---|---|---|
| `main` | `false` | stuck at 1GB | 200, deleted |
| this branch | `true` | 2GB applied | 409, refused |

- Added a regression test `provisions_and_reapplies_quota_on_restart` that covers
  both parts: provisioned on creation, and the flag re-armed plus quota
  re-applied on restart.
- Ran `cargo fmt --all` and `cargo test -p reductstore --lib syslog::`, 71 passed.

## Notes

- No new config or feature flags. This only changes when the existing
  `RS_SYSTEM_EVENTS_QUOTA_SIZE` gets applied, now on every startup instead of
  just the first time.
- Updated `CHANGELOG.md` under Fixed.
