### PR TITLE
docs: update README contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@
   <a href="https://community.reduct.store/signup"><img alt="Community" src="https://img.shields.io/discourse/status?server=https%3A%2F%2Fcommunity.reduct.store" /></a>
 </p>
 
-ReductStore makes robotics and industrial data queryable.
+## Make robotics and industrial data queryable
 
-Store terabytes of images, sensor readings, logs, files, and ROS bags with timestamps and labels in one system, then query them by time range and context instead of stitching together a TSDB, object storage, and custom retention jobs.
+ReductStore is high-performance, time-indexed object storage for robotics and industrial IoT.
+
+Store terabytes of images, video, sensor readings, logs, files, and ROS bags in their native binary formats. Every record is organized by timestamp and can be enriched with labels, so you can retrieve exactly the data you need by time range and operational context.
+
+Instead of combining a time-series database, generic object storage, metadata indexes, and custom retention jobs, ReductStore provides one system for ingesting, organizing, retaining, and querying unstructured time-series data.
 
 ## Why Teams Pick ReductStore
 
@@ -152,21 +156,22 @@ Thanks to everyone who has contributed to ReductStore.
   <a href="https://github.com/atimin"><img src="https://avatars.githubusercontent.com/u/67068?v=4" width="48" height="48" alt="@atimin" /></a>
   <a href="https://github.com/mother-6000"><img src="https://avatars.githubusercontent.com/u/270019311?v=4" width="48" height="48" alt="@mother-6000" /></a>
   <a href="https://github.com/AnthonyCvn"><img src="https://avatars.githubusercontent.com/u/26444489?v=4" width="48" height="48" alt="@AnthonyCvn" /></a>
-  <a href="https://github.com/rohankumardubey"><img src="https://avatars.githubusercontent.com/u/82864904?v=4" width="48" height="48" alt="@rohankumardubey" /></a>
   <a href="https://github.com/DibbayajyotiRoy"><img src="https://avatars.githubusercontent.com/u/125145390?v=4" width="48" height="48" alt="@DibbayajyotiRoy" /></a>
+  <a href="https://github.com/rohankumardubey"><img src="https://avatars.githubusercontent.com/u/82864904?v=4" width="48" height="48" alt="@rohankumardubey" /></a>
   <a href="https://github.com/rtadepalli"><img src="https://avatars.githubusercontent.com/u/105760760?v=4" width="48" height="48" alt="@rtadepalli" /></a>
   <a href="https://github.com/FirasCh3"><img src="https://avatars.githubusercontent.com/u/29213889?v=4" width="48" height="48" alt="@FirasCh3" /></a>
+  <a href="https://github.com/vbmade2000"><img src="https://avatars.githubusercontent.com/u/1904995?v=4" width="48" height="48" alt="@vbmade2000" /></a>
+  <a href="https://github.com/LordAizen1"><img src="https://avatars.githubusercontent.com/u/119096690?v=4" width="48" height="48" alt="@LordAizen1" /></a>
   <a href="https://github.com/tuanhungngyn"><img src="https://avatars.githubusercontent.com/u/165829382?v=4" width="48" height="48" alt="@tuanhungngyn" /></a>
   <a href="https://github.com/upuddu"><img src="https://avatars.githubusercontent.com/u/125773480?v=4" width="48" height="48" alt="@upuddu" /></a>
   <a href="https://github.com/gitcommit90"><img src="https://avatars.githubusercontent.com/u/294273268?v=4" width="48" height="48" alt="@gitcommit90" /></a>
-  <a href="https://github.com/vbmade2000"><img src="https://avatars.githubusercontent.com/u/1904995?v=4" width="48" height="48" alt="@vbmade2000" /></a>
+  <a href="https://github.com/lntutor"><img src="https://avatars.githubusercontent.com/u/1948922?v=4" width="48" height="48" alt="@lntutor" /></a>
   <a href="https://github.com/mambaz"><img src="https://avatars.githubusercontent.com/u/3928782?v=4" width="48" height="48" alt="@mambaz" /></a>
   <a href="https://github.com/victor1234"><img src="https://avatars.githubusercontent.com/u/1102205?v=4" width="48" height="48" alt="@victor1234" /></a>
   <a href="https://github.com/aschenbecherwespe"><img src="https://avatars.githubusercontent.com/u/94011659?v=4" width="48" height="48" alt="@aschenbecherwespe" /></a>
   <a href="https://github.com/renghen"><img src="https://avatars.githubusercontent.com/u/271285?v=4" width="48" height="48" alt="@renghen" /></a>
-  <a href="https://github.com/LordAizen1"><img src="https://avatars.githubusercontent.com/u/119096690?v=4" width="48" height="48" alt="@LordAizen1" /></a>
 </p>
 
 Your support fuels our passion and drives us to keep improving.
 
-Together, let's redefine the future of blob data storage! 🚀
+Together, let's build better storage for robotics and industrial data. 🚀


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Docs update.

### What was changed?

Updated the README contributor list to:

- include `@lntutor`, who appears in the current GitHub contributor list for the repository
- sort credited contributors by contribution count, using GitHub's contributor count order where available
- keep `@FirasCh3` in the sorted list based on recent merged PR commit attribution from PR #1527, because the contributors API does not currently return that account

Also refreshed the opening README definition around time-indexed object storage for robotics and industrial IoT, and replaced the closing slogan with a robotics and industrial data storage line.

### Related issues

None.

### Does this PR introduce a breaking change?

No.

### Other information:

Tests were not run because this is a README-only contributor credit update.
CHANGELOG.md was not updated because the change is documentation metadata only and does not affect users of the product.
