### PR TITLE
test: validate fork PR S3 cache guard

### DIFF
--- a/.github/actions/aws-cargo-cache/action.yml
+++ b/.github/actions/aws-cargo-cache/action.yml
@@ -27,6 +27,22 @@ runs:
         else
           echo "Using preset RUST_MINOR=${RUST_MINOR}"
         fi
+
+    - name: Detect S3 cache credentials
+      id: s3_cache
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.secret-access-key }}
+      run: |
+        if [[ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "S3_CARGO_CACHE_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "S3_CARGO_CACHE_ENABLED=false" >> "$GITHUB_ENV"
+          echo "S3 Cargo cache is disabled because credentials are unavailable."
+        fi
     #
     #    - name: Configure AWS credentials via OIDC (org-wide role)
     #      uses: aws-actions/configure-aws-credentials@v4
@@ -36,9 +52,11 @@ runs:
     #        aws-region: eu-central
 
     - name: Install sccache
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Configure sccache
+      if: steps.s3_cache.outputs.enabled == 'true'
       shell: bash
       run: |
         export RUSTC_WRAPPER=sccache
@@ -68,6 +86,7 @@ runs:
         sccache --start-server
 
     - name: Use cache for Cargo downloads
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: runs-on/cache@v4
       with:
         path: |
@@ -87,6 +106,7 @@ runs:
         AWS_DEFAULT_REGION: fsn1
 
     - name: Use cache for Cargo target
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: runs-on/cache@v4
       with:
         path: target/

--- a/.github/actions/build-binaries/action.yml
+++ b/.github/actions/build-binaries/action.yml
@@ -107,7 +107,12 @@ runs:
 
     - name: Show sccache stats
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Upload binary (PR)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -150,7 +155,12 @@ runs:
 
     - name: Show sccache stats after test export
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Upload tests
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -45,7 +45,12 @@ runs:
 
     - name: Show sccache stats
       shell: bash
-      run: sccache --show-stats
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        else
+          echo "sccache is disabled for this build."
+        fi
 
     - name: Upload coverage artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a


### PR DESCRIPTION
Temporary PR to validate fork CI skips S3 Cargo cache when repository secrets are unavailable. This will be closed after the cache step is verified.
