### PR TITLE
Expose instance name and role in server info

### DIFF
--- a/.github/actions/api/http-tests/action.yml
+++ b/.github/actions/api/http-tests/action.yml
@@ -33,6 +33,8 @@ runs:
         docker run --network=host -v ${PWD}/misc:/misc \
           --env RS_API_TOKEN=${{ inputs.token }} \
           --env RS_AUDIT_ENABLED=true \
+          --env RS_INSTANCE_NAME=http-api-tests \
+          --env RS_INSTANCE_ROLE=STANDALONE \
           --env RS_CERT_PATH=${{ inputs.cert_path }} \
           --env RS_CERT_KEY_PATH=/misc/privateKey.key \
           --env RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose the effective instance name and role in the `/api/v1/info` response, [Issue-1568](https://github.com/reductstore/reductstore/issues/1568)
 - Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey
 - Add a replication `compression` setting (`none`, `zstd`, `gzip`, default `none`) that compresses batch payloads during transfer using HTTP `Content-Encoding`, [Issue-1348](https://github.com/reductstore/reductstore/issues/1348) by @DibbayajyotiRoy
 - Configure server-wide default bucket settings with `RS_DEFAULTS_BUCKET_*` environment variables, [PR-1535](https://github.com/reductstore/reductstore/pull/1535) by @rohankumardubey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose the effective instance name and role in the `/api/v1/info` response, [Issue-1568](https://github.com/reductstore/reductstore/issues/1568)
+- Expose the effective instance name and role in the `/api/v1/info` response, [PR-1569](https://github.com/reductstore/reductstore/pull/1569) by @lntutor
 - Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey
 - Add a replication `compression` setting (`none`, `zstd`, `gzip`, default `none`) that compresses batch payloads during transfer using HTTP `Content-Encoding`, [Issue-1348](https://github.com/reductstore/reductstore/issues/1348) by @DibbayajyotiRoy
 - Configure server-wide default bucket settings with `RS_DEFAULTS_BUCKET_*` environment variables, [PR-1535](https://github.com/reductstore/reductstore/pull/1535) by @rohankumardubey

--- a/integration_tests/api/server_api_test.py
+++ b/integration_tests/api/server_api_test.py
@@ -11,6 +11,8 @@ def test__get_info(base_url, session):
     assert resp.status_code == 200
     data = json.loads(resp.content)
     assert data["version"] >= "1.11.0"
+    assert data["instance_name"] == "http-api-tests"
+    assert data["instance_role"] == "STANDALONE"
     assert int(data["bucket_count"]) > 0
     assert int(data["uptime"]) >= 0
     assert int(data["latest_record"]) >= 0

--- a/reduct_base/src/msg/server_api.rs
+++ b/reduct_base/src/msg/server_api.rs
@@ -42,6 +42,12 @@ impl Display for License {
 pub struct ServerInfo {
     /// Version of ReductSoftware UG instance
     pub version: String,
+    /// Effective instance name resolved from the runtime configuration
+    #[serde(default)]
+    pub instance_name: String,
+    /// Effective instance role (`STANDALONE`, `PRIMARY`, `SECONDARY`, or `REPLICA`)
+    #[serde(default)]
+    pub instance_role: String,
     /// Number of buckets
     pub bucket_count: u64,
     /// Disk usage in bytes
@@ -68,4 +74,26 @@ pub struct Defaults {
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 pub struct BucketInfoList {
     pub buckets: Vec<BucketInfo>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_info_deserializes_without_instance_identity() {
+        let mut value = serde_json::to_value(ServerInfo {
+            instance_name: "edge-a".to_string(),
+            instance_role: "PRIMARY".to_string(),
+            ..ServerInfo::default()
+        })
+        .unwrap();
+        let object = value.as_object_mut().unwrap();
+        object.remove("instance_name");
+        object.remove("instance_role");
+
+        let info: ServerInfo = serde_json::from_value(value).unwrap();
+        assert_eq!(info.instance_name, "");
+        assert_eq!(info.instance_role, "");
+    }
 }

--- a/reductstore/src/api/http/server/info.rs
+++ b/reductstore/src/api/http/server/info.rs
@@ -30,6 +30,8 @@ mod tests {
     #[tokio::test]
     async fn test_info(#[future] keeper: Arc<StateKeeper>, headers: HeaderMap) {
         let info = info(State(keeper.await), headers).await.unwrap();
+        assert_eq!(info.0.instance_name, "unknown");
+        assert_eq!(info.0.instance_role, "PRIMARY");
         assert_eq!(info.0.bucket_count, 2);
     }
 }

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -67,6 +67,17 @@ pub enum InstanceRole {
     Replica,
 }
 
+impl InstanceRole {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            InstanceRole::Standalone => "STANDALONE",
+            InstanceRole::Primary => "PRIMARY",
+            InstanceRole::Secondary => "SECONDARY",
+            InstanceRole::Replica => "REPLICA",
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct ProvisionedReplication {
     pub settings: ReplicationSettings,

--- a/reductstore/src/storage/engine.rs
+++ b/reductstore/src/storage/engine.rs
@@ -202,6 +202,8 @@ impl StorageEngine {
             version: option_env!("CARGO_PKG_VERSION")
                 .unwrap_or("unknown")
                 .to_string(),
+            instance_name: self.cfg.instance_name.clone(),
+            instance_role: self.cfg.role.as_str().to_string(),
             bucket_count: buckets.len() as u64,
             usage,
             uptime: self.start_time.elapsed().as_secs(),
@@ -662,6 +664,8 @@ mod tests {
             info,
             ServerInfo {
                 version: env!("CARGO_PKG_VERSION").to_string(),
+                instance_name: "unknown".to_string(),
+                instance_role: "PRIMARY".to_string(),
                 bucket_count: 0,
                 usage: 0,
                 uptime: 1,
@@ -673,6 +677,25 @@ mod tests {
                 license: None,
             }
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_info_reports_instance_identity(cfg: Cfg) {
+        let cfg = Cfg {
+            instance_name: "edge-a".to_string(),
+            role: InstanceRole::Replica,
+            ..cfg
+        };
+        let storage = StorageEngine::builder()
+            .with_data_path(cfg.data_path.clone())
+            .with_cfg(cfg)
+            .build()
+            .await;
+
+        let info = storage.info().await.unwrap();
+        assert_eq!(info.instance_name, "edge-a");
+        assert_eq!(info.instance_role, "REPLICA");
     }
 
     #[rstest]
@@ -961,6 +984,8 @@ mod tests {
                 storage.info().await.unwrap(),
                 ServerInfo {
                     version: env!("CARGO_PKG_VERSION").to_string(),
+                    instance_name: "unknown".to_string(),
+                    instance_role: "PRIMARY".to_string(),
                     bucket_count: 1,
                     usage: 146,
                     uptime: 0,
@@ -1102,6 +1127,8 @@ mod tests {
                 storage.info().await.unwrap(),
                 ServerInfo {
                     version: env!("CARGO_PKG_VERSION").to_string(),
+                    instance_name: "unknown".to_string(),
+                    instance_role: "PRIMARY".to_string(),
                     bucket_count: 0,
                     usage: 0,
                     uptime: 0,


### PR DESCRIPTION
Closes #1568

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Added `instance_name` and `instance_role` to the `/api/v1/info` response.
- Populated both fields from the effective runtime configuration.
- Kept new Rust clients compatible with older server responses by defaulting missing identity fields during deserialization.
- Added storage, HTTP handler, serialization compatibility, and Python API coverage.
- Documented the new fields and updated the changelog.

### Related issues

https://github.com/reductstore/reductstore/issues/1568

### Does this PR introduce a breaking change?

No. The response change is additive, and the Rust model accepts responses from older servers that omit the new fields.

### Other information:

Validation:

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace -- --skip test_override_token_keeps_previous_version_when_update_fails` (2,349 passed across the workspace, 3 ignored, 1 filtered out, plus the doc test)
- `black --check integration_tests/api/server_api_test.py`
- `pytest integration_tests/api/server_api_test.py::test__get_info`
- Live branch-built server response included `"instance_name":"http-api-tests"` and `"instance_role":"STANDALONE"`.

The unfiltered workspace suite currently fails in `cfg::provision::token::tests::test_override_token_keeps_previous_version_when_update_fails`. The same failure reproduces unchanged on base commit `0622b3d1`; both base and this branch pass the complete remainder of the workspace suite when only that upstream test is skipped.