### PR TITLE
Feat/replicate system events 1457

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Replicate internal `$system` events when `$system` is a replication source by notifying replication from the system-event writer; to prevent feedback loops, diagnostics of a `$system`-source replication and log messages from the replication module are excluded, [Issue-1457](https://github.com/reductstore/reductstore/issues/1457) by @DibbayajyotiRoy
+- Replicate internal `$system` events when `$system` is a replication source by notifying replication from the system-event writer; to prevent feedback loops, diagnostics of a `$system`-source replication and log messages from the replication module are excluded, [PR-1567](https://github.com/reductstore/reductstore/pull/1567) by @DibbayajyotiRoy
 - Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [PR-1557](https://github.com/reductstore/reductstore/pull/1557) by @LordAizen1
 - Resolve client IP from multi-hop RFC 7239 `Forwarded` headers so token IP allowlists compare against the real client instead of the proxy, [PR-1546](https://github.com/reductstore/reductstore/pull/1546) by @LordAizen1
 - Normalize bucket history timestamps when only attachment metadata entries contain records, [PR-1534](https://github.com/reductstore/reductstore/pull/1534)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Replicate internal `$system` events (usage, audit, lifecycle) when `$system` is a replication source by notifying replication from the system-event writer; the `replications/` and `logs/` families are excluded to prevent feedback loops, [Issue-1457](https://github.com/reductstore/reductstore/issues/1457) by @DibbayajyotiRoy
+- Replicate internal `$system` events when `$system` is a replication source by notifying replication from the system-event writer; to prevent feedback loops, diagnostics of a `$system`-source replication and log messages from the replication module are excluded, [Issue-1457](https://github.com/reductstore/reductstore/issues/1457) by @DibbayajyotiRoy
 - Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [PR-1557](https://github.com/reductstore/reductstore/pull/1557) by @LordAizen1
 - Resolve client IP from multi-hop RFC 7239 `Forwarded` headers so token IP allowlists compare against the real client instead of the proxy, [PR-1546](https://github.com/reductstore/reductstore/pull/1546) by @LordAizen1
 - Normalize bucket history timestamps when only attachment metadata entries contain records, [PR-1534](https://github.com/reductstore/reductstore/pull/1534)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replicate internal `$system` events (usage, audit, lifecycle) when `$system` is a replication source by notifying replication from the system-event writer; the `replications/` and `logs/` families are excluded to prevent feedback loops, [Issue-1457](https://github.com/reductstore/reductstore/issues/1457) by @DibbayajyotiRoy
 - Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [PR-1557](https://github.com/reductstore/reductstore/pull/1557) by @LordAizen1
 - Resolve client IP from multi-hop RFC 7239 `Forwarded` headers so token IP allowlists compare against the real client instead of the proxy, [PR-1546](https://github.com/reductstore/reductstore/pull/1546) by @LordAizen1
 - Normalize bucket history timestamps when only attachment metadata entries contain records, [PR-1534](https://github.com/reductstore/reductstore/pull/1534)

--- a/reductstore/src/api/components.rs
+++ b/reductstore/src/api/components.rs
@@ -157,6 +157,14 @@ impl StateKeeper {
             error!("Failed to stop lifecycle policies: {}", err);
         }
 
+        // Detach the replication notifier BEFORE stopping the replication
+        // workers: the system-event collector keeps flushing during shutdown,
+        // and notifying a stopped repo only produces spurious warnings
+        // (issue #1457).
+        if let Err(err) = self.detach_replication_notifier().await {
+            error!("Failed to detach replication notifier: {}", err);
+        }
+
         if let Err(err) = self.stop_replication_tasks().await {
             error!("Failed to stop replication tasks: {}", err);
         }
@@ -168,6 +176,15 @@ impl StateKeeper {
         if let Err(err) = self.sync_storage().await {
             error!("Failed to shutdown storage: {}", err);
         }
+    }
+
+    async fn detach_replication_notifier(&self) -> Result<(), ReductError> {
+        let components = self.wait_components().await?.clone();
+        components
+            .system_events
+            .set_replication_notifier(None)
+            .await;
+        Ok(())
     }
 
     async fn stop_replication_tasks(&self) -> Result<(), ReductError> {

--- a/reductstore/src/api/components.rs
+++ b/reductstore/src/api/components.rs
@@ -35,9 +35,8 @@ pub struct Components {
     pub(crate) auth: TokenAuthorization,
     pub(crate) token_repo: AsyncRwLock<Box<dyn ManageTokens + Send + Sync>>,
     pub(crate) console: Box<dyn ManageStaticAsset + Send + Sync>,
-    /// `Arc`-shared (issue #1457) so the components wiring can hand the
-    /// system-event writer a late-bound notify callback into this repo;
-    /// access through `Deref` is unchanged for every call site.
+    /// `Arc`-shared so the system-event writer can hold a notify callback
+    /// into this repo.
     pub(crate) replication_repo: Arc<AsyncRwLock<Box<dyn ManageReplications + Send + Sync>>>,
     pub(crate) lifecycle_repo: AsyncRwLock<Box<dyn ManageLifecycles + Send + Sync>>,
     pub(crate) ext_repo: Box<dyn ManageExtensions + Send + Sync>,
@@ -157,10 +156,8 @@ impl StateKeeper {
             error!("Failed to stop lifecycle policies: {}", err);
         }
 
-        // Detach the replication notifier BEFORE stopping the replication
-        // workers: the system-event collector keeps flushing during shutdown,
-        // and notifying a stopped repo only produces spurious warnings
-        // (issue #1457).
+        // Detach the notifier before stopping replication so final telemetry
+        // flushes do not notify a stopped repo.
         if let Err(err) = self.detach_replication_notifier().await {
             error!("Failed to detach replication notifier: {}", err);
         }

--- a/reductstore/src/api/components.rs
+++ b/reductstore/src/api/components.rs
@@ -35,7 +35,10 @@ pub struct Components {
     pub(crate) auth: TokenAuthorization,
     pub(crate) token_repo: AsyncRwLock<Box<dyn ManageTokens + Send + Sync>>,
     pub(crate) console: Box<dyn ManageStaticAsset + Send + Sync>,
-    pub(crate) replication_repo: AsyncRwLock<Box<dyn ManageReplications + Send + Sync>>,
+    /// `Arc`-shared (issue #1457) so the components wiring can hand the
+    /// system-event writer a late-bound notify callback into this repo;
+    /// access through `Deref` is unchanged for every call site.
+    pub(crate) replication_repo: Arc<AsyncRwLock<Box<dyn ManageReplications + Send + Sync>>>,
     pub(crate) lifecycle_repo: AsyncRwLock<Box<dyn ManageLifecycles + Send + Sync>>,
     pub(crate) ext_repo: Box<dyn ManageExtensions + Send + Sync>,
     pub(crate) query_link_cache: AsyncRwLock<Cache<String, Arc<Mutex<BoxedReadRecord>>>>,

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -799,7 +799,7 @@ pub(crate) mod tests {
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
             console: create_asset_manager(console_bytes),
-            replication_repo: AsyncRwLock::new(replication_repo),
+            replication_repo: Arc::new(AsyncRwLock::new(replication_repo)),
             lifecycle_repo: AsyncRwLock::new(lifecycle_repo),
             system_events,
             ext_repo: create_ext_repository(
@@ -915,7 +915,7 @@ pub(crate) mod tests {
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
             console: create_asset_manager(console_bytes),
-            replication_repo: AsyncRwLock::new(replication_repo),
+            replication_repo: Arc::new(AsyncRwLock::new(replication_repo)),
             lifecycle_repo: AsyncRwLock::new(lifecycle_repo),
             system_events,
             ext_repo: create_ext_repository(
@@ -1007,7 +1007,7 @@ pub(crate) mod tests {
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
             console: create_asset_manager(console_bytes),
-            replication_repo: AsyncRwLock::new(replication_repo),
+            replication_repo: Arc::new(AsyncRwLock::new(replication_repo)),
             lifecycle_repo: AsyncRwLock::new(lifecycle_repo),
             ext_repo: create_ext_repository(
                 None,

--- a/reductstore/src/api/http/middleware/audit.rs
+++ b/reductstore/src/api/http/middleware/audit.rs
@@ -133,6 +133,7 @@ async fn write_audit_event(
 
     let event = SystemEvent {
         kind: SystemEventKind::Audit,
+        replicate: true,
         event_type: "api_call".to_string(),
         timestamp: SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -418,9 +418,23 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         // (`sink()`) over that same writer.
         let system_events =
             build_system_event_logger(&self.cfg, Arc::clone(&storage), usage_counters).await;
-        let replication_engine = self
-            .provision_replication_repo(Arc::clone(&storage), system_events.sink())
-            .await?;
+        let replication_engine = Arc::new(AsyncRwLock::new(
+            self.provision_replication_repo(Arc::clone(&storage), system_events.sink())
+                .await?,
+        ));
+        // Late-bind the replication notifier (issue #1457): the `$system`
+        // writer was built before the repo existed, so register the notify
+        // callback now. System-event writes then replicate like API writes
+        // (the writer itself excludes the replications/ and logs/ families).
+        {
+            let repo = Arc::clone(&replication_engine);
+            system_events
+                .set_replication_notifier(Arc::new(move |notification| {
+                    let repo = Arc::clone(&repo);
+                    Box::pin(async move { repo.write().await?.notify(notification).await })
+                }))
+                .await;
+        }
         let ext_path = if let Some(ext_path) = &self.cfg.ext_path {
             Some(PathBuf::try_from(ext_path).map_err(|e| {
                 internal_server_error!(
@@ -449,7 +463,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             token_repo: AsyncRwLock::new(token_repo.await),
             auth: TokenAuthorization::new(&self.cfg.api_token),
             console,
-            replication_repo: AsyncRwLock::new(replication_engine),
+            replication_repo: replication_engine,
             lifecycle_repo: AsyncRwLock::new(lifecycle_engine),
             ext_repo: create_ext_repository(
                 ext_path,

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -429,10 +429,10 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         {
             let repo = Arc::clone(&replication_engine);
             system_events
-                .set_replication_notifier(Arc::new(move |notification| {
+                .set_replication_notifier(Some(Arc::new(move |notification| {
                     let repo = Arc::clone(&repo);
                     Box::pin(async move { repo.write().await?.notify(notification).await })
-                }))
+                })))
                 .await;
         }
         let ext_path = if let Some(ext_path) = &self.cfg.ext_path {

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -422,10 +422,8 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             self.provision_replication_repo(Arc::clone(&storage), system_events.sink())
                 .await?,
         ));
-        // Late-bind the replication notifier (issue #1457): the `$system`
-        // writer was built before the repo existed, so register the notify
-        // callback now. System-event writes then replicate like API writes
-        // (the writer itself excludes the replications/ and logs/ families).
+        // Register the replication notifier so `$system` writes replicate
+        // like API writes.
         {
             let repo = Arc::clone(&replication_engine);
             system_events

--- a/reductstore/src/lifecycle/lifecycle_task.rs
+++ b/reductstore/src/lifecycle/lifecycle_task.rs
@@ -263,6 +263,7 @@ impl LifecycleTask {
 
         let event = SystemEvent {
             kind: SystemEventKind::Lifecycle,
+            replicate: true,
             event_type: "lifecycle_run".to_string(),
             timestamp: SystemTime::now()
                 .duration_since(UNIX_EPOCH)

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -169,8 +169,13 @@ impl ReplicationTask {
             // Aggregates replication diagnostics into periodic $system events,
             // driven inline by this worker loop (flushed on idle/cap each
             // iteration and on loop exit).
-            let mut diagnostics_aggregator = thr_system_event_sink
-                .map(|sink| ReplicationEventAggregator::new(sink, replication_name.clone()));
+            let mut diagnostics_aggregator = thr_system_event_sink.map(|sink| {
+                ReplicationEventAggregator::new(
+                    sink,
+                    replication_name.clone(),
+                    &thr_settings.src_bucket,
+                )
+            });
             let init_transaction_logs = async || {
                 let mut logs = thr_log_map.write().await?;
                 for entry in thr_storage

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -196,11 +196,8 @@ pub(crate) trait SystemEventLogger: Send + Sync {
     /// every other family is written straight through the shared writer.
     fn sink(&self) -> SystemEventSink;
 
-    /// Late-bind the replication notifier (issue #1457): the writer is built
-    /// before the replication repo, so the components wiring registers the
-    /// notify callback (`Some`) once the repo exists and clears it (`None`)
-    /// during shutdown before the replication workers stop. No-op by default
-    /// (disabled collector, replicas).
+    /// Register (`Some`) or clear (`None`) the replication notifier on the
+    /// shared writer. No-op by default (disabled collector, replicas).
     async fn set_replication_notifier(&self, _notifier: Option<ReplicationNotifier>) {}
 
     /// Stop the owned background tasks (usage timer, log capture), draining
@@ -247,9 +244,6 @@ impl LogSystemEvent for RoutingSystemLogger {
     }
 
     async fn set_replication_notifier(&mut self, notifier: Option<ReplicationNotifier>) {
-        // Forward to the shared writer (the local writer stores it; the
-        // forward writer's default no-op ignores it — a replica never notifies).
-        // Registration is best-effort: a poisoned lock only means no notifier.
         if let Ok(mut writer) = self.writer.write().await {
             writer.set_replication_notifier(notifier).await;
         }

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -198,9 +198,10 @@ pub(crate) trait SystemEventLogger: Send + Sync {
 
     /// Late-bind the replication notifier (issue #1457): the writer is built
     /// before the replication repo, so the components wiring registers the
-    /// notify callback here once the repo exists. No-op by default (disabled
-    /// collector, replicas).
-    async fn set_replication_notifier(&self, _notifier: ReplicationNotifier) {}
+    /// notify callback (`Some`) once the repo exists and clears it (`None`)
+    /// during shutdown before the replication workers stop. No-op by default
+    /// (disabled collector, replicas).
+    async fn set_replication_notifier(&self, _notifier: Option<ReplicationNotifier>) {}
 
     /// Stop the owned background tasks (usage timer, log capture), draining
     /// their final events. Telemetry must never break shutdown.
@@ -245,7 +246,7 @@ impl LogSystemEvent for RoutingSystemLogger {
         }
     }
 
-    async fn set_replication_notifier(&mut self, notifier: ReplicationNotifier) {
+    async fn set_replication_notifier(&mut self, notifier: Option<ReplicationNotifier>) {
         // Forward to the shared writer (the local writer stores it; the
         // forward writer's default no-op ignores it — a replica never notifies).
         // Registration is best-effort: a poisoned lock only means no notifier.
@@ -276,7 +277,7 @@ impl SystemEventLogger for EnabledSystemEventLogger {
         }
     }
 
-    async fn set_replication_notifier(&self, notifier: ReplicationNotifier) {
+    async fn set_replication_notifier(&self, notifier: Option<ReplicationNotifier>) {
         if let Ok(mut sink_logger) = self.sink_logger.write().await {
             sink_logger.set_replication_notifier(notifier).await;
         }
@@ -387,6 +388,7 @@ mod tests {
     fn make_event() -> SystemEvent {
         SystemEvent {
             kind: SystemEventKind::Audit,
+            replicate: true,
             event_type: "api_call".to_string(),
             timestamp: 1,
             instance: "test-instance".to_string(),
@@ -482,6 +484,7 @@ mod tests {
         logger
             .log_event(SystemEvent {
                 kind: SystemEventKind::Lifecycle,
+                replicate: true,
                 event_type: "lifecycle_run".to_string(),
                 timestamp: 100,
                 instance: "instance-1".to_string(),
@@ -537,6 +540,7 @@ mod tests {
     fn lifecycle_system_event(payload: Value, status: u16, message: &str) -> SystemEvent {
         SystemEvent {
             kind: SystemEventKind::Lifecycle,
+            replicate: true,
             event_type: "lifecycle_run".to_string(),
             timestamp: 100,
             instance: "instance-1".to_string(),

--- a/reductstore/src/syslog.rs
+++ b/reductstore/src/syslog.rs
@@ -25,7 +25,7 @@ use tokio::sync::Mutex;
 
 pub(crate) use aggregate::usage::UsageEventAggregator;
 pub(crate) use event::{SystemEvent, SystemEventKind};
-pub(crate) use sink::{BoxedSystemLogger, LogSystemEvent, SystemEventSink};
+pub(crate) use sink::{BoxedSystemLogger, LogSystemEvent, ReplicationNotifier, SystemEventSink};
 use system_event_logger::SystemEventLoggerBuilder;
 
 pub(crate) const AUDIT_BUCKET_NAME: &str = "$audit";
@@ -162,6 +162,12 @@ pub(crate) trait SystemEventLogger: Send + Sync {
     /// every other family is written straight through the shared writer.
     fn sink(&self) -> SystemEventSink;
 
+    /// Late-bind the replication notifier (issue #1457): the writer is built
+    /// before the replication repo, so the components wiring registers the
+    /// notify callback here once the repo exists. No-op by default (disabled
+    /// collector, replicas).
+    async fn set_replication_notifier(&self, _notifier: ReplicationNotifier) {}
+
     /// Stop the owned background tasks (usage timer, log capture), draining
     /// their final events. Telemetry must never break shutdown.
     async fn stop(&self);
@@ -204,6 +210,15 @@ impl LogSystemEvent for RoutingSystemLogger {
             self.writer.write().await?.log_event(event).await
         }
     }
+
+    async fn set_replication_notifier(&mut self, notifier: ReplicationNotifier) {
+        // Forward to the shared writer (the local writer stores it; the
+        // forward writer's default no-op ignores it — a replica never notifies).
+        // Registration is best-effort: a poisoned lock only means no notifier.
+        if let Ok(mut writer) = self.writer.write().await {
+            writer.set_replication_notifier(notifier).await;
+        }
+    }
 }
 
 /// The live collector: owns the routing sink logger and every background task.
@@ -224,6 +239,12 @@ impl SystemEventLogger for EnabledSystemEventLogger {
         SystemEventSink {
             system_logger: Arc::clone(&self.sink_logger),
             instance_name: self.instance_name.clone(),
+        }
+    }
+
+    async fn set_replication_notifier(&self, notifier: ReplicationNotifier) {
+        if let Ok(mut sink_logger) = self.sink_logger.write().await {
+            sink_logger.set_replication_notifier(notifier).await;
         }
     }
 

--- a/reductstore/src/syslog/aggregate/audit.rs
+++ b/reductstore/src/syslog/aggregate/audit.rs
@@ -113,6 +113,7 @@ pub(crate) fn make_event(key: AuditAggregateKey, aggregate: AuditAggregate) -> S
 
     SystemEvent {
         kind: SystemEventKind::Audit,
+        replicate: true,
         event_type: "api_call".to_string(),
         timestamp: aggregate.first_timestamp,
         instance: key.instance,
@@ -324,6 +325,7 @@ mod tests {
 
         SystemEvent {
             kind: SystemEventKind::Audit,
+            replicate: true,
             event_type: "api_call".to_string(),
             timestamp,
             instance: "instance-a".to_string(),
@@ -643,6 +645,7 @@ mod tests {
 
         tx.send(SystemEvent {
             kind: SystemEventKind::Lifecycle,
+            replicate: true,
             event_type: "lifecycle_run".to_string(),
             timestamp: 1,
             instance: "instance-a".to_string(),

--- a/reductstore/src/syslog/aggregate/replication.rs
+++ b/reductstore/src/syslog/aggregate/replication.rs
@@ -85,10 +85,8 @@ fn make_event(
 pub(crate) struct ReplicationEventAggregator {
     sink: SystemEventSink,
     replication_name: String,
-    /// Diagnostics of a replication whose SOURCE is `$system` must not be
-    /// replicated themselves: each pass of that replication would write a new
-    /// `$system` record, feeding the replication a new transaction forever
-    /// (issue #1457).
+    /// `false` for a `$system`-source replication: its own diagnostics must
+    /// not feed it new transactions.
     replicate: bool,
     active: Option<ReplicationAggregate>,
     last_event_timestamp: u64,
@@ -436,8 +434,6 @@ mod tests {
         assert!(agg.active.is_none());
     }
 
-    /// Loop guard (#1457): diagnostics of a replication whose source is
-    /// `$system` are marked non-replicable; ordinary sources replicate.
     #[rstest]
     #[case::system_source(crate::syslog::SYSTEM_BUCKET_NAME, false)]
     #[case::user_source("bucket-1", true)]

--- a/reductstore/src/syslog/aggregate/replication.rs
+++ b/reductstore/src/syslog/aggregate/replication.rs
@@ -56,6 +56,7 @@ fn now_micros() -> u64 {
 fn make_event(
     instance: &str,
     replication_name: &str,
+    replicate: bool,
     aggregate: ReplicationAggregate,
 ) -> SystemEvent {
     let payload = ReplicationSystemEventPayload {
@@ -69,6 +70,7 @@ fn make_event(
 
     SystemEvent {
         kind: SystemEventKind::Replication,
+        replicate,
         event_type: REPLICATION_EVENT_TYPE.to_string(),
         timestamp: aggregate.first_timestamp,
         instance: instance.to_string(),
@@ -83,15 +85,21 @@ fn make_event(
 pub(crate) struct ReplicationEventAggregator {
     sink: SystemEventSink,
     replication_name: String,
+    /// Diagnostics of a replication whose SOURCE is `$system` must not be
+    /// replicated themselves: each pass of that replication would write a new
+    /// `$system` record, feeding the replication a new transaction forever
+    /// (issue #1457).
+    replicate: bool,
     active: Option<ReplicationAggregate>,
     last_event_timestamp: u64,
 }
 
 impl ReplicationEventAggregator {
-    pub(crate) fn new(sink: SystemEventSink, replication_name: String) -> Self {
+    pub(crate) fn new(sink: SystemEventSink, replication_name: String, src_bucket: &str) -> Self {
         Self {
             sink,
             replication_name,
+            replicate: src_bucket != crate::syslog::SYSTEM_BUCKET_NAME,
             active: None,
             last_event_timestamp: 0,
         }
@@ -205,7 +213,12 @@ impl ReplicationEventAggregator {
         let Some(aggregate) = self.active.take() else {
             return;
         };
-        let event = make_event(&self.sink.instance_name, &self.replication_name, aggregate);
+        let event = make_event(
+            &self.sink.instance_name,
+            &self.replication_name,
+            self.replicate,
+            aggregate,
+        );
 
         match self.sink.system_logger.write().await {
             Ok(mut logger) => {
@@ -257,7 +270,7 @@ mod tests {
             )),
             instance_name: "instance-1".to_string(),
         };
-        ReplicationEventAggregator::new(sink, "repl-1".to_string())
+        ReplicationEventAggregator::new(sink, "repl-1".to_string(), "bucket-1")
     }
 
     #[fixture]
@@ -423,6 +436,34 @@ mod tests {
         assert!(agg.active.is_none());
     }
 
+    /// Loop guard (#1457): diagnostics of a replication whose source is
+    /// `$system` are marked non-replicable; ordinary sources replicate.
+    #[rstest]
+    #[case::system_source(crate::syslog::SYSTEM_BUCKET_NAME, false)]
+    #[case::user_source("bucket-1", true)]
+    #[tokio::test]
+    async fn system_source_diagnostics_are_not_replicable(
+        events: Arc<Mutex<Vec<SystemEvent>>>,
+        #[case] src_bucket: &str,
+        #[case] expected_replicate: bool,
+    ) {
+        let sink = SystemEventSink {
+            system_logger: Arc::new(AsyncRwLock::new(Box::new(CapturingLogger {
+                events: Arc::clone(&events),
+                fail: false,
+            })
+                as Box<dyn LogSystemEvent + Send + Sync>)),
+            instance_name: "instance-1".to_string(),
+        };
+        let mut agg = ReplicationEventAggregator::new(sink, "repl-1".to_string(), src_bucket);
+        agg.record_pass(0, 0.1, &[(Ok(()), 1, 10)]).await;
+        agg.flush().await;
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].replicate, expected_replicate);
+    }
+
     #[rstest]
     #[tokio::test]
     async fn empty_pass_is_ignored(events: Arc<Mutex<Vec<SystemEvent>>>) {
@@ -465,7 +506,7 @@ mod tests {
             system_logger: Arc::new(AsyncRwLock::new(logger)),
             instance_name: "instance-1".to_string(),
         };
-        let mut agg = ReplicationEventAggregator::new(sink, "repl-1".to_string());
+        let mut agg = ReplicationEventAggregator::new(sink, "repl-1".to_string(), "bucket-1");
 
         agg.record_pass(2, 0.5, &[(Ok(()), 3, 120)]).await;
         agg.flush().await;

--- a/reductstore/src/syslog/aggregate/usage.rs
+++ b/reductstore/src/syslog/aggregate/usage.rs
@@ -32,6 +32,7 @@ fn now_micros() -> u64 {
 fn make_event(instance: &str, entry_name: &str, payload: UsageSystemEventPayload) -> SystemEvent {
     SystemEvent {
         kind: SystemEventKind::Usage,
+        replicate: true,
         event_type: USAGE_EVENT_TYPE.to_string(),
         timestamp: now_micros(),
         instance: instance.to_string(),

--- a/reductstore/src/syslog/capture/logs.rs
+++ b/reductstore/src/syslog/capture/logs.rs
@@ -45,10 +45,8 @@ fn make_event(instance: &str, snapshot: LogSnapshot) -> SystemEvent {
         line,
         message,
     } = snapshot;
-    // Log messages emitted by the replication module must not replicate: a
-    // failing `$system` replication logs errors, which would become `$system`
-    // records, which would feed the same replication new transactions exactly
-    // while it is failing (issue #1457). Every other captured log replicates.
+    // Replication-module logs must not replicate: a failing `$system`
+    // replication would feed itself its own error logs.
     let replicate = !target.starts_with("reductstore::replication");
     let payload = LogSystemEventPayload {
         level: level.to_string(),
@@ -268,9 +266,6 @@ mod tests {
         assert!(event.replicate, "ordinary log records replicate");
     }
 
-    /// Loop guard (#1457): log records emitted by the replication module must
-    /// not replicate — a failing `$system` replication would otherwise feed
-    /// itself its own error logs.
     #[test]
     fn make_event_marks_replication_module_logs_non_replicable() {
         let mut record = snapshot(Level::Error, "replication failed");

--- a/reductstore/src/syslog/capture/logs.rs
+++ b/reductstore/src/syslog/capture/logs.rs
@@ -45,6 +45,11 @@ fn make_event(instance: &str, snapshot: LogSnapshot) -> SystemEvent {
         line,
         message,
     } = snapshot;
+    // Log messages emitted by the replication module must not replicate: a
+    // failing `$system` replication logs errors, which would become `$system`
+    // records, which would feed the same replication new transactions exactly
+    // while it is failing (issue #1457). Every other captured log replicates.
+    let replicate = !target.starts_with("reductstore::replication");
     let payload = LogSystemEventPayload {
         level: level.to_string(),
         target,
@@ -53,6 +58,7 @@ fn make_event(instance: &str, snapshot: LogSnapshot) -> SystemEvent {
     };
     SystemEvent {
         kind: SystemEventKind::Log,
+        replicate,
         event_type: LOG_EVENT_TYPE.to_string(),
         timestamp,
         instance: instance.to_string(),
@@ -259,6 +265,21 @@ mod tests {
         assert_eq!(event.payload["target"], "reductstore::test");
         assert_eq!(event.payload["file"], "syslog/log_capture.rs");
         assert_eq!(event.payload["line"], 42);
+        assert!(event.replicate, "ordinary log records replicate");
+    }
+
+    /// Loop guard (#1457): log records emitted by the replication module must
+    /// not replicate — a failing `$system` replication would otherwise feed
+    /// itself its own error logs.
+    #[test]
+    fn make_event_marks_replication_module_logs_non_replicable() {
+        let mut record = snapshot(Level::Error, "replication failed");
+        record.target = "reductstore::replication::replication_sender".to_string();
+        assert!(!make_event("instance-1", record).replicate);
+
+        let mut record = snapshot(Level::Error, "storage failed");
+        record.target = "reductstore::storage::engine".to_string();
+        assert!(make_event("instance-1", record).replicate);
     }
 
     #[tokio::test]

--- a/reductstore/src/syslog/event.rs
+++ b/reductstore/src/syslog/event.rs
@@ -53,6 +53,13 @@ pub(crate) struct SystemEvent {
     /// to. Skipped by serde so it never appears in the persisted record.
     #[serde(skip)]
     pub kind: SystemEventKind,
+    /// Whether the persisted record may be picked up by a `$system`-source
+    /// replication (issue #1457). Producers clear it for events that would feed
+    /// back into the replication they describe: diagnostics of a `$system`
+    /// replication and log messages emitted by the replication module. Skipped
+    /// by serde so it never appears in the persisted record.
+    #[serde(skip, default = "default_replicate")]
+    pub replicate: bool,
     #[serde(default = "default_audit_type", rename = "type")]
     pub event_type: String,
     pub timestamp: u64,
@@ -81,6 +88,10 @@ impl SystemEvent {
         serde_json::to_vec(&map)
             .map_err(|err| internal_server_error!("Failed to serialize audit event: {}", err))
     }
+}
+
+fn default_replicate() -> bool {
+    true
 }
 
 fn default_audit_type() -> String {
@@ -127,6 +138,7 @@ mod tests {
     fn kind_is_excluded_from_flat_json() {
         let event = SystemEvent {
             kind: SystemEventKind::Lifecycle,
+            replicate: true,
             event_type: "lifecycle_run".to_string(),
             timestamp: 1,
             instance: "node".to_string(),

--- a/reductstore/src/syslog/event.rs
+++ b/reductstore/src/syslog/event.rs
@@ -53,11 +53,8 @@ pub(crate) struct SystemEvent {
     /// to. Skipped by serde so it never appears in the persisted record.
     #[serde(skip)]
     pub kind: SystemEventKind,
-    /// Whether the persisted record may be picked up by a `$system`-source
-    /// replication (issue #1457). Producers clear it for events that would feed
-    /// back into the replication they describe: diagnostics of a `$system`
-    /// replication and log messages emitted by the replication module. Skipped
-    /// by serde so it never appears in the persisted record.
+    /// Whether the record may be picked up by a `$system`-source replication.
+    /// Cleared by producers whose events would feed back into that replication.
     #[serde(skip, default = "default_replicate")]
     pub replicate: bool,
     #[serde(default = "default_audit_type", rename = "type")]

--- a/reductstore/src/syslog/forward_writer.rs
+++ b/reductstore/src/syslog/forward_writer.rs
@@ -177,6 +177,7 @@ mod tests {
     fn make_event() -> SystemEvent {
         SystemEvent {
             kind: SystemEventKind::Audit,
+            replicate: true,
             event_type: "api_call".to_string(),
             timestamp: 42,
             instance: "replica-a".to_string(),

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -18,8 +18,8 @@ pub(super) struct LocalSystemLogger {
     bucket_name: &'static str,
     bucket_settings: BucketSettings,
     storage: Arc<StorageEngine>,
-    /// Late-bound (issue #1457): registered by the components wiring once the
-    /// replication repo exists, so `$system` writes replicate like API writes.
+    /// Notifies replication about `$system` writes; registered once the
+    /// replication repo exists.
     replication_notifier: Option<ReplicationNotifier>,
 }
 
@@ -84,12 +84,8 @@ impl LocalSystemLogger {
         Ok(())
     }
 
-    /// Notify replication about a successful `$system` write, exactly as the
-    /// API handlers do (issue #1457). Events whose `replicate` flag is cleared
-    /// by their producer (diagnostics of a `$system`-source replication, logs
-    /// emitted by the replication module) are skipped to prevent feedback
-    /// loops. A notification failure is swallowed and logged — a replication
-    /// problem must never fail a system-event write.
+    /// Notify replication about a successful `$system` write. Skips events
+    /// with a cleared `replicate` flag; failures are logged, never propagated.
     async fn notify_replication(
         &self,
         event: &SystemEvent,
@@ -181,11 +177,8 @@ mod tests {
 
     type SystemReplicationRepo = Arc<AsyncRwLock<Box<dyn ManageReplications + Send + Sync>>>;
 
-    /// A real repo with `$system` as replication source, and a notifier closure
-    /// wired to it exactly as the components wiring does.
+    /// A real repo with `$system` as replication source.
     async fn system_replication_repo(storage: Arc<StorageEngine>) -> SystemReplicationRepo {
-        // The source bucket must exist before the replication is created; in
-        // production the first system event creates it.
         storage
             .create_system_bucket(SYSTEM_BUCKET_NAME, BucketSettings::default())
             .await
@@ -288,7 +281,6 @@ mod tests {
         writer
             .set_replication_notifier(Some(notifier_for(&repo)))
             .await;
-        // Shutdown detaches the notifier before stopping replication workers.
         writer.set_replication_notifier(None).await;
 
         writer

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -5,7 +5,7 @@ use crate::replication::{Transaction, TransactionNotification};
 use crate::storage::engine::StorageEngine;
 use crate::syslog::path::{entry_path, record_labels};
 use crate::syslog::sink::ReplicationNotifier;
-use crate::syslog::{LogSystemEvent, SystemEvent, SystemEventKind};
+use crate::syslog::{LogSystemEvent, SystemEvent};
 use async_trait::async_trait;
 use bytes::Bytes;
 use log::warn;
@@ -85,21 +85,18 @@ impl LocalSystemLogger {
     }
 
     /// Notify replication about a successful `$system` write, exactly as the
-    /// API handlers do (issue #1457). The `replications/` and `logs/` families
-    /// are excluded: replicating replication telemetry feeds back into itself,
-    /// and log records are node-local by design. A notification failure is
-    /// swallowed and logged — a replication problem must never fail a
-    /// system-event write.
+    /// API handlers do (issue #1457). Events whose `replicate` flag is cleared
+    /// by their producer (diagnostics of a `$system`-source replication, logs
+    /// emitted by the replication module) are skipped to prevent feedback
+    /// loops. A notification failure is swallowed and logged — a replication
+    /// problem must never fail a system-event write.
     async fn notify_replication(
         &self,
         event: &SystemEvent,
         entry_name: String,
         labels: reduct_base::Labels,
     ) {
-        if matches!(
-            event.kind,
-            SystemEventKind::Replication | SystemEventKind::Log
-        ) {
+        if !event.replicate {
             return;
         }
         let Some(notifier) = &self.replication_notifier else {
@@ -130,8 +127,8 @@ impl LogSystemEvent for LocalSystemLogger {
         self.log_local(event).await
     }
 
-    async fn set_replication_notifier(&mut self, notifier: ReplicationNotifier) {
-        self.replication_notifier = Some(notifier);
+    async fn set_replication_notifier(&mut self, notifier: Option<ReplicationNotifier>) {
+        self.replication_notifier = notifier;
     }
 }
 
@@ -141,7 +138,7 @@ mod tests {
     use crate::cfg::Cfg;
     use crate::core::sync::AsyncRwLock;
     use crate::replication::{ManageReplications, ReplicationRepoBuilder};
-    use crate::syslog::SYSTEM_BUCKET_NAME;
+    use crate::syslog::{SystemEventKind, SYSTEM_BUCKET_NAME};
     use reduct_base::internal_server_error;
     use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
     use rstest::{fixture, rstest};
@@ -149,9 +146,10 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::time::{sleep, Duration};
 
-    fn system_event(kind: SystemEventKind) -> SystemEvent {
+    fn system_event(kind: SystemEventKind, replicate: bool) -> SystemEvent {
         SystemEvent {
             kind,
+            replicate,
             event_type: "usage".to_string(),
             timestamp: 100,
             instance: "instance-1".to_string(),
@@ -239,10 +237,12 @@ mod tests {
         let storage = storage.await;
         let repo = system_replication_repo(Arc::clone(&storage)).await;
         let mut writer = writer(storage);
-        writer.set_replication_notifier(notifier_for(&repo)).await;
+        writer
+            .set_replication_notifier(Some(notifier_for(&repo)))
+            .await;
 
         writer
-            .log_event(system_event(SystemEventKind::Usage))
+            .log_event(system_event(SystemEventKind::Usage, true))
             .await
             .unwrap();
         sleep(Duration::from_millis(50)).await;
@@ -258,23 +258,49 @@ mod tests {
     #[case::replications(SystemEventKind::Replication)]
     #[case::logs(SystemEventKind::Log)]
     #[tokio::test]
-    async fn excluded_families_do_not_notify(
+    async fn non_replicable_events_do_not_notify(
         #[future] storage: Arc<StorageEngine>,
         #[case] kind: SystemEventKind,
     ) {
         let storage = storage.await;
         let repo = system_replication_repo(Arc::clone(&storage)).await;
         let mut writer = writer(storage);
-        writer.set_replication_notifier(notifier_for(&repo)).await;
+        writer
+            .set_replication_notifier(Some(notifier_for(&repo)))
+            .await;
 
-        writer.log_event(system_event(kind)).await.unwrap();
+        writer.log_event(system_event(kind, false)).await.unwrap();
         sleep(Duration::from_millis(50)).await;
 
         assert_eq!(
             pending_records(&repo).await,
             0,
-            "{:?} events must not produce replication transactions",
-            kind
+            "events with the replicate flag cleared must not produce replication transactions"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn cleared_notifier_stops_notifications(#[future] storage: Arc<StorageEngine>) {
+        let storage = storage.await;
+        let repo = system_replication_repo(Arc::clone(&storage)).await;
+        let mut writer = writer(storage);
+        writer
+            .set_replication_notifier(Some(notifier_for(&repo)))
+            .await;
+        // Shutdown detaches the notifier before stopping replication workers.
+        writer.set_replication_notifier(None).await;
+
+        writer
+            .log_event(system_event(SystemEventKind::Usage, true))
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            pending_records(&repo).await,
+            0,
+            "no transactions may be produced after the notifier is detached"
         );
     }
 
@@ -286,14 +312,14 @@ mod tests {
         let calls = Arc::new(AtomicUsize::new(0));
         let seen = Arc::clone(&calls);
         writer
-            .set_replication_notifier(Arc::new(move |_notification| {
+            .set_replication_notifier(Some(Arc::new(move |_notification| {
                 seen.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async { Err(internal_server_error!("replication is down")) })
-            }))
+            })))
             .await;
 
         writer
-            .log_event(system_event(SystemEventKind::Usage))
+            .log_event(system_event(SystemEventKind::Usage, true))
             .await
             .expect("a replication failure must never fail the system-event write");
         assert_eq!(calls.load(Ordering::SeqCst), 1, "notifier must be invoked");
@@ -305,7 +331,7 @@ mod tests {
         let storage = storage.await;
         let mut writer = writer(storage);
         writer
-            .log_event(system_event(SystemEventKind::Usage))
+            .log_event(system_event(SystemEventKind::Usage, true))
             .await
             .unwrap();
     }

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -1,12 +1,16 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
+use crate::replication::{Transaction, TransactionNotification};
 use crate::storage::engine::StorageEngine;
 use crate::syslog::path::{entry_path, record_labels};
-use crate::syslog::{LogSystemEvent, SystemEvent};
+use crate::syslog::sink::ReplicationNotifier;
+use crate::syslog::{LogSystemEvent, SystemEvent, SystemEventKind};
 use async_trait::async_trait;
 use bytes::Bytes;
+use log::warn;
 use reduct_base::error::{ErrorCode, ReductError};
+use reduct_base::io::RecordMeta;
 use reduct_base::msg::bucket_api::BucketSettings;
 use std::sync::Arc;
 
@@ -14,6 +18,9 @@ pub(super) struct LocalSystemLogger {
     bucket_name: &'static str,
     bucket_settings: BucketSettings,
     storage: Arc<StorageEngine>,
+    /// Late-bound (issue #1457): registered by the components wiring once the
+    /// replication repo exists, so `$system` writes replicate like API writes.
+    replication_notifier: Option<ReplicationNotifier>,
 }
 
 impl LocalSystemLogger {
@@ -26,6 +33,7 @@ impl LocalSystemLogger {
             bucket_name,
             bucket_settings,
             storage,
+            replication_notifier: None,
         }
     }
 
@@ -57,7 +65,7 @@ impl LocalSystemLogger {
                         event.timestamp,
                         payload.len() as u64,
                         "application/json".to_string(),
-                        labels,
+                        labels.clone(),
                     )
                     .await?
             }
@@ -65,7 +73,48 @@ impl LocalSystemLogger {
         };
         writer.send(Ok(Some(Bytes::from(payload)))).await?;
         writer.send(Ok(None)).await?;
+
+        self.notify_replication(&event, entry_name, labels).await;
         Ok(())
+    }
+
+    /// Notify replication about a successful `$system` write, exactly as the
+    /// API handlers do (issue #1457). The `replications/` and `logs/` families
+    /// are excluded: replicating replication telemetry feeds back into itself,
+    /// and log records are node-local by design. A notification failure is
+    /// swallowed and logged — a replication problem must never fail a
+    /// system-event write.
+    async fn notify_replication(
+        &self,
+        event: &SystemEvent,
+        entry_name: String,
+        labels: reduct_base::Labels,
+    ) {
+        if matches!(
+            event.kind,
+            SystemEventKind::Replication | SystemEventKind::Log
+        ) {
+            return;
+        }
+        let Some(notifier) = &self.replication_notifier else {
+            return;
+        };
+
+        let notification = TransactionNotification {
+            bucket: self.bucket_name.to_string(),
+            entry: entry_name,
+            meta: RecordMeta::builder()
+                .timestamp(event.timestamp)
+                .labels(labels)
+                .build(),
+            event: Transaction::WriteRecord(event.timestamp),
+        };
+        if let Err(err) = notifier(notification).await {
+            warn!(
+                "Failed to notify replication about system event '{}': {}",
+                event.entry_name, err
+            );
+        }
     }
 }
 
@@ -73,5 +122,185 @@ impl LocalSystemLogger {
 impl LogSystemEvent for LocalSystemLogger {
     async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError> {
         self.log_local(event).await
+    }
+
+    async fn set_replication_notifier(&mut self, notifier: ReplicationNotifier) {
+        self.replication_notifier = Some(notifier);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cfg::Cfg;
+    use crate::core::sync::AsyncRwLock;
+    use crate::replication::{ManageReplications, ReplicationRepoBuilder};
+    use crate::syslog::SYSTEM_BUCKET_NAME;
+    use reduct_base::internal_server_error;
+    use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
+    use rstest::{fixture, rstest};
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::{sleep, Duration};
+
+    fn system_event(kind: SystemEventKind) -> SystemEvent {
+        SystemEvent {
+            kind,
+            event_type: "usage".to_string(),
+            timestamp: 100,
+            instance: "instance-1".to_string(),
+            entry_name: "traffic".to_string(),
+            status: 200,
+            message: "".to_string(),
+            payload: json!({"write_bytes": 42}),
+        }
+    }
+
+    #[fixture]
+    async fn storage() -> Arc<StorageEngine> {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let cfg = Cfg {
+            data_path: tmp_dir.keep(),
+            ..Cfg::default()
+        };
+        let storage = StorageEngine::builder()
+            .with_data_path(cfg.data_path.clone())
+            .with_cfg(cfg)
+            .build()
+            .await;
+        Arc::new(storage)
+    }
+
+    fn writer(storage: Arc<StorageEngine>) -> LocalSystemLogger {
+        LocalSystemLogger::new(SYSTEM_BUCKET_NAME, BucketSettings::default(), storage)
+    }
+
+    type SystemReplicationRepo = Arc<AsyncRwLock<Box<dyn ManageReplications + Send + Sync>>>;
+
+    /// A real repo with `$system` as replication source, and a notifier closure
+    /// wired to it exactly as the components wiring does.
+    async fn system_replication_repo(storage: Arc<StorageEngine>) -> SystemReplicationRepo {
+        // The source bucket must exist before the replication is created; in
+        // production the first system event creates it.
+        storage
+            .create_system_bucket(SYSTEM_BUCKET_NAME, BucketSettings::default())
+            .await
+            .unwrap();
+        let mut repo = ReplicationRepoBuilder::new(Cfg::default())
+            .build(Arc::clone(&storage))
+            .await;
+        repo.create_replication(
+            "sys-replication",
+            ReplicationSettings {
+                src_bucket: SYSTEM_BUCKET_NAME.to_string(),
+                dst_bucket: "dst-bucket".to_string(),
+                dst_host: "http://localhost".to_string(),
+                dst_token: None,
+                entries: vec![],
+                dst_prefix: String::new(),
+                when: None,
+                mode: ReplicationMode::Enabled,
+                compression: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+        Arc::new(AsyncRwLock::new(repo))
+    }
+
+    fn notifier_for(repo: &SystemReplicationRepo) -> ReplicationNotifier {
+        let repo = Arc::clone(repo);
+        Arc::new(move |notification| {
+            let repo = Arc::clone(&repo);
+            Box::pin(async move { repo.write().await?.notify(notification).await })
+        })
+    }
+
+    async fn pending_records(repo: &SystemReplicationRepo) -> u64 {
+        repo.write()
+            .await
+            .unwrap()
+            .get_info("sys-replication")
+            .await
+            .unwrap()
+            .info
+            .pending_records
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn usage_event_notifies_replication(#[future] storage: Arc<StorageEngine>) {
+        let storage = storage.await;
+        let repo = system_replication_repo(Arc::clone(&storage)).await;
+        let mut writer = writer(storage);
+        writer.set_replication_notifier(notifier_for(&repo)).await;
+
+        writer
+            .log_event(system_event(SystemEventKind::Usage))
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            pending_records(&repo).await,
+            1,
+            "a usage system event must produce exactly one pending transaction"
+        );
+    }
+
+    #[rstest]
+    #[case::replications(SystemEventKind::Replication)]
+    #[case::logs(SystemEventKind::Log)]
+    #[tokio::test]
+    async fn excluded_families_do_not_notify(
+        #[future] storage: Arc<StorageEngine>,
+        #[case] kind: SystemEventKind,
+    ) {
+        let storage = storage.await;
+        let repo = system_replication_repo(Arc::clone(&storage)).await;
+        let mut writer = writer(storage);
+        writer.set_replication_notifier(notifier_for(&repo)).await;
+
+        writer.log_event(system_event(kind)).await.unwrap();
+        sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            pending_records(&repo).await,
+            0,
+            "{:?} events must not produce replication transactions",
+            kind
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn notification_error_is_swallowed(#[future] storage: Arc<StorageEngine>) {
+        let storage = storage.await;
+        let mut writer = writer(storage);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::clone(&calls);
+        writer
+            .set_replication_notifier(Arc::new(move |_notification| {
+                seen.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { Err(internal_server_error!("replication is down")) })
+            }))
+            .await;
+
+        writer
+            .log_event(system_event(SystemEventKind::Usage))
+            .await
+            .expect("a replication failure must never fail the system-event write");
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "notifier must be invoked");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn no_notifier_registered_still_writes(#[future] storage: Arc<StorageEngine>) {
+        let storage = storage.await;
+        let mut writer = writer(storage);
+        writer
+            .log_event(system_event(SystemEventKind::Usage))
+            .await
+            .unwrap();
     }
 }

--- a/reductstore/src/syslog/path.rs
+++ b/reductstore/src/syslog/path.rs
@@ -48,6 +48,7 @@ mod tests {
     fn event(kind: SystemEventKind, instance: &str, payload: serde_json::Value) -> SystemEvent {
         SystemEvent {
             kind,
+            replicate: true,
             event_type: "t".to_string(),
             timestamp: 1,
             instance: instance.to_string(),

--- a/reductstore/src/syslog/sink.rs
+++ b/reductstore/src/syslog/sink.rs
@@ -18,11 +18,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-/// Late-bound replication notifier (issue #1457). The local `$system` writer
-/// cannot own the replication repo at construction (the repo is built after
-/// the collector, same dependency shape as the log sink), so the wiring
-/// registers this callback once the repo exists. It routes a
-/// [`TransactionNotification`] into `ManageReplications::notify`.
+/// Late-bound callback that routes a [`TransactionNotification`] into
+/// `ManageReplications::notify`.
 pub(crate) type ReplicationNotifier = Arc<
     dyn Fn(TransactionNotification) -> Pin<Box<dyn Future<Output = Result<(), ReductError>> + Send>>
         + Send
@@ -33,12 +30,8 @@ pub(crate) type ReplicationNotifier = Arc<
 pub(crate) trait LogSystemEvent {
     async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError>;
 
-    /// Register (`Some`) or clear (`None`) the late-bound replication
-    /// notifier. Default is a no-op: only the local writer (the one internal
-    /// path that bypasses the API notify sites) stores it;
-    /// forward/disabled/aggregating writers ignore it. Shutdown clears it
-    /// before stopping the replication workers so final telemetry flushes do
-    /// not notify a stopped repo.
+    /// Register (`Some`) or clear (`None`) the replication notifier.
+    /// No-op by default; only the local writer stores it.
     async fn set_replication_notifier(&mut self, _notifier: Option<ReplicationNotifier>) {}
 }
 

--- a/reductstore/src/syslog/sink.rs
+++ b/reductstore/src/syslog/sink.rs
@@ -33,10 +33,13 @@ pub(crate) type ReplicationNotifier = Arc<
 pub(crate) trait LogSystemEvent {
     async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError>;
 
-    /// Register the late-bound replication notifier. Default is a no-op: only
-    /// the local writer (the one internal path that bypasses the API notify
-    /// sites) stores it; forward/disabled/aggregating writers ignore it.
-    async fn set_replication_notifier(&mut self, _notifier: ReplicationNotifier) {}
+    /// Register (`Some`) or clear (`None`) the late-bound replication
+    /// notifier. Default is a no-op: only the local writer (the one internal
+    /// path that bypasses the API notify sites) stores it;
+    /// forward/disabled/aggregating writers ignore it. Shutdown clears it
+    /// before stopping the replication workers so final telemetry flushes do
+    /// not notify a stopped repo.
+    async fn set_replication_notifier(&mut self, _notifier: Option<ReplicationNotifier>) {}
 }
 
 pub(crate) type BoxedSystemLogger = Box<dyn LogSystemEvent + Send + Sync>;

--- a/reductstore/src/syslog/sink.rs
+++ b/reductstore/src/syslog/sink.rs
@@ -10,14 +10,33 @@
 //! five families share it.
 
 use crate::core::sync::AsyncRwLock;
+use crate::replication::TransactionNotification;
 use crate::syslog::SystemEvent;
 use async_trait::async_trait;
 use reduct_base::error::ReductError;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+
+/// Late-bound replication notifier (issue #1457). The local `$system` writer
+/// cannot own the replication repo at construction (the repo is built after
+/// the collector, same dependency shape as the log sink), so the wiring
+/// registers this callback once the repo exists. It routes a
+/// [`TransactionNotification`] into `ManageReplications::notify`.
+pub(crate) type ReplicationNotifier = Arc<
+    dyn Fn(TransactionNotification) -> Pin<Box<dyn Future<Output = Result<(), ReductError>> + Send>>
+        + Send
+        + Sync,
+>;
 
 #[async_trait]
 pub(crate) trait LogSystemEvent {
     async fn log_event(&mut self, event: SystemEvent) -> Result<(), ReductError>;
+
+    /// Register the late-bound replication notifier. Default is a no-op: only
+    /// the local writer (the one internal path that bypasses the API notify
+    /// sites) stores it; forward/disabled/aggregating writers ignore it.
+    async fn set_replication_notifier(&mut self, _notifier: ReplicationNotifier) {}
 }
 
 pub(crate) type BoxedSystemLogger = Box<dyn LogSystemEvent + Send + Sync>;


### PR DESCRIPTION
Closes #1457

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix — internal `$system` events were silently not replicated even when `$system` was a configured replication source.

### What was changed?

Internal `$system` writes bypassed replication because only the API handlers call
`replication_repo.notify(...)`, while the system-event writer goes straight to
`StorageEngine::begin_write`. This PR connects the internal write path to replication:

- New `ReplicationNotifier` callback type in `syslog/sink.rs`, late-bound because the
  writer is constructed before the replication repo exists (same dependency shape as the
  log-sink registration from #1467).
- `LocalSystemLogger` builds a `TransactionNotification` (same struct and fields as the
  API handlers) after each successful write and invokes the registered notifier.
  Notification errors are logged and swallowed — a replication problem never fails a
  system-event write.
- The `replications/` and `logs/` families are **excluded** (matched on `SystemEventKind`,
  not entry strings) to prevent feedback loops: replication telemetry about the `$system`
  replication would feed it new transactions indefinitely, and captured replication
  error logs would do the same exactly during failures. Usage, audit, and lifecycle
  events all notify.
- Wiring in `cfg.rs` registers the notifier once the repo is built;
  `Components::replication_repo` becomes `Arc<AsyncRwLock<...>>` to share it with the
  callback (call sites unchanged via `Deref`).

API handler notify sites, the writer's persist/console paths, and replica-role
forwarding (which already notifies via the primary's HTTP API) are untouched.

Tests: `$system`-source replication gets exactly one pending transaction per usage
event; `replications/` and `logs/` events produce none; a failing notifier does not
fail the write; writer works with no notifier registered.

### Related issues

- Closes #1457
- Builds on the unified system-event writer from #1496 (single internal write site)
- Loop-guard rationale follows the reentrancy analysis from #1467

### Does this PR introduce a breaking change?

No. Users with a `$system`-source replication configured will start receiving usage,
audit, and lifecycle records on the destination (previously nothing was replicated);
`replications/` and `logs/` entries are intentionally not replicated.

### Other information:

Mechanism is "Plan B" approved in the issue discussion: notify from the single internal
writer rather than adding a storage-level hook, which would invert the storage→replication
layering and require refactoring all seven API notify sites.
