### PR TITLE
Fix replication delete lock inversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Avoid a lock inversion when deleting a replication task that emits final `$system` diagnostics by using shared outer replication repository access for removal and transaction notifications, [PR-1572](https://github.com/reductstore/reductstore/pull/1572)
 - Replicate internal `$system` events when `$system` is a replication source by notifying replication from the system-event writer; to prevent feedback loops, diagnostics of a `$system`-source replication and log messages from the replication module are excluded, [PR-1567](https://github.com/reductstore/reductstore/pull/1567) by @DibbayajyotiRoy
 - Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [PR-1557](https://github.com/reductstore/reductstore/pull/1557) by @LordAizen1
 - Resolve client IP from multi-hop RFC 7239 `Forwarded` headers so token IP allowlists compare against the real client instead of the proxy, [PR-1546](https://github.com/reductstore/reductstore/pull/1546) by @LordAizen1

--- a/reductstore/src/api/http/entry/update_batched.rs
+++ b/reductstore/src/api/http/entry/update_batched.rs
@@ -87,7 +87,7 @@ pub(super) async fn update_batched_records(
                 err_to_batched_header(&mut headers, time, &err);
             }
             Ok(new_labels) => {
-                let mut replication_repo = components.replication_repo.write().await?;
+                let replication_repo = components.replication_repo.read().await?;
                 replication_repo
                     .notify(TransactionNotification {
                         bucket: bucket_name.clone(),

--- a/reductstore/src/api/http/entry/update_single.rs
+++ b/reductstore/src/api/http/entry/update_single.rs
@@ -72,7 +72,7 @@ pub(super) async fn update_record(
 
     components
         .replication_repo
-        .write()
+        .read()
         .await?
         .notify(TransactionNotification {
             bucket: bucket.clone(),

--- a/reductstore/src/api/http/entry/write_batched.rs
+++ b/reductstore/src/api/http/entry/write_batched.rs
@@ -119,7 +119,7 @@ async fn notify_replication_write(
 ) -> Result<(), ReductError> {
     components
         .replication_repo
-        .write()
+        .read()
         .await?
         .notify(TransactionNotification {
             bucket: bucket.to_string(),

--- a/reductstore/src/api/http/entry/write_single.rs
+++ b/reductstore/src/api/http/entry/write_single.rs
@@ -127,7 +127,7 @@ pub(super) async fn write_record(
 
             components
                 .replication_repo
-                .write()
+                .read()
                 .await?
                 .notify(TransactionNotification {
                     bucket: bucket.clone(),

--- a/reductstore/src/api/http/io/update.rs
+++ b/reductstore/src/api/http/io/update.rs
@@ -62,7 +62,7 @@ pub(super) async fn update_batched_records(
             if let Some(res) = entry_results.get(&update.time) {
                 match res {
                     Ok(labels) => {
-                        let mut replication_repo = components.replication_repo.write().await?;
+                        let replication_repo = components.replication_repo.read().await?;
                         replication_repo
                             .notify(TransactionNotification {
                                 bucket: bucket_name.clone(),

--- a/reductstore/src/api/http/io/write.rs
+++ b/reductstore/src/api/http/io/write.rs
@@ -179,7 +179,7 @@ async fn notify_replication_write(
 ) -> Result<(), ReductError> {
     components
         .replication_repo
-        .write()
+        .read()
         .await?
         .notify(TransactionNotification {
             bucket: bucket.to_string(),

--- a/reductstore/src/api/http/replication/remove.rs
+++ b/reductstore/src/api/http/replication/remove.rs
@@ -18,7 +18,7 @@ pub(super) async fn remove_replication(
         .await?;
     components
         .replication_repo
-        .write()
+        .read()
         .await?
         .remove_replication(&replication_name)
         .await?;

--- a/reductstore/src/api/zenoh/subscriber.rs
+++ b/reductstore/src/api/zenoh/subscriber.rs
@@ -111,7 +111,7 @@ impl SubscriberPipeline {
     ) -> Result<(), ReductError> {
         self.components
             .replication_repo
-            .write()
+            .read()
             .await?
             .notify(TransactionNotification {
                 bucket: bucket.to_string(),

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -429,7 +429,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             system_events
                 .set_replication_notifier(Some(Arc::new(move |notification| {
                     let repo = Arc::clone(&repo);
-                    Box::pin(async move { repo.write().await?.notify(notification).await })
+                    Box::pin(async move { repo.read().await?.notify(notification).await })
                 })))
                 .await;
         }

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -132,7 +132,7 @@ pub trait ManageReplications {
     ) -> Result<(), ReductError>;
 
     /// Remove a replication task
-    async fn remove_replication(&mut self, name: &str) -> Result<(), ReductError>;
+    async fn remove_replication(&self, name: &str) -> Result<(), ReductError>;
 
     /// Update replication mode
     async fn set_mode(&mut self, name: &str, mode: ReplicationMode) -> Result<(), ReductError>;
@@ -146,7 +146,7 @@ pub trait ManageReplications {
     /// # Errors
     ///
     /// A `ReductError` is returned if the notification fails.
-    async fn notify(&mut self, notification: TransactionNotification) -> Result<(), ReductError>;
+    async fn notify(&self, notification: TransactionNotification) -> Result<(), ReductError>;
 
     /// Start background workers if they are not running yet.
     fn start(&mut self);

--- a/reductstore/src/replication/replication_repository/read_only.rs
+++ b/reductstore/src/replication/replication_repository/read_only.rs
@@ -66,7 +66,7 @@ impl ManageReplications for ReadOnlyReplicationRepository {
         ))
     }
 
-    async fn remove_replication(&mut self, _name: &str) -> Result<(), ReductError> {
+    async fn remove_replication(&self, _name: &str) -> Result<(), ReductError> {
         Err(forbidden!("Cannot remove replication in read-only mode"))
     }
 
@@ -76,7 +76,7 @@ impl ManageReplications for ReadOnlyReplicationRepository {
         ))
     }
 
-    async fn notify(&mut self, _notification: TransactionNotification) -> Result<(), ReductError> {
+    async fn notify(&self, _notification: TransactionNotification) -> Result<(), ReductError> {
         Err(forbidden!("Cannot notify replication in read-only mode"))
     }
 
@@ -193,7 +193,7 @@ mod tests {
         use reduct_base::io::RecordMeta;
         #[rstest]
         #[tokio::test]
-        async fn test_notify_forbidden(mut repo: ReadOnlyReplicationRepository) {
+        async fn test_notify_forbidden(repo: ReadOnlyReplicationRepository) {
             let notification = TransactionNotification {
                 bucket: "bucket".to_string(),
                 entry: "entry".to_string(),

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -362,7 +362,7 @@ impl ManageReplications for ReplicationRepository {
         Ok(())
     }
 
-    async fn remove_replication(&mut self, name: &str) -> Result<(), ReductError> {
+    async fn remove_replication(&self, name: &str) -> Result<(), ReductError> {
         let mut guard = self.replications.write().await?;
         let repl = guard.get(name).ok_or_else(|| {
             ReductError::not_found(&format!("Replication '{}' does not exist", name))
@@ -392,7 +392,7 @@ impl ManageReplications for ReplicationRepository {
         self.save_repo().await
     }
 
-    async fn notify(&mut self, notification: TransactionNotification) -> Result<(), ReductError> {
+    async fn notify(&self, notification: TransactionNotification) -> Result<(), ReductError> {
         let should_enqueue = {
             let guard = self.replications.read().await?;
             guard
@@ -1223,8 +1223,8 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_remove_non_existing_replication(#[future] mut repo: ReplicationRepository) {
-            let mut repo = repo.await;
+        async fn test_remove_non_existing_replication(#[future] repo: ReplicationRepository) {
+            let repo = repo.await;
             assert_eq!(
                 repo.remove_replication("test-2").await,
                 Err(not_found!("Replication 'test-2' does not exist")),

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -132,15 +132,24 @@ impl LogSystemEvent for LocalSystemLogger {
 mod tests {
     use super::*;
     use crate::cfg::Cfg;
-    use crate::core::sync::AsyncRwLock;
+    use crate::core::sync::{reset_rwlock_config, set_rwlock_timeout, AsyncRwLock};
     use crate::replication::{ManageReplications, ReplicationRepoBuilder};
     use crate::syslog::{SystemEventKind, SYSTEM_BUCKET_NAME};
     use reduct_base::internal_server_error;
     use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
     use rstest::{fixture, rstest};
     use serde_json::json;
+    use serial_test::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::time::{sleep, Duration};
+
+    struct ResetRwLockConfig;
+
+    impl Drop for ResetRwLockConfig {
+        fn drop(&mut self) {
+            reset_rwlock_config();
+        }
+    }
 
     fn system_event(kind: SystemEventKind, replicate: bool) -> SystemEvent {
         SystemEvent {
@@ -209,12 +218,12 @@ mod tests {
         let repo = Arc::clone(repo);
         Arc::new(move |notification| {
             let repo = Arc::clone(&repo);
-            Box::pin(async move { repo.write().await?.notify(notification).await })
+            Box::pin(async move { repo.read().await?.notify(notification).await })
         })
     }
 
     async fn pending_records(repo: &SystemReplicationRepo) -> u64 {
-        repo.write()
+        repo.read()
             .await
             .unwrap()
             .get_info("sys-replication")
@@ -244,6 +253,37 @@ mod tests {
             pending_records(&repo).await,
             1,
             "a usage system event must produce exactly one pending transaction"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[serial]
+    async fn usage_event_notifies_replication_while_repo_read_guard_is_held(
+        #[future] storage: Arc<StorageEngine>,
+    ) {
+        let _reset = ResetRwLockConfig;
+        set_rwlock_timeout(Duration::from_millis(20));
+
+        let storage = storage.await;
+        let repo = system_replication_repo(Arc::clone(&storage)).await;
+        let mut writer = writer(storage);
+        writer
+            .set_replication_notifier(Some(notifier_for(&repo)))
+            .await;
+
+        let guard = repo.read().await.unwrap();
+        writer
+            .log_event(system_event(SystemEventKind::Usage, true))
+            .await
+            .unwrap();
+        drop(guard);
+        sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            pending_records(&repo).await,
+            1,
+            "a caller holding the outer repository read guard must not block system-event replication"
         );
     }
 

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -132,7 +132,7 @@ impl LogSystemEvent for LocalSystemLogger {
 mod tests {
     use super::*;
     use crate::cfg::Cfg;
-    use crate::core::sync::{reset_rwlock_config, set_rwlock_timeout, AsyncRwLock};
+    use crate::core::sync::{rwlock_timeout, set_rwlock_timeout, AsyncRwLock};
     use crate::replication::{ManageReplications, ReplicationRepoBuilder};
     use crate::syslog::{SystemEventKind, SYSTEM_BUCKET_NAME};
     use reduct_base::internal_server_error;
@@ -143,11 +143,11 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::time::{sleep, Duration};
 
-    struct ResetRwLockConfig;
+    struct RestoreRwLockTimeout(Duration);
 
-    impl Drop for ResetRwLockConfig {
+    impl Drop for RestoreRwLockTimeout {
         fn drop(&mut self) {
-            reset_rwlock_config();
+            set_rwlock_timeout(self.0);
         }
     }
 
@@ -262,7 +262,7 @@ mod tests {
     async fn usage_event_notifies_replication_while_repo_read_guard_is_held(
         #[future] storage: Arc<StorageEngine>,
     ) {
-        let _reset = ResetRwLockConfig;
+        let _restore_timeout = RestoreRwLockTimeout(rwlock_timeout());
         set_rwlock_timeout(Duration::from_millis(20));
 
         let storage = storage.await;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Let replication removal and transaction notification use shared access to the outer replication repository trait object.
- Use read guards for API, Zenoh, and `$system` replication notification paths.
- Keep actual mutation protected by the internal replication-map locks.
- Add a regression test that logs a replicable `$system` event while an outer repository read guard is held, covering the lock pattern hit when deleting a replication task that flushes final diagnostics.

This prevents the DELETE /api/v1/replications/{name} path from holding an exclusive outer repository lock while a stopping replication task emits final `$system` diagnostics that notify replication.

### Related issues

Observed from website PR #363 CI: the documentation Go example `data_replication_remove.go` timed out deleting `repl-to-remove`, and server logs showed `$system` replication notification failing to acquire the async write lock.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p reductstore syslog::local_writer::tests::usage_event_notifies_replication_while_repo_read_guard_is_held --features "fs-backend"`

Note: the first test rebuild hit `No space left on device`; I ran `cargo clean` in this worktree, which freed 5.6 GiB, then reran the validation successfully.