### PR TITLE
Avoid blocking system-event replication on replication updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Avoid blocking `$system` event replication notifications while a replication task is being created, updated, or has its mode changed, by using shared outer replication repository access for those operations instead of exclusive access, the same pattern already used for removal, [Issue-1593](https://github.com/reductstore/reductstore/issues/1593)
 - Avoid a lock inversion when deleting a replication task that emits final `$system` diagnostics by using shared outer replication repository access for removal and transaction notifications, [PR-1572](https://github.com/reductstore/reductstore/pull/1572)
 - Replicate internal `$system` events when `$system` is a replication source by notifying replication from the system-event writer; to prevent feedback loops, diagnostics of a `$system`-source replication and log messages from the replication module are excluded, [PR-1567](https://github.com/reductstore/reductstore/pull/1567) by @DibbayajyotiRoy
 - Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [PR-1557](https://github.com/reductstore/reductstore/pull/1557) by @LordAizen1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Avoid blocking `$system` event replication notifications while a replication task is being created, updated, or has its mode changed, by using shared outer replication repository access for those operations instead of exclusive access, the same pattern already used for removal, [Issue-1593](https://github.com/reductstore/reductstore/issues/1593)
+- Avoid blocking `$system` event replication notifications while a replication task is being created, updated, or has its mode changed, by using shared outer replication repository access for those operations instead of exclusive access, the same pattern already used for removal, [PR-1594](https://github.com/reductstore/reductstore/pull/1594) by @vjymisal0
 - Avoid a lock inversion when deleting a replication task that emits final `$system` diagnostics by using shared outer replication repository access for removal and transaction notifications, [PR-1572](https://github.com/reductstore/reductstore/pull/1572)
 - Replicate internal `$system` events when `$system` is a replication source by notifying replication from the system-event writer; to prevent feedback loops, diagnostics of a `$system`-source replication and log messages from the replication module are excluded, [PR-1567](https://github.com/reductstore/reductstore/pull/1567) by @DibbayajyotiRoy
 - Treat the `$system` bucket as provisioned so it cannot be removed through the API, and reapply `RS_SYSTEM_EVENTS_QUOTA_SIZE` on startup instead of only at first creation, [PR-1557](https://github.com/reductstore/reductstore/pull/1557) by @LordAizen1

--- a/reductstore/src/api/http/replication/create.rs
+++ b/reductstore/src/api/http/replication/create.rs
@@ -20,7 +20,7 @@ pub(super) async fn create_replication(
         .await?;
     components
         .replication_repo
-        .write()
+        .read()
         .await?
         .create_replication(&replication_name, settings.into())
         .await?;

--- a/reductstore/src/api/http/replication/set_mode.rs
+++ b/reductstore/src/api/http/replication/set_mode.rs
@@ -21,7 +21,7 @@ pub(super) async fn set_mode(
 
     components
         .replication_repo
-        .write()
+        .read()
         .await?
         .set_mode(&replication_name, payload.0.mode)
         .await?;

--- a/reductstore/src/api/http/replication/update.rs
+++ b/reductstore/src/api/http/replication/update.rs
@@ -20,7 +20,7 @@ pub(super) async fn update_replication(
         .await?;
     components
         .replication_repo
-        .write()
+        .read()
         .await?
         .update_replication(&replication_name, settings.into())
         .await?;

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -20,7 +20,7 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         storage: Arc<StorageEngine>,
         system_event_sink: SystemEventSink,
     ) -> Result<Box<dyn ManageReplications + Send + Sync>, ReductError> {
-        let mut repo = ReplicationRepoBuilder::new(self.cfg.clone())
+        let repo = ReplicationRepoBuilder::new(self.cfg.clone())
             .with_system_event_sink(system_event_sink)
             .build(Arc::clone(&storage))
             .await;
@@ -596,7 +596,7 @@ mod tests {
             .create_bucket("bucket1", Default::default())
             .await
             .unwrap();
-        let mut repo = create_replication_repo(
+        let repo = create_replication_repo(
             Arc::new(storage),
             Cfg {
                 replication_conf: ReplicationConfig {
@@ -704,7 +704,7 @@ mod tests {
             .create_bucket("bucket1", Default::default())
             .await
             .unwrap();
-        let mut repo = create_replication_repo(
+        let repo = create_replication_repo(
             storage.clone(),
             Cfg {
                 replication_conf: ReplicationConfig {
@@ -786,7 +786,7 @@ mod tests {
             .create_bucket("bucket1", Default::default())
             .await
             .unwrap();
-        let mut repo = create_replication_repo(
+        let repo = create_replication_repo(
             storage.clone(),
             Cfg {
                 replication_conf: ReplicationConfig {

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -88,7 +88,7 @@ pub trait ManageReplications {
     /// * `ReductError::BadRequest` - Invalid destination host.
     /// * `ReductError::NotFound` - Source bucket does not exist.
     async fn create_replication(
-        &mut self,
+        &self,
         name: &str,
         settings: ReplicationSettings,
     ) -> Result<(), ReductError>;
@@ -104,7 +104,7 @@ pub trait ManageReplications {
     ///
     /// A `ReductError` is returned if the update fails.
     async fn update_replication(
-        &mut self,
+        &self,
         name: &str,
         settings: ReplicationSettings,
     ) -> Result<(), ReductError>;
@@ -126,7 +126,7 @@ pub trait ManageReplications {
 
     /// Mark replication as provisioned/unprovisioned.
     async fn set_replication_provisioned(
-        &mut self,
+        &self,
         name: &str,
         provisioned: bool,
     ) -> Result<(), ReductError>;
@@ -135,7 +135,7 @@ pub trait ManageReplications {
     async fn remove_replication(&self, name: &str) -> Result<(), ReductError>;
 
     /// Update replication mode
-    async fn set_mode(&mut self, name: &str, mode: ReplicationMode) -> Result<(), ReductError>;
+    async fn set_mode(&self, name: &str, mode: ReplicationMode) -> Result<(), ReductError>;
 
     /// Notify replication task about a new transaction.
     ///

--- a/reductstore/src/replication/replication_repository/read_only.rs
+++ b/reductstore/src/replication/replication_repository/read_only.rs
@@ -20,7 +20,7 @@ impl ReadOnlyReplicationRepository {
 #[async_trait]
 impl ManageReplications for ReadOnlyReplicationRepository {
     async fn create_replication(
-        &mut self,
+        &self,
         _name: &str,
         _settings: ReplicationSettings,
     ) -> Result<(), ReductError> {
@@ -28,7 +28,7 @@ impl ManageReplications for ReadOnlyReplicationRepository {
     }
 
     async fn update_replication(
-        &mut self,
+        &self,
         _name: &str,
         _settings: ReplicationSettings,
     ) -> Result<(), ReductError> {
@@ -57,7 +57,7 @@ impl ManageReplications for ReadOnlyReplicationRepository {
     }
 
     async fn set_replication_provisioned(
-        &mut self,
+        &self,
         _name: &str,
         _provisioned: bool,
     ) -> Result<(), ReductError> {
@@ -70,7 +70,7 @@ impl ManageReplications for ReadOnlyReplicationRepository {
         Err(forbidden!("Cannot remove replication in read-only mode"))
     }
 
-    async fn set_mode(&mut self, _name: &str, _mode: ReplicationMode) -> Result<(), ReductError> {
+    async fn set_mode(&self, _name: &str, _mode: ReplicationMode) -> Result<(), ReductError> {
         Err(forbidden!(
             "Cannot update replication mode in read-only mode"
         ))

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -263,7 +263,7 @@ pub(crate) struct ReplicationRepository {
 #[async_trait]
 impl ManageReplications for ReplicationRepository {
     async fn create_replication(
-        &mut self,
+        &self,
         name: &str,
         settings: ReplicationSettings,
     ) -> Result<(), ReductError> {
@@ -279,7 +279,7 @@ impl ManageReplications for ReplicationRepository {
     }
 
     async fn update_replication(
-        &mut self,
+        &self,
         name: &str,
         settings: ReplicationSettings,
     ) -> Result<(), ReductError> {
@@ -350,7 +350,7 @@ impl ManageReplications for ReplicationRepository {
     }
 
     async fn set_replication_provisioned(
-        &mut self,
+        &self,
         name: &str,
         provisioned: bool,
     ) -> Result<(), ReductError> {
@@ -382,7 +382,7 @@ impl ManageReplications for ReplicationRepository {
         self.remove_transaction_logs_for_replication(name).await
     }
 
-    async fn set_mode(&mut self, name: &str, mode: ReplicationMode) -> Result<(), ReductError> {
+    async fn set_mode(&self, name: &str, mode: ReplicationMode) -> Result<(), ReductError> {
         let mut guard = self.replications.write().await?;
         let replication = guard.get_mut(name).ok_or_else(|| {
             ReductError::not_found(&format!("Replication '{}' does not exist", name))
@@ -540,7 +540,7 @@ impl ReplicationRepository {
     }
 
     async fn create_or_update_replication_task(
-        &mut self,
+        &self,
         name: &str,
         settings: ReplicationSettings,
     ) -> Result<(), ReductError> {

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -287,21 +287,7 @@ mod tests {
         );
     }
 
-    /// Regression test for #1593: updating a replication task must not hold
-    /// the outer `replication_repo` lock across the awaited update, or the
-    /// `$system` event notifier (which also needs the outer lock) times out.
-    ///
-    /// The fixed HTTP handler (`api/http/replication/update.rs`) now acquires
-    /// only `replication_repo.read()` before calling `update_replication`,
-    /// because `ManageReplications::update_replication` takes `&self` and
-    /// relies on the repo's own internal locking. This test mirrors that
-    /// handler by driving the update through a read guard concurrently with
-    /// a `$system` event write, and asserts both complete under a tight
-    /// rwlock timeout. If `update_replication` ever regresses back to
-    /// `&mut self`, this test stops compiling (a read guard cannot provide
-    /// `&mut self`); if the handler ever regresses back to `.write()`, this
-    /// scenario is exactly what would reintroduce the timeout from the
-    /// issue.
+    /// Regression test for #1593.
     #[rstest]
     #[tokio::test]
     #[serial]

--- a/reductstore/src/syslog/local_writer.rs
+++ b/reductstore/src/syslog/local_writer.rs
@@ -287,6 +287,73 @@ mod tests {
         );
     }
 
+    /// Regression test for #1593: updating a replication task must not hold
+    /// the outer `replication_repo` lock across the awaited update, or the
+    /// `$system` event notifier (which also needs the outer lock) times out.
+    ///
+    /// The fixed HTTP handler (`api/http/replication/update.rs`) now acquires
+    /// only `replication_repo.read()` before calling `update_replication`,
+    /// because `ManageReplications::update_replication` takes `&self` and
+    /// relies on the repo's own internal locking. This test mirrors that
+    /// handler by driving the update through a read guard concurrently with
+    /// a `$system` event write, and asserts both complete under a tight
+    /// rwlock timeout. If `update_replication` ever regresses back to
+    /// `&mut self`, this test stops compiling (a read guard cannot provide
+    /// `&mut self`); if the handler ever regresses back to `.write()`, this
+    /// scenario is exactly what would reintroduce the timeout from the
+    /// issue.
+    #[rstest]
+    #[tokio::test]
+    #[serial]
+    async fn concurrent_replication_update_does_not_block_system_event_notification(
+        #[future] storage: Arc<StorageEngine>,
+    ) {
+        let _restore_timeout = RestoreRwLockTimeout(rwlock_timeout());
+        set_rwlock_timeout(Duration::from_millis(20));
+
+        let storage = storage.await;
+        let repo = system_replication_repo(Arc::clone(&storage)).await;
+        let mut writer = writer(storage);
+        writer
+            .set_replication_notifier(Some(notifier_for(&repo)))
+            .await;
+
+        let update_repo = Arc::clone(&repo);
+        let update = async move {
+            update_repo
+                .read()
+                .await
+                .unwrap()
+                .update_replication(
+                    "sys-replication",
+                    ReplicationSettings {
+                        src_bucket: SYSTEM_BUCKET_NAME.to_string(),
+                        dst_bucket: "dst-bucket".to_string(),
+                        dst_host: "http://localhost".to_string(),
+                        dst_token: None,
+                        entries: vec![],
+                        dst_prefix: String::new(),
+                        when: None,
+                        mode: ReplicationMode::Enabled,
+                        compression: Default::default(),
+                    },
+                )
+                .await
+        };
+        let notify = writer.log_event(system_event(SystemEventKind::Usage, true));
+
+        let (update_result, log_result) = tokio::join!(update, notify);
+        update_result.expect("update_replication must not be blocked by the notifier");
+        log_result.expect("the system event write itself must always succeed");
+
+        sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            pending_records(&repo).await,
+            1,
+            "a concurrent replication update must not drop the system-event replication notification"
+        );
+    }
+
     #[rstest]
     #[case::replications(SystemEventKind::Replication)]
     #[case::logs(SystemEventKind::Log)]


### PR DESCRIPTION
Closes #1593

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix (lock ordering / concurrency).

### What was changed?

Confirmed the root cause in the actual code: `create_replication`, `update_replication`, `set_replication_provisioned`, and `set_mode` on `ManageReplications` all took `&mut self`, so the HTTP handlers had to call `components.replication_repo.write()` before invoking them. Their implementations, however, only mutate the repo's internal `Arc<AsyncRwLock<HashMap<String, ReplicationTask>>>` — the outer `&mut self` wasn't actually needed for these methods (only `start()`/`stop()` mutate plain fields and genuinely need it).

While the outer write lock was held across the awaited `update_replication(...)` call, a `$system` event written during that update tried to replicate itself through the notifier registered in `cfg.rs`, which does `repo.read().await?.notify(...)`. That read could never be granted while the write guard was alive, producing the async read-lock timeout from the issue.

This is the same pattern already applied to `remove_replication` in PR-1572 (shared/read access instead of exclusive access) — I extended it to the remaining CRUD methods:

- `reductstore/src/replication.rs`: changed `create_replication`, `update_replication`, `set_replication_provisioned`, `set_mode` to `&self` on the `ManageReplications` trait.
- `reductstore/src/replication/replication_repository/repo.rs`: updated the `ReplicationRepository` impl and its internal `create_or_update_replication_task` helper to `&self`.
- `reductstore/src/replication/replication_repository/read_only.rs`: updated the `ReadOnlyReplicationRepository` impl signatures to match.
- `reductstore/src/api/http/replication/{create,update,set_mode}.rs`: switched from `replication_repo.write()` to `replication_repo.read()`.
- `reductstore/src/cfg/provision/replication.rs`: dropped now-unnecessary `mut` bindings on the provisioning-time repo.
- `reductstore/src/syslog/local_writer.rs`: added `concurrent_replication_update_does_not_block_system_event_notification`, which drives `update_replication` through a read guard concurrently with a `$system` event write under a tight rwlock timeout (mirrors the existing `usage_event_notifies_replication_while_repo_read_guard_is_held` test). It also acts as a compile-time guard: if `update_replication` ever regresses to `&mut self`, calling it through a read guard stops compiling.
- `CHANGELOG.md`: added a `Fixed` entry under `Unreleased`.

`start()`/`stop()` still take `&mut self` and the HTTP layer / launcher still acquire `.write()` for those, since they mutate the repository's own `started`/`notification_worker` fields directly.

### Related issues

Closes #1593

### Does this PR introduce a breaking change?

No public API/behavior change. `ManageReplications` is `pub(crate)`-only surface (not exposed outside the crate), so the trait signature change is internal.

### Other information

I could not run `cargo fmt` / `cargo check` / `cargo test` locally — this environment has no Rust toolchain installed. I reviewed the diff manually, cross-checked every caller and both trait implementors (`ReplicationRepository`, `ReadOnlyReplicationRepository`) for the changed methods, and mirrored existing, already-compiling patterns in the same files (e.g. `remove_replication`/`notify` already using `&self` + `.read()`, and the existing rwlock-timeout test pattern in `syslog/local_writer.rs`) to minimize risk. Please let CI's `unit_tests` job be the actual pass/fail signal here — happy to fix anything it flags.
