### PR TITLE
Remove auth-disabled HTTP API integration tests

### DIFF
--- a/.github/actions/api/http-tests/action.yml
+++ b/.github/actions/api/http-tests/action.yml
@@ -31,11 +31,9 @@ runs:
       shell: bash
       env:
         RS_API_TOKEN: ${{ inputs.token }}
-        RS_DISABLE_AUTH: ${{ inputs.token == '' }}
       run: |
         docker run --network=host -v ${PWD}/misc:/misc \
           --env RS_API_TOKEN="${RS_API_TOKEN}" \
-          --env RS_DISABLE_AUTH="${RS_DISABLE_AUTH}" \
           --env RS_AUDIT_ENABLED=true \
           --env RS_INSTANCE_NAME=http-api-tests \
           --env RS_INSTANCE_ROLE=STANDALONE \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
       - build_test_docker_image
     strategy:
       matrix:
-        token: [ "", "XXXX" ]
+        token: [ "XXXX" ]
         cert_path: [ "", "/misc/certificate.crt" ]
         include:
           - cert_path: "/misc/certificate.crt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,6 @@ jobs:
       - build_test_docker_image
     strategy:
       matrix:
-        token: [ "XXXX" ]
         cert_path: [ "", "/misc/certificate.crt" ]
         include:
           - cert_path: "/misc/certificate.crt"
@@ -227,7 +226,7 @@ jobs:
 
       - uses: ./.github/actions/api/http-tests
         with:
-          token: ${{ matrix.token }}
+          token: XXXX
           cert_path: ${{ matrix.cert_path }}
           url: ${{ matrix.url }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove auth-disabled HTTP API integration test runs; CI now exercises the HTTP API with explicit credentials only, [PR-1575](https://github.com/reductstore/reductstore/pull/1575)
 - Remove deprecated `each_n` query and replication API field; use the `$each_n` operator in the `when` condition instead, [Issue-1359](https://github.com/reductstore/reductstore/issues/1359), [PR-1555](https://github.com/reductstore/reductstore/pull/1555)
 - `include` and `exclude` parameters in `QueryBuilder` and `ReplicationSettings` are removed, [PR-1497](https://github.com/reductstore/reductstore/pull/1497) by @vbmade2000
 - `each_s` parameter in `QueryBuilder` and `ReplicationSettings` are removed, [PR-1414](https://github.com/reductstore/reductstore/pull/1414) by @vbmade2000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove auth-disabled HTTP API integration test runs; CI now exercises the HTTP API with explicit credentials only.
+- Remove auth-disabled HTTP API integration test runs; CI now exercises the HTTP API with explicit credentials only, [PR-1575](https://github.com/reductstore/reductstore/pull/1575)
 - Remove deprecated `each_n` query and replication API field; use the `$each_n` operator in the `when` condition instead, [Issue-1359](https://github.com/reductstore/reductstore/issues/1359), [PR-1555](https://github.com/reductstore/reductstore/pull/1555)
 - `include` and `exclude` parameters in `QueryBuilder` and `ReplicationSettings` are removed, [PR-1497](https://github.com/reductstore/reductstore/pull/1497) by @vbmade2000
 - `each_s` parameter in `QueryBuilder` and `ReplicationSettings` are removed, [PR-1414](https://github.com/reductstore/reductstore/pull/1414) by @vbmade2000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove auth-disabled HTTP API integration test runs; CI now exercises the HTTP API with explicit credentials only.
 - Remove deprecated `each_n` query and replication API field; use the `$each_n` operator in the `when` condition instead, [Issue-1359](https://github.com/reductstore/reductstore/issues/1359), [PR-1555](https://github.com/reductstore/reductstore/pull/1555)
 - `include` and `exclude` parameters in `QueryBuilder` and `ReplicationSettings` are removed, [PR-1497](https://github.com/reductstore/reductstore/pull/1497) by @vbmade2000
 - `each_s` parameter in `QueryBuilder` and `ReplicationSettings` are removed, [PR-1414](https://github.com/reductstore/reductstore/pull/1414) by @vbmade2000


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

CI cleanup

### What was changed?

Removed the auth-disabled HTTP API integration test run from CI because ReductStore no longer supports working without credentials as the default behavior.

The HTTP API job now keeps only the certificate-path matrix and passes a fixed explicit token to the HTTP API test action.

### Related issues

N/A

### Does this PR introduce a breaking change?

No. This only updates CI coverage to match the current explicit-auth configuration behavior.

### Other information:

Validation:

- Parsed `.github/workflows/ci.yml` and `.github/actions/api/http-tests/action.yml` with Python YAML.
- Ran `git diff --check`.
- Confirmed no token matrix, `matrix.token`, `RS_DISABLE_AUTH`, or changelog entry for this PR remains.