### PR TITLE
require explicit API token auth configuration

### DIFF
--- a/.github/actions/api/http-tests/action.yml
+++ b/.github/actions/api/http-tests/action.yml
@@ -29,9 +29,13 @@ runs:
 
     - name: Run ReductStore
       shell: bash
+      env:
+        RS_API_TOKEN: ${{ inputs.token }}
+        RS_DISABLE_AUTH: ${{ inputs.token == '' }}
       run: |
         docker run --network=host -v ${PWD}/misc:/misc \
-          --env RS_API_TOKEN=${{ inputs.token }} \
+          --env RS_API_TOKEN="${RS_API_TOKEN}" \
+          --env RS_DISABLE_AUTH="${RS_DISABLE_AUTH}" \
           --env RS_AUDIT_ENABLED=true \
           --env RS_CERT_PATH=${{ inputs.cert_path }} \
           --env RS_CERT_KEY_PATH=/misc/privateKey.key \

--- a/.github/actions/api/zenoh-tests/action.yml
+++ b/.github/actions/api/zenoh-tests/action.yml
@@ -72,6 +72,7 @@ runs:
         RS_ZENOH_AUTH_DICTIONARY: ${{ inputs.auth_dictionary }}
       run: |
         docker run --network=host -v ${PWD}/misc:/misc \
+          --env RS_DISABLE_AUTH=true \
           --env RS_ZENOH_ENABLED=1 \
           --env RS_ZENOH_CONFIG="${{ steps.zenoh-endpoint.outputs.config }}" \
           --env RS_ZENOH_SUB_KEYEXPRS="**" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ For most changes, build and run ReductStore locally:
 
 ```bash
 mkdir -p ./data
-RS_DATA_PATH=./data cargo run -p reductstore --features "fs-backend web-console"
+RS_DATA_PATH=./data RS_DISABLE_AUTH=true cargo run -p reductstore --features "fs-backend web-console"
 ```
 
 Then exercise the API, replication flow, query behavior, lifecycle policy, or UI path that your change touches.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The quickest way to get up and running is with Docker:
 ```bash
 mkdir -p ./data
 sudo chown -R 10001:10001 ./data
-docker run -p 8383:8383 -v ${PWD}/data:/data reduct/store:latest
+docker run -p 8383:8383 -v ${PWD}/data:/data \
+  -e RS_API_TOKEN=my-secret-token reduct/store:latest
 ```
 
 Or download a Linux binary directly from the latest release:
@@ -73,7 +74,7 @@ Or download a Linux binary directly from the latest release:
 curl -LO https://github.com/reductstore/reductstore/releases/latest/download/reductstore.x86_64-unknown-linux-gnu.tar.gz
 tar -xzf reductstore.x86_64-unknown-linux-gnu.tar.gz
 mkdir -p ./data
-RS_DATA_PATH=./data ./reductstore
+RS_DATA_PATH=./data RS_API_TOKEN=my-secret-token ./reductstore
 ```
 
 For a more in-depth guide, visit the **[Getting Started](https://reduct.store/docs/)** and **[Download](https://www.reduct.store/download)** sections.
@@ -86,7 +87,7 @@ import asyncio
 from reduct import Client
 
 async def main():
-    async with Client("http://localhost:8383") as client:
+    async with Client("http://localhost:8383", api_token="my-secret-token") as client:
         bucket = await client.create_bucket("my-bucket", exist_ok=True)
 
         await bucket.write(

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -9,7 +9,7 @@ docker run --init -d --name zenoh-router -p 7447:7447/tcp eclipse/zenoh
 
 2) Start ReductStore:
 ```bash
-RS_DATA_PATH=~/data-test RS_ZENOH_ENABLED=1 RS_ZENOH_CONFIG="mode=client;connect/endpoints=[tcp/127.0.0.1:7447]" RS_ZENOH_SUB_KEYEXPRS="**" RS_ZENOH_QUERY_KEYEXPRS="**" RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com" cargo run -p reductstore --features "fs-backend web-console zenoh-api"
+RS_DATA_PATH=~/data-test RS_DISABLE_AUTH=true RS_ZENOH_ENABLED=1 RS_ZENOH_CONFIG="mode=client;connect/endpoints=[tcp/127.0.0.1:7447]" RS_ZENOH_SUB_KEYEXPRS="**" RS_ZENOH_QUERY_KEYEXPRS="**" RS_CORS_ALLOW_ORIGIN="https://first-allowed-origin.com, https://second-allowed-origin.com" cargo run -p reductstore --features "fs-backend web-console zenoh-api"
 ```
 
 3) Run tests:
@@ -45,7 +45,7 @@ To test inline credentials, start ReductStore with the credential env vars, then
 ```bash
 docker rm -f zenoh-router && docker run --init -d --name zenoh-router -p 7447:7447/tcp eclipse/zenoh
 
-RS_DATA_PATH=~/data-test RS_ZENOH_ENABLED=1 RS_ZENOH_CONFIG="mode=client;connect/endpoints=[tcp/127.0.0.1:7447]" RS_ZENOH_SUB_KEYEXPRS="**" RS_ZENOH_AUTH_DICTIONARY="testuser:testpassword" cargo run -p reductstore --features "fs-backend web-console zenoh-api"
+RS_DATA_PATH=~/data-test RS_DISABLE_AUTH=true RS_ZENOH_ENABLED=1 RS_ZENOH_CONFIG="mode=client;connect/endpoints=[tcp/127.0.0.1:7447]" RS_ZENOH_SUB_KEYEXPRS="**" RS_ZENOH_AUTH_DICTIONARY="testuser:testpassword" cargo run -p reductstore --features "fs-backend web-console zenoh-api"
 ```
 
 2) Run tests:
@@ -78,7 +78,7 @@ docker rm -f zenoh-router && docker run --init -d --name zenoh-router -p 7447:74
 
 Start ReductStore and run tests:
 ```bash
