### PR TITLE
ci: use GitHub-hosted runners on stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,16 @@ jobs:
               ]
         include:
           - target: "x86_64-unknown-linux-gnu"
-            os: self-hosted
+            os: ubuntu-22.04
             compiler: "gcc"
           - target: "aarch64-unknown-linux-gnu"
-            os: self-hosted
+            os: ubuntu-22.04
             compiler: "gcc-aarch64-linux-gnu"
           - target: "armv7-unknown-linux-gnueabihf"
-            os: self-hosted
+            os: ubuntu-22.04
             compiler: "gcc-arm-linux-gnueabihf"
           - target: "x86_64-pc-windows-gnu"
-            os: self-hosted
+            os: ubuntu-22.04
             compiler: "gcc-mingw-w64-x86-64"
           - target: "x86_64-apple-darwin"
             os: macos-14


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features) - not applicable, CI configuration only
- [x] Docs have been added / updated (for bug fixes / features) - not applicable
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs) - not applicable

### What kind of change does this PR introduce?

CI maintenance.

### What was changed?

Backported the GitHub-hosted runner matrix from `main` to the `stable` branch CI workflow.

The Linux and Windows cross-build jobs now run on `ubuntu-22.04` instead of `self-hosted`:

- `x86_64-unknown-linux-gnu`
- `aarch64-unknown-linux-gnu`
- `armv7-unknown-linux-gnueabihf`
- `x86_64-pc-windows-gnu`

### Related issues

None.

### Does this PR introduce a breaking change?

No.

### Other information:

Validated locally with:

- `rg -n "self-hosted|runs-on" .github/workflows/ci.yml`
- `git diff --check`
- YAML parse via Python `yaml.safe_load`
