### PR TITLE
fix FIFO eviction of compressed blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove compressed block files and decompression cache entries during FIFO quota eviction, [PR-1578](https://github.com/reductstore/reductstore/pull/1578)
+
 ## 1.20.9 - 2026-07-08
 
 ### Fixed

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -32,7 +32,7 @@ use reduct_base::too_early;
 use std::fs::OpenOptions;
 use std::io::ErrorKind::UnexpectedEof;
 use std::io::{Read, SeekFrom, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -63,6 +63,15 @@ pub const DATA_FILE_EXT: &str = ".blk";
 pub const COMPRESSED_DESCRIPTOR_FILE_EXT: &str = ".meta.zst";
 pub const COMPRESSED_DATA_FILE_EXT: &str = ".blk.zst";
 pub const BLOCK_INDEX_FILE: &str = "blocks.idx";
+
+fn all_block_file_paths(entry_path: &Path, block_id: u64) -> [PathBuf; 4] {
+    [
+        entry_path.join(format!("{}{}", block_id, DATA_FILE_EXT)),
+        entry_path.join(format!("{}{}", block_id, DESCRIPTOR_FILE_EXT)),
+        entry_path.join(format!("{}{}", block_id, COMPRESSED_DATA_FILE_EXT)),
+        entry_path.join(format!("{}{}", block_id, COMPRESSED_DESCRIPTOR_FILE_EXT)),
+    ]
+}
 
 // we need 2 to avoid double sync when start a new one but not yet saved the old one when the record is written
 const WRITE_BLOCK_CACHE_SIZE: usize = 2;
@@ -427,12 +436,7 @@ impl BlockManager {
     pub async fn remove_block(&mut self, block_id: u64) -> Result<(), ReductError> {
         self.wal.append(block_id, WalEntry::RemoveBlock).await?;
 
-        for path in [
-            self.path_to_data(block_id),
-            self.path_to_desc(block_id),
-            self.path_to_compressed_data(block_id),
-            self.path_to_compressed_desc(block_id),
-        ] {
+        for path in all_block_file_paths(&self.path, block_id) {
             if FILE_CACHE.try_exists(&path).await? {
                 // The block may still exist only in WAL during recovery.
                 FILE_CACHE.remove(&path).await?;
@@ -899,15 +903,8 @@ impl BlockManager {
     }
 
     async fn invalidate_replica_block_cache(&self, block_id: u64) -> Result<(), ReductError> {
-        let paths = [
-            self.path_to_desc(block_id),
-            self.path_to_data(block_id),
-            self.path_to_compressed_desc(block_id),
-            self.path_to_compressed_data(block_id),
-        ];
-
         let mut first_err = None;
-        for path in paths {
+        for path in all_block_file_paths(&self.path, block_id) {
             if let Err(err) = FILE_CACHE.invalidate_local_cache_file(&path).await {
                 warn!(
                     "Failed to invalidate replica cache file {:?} for {}/{}: {}",

--- a/reductstore/src/storage/block_manager.rs
+++ b/reductstore/src/storage/block_manager.rs
@@ -427,22 +427,23 @@ impl BlockManager {
     pub async fn remove_block(&mut self, block_id: u64) -> Result<(), ReductError> {
         self.wal.append(block_id, WalEntry::RemoveBlock).await?;
 
-        let data_block_path = self.path_to_data(block_id);
-        if FILE_CACHE.try_exists(&data_block_path).await? {
-            // it can be still in WAL only
-            FILE_CACHE.remove(&data_block_path).await?;
-        }
-
-        let desc_block_path = self.path_to_desc(block_id);
-        if FILE_CACHE.try_exists(&desc_block_path).await? {
-            // it can be still in WAL only
-            FILE_CACHE.remove(&desc_block_path).await?;
+        for path in [
+            self.path_to_data(block_id),
+            self.path_to_desc(block_id),
+            self.path_to_compressed_data(block_id),
+            self.path_to_compressed_desc(block_id),
+        ] {
+            if FILE_CACHE.try_exists(&path).await? {
+                // The block may still exist only in WAL during recovery.
+                FILE_CACHE.remove(&path).await?;
+            }
         }
 
         self.block_index.remove_block(block_id);
         self.block_index.save().await?;
 
         self.block_cache.remove(&block_id);
+        self.decompress_cache.invalidate(&self.path, block_id).await;
 
         self.wal.remove(block_id).await?;
         Ok(())
@@ -1494,6 +1495,60 @@ mod tests {
         async fn test_remove_non_existing_block(#[future] block_manager: BlockManager) {
             let mut block_manager = block_manager.await;
             block_manager.remove_block(999999).await.expect("No error");
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_remove_compressed_block_cleans_files_and_caches(
+            #[future] block_manager: BlockManager,
+            block_id: u64,
+        ) {
+            let mut block_manager = block_manager.await;
+            block_manager
+                .compress_block(block_id, CompressionAlgorithm::Zstd)
+                .await
+                .unwrap();
+
+            let compressed_data_path = block_manager.path_to_compressed_data(block_id);
+            let compressed_desc_path = block_manager.path_to_compressed_desc(block_id);
+            let cached_data_path = block_manager
+                .decompress_cache
+                .get_or_decompress(
+                    block_manager.path(),
+                    block_id,
+                    DecompressedFileType::Data,
+                    &compressed_data_path,
+                )
+                .await
+                .unwrap();
+            let cached_desc_path = block_manager
+                .decompress_cache
+                .get_or_decompress(
+                    block_manager.path(),
+                    block_id,
+                    DecompressedFileType::Descriptor,
+                    &compressed_desc_path,
+                )
+                .await
+                .unwrap();
+
+            block_manager.remove_block(block_id).await.unwrap();
+
+            assert!(!block_manager.path_to_data(block_id).exists());
+            assert!(!block_manager.path_to_desc(block_id).exists());
+            assert!(!compressed_data_path.exists());
+            assert!(!compressed_desc_path.exists());
+            assert!(!cached_data_path.exists());
+            assert!(!cached_desc_path.exists());
+            assert!(block_manager.block_cache.get_read(&block_id).is_none());
+            assert!(block_manager.index().get_block(block_id).is_none());
+            assert!(
+                BlockIndex::try_load(block_manager.path.join(BLOCK_INDEX_FILE))
+                    .await
+                    .unwrap()
+                    .get_block(block_id)
+                    .is_none()
+            );
         }
     }
 

--- a/reductstore/src/storage/block_manager/read_only.rs
+++ b/reductstore/src/storage/block_manager/read_only.rs
@@ -4,10 +4,7 @@
 use crate::cfg::InstanceRole;
 use crate::core::file_cache::FILE_CACHE;
 use crate::storage::block_manager::block_index::BlockIndex;
-use crate::storage::block_manager::{
-    BlockManager, BLOCK_INDEX_FILE, COMPRESSED_DATA_FILE_EXT, COMPRESSED_DESCRIPTOR_FILE_EXT,
-    DATA_FILE_EXT, DESCRIPTOR_FILE_EXT,
-};
+use crate::storage::block_manager::{all_block_file_paths, BlockManager, BLOCK_INDEX_FILE};
 use crate::storage::proto::block_index::Block as BlockEntry;
 use log::warn;
 use reduct_base::error::ReductError;
@@ -34,15 +31,7 @@ impl ReplicaIndexReload {
         for (block_id, new_block_info) in updated_index.info().iter() {
             if let Some(previous_block_info) = self.previous_state.get(block_id) {
                 if previous_block_info.crc64 != new_block_info.crc64 {
-                    let extensions = [
-                        DESCRIPTOR_FILE_EXT,
-                        DATA_FILE_EXT,
-                        COMPRESSED_DESCRIPTOR_FILE_EXT,
-                        COMPRESSED_DATA_FILE_EXT,
-                    ];
-
-                    for ext in extensions {
-                        let path = self.entry_path.join(format!("{}{}", block_id, ext));
+                    for path in all_block_file_paths(&self.entry_path, *block_id) {
                         if let Err(err) = FILE_CACHE.invalidate_local_cache_file(&path).await {
                             warn!(
                                 "Failed to invalidate replica cache file {:?}: {}",

--- a/reductstore/src/storage/bucket/quotas.rs
+++ b/reductstore/src/storage/bucket/quotas.rs
@@ -105,11 +105,14 @@ impl Bucket {
 
 #[cfg(test)]
 mod tests {
+    use crate::cfg::Cfg;
     use crate::storage::bucket::tests::{bucket, path, write, write_meta};
+    use crate::storage::bucket::Bucket;
     use reduct_base::error::ReductError;
     use reduct_base::msg::bucket_api::{BucketSettings, QuotaType};
     use rstest::rstest;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     #[rstest]
     #[tokio::test]
@@ -224,5 +227,62 @@ mod tests {
                 "Failed to keep quota of 'test'"
             ))
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_fifo_quota_removes_compressed_oldest_block(path: PathBuf) {
+        let bucket = bucket(
+            BucketSettings {
+                quota_type: Some(QuotaType::NONE),
+                max_block_records: Some(1),
+                ..BucketSettings::default()
+            },
+            path,
+        )
+        .await;
+        let blob: &[u8] = &[0; 40];
+
+        write(&bucket, "entry", 1, blob).await.unwrap();
+        write(&bucket, "entry", 2, blob).await.unwrap();
+        bucket.sync_fs().await.unwrap();
+        let bucket = Arc::new(
+            Bucket::builder()
+                .path(bucket.path.clone())
+                .cfg(Cfg::default())
+                .usage_counters(Default::default())
+                .restore()
+                .await
+                .unwrap(),
+        );
+        bucket
+            .clone()
+            .compress_blocks(Some(vec!["entry".into()]), None, Some(2))
+            .await
+            .unwrap();
+
+        let compressed_data_path = bucket.path.join("entry/1.blk.zst");
+        let compressed_desc_path = bucket.path.join("entry/1.meta.zst");
+        assert!(compressed_data_path.exists());
+        assert!(compressed_desc_path.exists());
+
+        let size = bucket.clone().info().await.unwrap().info.size;
+        bucket
+            .set_settings(BucketSettings {
+                quota_type: Some(QuotaType::FIFO),
+                quota_size: Some(size + blob.len() as u64 - 1),
+                max_block_records: Some(1),
+                ..BucketSettings::default()
+            })
+            .await
+            .unwrap();
+        write(&bucket, "entry", 3, blob).await.unwrap();
+
+        assert!(crate::storage::bucket::tests::read(&bucket, "entry", 1)
+            .await
+            .is_err());
+        assert!(!compressed_data_path.exists());
+        assert!(!compressed_desc_path.exists());
+        assert!(bucket.clone().info().await.unwrap().info.size <= size + blob.len() as u64 - 1);
     }
 }

--- a/reductstore/src/storage/entry.rs
+++ b/reductstore/src/storage/entry.rs
@@ -23,7 +23,7 @@ use crate::storage::query::base::QueryOptions;
 use crate::storage::query::{build_query, next_query_id, spawn_query_task, QueryRx};
 pub(crate) use io::record_reader::RecordReader;
 pub(crate) use io::record_writer::{RecordDrainer, RecordWriter};
-use log::{debug, error};
+use log::debug;
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::{EntryInfo, QueryEntry};
 use reduct_base::msg::status::ResourceStatus;
@@ -323,9 +323,7 @@ impl Entry {
             }
         };
 
-        bm.remove_block(oldest_block_id).await.unwrap_or_else(|e| {
-            error!("Failed to remove oldest block {}: {}", oldest_block_id, e);
-        });
+        bm.remove_block(oldest_block_id).await?;
         debug!(
             "Removing the oldest block {}.blk",
             bm.path().join(oldest_block_id.to_string()).display()
@@ -975,6 +973,19 @@ mod tests {
             let info = entry.info().await.unwrap();
             assert_eq!(info.block_count, 1);
             assert_eq!(info.size, 524309);
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_returns_error_when_removing_oldest_block_fails(#[future] entry: Arc<Entry>) {
+            let entry = entry.await;
+            write_stub_record(&entry, 1000000).await;
+            let data_path = entry.path.join("1000000.blk");
+            std::fs::remove_file(&data_path).unwrap();
+            std::fs::create_dir(&data_path).unwrap();
+
+            assert!(entry.try_remove_oldest_block().await.is_err());
+            assert_eq!(entry.info().await.unwrap().block_count, 1);
         }
 
         #[rstest]


### PR DESCRIPTION
Closes #1576

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Remove both plain and compressed block data and descriptor files during block deletion.
- Centralize physical block-file variant paths for deletion and replica cache invalidation.
- Invalidate decompressed temporary files after successful block removal.
- Propagate FIFO eviction deletion failures instead of reporting a successful removal.
- Add regression coverage for compressed cleanup, deletion failures, and FIFO eviction.

### Related issues

https://github.com/reductstore/reductstore/issues/1576

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with `cargo fmt --all -- --check`, `cargo check --workspace`, and `cargo test --workspace`.