-RS_DATA_PATH=~/data-test RS_ZENOH_ENABLED=1 RS_ZENOH_CONFIG="mode=client;connect/endpoints=[tls/127.0.0.1:7447]" RS_ZENOH_SUB_KEYEXPRS="**" RS_ZENOH_TLS_ROOT_CA="$(cat misc/ca.crt)" cargo run -p reductstore --features "fs-backend web-console zenoh-api"
+RS_DATA_PATH=~/data-test RS_DISABLE_AUTH=true RS_ZENOH_ENABLED=1 RS_ZENOH_CONFIG="mode=client;connect/endpoints=[tls/127.0.0.1:7447]" RS_ZENOH_SUB_KEYEXPRS="**" RS_ZENOH_TLS_ROOT_CA="$(cat misc/ca.crt)" cargo run -p reductstore --features "fs-backend web-console zenoh-api"
 
 RS_ZENOH_TLS_ROOT_CA="$(cat misc/ca.crt)" pytest integration_tests/zenoh/credentials_test.py -v
 ```

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -511,7 +511,7 @@ pub(crate) mod tests {
         async fn test_builder_builds_and_redirects_to_ui() {
             let cfg = Cfg {
                 data_path: tempfile::tempdir().unwrap().keep(),
-                api_token: "init-token".to_string(),
+                api_token: crate::cfg::ApiToken::Provisioned("init-token".to_string()),
                 api_base_path: "/".to_string(),
                 ..Cfg::default()
             };
@@ -821,7 +821,7 @@ pub(crate) mod tests {
     async fn keeper_with_limits_impl(limits_config: LimitsConfig) -> Arc<StateKeeper> {
         let mut cfg = Cfg {
             data_path: tempfile::tempdir().unwrap().keep(),
-            api_token: "init-token".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("init-token".to_string()),
             ..Cfg::default()
         };
         cfg.system_events_conf.enabled = true;
@@ -946,7 +946,7 @@ pub(crate) mod tests {
     pub(crate) async fn keeper_with_engine_limit(max_storage_size: u64) -> Arc<StateKeeper> {
         let mut cfg = Cfg {
             data_path: tempfile::tempdir().unwrap().keep(),
-            api_token: "init-token".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("init-token".to_string()),
             ..Cfg::default()
         };
         cfg.engine_config.max_storage_size = Some(max_storage_size);

--- a/reductstore/src/api/http/links/get.rs
+++ b/reductstore/src/api/http/links/get.rs
@@ -1054,7 +1054,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_permissions_with_token_repo_expired_token() {
         let cfg = Cfg {
-            api_token: "init-token".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("init-token".to_string()),
             ..Cfg::default()
         };
         let path = tempdir().unwrap().keep();

--- a/reductstore/src/auth/token_auth.rs
+++ b/reductstore/src/auth/token_auth.rs
@@ -111,7 +111,7 @@ mod tests {
 
     async fn setup() -> (BoxedTokenRepository, TokenAuthorization) {
         let cfg = Cfg {
-            api_token: "test".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("test".to_string()),
             ..Cfg::default()
         };
         let repo = TokenRepositoryBuilder::new(cfg)

--- a/reductstore/src/auth/token_repository.rs
+++ b/reductstore/src/auth/token_repository.rs
@@ -417,8 +417,15 @@ impl TokenRepositoryBuilder {
         }
 
         if !self.cfg.api_token.is_empty() {
-            Box::new(TokenRepository::new(config_path, self.cfg.api_token, storage).await)
-                as BoxedTokenRepository
+            Box::new(
+                TokenRepository::new(
+                    config_path,
+                    self.cfg.api_token,
+                    self.cfg.api_token_is_provisioned,
+                    storage,
+                )
+                .await,
+            ) as BoxedTokenRepository
         } else {
             Box::new(NoAuthRepository::new()) as BoxedTokenRepository
         }

--- a/reductstore/src/auth/token_repository.rs
+++ b/reductstore/src/auth/token_repository.rs
@@ -9,7 +9,7 @@ use crate::auth::token_repository::disabled::NoAuthRepository;
 use crate::auth::token_repository::read_only::ReadOnlyTokenRepository;
 use crate::auth::token_repository::repo::TokenRepository;
 use crate::auth::token_secret::verify_token_secret;
-use crate::cfg::{Cfg, InstanceRole};
+use crate::cfg::{ApiToken, Cfg, InstanceRole};
 use crate::storage::engine::StorageEngine;
 use crate::syslog::SYSTEM_AUDIT_ENTRY_PREFIX;
 use async_trait::async_trait;
@@ -416,18 +416,10 @@ impl TokenRepositoryBuilder {
             ) as BoxedTokenRepository;
         }
 
-        if !self.cfg.api_token.is_empty() {
-            Box::new(
-                TokenRepository::new(
-                    config_path,
-                    self.cfg.api_token,
-                    self.cfg.api_token_is_provisioned,
-                    storage,
-                )
-                .await,
-            ) as BoxedTokenRepository
-        } else {
-            Box::new(NoAuthRepository::new()) as BoxedTokenRepository
+        match self.cfg.api_token {
+            ApiToken::NoToken => Box::new(NoAuthRepository::new()) as BoxedTokenRepository,
+            api_token => Box::new(TokenRepository::new(config_path, api_token, storage).await)
+                as BoxedTokenRepository,
         }
     }
 }

--- a/reductstore/src/auth/token_repository/read_only.rs
+++ b/reductstore/src/auth/token_repository/read_only.rs
@@ -96,7 +96,7 @@ impl ReadOnlyTokenRepository {
             client_build: "Failed to build system-events read-only token client",
             kind: ClientBuildErrorKind::InternalServerError,
         })
-        .api_token(&cfg.api_token)
+        .api_token(cfg.api_token.as_str())
         .verify_ssl(cfg.system_events_conf.remote_verify_ssl)
         .ca_path(cfg.system_events_conf.remote_ca_path.as_ref())
         .connect_timeout(cfg.system_events_conf.remote_timeout)
@@ -119,7 +119,7 @@ impl ReadOnlyTokenRepository {
     }
 
     async fn load_repo(&self) -> Result<HashMap<String, Token>, ReductError> {
-        let api_token = self.cfg.api_token.clone();
+        let api_token = self.cfg.api_token.as_str().to_string();
 
         FILE_CACHE.discard_recursive(&self.config_path).await?; // ensure we update it from backend
         let mut repo: HashMap<String, Token> = HashMap::new();
@@ -409,7 +409,7 @@ mod tests {
             let (mut repo, _) = repo_fixture.await;
             let token = repo.get_token(INIT_TOKEN_NAME).await.unwrap();
             assert!(is_hashed_token_secret(&token.value));
-            assert!(verify_token_secret(&token.value, &cfg.api_token));
+            assert!(verify_token_secret(&token.value, cfg.api_token.as_str()));
             assert!(token.is_provisioned);
         }
 
@@ -487,7 +487,7 @@ mod tests {
             let token = repo.get_token(INIT_TOKEN_NAME).await.unwrap().clone();
             assert_eq!(token.name, INIT_TOKEN_NAME.to_string());
             assert!(is_hashed_token_secret(&token.value));
-            assert!(verify_token_secret(&token.value, &cfg.api_token));
+            assert!(verify_token_secret(&token.value, cfg.api_token.as_str()));
             assert_eq!(
                 token.permissions,
                 Some(Permissions {
@@ -545,14 +545,14 @@ mod tests {
             cfg: Cfg,
         ) {
             let (mut repo, _) = repo_fixture.await;
-            let header = format!("Bearer {}", cfg.api_token);
+            let header = format!("Bearer {}", cfg.api_token.as_str());
             let res = repo
                 .validate_token(Some(header.as_str()), None)
                 .await
                 .unwrap();
             assert_eq!(res.name, INIT_TOKEN_NAME.to_string());
             assert!(is_hashed_token_secret(&res.value));
-            assert!(verify_token_secret(&res.value, &cfg.api_token));
+            assert!(verify_token_secret(&res.value, cfg.api_token.as_str()));
             assert_eq!(
                 res.permissions,
                 Some(Permissions {
@@ -715,7 +715,7 @@ mod tests {
     #[tokio::test]
     async fn test_build_audit_client_none_with_invalid_ca() {
         let mut cfg = Cfg::default();
-        cfg.api_token = "secret".to_string();
+        cfg.api_token = crate::cfg::ApiToken::Provisioned("secret".to_string());
         cfg.primary_url = Some("http://127.0.0.1:1/".to_string());
         cfg.system_events_conf.remote_ca_path = Some("/tmp/does-not-exist-ca.pem".into());
         assert!(ReadOnlyTokenRepository::build_audit_client(&cfg).is_none());
@@ -736,7 +736,7 @@ mod tests {
         let base_url = start_bucket_info_server(body).await;
 
         let mut cfg = Cfg::default();
-        cfg.api_token = "test_token".to_string();
+        cfg.api_token = crate::cfg::ApiToken::Provisioned("test_token".to_string());
         cfg.role = InstanceRole::Replica;
         cfg.primary_url = Some(base_url);
 
@@ -767,7 +767,7 @@ mod tests {
     #[fixture]
     fn cfg() -> Cfg {
         let mut cfg = Cfg::default();
-        cfg.api_token = "test_token".to_string();
+        cfg.api_token = crate::cfg::ApiToken::Provisioned("test_token".to_string());
         cfg.role = InstanceRole::Replica;
         cfg.engine_config.replica_update_interval = std::time::Duration::from_millis(100);
         cfg

--- a/reductstore/src/auth/token_repository/repo.rs
+++ b/reductstore/src/auth/token_repository/repo.rs
@@ -55,7 +55,8 @@ impl TokenRepository {
     /// # Arguments
     ///
     /// * `data_path` - The path to the data directory
-    /// * `api_token` - The API token with full access to the repository. If it is empty, no authentication is required.
+    /// * `api_token` - The API token with full access to the repository.
+    /// * `api_token_is_provisioned` - Whether the initial token is managed by configuration.
     ///
     /// # Returns
     ///
@@ -63,6 +64,7 @@ impl TokenRepository {
     pub async fn new(
         data_path: PathBuf,
         api_token: String,
+        api_token_is_provisioned: bool,
         storage: Option<Arc<StorageEngine>>,
     ) -> TokenRepository {
         let config_path = data_path.join(TOKEN_REPO_FILE_NAME);
@@ -115,48 +117,57 @@ impl TokenRepository {
             }
         };
 
-        let mut migrated = false;
+        let mut repository_changed = false;
         for token in token_repository.repo.values_mut() {
             if Self::ensure_hashed_token_secret(token).expect("Failed to hash token secret") {
-                migrated = true;
+                repository_changed = true;
             }
         }
 
-        let full_access_permissions = Some(Permissions {
-            full_access: true,
-            read: vec![],
-            write: vec![],
-        });
         let existing_init_token = token_repository.repo.get(INIT_TOKEN_NAME).cloned();
-        let init_token_value = token_repository
-            .repo
-            .get(INIT_TOKEN_NAME)
-            .and_then(|token| matched_hashed_token_secret(&token.value, &api_token))
-            .map(|secret| secret.to_string())
-            .unwrap_or_else(|| {
-                hash_token_secret(&api_token).expect("Failed to hash init token secret")
-            });
-
-        let init_token = Token {
-            name: INIT_TOKEN_NAME.to_string(),
-            value: init_token_value,
-            created_at: existing_init_token
+        let should_initialize_token = api_token_is_provisioned
+            || existing_init_token
                 .as_ref()
-                .map(|token| token.created_at)
-                .unwrap_or_else(|| DateTime::<Utc>::from(SystemTime::now())),
-            permissions: full_access_permissions.clone(),
-            is_provisioned: true,
-            expires_at: None,
-            ttl: None,
-            last_access: None,
-            ip_allowlist: vec![],
-            is_expired: false,
-        };
+                .map_or(true, |token| token.is_provisioned);
 
-        token_repository
-            .repo
-            .insert(init_token.name.clone(), init_token);
-        if migrated {
+        if should_initialize_token {
+            let init_token_value = existing_init_token
+                .as_ref()
+                .and_then(|token| matched_hashed_token_secret(&token.value, &api_token))
+                .map(|secret| secret.to_string())
+                .unwrap_or_else(|| {
+                    hash_token_secret(&api_token).expect("Failed to hash init token secret")
+                });
+
+            let init_token = Token {
+                name: INIT_TOKEN_NAME.to_string(),
+                value: init_token_value,
+                created_at: existing_init_token
+                    .as_ref()
+                    .map(|token| token.created_at)
+                    .unwrap_or_else(|| DateTime::<Utc>::from(SystemTime::now())),
+                permissions: Some(Permissions {
+                    full_access: true,
+                    read: vec![],
+                    write: vec![],
+                }),
+                is_provisioned: api_token_is_provisioned,
+                expires_at: None,
+                ttl: None,
+                last_access: None,
+                ip_allowlist: vec![],
+                is_expired: false,
+            };
+
+            token_repository
+                .repo
+                .insert(init_token.name.clone(), init_token);
+            if !api_token_is_provisioned {
+                repository_changed = true;
+            }
+        }
+
+        if repository_changed {
             token_repository
                 .save_repo()
                 .await
@@ -433,6 +444,27 @@ impl ManageTokens for TokenRepository {
             if token.is_provisioned {
                 return Err(conflict!("Can't remove provisioned token '{}'", name));
             }
+
+            let is_full_access = token
+                .permissions
+                .as_ref()
+                .is_some_and(|permissions| permissions.full_access);
+            let full_access_token_count = self
+                .repo
+                .values()
+                .filter(|token| {
+                    token
+                        .permissions
+                        .as_ref()
+                        .is_some_and(|permissions| permissions.full_access)
+                })
+                .count();
+            if is_full_access && full_access_token_count == 1 {
+                return Err(conflict!(
+                    "Can't remove token '{}': at least one full-access token must remain",
+                    name
+                ));
+            }
         }
 
         if self.repo.remove(name).is_none() {
@@ -445,10 +477,6 @@ impl ManageTokens for TokenRepository {
     }
 
     async fn rotate_token(&mut self, name: &str) -> Result<TokenCreateResponse, ReductError> {
-        if name == INIT_TOKEN_NAME {
-            return Err(conflict!("Can't rotate init token"));
-        }
-
         let token = self
             .repo
             .get_mut(name)
@@ -1171,6 +1199,79 @@ mod tests {
             let err = repo.remove_token("test").await.err().unwrap();
             assert_eq!(err, conflict!("Can't remove provisioned token 'test'"))
         }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_reject_remove_last_full_access_token(path: PathBuf, init_token: &str) {
+            let cfg = Cfg {
+                api_token: init_token.to_string(),
+                api_token_is_provisioned: false,
+                ..Default::default()
+            };
+            let mut repo = build_repo_at(&path, &cfg).await;
+
+            let err = repo.remove_token(INIT_TOKEN_NAME).await.err().unwrap();
+
+            assert_eq!(
+                err,
+                conflict!(
+                    "Can't remove token 'init-token': at least one full-access token must remain"
+                )
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_recreate_removed_init_token_from_initial_api_token(
+            path: PathBuf,
+            init_token: &str,
+        ) {
+            let cfg = Cfg {
+                api_token: init_token.to_string(),
+                api_token_is_provisioned: false,
+                ..Default::default()
+            };
+            let mut repo = build_repo_at(&path, &cfg).await;
+            repo.generate_token(
+                "admin",
+                TokenCreateRequest {
+                    permissions: Permissions {
+                        full_access: true,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+            repo.remove_token(INIT_TOKEN_NAME).await.unwrap();
+            drop(repo);
+
+            let mut repo = build_repo_at(&path, &cfg).await;
+            let token = repo.get_token(INIT_TOKEN_NAME).await.unwrap();
+            assert!(!token.is_provisioned);
+            assert!(token
+                .permissions
+                .as_ref()
+                .is_some_and(|permissions| permissions.full_access));
+            repo.validate_token(Some(&format!("Bearer {}", init_token)), None)
+                .await
+                .unwrap();
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_remove_non_full_access_token_when_only_one_admin_remains(
+            #[future] repo: BoxedTokenRepository,
+        ) {
+            let mut repo = repo.await;
+            let mut token = repo.get_token("test").await.unwrap().clone();
+            token.permissions = Some(Permissions::default());
+            repo.update_token(token).await.unwrap();
+
+            repo.remove_token("test").await.unwrap();
+        }
     }
 
     mod rotate_token {
@@ -1202,10 +1303,40 @@ mod tests {
 
         #[rstest]
         #[tokio::test]
-        async fn test_rotate_init_token(#[future] repo: BoxedTokenRepository) {
+        async fn test_rotate_provisioned_init_token(#[future] repo: BoxedTokenRepository) {
             let mut repo = repo.await;
             let err = repo.rotate_token(INIT_TOKEN_NAME).await.err().unwrap();
-            assert_eq!(err, conflict!("Can't rotate init token"));
+            assert_eq!(
+                err,
+                conflict!("Can't rotate provisioned token 'init-token'")
+            );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_rotate_initial_api_token(path: PathBuf, init_token: &str) {
+            let cfg = Cfg {
+                api_token: init_token.to_string(),
+                api_token_is_provisioned: false,
+                ..Default::default()
+            };
+            let mut repo = build_repo_at(&path, &cfg).await;
+
+            let rotated = repo.rotate_token(INIT_TOKEN_NAME).await.unwrap();
+            drop(repo);
+
+            let mut repo = build_repo_at(&path, &cfg).await;
+            let token = repo
+                .validate_token(Some(&format!("Bearer {}", rotated.value)), None)
+                .await
+                .unwrap();
+            assert_eq!(token.name, INIT_TOKEN_NAME);
+            assert!(!token.is_provisioned);
+            assert_eq!(
+                repo.validate_token(Some(&format!("Bearer {}", init_token)), None)
+                    .await,
+                Err(unauthorized!("Invalid token"))
+            );
         }
 
         #[rstest]

--- a/reductstore/src/auth/token_repository/repo.rs
+++ b/reductstore/src/auth/token_repository/repo.rs
@@ -10,6 +10,7 @@ use crate::auth::token_repository::{
 use crate::auth::token_secret::{
     hash_token_secret, is_hashed_token_secret, matched_hashed_token_secret,
 };
+use crate::cfg::ApiToken;
 use crate::core::cache::Cache;
 use crate::core::file_cache::FILE_CACHE;
 use crate::storage::engine::StorageEngine;
@@ -55,16 +56,14 @@ impl TokenRepository {
     /// # Arguments
     ///
     /// * `data_path` - The path to the data directory
-    /// * `api_token` - The API token with full access to the repository.
-    /// * `api_token_is_provisioned` - Whether the initial token is managed by configuration.
+    /// * `api_token` - The configured API token with full access to the repository.
     ///
     /// # Returns
     ///
     /// The repository
     pub async fn new(
         data_path: PathBuf,
-        api_token: String,
-        api_token_is_provisioned: bool,
+        api_token: ApiToken,
         storage: Option<Arc<StorageEngine>>,
     ) -> TokenRepository {
         let config_path = data_path.join(TOKEN_REPO_FILE_NAME);
@@ -125,18 +124,22 @@ impl TokenRepository {
         }
 
         let existing_init_token = token_repository.repo.get(INIT_TOKEN_NAME).cloned();
-        let should_initialize_token = api_token_is_provisioned
-            || existing_init_token
+        let should_initialize_token = match &api_token {
+            ApiToken::NoToken => false,
+            ApiToken::Provisioned(_) => true,
+            ApiToken::Initialized(_) => existing_init_token
                 .as_ref()
-                .map_or(true, |token| token.is_provisioned);
+                .map_or(true, |token| token.is_provisioned),
+        };
 
         if should_initialize_token {
+            let api_token_value = api_token.as_str();
             let init_token_value = existing_init_token
                 .as_ref()
-                .and_then(|token| matched_hashed_token_secret(&token.value, &api_token))
+                .and_then(|token| matched_hashed_token_secret(&token.value, api_token_value))
                 .map(|secret| secret.to_string())
                 .unwrap_or_else(|| {
-                    hash_token_secret(&api_token).expect("Failed to hash init token secret")
+                    hash_token_secret(api_token_value).expect("Failed to hash init token secret")
                 });
 
             let init_token = Token {
@@ -151,7 +154,7 @@ impl TokenRepository {
                     read: vec![],
                     write: vec![],
                 }),
-                is_provisioned: api_token_is_provisioned,
+                is_provisioned: matches!(&api_token, ApiToken::Provisioned(_)),
                 expires_at: None,
                 ttl: None,
                 last_access: None,
@@ -162,7 +165,7 @@ impl TokenRepository {
             token_repository
                 .repo
                 .insert(init_token.name.clone(), init_token);
-            if !api_token_is_provisioned {
+            if matches!(&api_token, ApiToken::Initialized(_)) {
                 repository_changed = true;
             }
         }
@@ -714,7 +717,7 @@ mod tests {
         #[tokio::test]
         async fn test_create_token_persistent(path: PathBuf, init_token: &str) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
+                api_token: ApiToken::Provisioned(init_token.to_string()),
                 ..Default::default()
             };
 
@@ -743,7 +746,7 @@ mod tests {
         #[tokio::test]
         async fn test_migrate_plaintext_token_on_startup(path: PathBuf, init_token: &str) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
+                api_token: ApiToken::Provisioned(init_token.to_string()),
                 ..Default::default()
             };
 
@@ -784,7 +787,7 @@ mod tests {
         #[tokio::test]
         async fn test_create_token_expiry_persistent(path: PathBuf, init_token: &str) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
+                api_token: ApiToken::Provisioned(init_token.to_string()),
                 ..Default::default()
             };
 
@@ -911,7 +914,7 @@ mod tests {
         #[tokio::test]
         async fn test_update_token_persistent(path: PathBuf, init_token: &str) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
+                api_token: ApiToken::Provisioned(init_token.to_string()),
                 ..Default::default()
             };
 
@@ -1082,7 +1085,7 @@ mod tests {
         #[tokio::test]
         async fn test_validate_token_cache_invalidation_on_update(path: PathBuf, init_token: &str) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
+                api_token: ApiToken::Provisioned(init_token.to_string()),
                 ..Default::default()
             };
 
@@ -1204,8 +1207,7 @@ mod tests {
         #[tokio::test]
         async fn test_reject_remove_last_full_access_token(path: PathBuf, init_token: &str) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
-                api_token_is_provisioned: false,
+                api_token: ApiToken::Initialized(init_token.to_string()),
                 ..Default::default()
             };
             let mut repo = build_repo_at(&path, &cfg).await;
@@ -1227,8 +1229,7 @@ mod tests {
             init_token: &str,
         ) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
-                api_token_is_provisioned: false,
+                api_token: ApiToken::Initialized(init_token.to_string()),
                 ..Default::default()
             };
             let mut repo = build_repo_at(&path, &cfg).await;
@@ -1316,8 +1317,7 @@ mod tests {
         #[tokio::test]
         async fn test_rotate_initial_api_token(path: PathBuf, init_token: &str) {
             let cfg = Cfg {
-                api_token: init_token.to_string(),
-                api_token_is_provisioned: false,
+                api_token: ApiToken::Initialized(init_token.to_string()),
                 ..Default::default()
             };
             let mut repo = build_repo_at(&path, &cfg).await;
@@ -1482,7 +1482,7 @@ mod tests {
             let temp_dir = tempdir().unwrap();
             let mut cfg = Cfg {
                 data_path: temp_dir.keep(),
-                api_token: "init-token".to_string(),
+                api_token: ApiToken::Provisioned("init-token".to_string()),
                 ..Cfg::default()
             };
             cfg.system_events_conf.enabled = true;
@@ -1580,7 +1580,7 @@ mod tests {
     #[fixture]
     fn cfg(init_token: &str) -> Cfg {
         Cfg {
-            api_token: init_token.to_string(),
+            api_token: ApiToken::Provisioned(init_token.to_string()),
             ..Default::default()
         }
     }

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -88,6 +88,7 @@ pub struct Cfg {
     pub api_base_path: String,
     pub data_path: PathBuf,
     pub api_token: String,
+    pub api_token_is_provisioned: bool,
     pub cert_path: Option<PathBuf>,
     pub cert_key_path: Option<PathBuf>,
     pub ext_path: Option<PathBuf>,
@@ -124,6 +125,7 @@ impl Default for Cfg {
             api_base_path: "/".to_string(),
             data_path: PathBuf::from("/data"),
             api_token: "".to_string(),
+            api_token_is_provisioned: true,
             cert_path: None,
             cert_key_path: None,
             ext_path: None,
@@ -291,7 +293,8 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         let lifecycles = Self::parse_lifecycles(&mut env);
         let has_lifecycles = !lifecycles.is_empty();
 
-        let api_token = env.get_masked("RS_API_TOKEN", "".to_string());
+        let (api_token, api_token_is_provisioned) =
+            Self::parse_auth_config(&mut env, ext_cfg.role());
 
         let cfg = Cfg {
             log_level: env.get("RS_LOG_LEVEL", DEFAULT_LOG_LEVEL.to_string()),
@@ -301,6 +304,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             api_base_path,
             data_path: ext_cfg.data_path(),
             api_token: api_token.clone(),
+            api_token_is_provisioned,
             cert_path,
             cert_key_path,
             role: ext_cfg.role(),
@@ -516,6 +520,38 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect()
+    }
+
+    fn parse_auth_config(env: &mut Env<EnvGetter>, instance_role: InstanceRole) -> (String, bool) {
+        if instance_role == InstanceRole::Replica {
+            return (env.get_masked("RS_API_TOKEN", String::new()), true);
+        }
+
+        if env.get("RS_DISABLE_AUTH", false) {
+            return (String::new(), false);
+        }
+
+        let api_token = env.get_masked_optional::<String>("RS_API_TOKEN");
+        let init_api_token = env.get_masked_optional::<String>("RS_INIT_API_TOKEN");
+
+        match (api_token, init_api_token) {
+            (Some(_), Some(_)) => {
+                panic!("RS_API_TOKEN and RS_INIT_API_TOKEN must not both be set")
+            }
+            (None, None) => {
+                panic!(
+                    "Authentication is enabled: set exactly one of RS_API_TOKEN or RS_INIT_API_TOKEN"
+                )
+            }
+            (Some(token), None) => {
+                assert!(!token.is_empty(), "RS_API_TOKEN must not be empty");
+                (token, true)
+            }
+            (None, Some(token)) => {
+                assert!(!token.is_empty(), "RS_INIT_API_TOKEN must not be empty");
+                (token, false)
+            }
+        }
     }
 }
 
@@ -845,19 +881,191 @@ mod tests {
         assert_eq!(parser.cfg.data_path, PathBuf::from("/tmp"));
     }
 
-    #[rstest]
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_api_token(mut env_getter: MockEnvGetter) {
-        env_getter
-            .expect_get()
-            .with(eq("RS_API_TOKEN"))
-            .times(1)
-            .return_const(Ok("XXX".to_string()));
-        env_getter
-            .expect_get()
-            .return_const(Err(VarError::NotPresent));
-        let parser = CfgParser::from_env(env_getter, "0.0.0").await;
-        assert_eq!(parser.cfg.api_token, "XXX");
+    mod auth_config {
+        use super::*;
+
+        #[rstest]
+        fn api_token_is_provisioned() {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Err(VarError::NotPresent));
+            env_getter
+                .expect_get()
+                .with(eq("RS_API_TOKEN"))
+                .return_const(Ok("api-token".to_string()));
+            env_getter
+                .expect_get()
+                .with(eq("RS_INIT_API_TOKEN"))
+                .return_const(Err(VarError::NotPresent));
+
+            let mut env = Env::new(env_getter);
+            assert_eq!(
+                CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Standalone),
+                ("api-token".to_string(), true)
+            );
+        }
+
+        #[rstest]
+        fn init_api_token_is_not_provisioned() {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Err(VarError::NotPresent));
+            env_getter
+                .expect_get()
+                .with(eq("RS_API_TOKEN"))
+                .return_const(Err(VarError::NotPresent));
+            env_getter
+                .expect_get()
+                .with(eq("RS_INIT_API_TOKEN"))
+                .return_const(Ok("init-api-token".to_string()));
+
+            let mut env = Env::new(env_getter);
+            assert_eq!(
+                CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Standalone),
+                ("init-api-token".to_string(), false)
+            );
+        }
+
+        #[rstest]
+        fn disabled_auth_ignores_token_variables() {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Ok("true".to_string()));
+            env_getter.expect_get().with(eq("RS_API_TOKEN")).times(0);
+            env_getter
+                .expect_get()
+                .with(eq("RS_INIT_API_TOKEN"))
+                .times(0);
+
+            let mut env = Env::new(env_getter);
+            assert_eq!(
+                CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Standalone),
+                (String::new(), false)
+            );
+        }
+
+        #[rstest]
+        fn replica_uses_api_token_without_new_auth_configuration() {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .with(eq("RS_API_TOKEN"))
+                .return_const(Ok("replica-token".to_string()));
+            env_getter.expect_get().with(eq("RS_DISABLE_AUTH")).times(0);
+            env_getter
+                .expect_get()
+                .with(eq("RS_INIT_API_TOKEN"))
+                .times(0);
+
+            let mut env = Env::new(env_getter);
+            assert_eq!(
+                CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Replica),
+                ("replica-token".to_string(), true)
+            );
+        }
+
+        #[rstest]
+        fn replica_allows_missing_api_token() {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .with(eq("RS_API_TOKEN"))
+                .return_const(Err(VarError::NotPresent));
+
+            let mut env = Env::new(env_getter);
+            assert_eq!(
+                CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Replica),
+                (String::new(), true)
+            );
+        }
+
+        #[rstest]
+        #[should_panic(expected = "RS_API_TOKEN and RS_INIT_API_TOKEN must not both be set")]
+        fn rejects_both_token_variables() {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Err(VarError::NotPresent));
+            env_getter
+                .expect_get()
+                .with(eq("RS_API_TOKEN"))
+                .return_const(Ok("api-token".to_string()));
+            env_getter
+                .expect_get()
+                .with(eq("RS_INIT_API_TOKEN"))
+                .return_const(Ok("init-api-token".to_string()));
+
+            CfgParser::<MockEnvGetter>::parse_auth_config(
+                &mut Env::new(env_getter),
+                InstanceRole::Standalone,
+            );
+        }
+
+        #[rstest]
+        #[should_panic(
+            expected = "Authentication is enabled: set exactly one of RS_API_TOKEN or RS_INIT_API_TOKEN"
+        )]
+        fn rejects_missing_token_variables() {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .return_const(Err(VarError::NotPresent));
+
+            CfgParser::<MockEnvGetter>::parse_auth_config(
+                &mut Env::new(env_getter),
+                InstanceRole::Standalone,
+            );
+        }
+
+        #[rstest]
+        #[case("RS_API_TOKEN", "RS_API_TOKEN must not be empty")]
+        #[case("RS_INIT_API_TOKEN", "RS_INIT_API_TOKEN must not be empty")]
+        fn rejects_empty_token_variable(#[case] variable: &str, #[case] expected: &str) {
+            let mut env_getter = MockEnvGetter::new();
+            env_getter
+                .expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Err(VarError::NotPresent));
+            let selected_variable = variable.to_string();
+            env_getter
+                .expect_get()
+                .withf(move |name| name == selected_variable)
+                .return_const(Ok(String::new()));
+            let missing_variable = if variable == "RS_API_TOKEN" {
+                "RS_INIT_API_TOKEN"
+            } else {
+                "RS_API_TOKEN"
+            };
+            env_getter
+                .expect_get()
+                .with(eq(missing_variable))
+                .return_const(Err(VarError::NotPresent));
+
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                CfgParser::<MockEnvGetter>::parse_auth_config(
+                    &mut Env::new(env_getter),
+                    InstanceRole::Standalone,
+                );
+            }));
+            let payload = result.err().unwrap();
+            let panic_message = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| {
+                    payload
+                        .downcast_ref::<&str>()
+                        .map(|value| value.to_string())
+                })
+                .unwrap();
+            assert_eq!(panic_message, expected);
+        }
     }
 
     #[rstest]
@@ -992,6 +1200,10 @@ mod tests {
     async fn test_remote_storage_s3() {
         // we cover only s3 parts here, filesystem is used as backend
         let mut env_getter = MockEnvGetter::new();
+        env_getter
+            .expect_get()
+            .with(eq("RS_DISABLE_AUTH"))
+            .return_const(Ok("true".to_string()));
         env_getter
             .expect_get()
             .with(eq("RS_DATA_PATH"))
@@ -1137,6 +1349,10 @@ mod tests {
     #[fixture]
     fn env_getter() -> MockEnvGetter {
         let mut mock_getter = MockEnvGetter::new();
+        mock_getter
+            .expect_get()
+            .with(eq("RS_DISABLE_AUTH"))
+            .return_const(Ok("true".to_string()));
         mock_getter.expect_all().returning(|| BTreeMap::new());
         mock_getter
     }

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -67,6 +67,23 @@ pub enum InstanceRole {
     Replica,
 }
 
+#[derive(Debug, PartialEq, Clone, Default)]
+pub enum ApiToken {
+    #[default]
+    NoToken,
+    Provisioned(String),
+    Initialized(String),
+}
+
+impl ApiToken {
+    pub fn as_str(&self) -> &str {
+        match self {
+            ApiToken::NoToken => "",
+            ApiToken::Provisioned(token) | ApiToken::Initialized(token) => token,
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct ProvisionedReplication {
     pub settings: ReplicationSettings,
@@ -87,8 +104,7 @@ pub struct Cfg {
     pub public_url: String,
     pub api_base_path: String,
     pub data_path: PathBuf,
-    pub api_token: String,
-    pub api_token_is_provisioned: bool,
+    pub api_token: ApiToken,
     pub cert_path: Option<PathBuf>,
     pub cert_key_path: Option<PathBuf>,
     pub ext_path: Option<PathBuf>,
@@ -124,8 +140,7 @@ impl Default for Cfg {
             public_url: format!("http://{}:{}/", DEFAULT_HOST, DEFAULT_PORT),
             api_base_path: "/".to_string(),
             data_path: PathBuf::from("/data"),
-            api_token: "".to_string(),
-            api_token_is_provisioned: true,
+            api_token: ApiToken::NoToken,
             cert_path: None,
             cert_key_path: None,
             ext_path: None,
@@ -293,8 +308,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         let lifecycles = Self::parse_lifecycles(&mut env);
         let has_lifecycles = !lifecycles.is_empty();
 
-        let (api_token, api_token_is_provisioned) =
-            Self::parse_auth_config(&mut env, ext_cfg.role());
+        let api_token = Self::parse_auth_config(&mut env, ext_cfg.role());
 
         let cfg = Cfg {
             log_level: env.get("RS_LOG_LEVEL", DEFAULT_LOG_LEVEL.to_string()),
@@ -303,8 +317,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             port,
             api_base_path,
             data_path: ext_cfg.data_path(),
-            api_token: api_token.clone(),
-            api_token_is_provisioned,
+            api_token,
             cert_path,
             cert_key_path,
             role: ext_cfg.role(),
@@ -463,7 +476,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         Ok(Components {
             storage: Arc::clone(&storage),
             token_repo: AsyncRwLock::new(token_repo.await),
-            auth: TokenAuthorization::new(&self.cfg.api_token),
+            auth: TokenAuthorization::new(self.cfg.api_token.as_str()),
             console,
             replication_repo: replication_engine,
             lifecycle_repo: AsyncRwLock::new(lifecycle_engine),
@@ -522,13 +535,18 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             .collect()
     }
 
-    fn parse_auth_config(env: &mut Env<EnvGetter>, instance_role: InstanceRole) -> (String, bool) {
+    fn parse_auth_config(env: &mut Env<EnvGetter>, instance_role: InstanceRole) -> ApiToken {
         if instance_role == InstanceRole::Replica {
-            return (env.get_masked("RS_API_TOKEN", String::new()), true);
+            let token = env.get_masked("RS_API_TOKEN", String::new());
+            return if token.is_empty() {
+                ApiToken::NoToken
+            } else {
+                ApiToken::Provisioned(token)
+            };
         }
 
         if env.get("RS_DISABLE_AUTH", false) {
-            return (String::new(), false);
+            return ApiToken::NoToken;
         }
 
         let api_token = env.get_masked_optional::<String>("RS_API_TOKEN");
@@ -545,11 +563,11 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             }
             (Some(token), None) => {
                 assert!(!token.is_empty(), "RS_API_TOKEN must not be empty");
-                (token, true)
+                ApiToken::Provisioned(token)
             }
             (None, Some(token)) => {
                 assert!(!token.is_empty(), "RS_INIT_API_TOKEN must not be empty");
-                (token, false)
+                ApiToken::Initialized(token)
             }
         }
     }
@@ -654,7 +672,7 @@ mod tests {
         assert_eq!(parser.cfg.api_base_path, "/");
         assert_eq!(parser.cfg.public_url, "http://0.0.0.0:8383/");
         assert_eq!(parser.cfg.data_path, PathBuf::from("/data"));
-        assert_eq!(parser.cfg.api_token, "");
+        assert_eq!(parser.cfg.api_token, ApiToken::NoToken);
         assert_eq!(parser.cfg.cert_path, None);
         assert_eq!(parser.cfg.cert_key_path, None);
         assert_eq!(parser.cfg.cors_allow_origin.len(), 0);
@@ -885,7 +903,7 @@ mod tests {
         use super::*;
 
         #[rstest]
-        fn api_token_is_provisioned() {
+        fn parses_api_token_as_provisioned() {
             let mut env_getter = MockEnvGetter::new();
             env_getter
                 .expect_get()
@@ -903,12 +921,12 @@ mod tests {
             let mut env = Env::new(env_getter);
             assert_eq!(
                 CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Standalone),
-                ("api-token".to_string(), true)
+                ApiToken::Provisioned("api-token".to_string())
             );
         }
 
         #[rstest]
-        fn init_api_token_is_not_provisioned() {
+        fn parses_init_api_token_as_initialized() {
             let mut env_getter = MockEnvGetter::new();
             env_getter
                 .expect_get()
@@ -926,7 +944,7 @@ mod tests {
             let mut env = Env::new(env_getter);
             assert_eq!(
                 CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Standalone),
-                ("init-api-token".to_string(), false)
+                ApiToken::Initialized("init-api-token".to_string())
             );
         }
 
@@ -946,7 +964,7 @@ mod tests {
             let mut env = Env::new(env_getter);
             assert_eq!(
                 CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Standalone),
-                (String::new(), false)
+                ApiToken::NoToken
             );
         }
 
@@ -966,7 +984,7 @@ mod tests {
             let mut env = Env::new(env_getter);
             assert_eq!(
                 CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Replica),
-                ("replica-token".to_string(), true)
+                ApiToken::Provisioned("replica-token".to_string())
             );
         }
 
@@ -981,7 +999,7 @@ mod tests {
             let mut env = Env::new(env_getter);
             assert_eq!(
                 CfgParser::<MockEnvGetter>::parse_auth_config(&mut env, InstanceRole::Replica),
-                (String::new(), true)
+                ApiToken::NoToken
             );
         }
 

--- a/reductstore/src/cfg/provision/bucket.rs
+++ b/reductstore/src/cfg/provision/bucket.rs
@@ -204,6 +204,10 @@ mod tests {
         env_getter.expect_all().returning(BTreeMap::new);
         env_getter
             .expect_get()
+            .with(eq("RS_DISABLE_AUTH"))
+            .return_const(Ok("true".to_string()));
+        env_getter
+            .expect_get()
             .with(eq("RS_DEFAULTS_BUCKET_QUOTA_TYPE"))
             .return_const(Ok("FIFO".to_string()));
         env_getter
@@ -241,6 +245,10 @@ mod tests {
     async fn test_bucket_defaults_from_env_fill_missing() {
         let mut env_getter = MockEnvGetter::new();
         env_getter.expect_all().returning(BTreeMap::new);
+        env_getter
+            .expect_get()
+            .with(eq("RS_DISABLE_AUTH"))
+            .return_const(Ok("true".to_string()));
         env_getter
             .expect_get()
             .with(eq("RS_DEFAULTS_BUCKET_MAX_BLOCK_SIZE"))
@@ -331,6 +339,10 @@ mod tests {
     fn env_with_buckets() -> MockEnvGetter {
         let tmp = tempfile::tempdir().unwrap();
         let mut mock_getter = MockEnvGetter::new();
+        mock_getter
+            .expect_get()
+            .with(eq("RS_DISABLE_AUTH"))
+            .return_const(Ok("true".to_string()));
         mock_getter
             .expect_get()
             .with(eq("RS_DATA_PATH"))

--- a/reductstore/src/cfg/provision/lifecycle.rs
+++ b/reductstore/src/cfg/provision/lifecycle.rs
@@ -218,6 +218,7 @@ mod tests {
 
     fn lifecycle_env(path: PathBuf, overrides: &[(&str, &str)]) -> TestEnvGetter {
         let mut values = BTreeMap::from([
+            ("RS_DISABLE_AUTH".to_string(), "true".to_string()),
             (
                 "RS_DATA_PATH".to_string(),
                 path.to_str().unwrap().to_string(),

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -917,6 +917,9 @@ mod tests {
         fn env_with_each_s(path: PathBuf) -> MockEnvGetter {
             let mut env = MockEnvGetter::new();
             env.expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Ok("true".to_string()));
+            env.expect_get()
                 .with(eq("RS_DATA_PATH"))
                 .return_const(Ok(path.to_str().unwrap().to_string()));
 
@@ -1037,6 +1040,9 @@ mod tests {
             include_value: &str,
         ) -> MockEnvGetter {
             let mut env = MockEnvGetter::new();
+            env.expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Ok("true".to_string()));
             env.expect_get()
                 .with(eq("RS_DATA_PATH"))
                 .return_const(Ok(path.to_str().unwrap().to_string()));
@@ -1172,6 +1178,9 @@ mod tests {
         ) -> MockEnvGetter {
             let mut env = MockEnvGetter::new();
             env.expect_get()
+                .with(eq("RS_DISABLE_AUTH"))
+                .return_const(Ok("true".to_string()));
+            env.expect_get()
                 .with(eq("RS_DATA_PATH"))
                 .return_const(Ok(path.to_str().unwrap().to_string()));
 
@@ -1231,6 +1240,10 @@ mod tests {
     #[fixture]
     fn env_with_replications(path: PathBuf) -> MockEnvGetter {
         let mut mock_getter = MockEnvGetter::new();
+        mock_getter
+            .expect_get()
+            .with(eq("RS_DISABLE_AUTH"))
+            .return_const(Ok("true".to_string()));
         mock_getter
             .expect_get()
             .with(eq("RS_DATA_PATH"))

--- a/reductstore/src/cfg/provision/token.rs
+++ b/reductstore/src/cfg/provision/token.rs
@@ -306,7 +306,7 @@ mod tests {
         let mut env_with_tokens = env_with_tokens.await;
         let data_path = env_with_tokens.get("RS_DATA_PATH").unwrap();
         let mut auth_repo = TokenRepositoryBuilder::new(Cfg {
-            api_token: "init".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("init".to_string()),
             ..Default::default()
         })
         .build(data_path.clone().into())
@@ -341,7 +341,7 @@ mod tests {
         drop(repo);
 
         let mut repo = TokenRepositoryBuilder::new(Cfg {
-            api_token: "XXX".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("XXX".to_string()),
             ..Default::default()
         })
         .build(data_path.into())
@@ -362,7 +362,7 @@ mod tests {
         let data_path = PathBuf::from(env_with_tokens.get("RS_DATA_PATH").unwrap());
 
         let mut auth_repo = TokenRepositoryBuilder::new(Cfg {
-            api_token: "init".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("init".to_string()),
             ..Default::default()
         })
         .build(data_path.clone())
@@ -399,7 +399,7 @@ mod tests {
         fs::set_permissions(&data_path, fs::Permissions::from_mode(0o755)).unwrap();
 
         let mut repo = TokenRepositoryBuilder::new(Cfg {
-            api_token: "XXX".to_string(),
+            api_token: crate::cfg::ApiToken::Provisioned("XXX".to_string()),
             ..Default::default()
         })
         .build(data_path)
@@ -476,7 +476,7 @@ mod tests {
         CfgParser {
             cfg: Cfg {
                 data_path: data_path.clone(),
-                api_token: "XXX".to_string(),
+                api_token: crate::cfg::ApiToken::Provisioned("XXX".to_string()),
                 tokens,
                 ..Default::default()
             },

--- a/reductstore/src/core/env.rs
+++ b/reductstore/src/core/env.rs
@@ -84,6 +84,15 @@ impl<EnvGetter: GetEnv> Env<EnvGetter> {
 
     /// Get a value from the environment. without default value
     pub fn get_optional<T: EnvValue>(&mut self, key: &str) -> Option<T> {
+        self.get_optional_impl(key, false)
+    }
+
+    /// Get a value from the environment without a default value and mask it in the log.
+    pub fn get_masked_optional<T: EnvValue>(&mut self, key: &str) -> Option<T> {
+        self.get_optional_impl(key, true)
+    }
+
+    fn get_optional_impl<T: EnvValue>(&mut self, key: &str, masked: bool) -> Option<T> {
         let mut additional = String::new();
         let value = match self.getter.get(key) {
             Ok(value) => match T::from_str(&value) {
@@ -103,8 +112,17 @@ impl<EnvGetter: GetEnv> Env<EnvGetter> {
 
         if !print_value.is_empty() {
             // Add to the message
-            self.message
-                .push_str(&format!("\t{} = {} {}\n", key, print_value, additional));
+            if masked {
+                self.message.push_str(&format!(
+                    "\t{} = {} {}\n",
+                    key,
+                    "*".repeat(print_value.len()),
+                    additional
+                ));
+            } else {
+                self.message
+                    .push_str(&format!("\t{} = {} {}\n", key, print_value, additional));
+            }
         }
 
         value.ok()
@@ -200,6 +218,15 @@ mod tests {
 
         let value = env.get_masked("TEST", String::from("default"));
         assert_eq!(value, "123");
+        assert_eq!(env.message(), "\tTEST = *** \n");
+    }
+
+    #[rstest]
+    fn masked_optional_values(mut env: Env) {
+        std::env::set_var("TEST", "123");
+
+        let value = env.get_masked_optional::<String>("TEST");
+        assert_eq!(value, Some("123".to_string()));
         assert_eq!(env.message(), "\tTEST = *** \n");
     }
 

--- a/reductstore/src/launcher.rs
+++ b/reductstore/src/launcher.rs
@@ -385,6 +385,7 @@ mod tests {
 
         let data_path = tempdir().unwrap().keep();
         env::set_var("RS_DATA_PATH", data_path.to_str().unwrap());
+        env::set_var("RS_DISABLE_AUTH", "true");
         let parser = CfgParser::from_env(StdEnvGetter::default(), "0.0.0").await;
         let storage = parser.build().await.unwrap().storage;
 
@@ -480,6 +481,7 @@ mod tests {
         env::set_var("RS_CERT_KEY_PATH", "");
         env::set_var("RS_INSTANCE_ROLE", "STANDALONE");
         env::set_var("RS_ENGINE_REPLICA_UPDATE_INTERVAL", "60");
+        env::set_var("RS_DISABLE_AUTH", "true");
 
         for (key, value) in cfg {
             env::set_var(key, value);

--- a/reductstore/src/syslog/forward_writer.rs
+++ b/reductstore/src/syslog/forward_writer.rs
@@ -35,7 +35,7 @@ impl ForwardSystemLogger {
             client_build: "Failed to build system bucket replica HTTP client",
             kind: ClientBuildErrorKind::InternalServerError,
         })
-        .api_token(&cfg.api_token)
+        .api_token(cfg.api_token.as_str())
         .verify_ssl(remote_verify_ssl)
         .ca_path(remote_ca_path)
         .connect_timeout(remote_timeout)


### PR DESCRIPTION
Closes #1501

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security improvement and breaking configuration change.

### What was changed?

- Added `RS_DISABLE_AUTH=true` as the explicit way to disable authentication.
- Require exactly one of `RS_API_TOKEN` or `RS_INIT_API_TOKEN` when authentication is enabled.
- Added `RS_INIT_API_TOKEN` for creating a rotatable and removable initial full-access token.
- Reject empty or conflicting bootstrap token configurations.
- Prevent deletion of the last full-access token.
- Recreate a removed `init-token` from `RS_INIT_API_TOKEN` on restart.
- Preserve the existing authentication behavior for read-only replicas.
- Mask bootstrap token values in configuration logs.
- Updated documentation, development commands, and CI test environments.
- Added tests covering configuration validation, token rotation and removal, restart behavior, and replicas.

### Related issues

https://github.com/reductstore/reductstore/issues/1501

### Does this PR introduce a breaking change?

Yes. Non-replica instances must now explicitly configure authentication by setting exactly one of `RS_API_TOKEN` or `RS_INIT_API_TOKEN`. To run without authentication, users must explicitly set `RS_DISABLE_AUTH=true`.

Read-only replica behavior remains unchanged.

### Other information:

Validation completed successfully:

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace --no-fail-fast -- --test-threads=1`