### PR TITLE
add replication license device enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Send `x-reduct-node-id`, `x-reduct-store-id`, and `x-reduct-license-hash` headers with replication requests, [Issue-1580](https://github.com/reductstore/reductstore/issues/1580)
+- Send `x-reduct-node-id`, `x-reduct-store-id`, and `x-reduct-license-hash` headers with replication requests, enforcing matching commercial licenses and device limits on receivers, [Issue-1580](https://github.com/reductstore/reductstore/issues/1580)
 - Persist a deployment UUID in `.uuid` on the configured filesystem, S3, or Azure Blob storage, [PR-1606](https://github.com/reductstore/reductstore/pull/1606) by @anthonycvn
 - Expose the effective instance name and role in the `/api/v1/info` response, [PR-1569](https://github.com/reductstore/reductstore/pull/1569) by @lntutor
 - Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Send `x-reduct-node-id`, `x-reduct-store-id`, and `x-reduct-license-hash` headers with replication requests, enforcing matching commercial licenses and device limits on receivers, [Issue-1580](https://github.com/reductstore/reductstore/issues/1580)
+- Send `x-reduct-node-id`, `x-reduct-store-id`, and `x-reduct-license-hash` headers with replication requests, enforcing matching commercial licenses and device limits on receivers, [Issue-1580](https://github.com/reductstore/reductstore/issues/1580), [#1611](https://github.com/reductstore/reductstore/pull/1611) by @atimin
 - Persist a deployment UUID in `.uuid` on the configured filesystem, S3, or Azure Blob storage, [PR-1606](https://github.com/reductstore/reductstore/pull/1606) by @anthonycvn
 - Expose the effective instance name and role in the `/api/v1/info` response, [PR-1569](https://github.com/reductstore/reductstore/pull/1569) by @lntutor
 - Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Send `x-reduct-node-id`, `x-reduct-store-id`, and `x-reduct-license-hash` headers with replication requests, [Issue-1580](https://github.com/reductstore/reductstore/issues/1580)
 - Persist a deployment UUID in `.uuid` on the configured filesystem, S3, or Azure Blob storage, [PR-1606](https://github.com/reductstore/reductstore/pull/1606) by @anthonycvn
 - Expose the effective instance name and role in the `/api/v1/info` response, [PR-1569](https://github.com/reductstore/reductstore/pull/1569) by @lntutor
 - Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Send `x-reduct-node-id`, `x-reduct-store-id`, and `x-reduct-license-hash` headers with replication requests, enforcing matching commercial licenses and device limits on receivers, [Issue-1580](https://github.com/reductstore/reductstore/issues/1580), [#1611](https://github.com/reductstore/reductstore/pull/1611) by @atimin
+- Send `x-reduct-node-id`, `x-reduct-store-id`, and `x-reduct-license-hash` headers with replication requests, enforcing matching commercial licenses, device limits, and one active node identity per capped device on receivers, [Issue-1580](https://github.com/reductstore/reductstore/issues/1580), [#1611](https://github.com/reductstore/reductstore/pull/1611) by @atimin
 - Persist a deployment UUID in `.uuid` on the configured filesystem, S3, or Azure Blob storage, [PR-1606](https://github.com/reductstore/reductstore/pull/1606) by @anthonycvn
 - Expose the effective instance name and role in the `/api/v1/info` response, [PR-1569](https://github.com/reductstore/reductstore/pull/1569) by @lntutor
 - Automatically create missing destination buckets during replication, [PR-1539](https://github.com/reductstore/reductstore/pull/1539) by @rohankumardubey

--- a/reductstore/src/api.rs
+++ b/reductstore/src/api.rs
@@ -3,6 +3,7 @@
 
 pub mod components;
 pub mod http;
+pub(crate) mod license_device_guard;
 pub mod limits;
 #[cfg(feature = "zenoh-api")]
 pub mod zenoh;

--- a/reductstore/src/api/components.rs
+++ b/reductstore/src/api/components.rs
@@ -3,6 +3,7 @@
 
 //! Server-wide shared state used by all API layers (HTTP, Zenoh).
 
+use crate::api::license_device_guard::LicenseDeviceGuard;
 use crate::api::limits::BoxedLimits;
 use crate::asset::asset_manager::ManageStaticAsset;
 use crate::auth::policy::Policy;
@@ -45,6 +46,7 @@ pub struct Components {
     pub(crate) ext_repo: Box<dyn ManageExtensions + Send + Sync>,
     pub(crate) query_link_cache: AsyncRwLock<Cache<String, Arc<Mutex<BoxedReadRecord>>>>,
     pub(crate) limits: BoxedLimits,
+    pub(crate) license_device_guard: LicenseDeviceGuard,
     /// The single system-event collector: owns every aggregator/task (audit
     /// batching, usage timer, log capture) and the one shared `$system` writer
     /// they fan through. A no-op when system events are disabled, so no `Option`
@@ -101,6 +103,8 @@ impl StateKeeper {
                 policy,
             )
             .await?;
+
+        components.license_device_guard.check(headers)?;
 
         Ok(components)
     }

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -812,10 +812,10 @@ pub(crate) mod tests {
         let (store_id, node_id) = test_deployment_ids(&cfg).await;
         Components {
             store_id,
-            node_id,
+            node_id: node_id.clone(),
             storage: Arc::clone(&storage),
             license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
-                None, store_id,
+                None, store_id, node_id,
             ),
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
@@ -937,10 +937,10 @@ pub(crate) mod tests {
         let (store_id, node_id) = test_deployment_ids(&cfg).await;
         let components = Components {
             store_id,
-            node_id,
+            node_id: node_id.clone(),
             storage: Arc::clone(&storage),
             license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
-                license, store_id,
+                license, store_id, node_id,
             ),
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
@@ -1051,10 +1051,10 @@ pub(crate) mod tests {
         let (store_id, node_id) = test_deployment_ids(&cfg).await;
         let components = Components {
             store_id,
-            node_id,
+            node_id: node_id.clone(),
             storage: Arc::clone(&storage),
             license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
-                None, store_id,
+                None, store_id, node_id,
             ),
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),

--- a/reductstore/src/api/http.rs
+++ b/reductstore/src/api/http.rs
@@ -33,6 +33,7 @@ use lifecycle::create_lifecycle_policy_api_routes;
 use log::{error, warn};
 use middleware::{
     attach_client_ip, audit_requests, check_api_rate_limit, default_headers, print_statuses,
+    validate_replication_identity,
 };
 pub use reduct_base::error::ErrorCode;
 use reduct_base::error::ReductError;
@@ -265,6 +266,10 @@ impl AxumAppBuilder {
                 // content-length header is consumed by the decompression.
                 .layer(RequestDecompressionLayer::new())
                 .layer(from_fn(attach_client_ip))
+                .layer(from_fn_with_state(
+                    state_keeper.clone(),
+                    validate_replication_identity,
+                ))
                 .layer(from_fn_with_state(state_keeper.clone(), audit_requests))
                 .layer(from_fn(default_headers))
                 .layer(from_fn(print_statuses))
@@ -323,7 +328,7 @@ pub(crate) mod tests {
     use reduct_base::msg::replication_api::{
         ReplicationCompression, ReplicationMode, ReplicationSettings,
     };
-    use reduct_base::msg::server_api::ServerInfo;
+    use reduct_base::msg::server_api::{License, ServerInfo};
     use reduct_base::msg::token_api::{Permissions, TokenCreateRequest};
     use rstest::fixture;
     use std::collections::HashMap;
@@ -809,6 +814,9 @@ pub(crate) mod tests {
             store_id,
             node_id,
             storage: Arc::clone(&storage),
+            license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
+                None, store_id,
+            ),
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
             console: create_asset_manager(console_bytes),
@@ -831,7 +839,10 @@ pub(crate) mod tests {
         }
     }
 
-    async fn keeper_with_limits_impl(limits_config: LimitsConfig) -> Arc<StateKeeper> {
+    async fn keeper_with_limits_impl(
+        limits_config: LimitsConfig,
+        license: Option<License>,
+    ) -> Arc<StateKeeper> {
         let mut cfg = Cfg {
             data_path: tempfile::tempdir().unwrap().keep(),
             api_token: crate::cfg::ApiToken::Provisioned("init-token".to_string()),
@@ -928,6 +939,9 @@ pub(crate) mod tests {
             store_id,
             node_id,
             storage: Arc::clone(&storage),
+            license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
+                license, store_id,
+            ),
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
             console: create_asset_manager(console_bytes),
@@ -956,7 +970,23 @@ pub(crate) mod tests {
     }
 
     pub(crate) async fn keeper_with_limits(limits_config: LimitsConfig) -> Arc<StateKeeper> {
-        keeper_with_limits_impl(limits_config).await
+        keeper_with_limits_impl(limits_config, None).await
+    }
+
+    pub(crate) async fn licensed_keeper(device_number: u32) -> Arc<StateKeeper> {
+        keeper_with_limits_impl(
+            LimitsConfig::default(),
+            Some(License {
+                licensee: String::new(),
+                invoice: String::new(),
+                expiry_date: chrono::Utc::now(),
+                plan: String::new(),
+                device_number,
+                disk_quota: 0,
+                fingerprint: "license-fingerprint".to_string(),
+            }),
+        )
+        .await
     }
 
     pub(crate) async fn keeper_with_engine_limit(max_storage_size: u64) -> Arc<StateKeeper> {
@@ -1023,6 +1053,9 @@ pub(crate) mod tests {
             store_id,
             node_id,
             storage: Arc::clone(&storage),
+            license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
+                None, store_id,
+            ),
             auth: TokenAuthorization::new("init-token"),
             token_repo: AsyncRwLock::new(token_repo),
             console: create_asset_manager(console_bytes),

--- a/reductstore/src/api/http/middleware.rs
+++ b/reductstore/src/api/http/middleware.rs
@@ -172,7 +172,7 @@ mod tests {
     use axum::{middleware::from_fn_with_state, Router};
     use log::Level;
     use reduct_base::io::ReadRecord;
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
     use std::sync::Arc;
     use tokio::time::{sleep, Duration};
     use tower::ServiceExt;
@@ -389,46 +389,36 @@ mod tests {
             .contains("api requests"));
     }
 
-    #[rstest]
-    #[tokio::test]
-    async fn rejects_partial_commercial_identity_before_the_handler() {
-        let keeper = licensed_keeper(1).await;
-        let app = Router::new()
-            .route("/test", get(|| async { StatusCode::OK }))
-            .layer(from_fn_with_state(keeper, validate_replication_identity));
-
-        let response = app
-            .oneshot(
-                Request::get("/test")
-                    .header("x-reduct-node-id", "node")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    #[fixture]
+    async fn commercial_keeper() -> Arc<StateKeeper> {
+        licensed_keeper(1).await
     }
 
     #[rstest]
+    #[case::partial(false, StatusCode::TOO_MANY_REQUESTS)]
+    #[case::complete(true, StatusCode::OK)]
     #[tokio::test]
-    async fn accepts_complete_commercial_identity() {
-        let keeper = licensed_keeper(1).await;
+    async fn validates_commercial_identity_before_the_handler(
+        #[future] commercial_keeper: Arc<StateKeeper>,
+        #[case] complete: bool,
+        #[case] expected_status: StatusCode,
+    ) {
+        let keeper = commercial_keeper.await;
         let app = Router::new()
             .route("/test", get(|| async { StatusCode::OK }))
             .layer(from_fn_with_state(keeper, validate_replication_identity));
 
+        let mut request = Request::get("/test").header("x-reduct-node-id", "node");
+        if complete {
+            request = request
+                .header("x-reduct-store-id", uuid::Uuid::new_v4().to_string())
+                .header("x-reduct-license-hash", "license-fingerprint");
+        }
         let response = app
-            .oneshot(
-                Request::get("/test")
-                    .header("x-reduct-node-id", "node")
-                    .header("x-reduct-store-id", uuid::Uuid::new_v4().to_string())
-                    .header("x-reduct-license-hash", "license-fingerprint")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(request.body(Body::empty()).unwrap())
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), expected_status);
     }
 
     #[rstest]

--- a/reductstore/src/api/http/middleware.rs
+++ b/reductstore/src/api/http/middleware.rs
@@ -88,6 +88,18 @@ pub(super) async fn check_api_rate_limit(
     Ok(next.run(request).await)
 }
 
+pub(super) async fn validate_replication_identity(
+    State(keeper): State<Arc<StateKeeper>>,
+    request: Request<Body>,
+    next: Next,
+) -> Result<impl IntoResponse, HttpError> {
+    let components = keeper.get_anonymous().await?;
+    components
+        .license_device_guard
+        .validate_headers(request.headers())?;
+    Ok(next.run(request).await)
+}
+
 pub async fn print_statuses(
     request: Request<Body>,
     next: Next,
@@ -151,7 +163,7 @@ mod tests {
     use super::client_ip::{parse_forwarded_for, parse_x_forwarded_for};
     use super::*;
     use crate::api::components::StateKeeper;
-    use crate::api::http::tests::{api_limited_keeper, keeper, waiting_keeper};
+    use crate::api::http::tests::{api_limited_keeper, keeper, licensed_keeper, waiting_keeper};
     use crate::syslog::{SYSTEM_AUDIT_ENTRY_PREFIX, SYSTEM_BUCKET_NAME};
     use axum::extract::ConnectInfo;
     use axum::http::Request;
@@ -375,6 +387,48 @@ mod tests {
             .to_str()
             .unwrap()
             .contains("api requests"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn rejects_partial_commercial_identity_before_the_handler() {
+        let keeper = licensed_keeper(1).await;
+        let app = Router::new()
+            .route("/test", get(|| async { StatusCode::OK }))
+            .layer(from_fn_with_state(keeper, validate_replication_identity));
+
+        let response = app
+            .oneshot(
+                Request::get("/test")
+                    .header("x-reduct-node-id", "node")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn accepts_complete_commercial_identity() {
+        let keeper = licensed_keeper(1).await;
+        let app = Router::new()
+            .route("/test", get(|| async { StatusCode::OK }))
+            .layer(from_fn_with_state(keeper, validate_replication_identity));
+
+        let response = app
+            .oneshot(
+                Request::get("/test")
+                    .header("x-reduct-node-id", "node")
+                    .header("x-reduct-store-id", uuid::Uuid::new_v4().to_string())
+                    .header("x-reduct-license-hash", "license-fingerprint")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[rstest]

--- a/reductstore/src/api/license_device_guard.rs
+++ b/reductstore/src/api/license_device_guard.rs
@@ -1,0 +1,268 @@
+// Copyright 2021-2026 ReductSoftware UG
+// Licensed under the Apache License, Version 2.0
+
+use crate::core::deployment_id::StoreId;
+use crate::replication::{
+    REPLICATION_LICENSE_HASH_HEADER, REPLICATION_NODE_ID_HEADER, REPLICATION_STORE_ID_HEADER,
+};
+use axum::http::HeaderMap;
+use parking_lot::Mutex;
+use reduct_base::error::{ErrorCode, ReductError};
+use reduct_base::msg::server_api::License;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+const DEVICE_IDLE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+const INVALID_LICENSE_MESSAGE: &str = "Invalid replication license identity";
+const DEVICE_LIMIT_MESSAGE: &str = "Replication device limit reached";
+
+#[derive(Debug, PartialEq)]
+struct ReplicationIdentity {
+    node_id: String,
+    store_id: String,
+    license_hash: String,
+}
+
+pub(crate) struct LicenseDeviceGuard {
+    license: Option<License>,
+    receiver_store_id: Uuid,
+    devices: Mutex<HashMap<Uuid, HashMap<String, Instant>>>,
+}
+
+impl LicenseDeviceGuard {
+    pub(crate) fn new(license: Option<License>, receiver_store_id: StoreId) -> Self {
+        Self::with_receiver_store_id(license, receiver_store_id.as_uuid())
+    }
+
+    fn with_receiver_store_id(license: Option<License>, receiver_store_id: Uuid) -> Self {
+        Self {
+            license,
+            receiver_store_id,
+            devices: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn validate_headers(&self, headers: &HeaderMap) -> Result<(), ReductError> {
+        if self.license.is_some() {
+            parse_identity(headers)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check(&self, headers: &HeaderMap) -> Result<(), ReductError> {
+        let Some(license) = &self.license else {
+            return Ok(());
+        };
+
+        let Some(identity) = parse_identity(headers)? else {
+            return Ok(());
+        };
+
+        if identity.license_hash == "null" || identity.license_hash != license.fingerprint {
+            return Err(invalid_license_error());
+        }
+
+        let store_id = Uuid::parse_str(&identity.store_id).map_err(|_| invalid_license_error())?;
+        self.check_at(
+            store_id,
+            identity.node_id,
+            Instant::now(),
+            license.device_number,
+        )
+    }
+
+    fn check_at(
+        &self,
+        store_id: Uuid,
+        node_id: String,
+        now: Instant,
+        device_number: u32,
+    ) -> Result<(), ReductError> {
+        if store_id == self.receiver_store_id {
+            return Ok(());
+        }
+
+        let mut devices = self.devices.lock();
+        devices.retain(|_, nodes| {
+            nodes.retain(|_, last_seen| now.duration_since(*last_seen) <= DEVICE_IDLE_TIMEOUT);
+            !nodes.is_empty()
+        });
+
+        if !devices.contains_key(&store_id)
+            && device_number != 0
+            && devices.len() >= device_number as usize
+        {
+            return Err(ReductError::new(
+                ErrorCode::TooManyRequests,
+                DEVICE_LIMIT_MESSAGE,
+            ));
+        }
+
+        devices.entry(store_id).or_default().insert(node_id, now);
+        Ok(())
+    }
+}
+
+fn parse_identity(headers: &HeaderMap) -> Result<Option<ReplicationIdentity>, ReductError> {
+    let values = [
+        headers.get(REPLICATION_NODE_ID_HEADER),
+        headers.get(REPLICATION_STORE_ID_HEADER),
+        headers.get(REPLICATION_LICENSE_HASH_HEADER),
+    ];
+    if values.iter().all(Option::is_none) {
+        return Ok(None);
+    }
+
+    let values: Vec<&str> = values
+        .into_iter()
+        .map(|value| {
+            value
+                .and_then(|value| value.to_str().ok())
+                .filter(|value| !value.is_empty())
+        })
+        .collect::<Option<_>>()
+        .ok_or_else(invalid_license_error)?;
+    Ok(Some(ReplicationIdentity {
+        node_id: values[0].to_string(),
+        store_id: values[1].to_string(),
+        license_hash: values[2].to_string(),
+    }))
+}
+
+fn invalid_license_error() -> ReductError {
+    ReductError::new(ErrorCode::TooManyRequests, INVALID_LICENSE_MESSAGE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+    use chrono::Utc;
+
+    fn license(device_number: u32) -> License {
+        License {
+            licensee: String::new(),
+            invoice: String::new(),
+            expiry_date: Utc::now(),
+            plan: String::new(),
+            device_number,
+            disk_quota: 0,
+            fingerprint: "license-fingerprint".to_string(),
+        }
+    }
+
+    fn headers(store_id: Uuid, node_id: &str, fingerprint: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(REPLICATION_NODE_ID_HEADER, node_id.parse().unwrap());
+        headers.insert(
+            REPLICATION_STORE_ID_HEADER,
+            store_id.to_string().parse().unwrap(),
+        );
+        headers.insert(
+            REPLICATION_LICENSE_HASH_HEADER,
+            fingerprint.parse().unwrap(),
+        );
+        headers
+    }
+
+    fn guard(license: Option<License>) -> LicenseDeviceGuard {
+        LicenseDeviceGuard::with_receiver_store_id(license, Uuid::nil())
+    }
+
+    #[test]
+    fn bypasses_unlicensed_and_identity_free_requests() {
+        assert!(guard(None).check(&HeaderMap::new()).is_ok());
+        assert!(guard(Some(license(1))).check(&HeaderMap::new()).is_ok());
+    }
+
+    #[test]
+    fn rejects_partial_or_invalid_identity_headers() {
+        let guard = guard(Some(license(1)));
+        for header in [
+            REPLICATION_NODE_ID_HEADER,
+            REPLICATION_STORE_ID_HEADER,
+            REPLICATION_LICENSE_HASH_HEADER,
+        ] {
+            let mut partial = HeaderMap::new();
+            partial.insert(header, HeaderValue::from_static("value"));
+            assert_eq!(
+                guard.validate_headers(&partial).unwrap_err().status,
+                ErrorCode::TooManyRequests
+            );
+        }
+
+        let mut empty = headers(Uuid::new_v4(), "node", "license-fingerprint");
+        empty.insert(REPLICATION_NODE_ID_HEADER, HeaderValue::from_static(""));
+        assert_eq!(
+            guard.validate_headers(&empty).unwrap_err().status,
+            ErrorCode::TooManyRequests
+        );
+
+        let mut non_utf8 = headers(Uuid::new_v4(), "node", "license-fingerprint");
+        non_utf8.insert(
+            REPLICATION_NODE_ID_HEADER,
+            HeaderValue::from_bytes(b"\xff").unwrap(),
+        );
+        assert_eq!(
+            guard.validate_headers(&non_utf8).unwrap_err().status,
+            ErrorCode::TooManyRequests
+        );
+
+        let invalid = headers(Uuid::new_v4(), "node", "null");
+        assert_eq!(
+            guard.check(&invalid).unwrap_err().status,
+            ErrorCode::TooManyRequests
+        );
+        let invalid = headers(Uuid::new_v4(), "node", "different-fingerprint");
+        assert_eq!(
+            guard.check(&invalid).unwrap_err().status,
+            ErrorCode::TooManyRequests
+        );
+    }
+
+    #[test]
+    fn admits_matching_identity_and_enforces_distinct_stores() {
+        let guard = guard(Some(license(1)));
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        assert!(guard
+            .check(&headers(first, "node-a", "license-fingerprint"))
+            .is_ok());
+        assert!(guard
+            .check(&headers(first, "node-b", "license-fingerprint"))
+            .is_ok());
+        assert_eq!(
+            guard
+                .check(&headers(second, "node-a", "license-fingerprint"))
+                .unwrap_err()
+                .status,
+            ErrorCode::TooManyRequests
+        );
+    }
+
+    #[test]
+    fn supports_unlimited_devices_and_releases_expired_stores() {
+        let unlimited_guard = guard(Some(license(0)));
+        assert!(unlimited_guard
+            .check(&headers(Uuid::new_v4(), "node", "license-fingerprint"))
+            .is_ok());
+        assert!(unlimited_guard
+            .check(&headers(Uuid::new_v4(), "node", "license-fingerprint"))
+            .is_ok());
+
+        let guard = guard(Some(license(1)));
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let now = Instant::now();
+        guard.check_at(first, "node-a".to_string(), now, 1).unwrap();
+        guard
+            .check_at(
+                second,
+                "node-b".to_string(),
+                now + DEVICE_IDLE_TIMEOUT + Duration::from_secs(1),
+                1,
+            )
+            .unwrap();
+    }
+}

--- a/reductstore/src/api/license_device_guard.rs
+++ b/reductstore/src/api/license_device_guard.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2026 ReductSoftware UG
 // Licensed under the Apache License, Version 2.0
 
-use crate::core::deployment_id::StoreId;
+use crate::core::deployment_id::{NodeId, StoreId};
 use crate::replication::{
     REPLICATION_LICENSE_HASH_HEADER, REPLICATION_NODE_ID_HEADER, REPLICATION_STORE_ID_HEADER,
 };
@@ -16,6 +16,7 @@ use uuid::Uuid;
 const DEVICE_IDLE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 const INVALID_LICENSE_MESSAGE: &str = "Invalid replication license identity";
 const DEVICE_LIMIT_MESSAGE: &str = "Replication device limit reached";
+const ACTIVE_NODE_MESSAGE: &str = "Replication node is already active for this device";
 
 #[derive(Debug, PartialEq)]
 struct ReplicationIdentity {
@@ -24,21 +25,40 @@ struct ReplicationIdentity {
     license_hash: String,
 }
 
+struct ActiveNode {
+    node_id: String,
+    last_seen: Instant,
+}
+
 pub(crate) struct LicenseDeviceGuard {
     license: Option<License>,
     receiver_store_id: Uuid,
-    devices: Mutex<HashMap<Uuid, HashMap<String, Instant>>>,
+    receiver_node_id: String,
+    devices: Mutex<HashMap<Uuid, ActiveNode>>,
 }
 
 impl LicenseDeviceGuard {
-    pub(crate) fn new(license: Option<License>, receiver_store_id: StoreId) -> Self {
-        Self::with_receiver_store_id(license, receiver_store_id.as_uuid())
+    pub(crate) fn new(
+        license: Option<License>,
+        receiver_store_id: StoreId,
+        receiver_node_id: NodeId,
+    ) -> Self {
+        Self::with_receiver_identity(
+            license,
+            receiver_store_id.as_uuid(),
+            receiver_node_id.to_string(),
+        )
     }
 
-    fn with_receiver_store_id(license: Option<License>, receiver_store_id: Uuid) -> Self {
+    fn with_receiver_identity(
+        license: Option<License>,
+        receiver_store_id: Uuid,
+        receiver_node_id: String,
+    ) -> Self {
         Self {
             license,
             receiver_store_id,
+            receiver_node_id,
             devices: Mutex::new(HashMap::new()),
         }
     }
@@ -80,26 +100,42 @@ impl LicenseDeviceGuard {
         device_number: u32,
     ) -> Result<(), ReductError> {
         if store_id == self.receiver_store_id {
+            return if node_id == self.receiver_node_id {
+                Ok(())
+            } else {
+                Err(active_node_error())
+            };
+        }
+
+        if device_number == 0 {
             return Ok(());
         }
 
         let mut devices = self.devices.lock();
-        devices.retain(|_, nodes| {
-            nodes.retain(|_, last_seen| now.duration_since(*last_seen) <= DEVICE_IDLE_TIMEOUT);
-            !nodes.is_empty()
+        devices.retain(|_, active_node| {
+            now.duration_since(active_node.last_seen) <= DEVICE_IDLE_TIMEOUT
         });
 
-        if !devices.contains_key(&store_id)
-            && device_number != 0
-            && devices.len() >= device_number as usize
-        {
-            return Err(ReductError::new(
-                ErrorCode::TooManyRequests,
-                DEVICE_LIMIT_MESSAGE,
-            ));
+        if let Some(active_node) = devices.get_mut(&store_id) {
+            if active_node.node_id == node_id {
+                active_node.last_seen = now;
+                return Ok(());
+            }
+
+            return Err(active_node_error());
         }
 
-        devices.entry(store_id).or_default().insert(node_id, now);
+        if devices.len() >= device_number as usize {
+            return Err(device_limit_error());
+        }
+
+        devices.insert(
+            store_id,
+            ActiveNode {
+                node_id,
+                last_seen: now,
+            },
+        );
         Ok(())
     }
 }
@@ -132,6 +168,14 @@ fn parse_identity(headers: &HeaderMap) -> Result<Option<ReplicationIdentity>, Re
 
 fn invalid_license_error() -> ReductError {
     ReductError::new(ErrorCode::TooManyRequests, INVALID_LICENSE_MESSAGE)
+}
+
+fn active_node_error() -> ReductError {
+    ReductError::new(ErrorCode::TooManyRequests, ACTIVE_NODE_MESSAGE)
+}
+
+fn device_limit_error() -> ReductError {
+    ReductError::new(ErrorCode::TooManyRequests, DEVICE_LIMIT_MESSAGE)
 }
 
 #[cfg(test)]
@@ -173,7 +217,11 @@ mod tests {
     }
 
     fn guard(license: Option<License>) -> LicenseDeviceGuard {
-        LicenseDeviceGuard::with_receiver_store_id(license, Uuid::nil())
+        LicenseDeviceGuard::with_receiver_identity(
+            license,
+            Uuid::nil(),
+            "receiver-node".to_string(),
+        )
     }
 
     fn partial_headers(header: axum::http::HeaderName) -> HeaderMap {
@@ -238,14 +286,14 @@ mod tests {
     }
 
     #[rstest]
-    fn admits_matching_identity_and_enforces_distinct_stores(licensed_guard: LicenseDeviceGuard) {
+    fn admits_matching_node_and_enforces_distinct_stores(licensed_guard: LicenseDeviceGuard) {
         let first = Uuid::new_v4();
         let second = Uuid::new_v4();
         assert!(licensed_guard
             .check(&headers(first, "node-a", "license-fingerprint"))
             .is_ok());
         assert!(licensed_guard
-            .check(&headers(first, "node-b", "license-fingerprint"))
+            .check(&headers(first, "node-a", "license-fingerprint"))
             .is_ok());
         assert_eq!(
             licensed_guard
@@ -254,13 +302,93 @@ mod tests {
                 .status,
             ErrorCode::TooManyRequests
         );
+        let devices = licensed_guard.devices.lock();
+        assert_eq!(devices.len(), 1);
+        assert!(!devices.contains_key(&second));
+    }
+
+    #[rstest]
+    fn refreshes_matching_node_activity(licensed_guard: LicenseDeviceGuard) {
+        let store_id = Uuid::new_v4();
+        let now = Instant::now();
+
+        licensed_guard
+            .check_at(store_id, "node-a".to_string(), now, 1)
+            .unwrap();
+        licensed_guard
+            .check_at(
+                store_id,
+                "node-a".to_string(),
+                now + Duration::from_secs(30),
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            licensed_guard
+                .check_at(
+                    store_id,
+                    "node-b".to_string(),
+                    now + DEVICE_IDLE_TIMEOUT + Duration::from_secs(1),
+                    1,
+                )
+                .unwrap_err()
+                .message,
+            ACTIVE_NODE_MESSAGE
+        );
+    }
+
+    #[rstest]
+    fn rejects_different_active_node_without_refreshing_it() {
+        let guard = guard(Some(license(1)));
+        let store_id = Uuid::new_v4();
+        let now = Instant::now();
+
+        guard
+            .check_at(store_id, "node-a".to_string(), now, 1)
+            .unwrap();
+        assert_eq!(
+            guard
+                .check_at(
+                    store_id,
+                    "node-b".to_string(),
+                    now + Duration::from_secs(30),
+                    1,
+                )
+                .unwrap_err()
+                .message,
+            ACTIVE_NODE_MESSAGE
+        );
+        guard
+            .check_at(
+                store_id,
+                "node-b".to_string(),
+                now + DEVICE_IDLE_TIMEOUT + Duration::from_secs(1),
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            guard
+                .check_at(
+                    store_id,
+                    "node-a".to_string(),
+                    now + DEVICE_IDLE_TIMEOUT + Duration::from_secs(2),
+                    1,
+                )
+                .unwrap_err()
+                .message,
+            ACTIVE_NODE_MESSAGE
+        );
     }
 
     #[rstest]
     fn supports_unlimited_devices_and_releases_expired_stores() {
         let unlimited_guard = guard(Some(license(0)));
+        let unlimited_store = Uuid::new_v4();
         assert!(unlimited_guard
-            .check(&headers(Uuid::new_v4(), "node", "license-fingerprint"))
+            .check(&headers(unlimited_store, "node-a", "license-fingerprint"))
+            .is_ok());
+        assert!(unlimited_guard
+            .check(&headers(unlimited_store, "node-b", "license-fingerprint"))
             .is_ok());
         assert!(unlimited_guard
             .check(&headers(Uuid::new_v4(), "node", "license-fingerprint"))
@@ -279,5 +407,25 @@ mod tests {
                 1,
             )
             .unwrap();
+    }
+
+    #[rstest]
+    #[case::capped(1)]
+    #[case::unlimited(0)]
+    fn admits_receiver_identity_without_a_seat_and_rejects_other_nodes(#[case] device_number: u32) {
+        let guard = guard(Some(license(device_number)));
+        let now = Instant::now();
+
+        guard
+            .check_at(Uuid::nil(), "receiver-node".to_string(), now, device_number)
+            .unwrap();
+        assert!(guard.devices.lock().is_empty());
+        assert_eq!(
+            guard
+                .check_at(Uuid::nil(), "other-node".to_string(), now, device_number,)
+                .unwrap_err()
+                .message,
+            ACTIVE_NODE_MESSAGE
+        );
     }
 }

--- a/reductstore/src/api/license_device_guard.rs
+++ b/reductstore/src/api/license_device_guard.rs
@@ -139,6 +139,7 @@ mod tests {
     use super::*;
     use axum::http::HeaderValue;
     use chrono::Utc;
+    use rstest::{fixture, rstest};
 
     fn license(device_number: u32) -> License {
         License {
@@ -166,74 +167,88 @@ mod tests {
         headers
     }
 
+    #[fixture]
+    fn licensed_guard() -> LicenseDeviceGuard {
+        guard(Some(license(1)))
+    }
+
     fn guard(license: Option<License>) -> LicenseDeviceGuard {
         LicenseDeviceGuard::with_receiver_store_id(license, Uuid::nil())
     }
 
-    #[test]
-    fn bypasses_unlicensed_and_identity_free_requests() {
-        assert!(guard(None).check(&HeaderMap::new()).is_ok());
-        assert!(guard(Some(license(1))).check(&HeaderMap::new()).is_ok());
+    fn partial_headers(header: axum::http::HeaderName) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header, HeaderValue::from_static("value"));
+        headers
     }
 
-    #[test]
-    fn rejects_partial_or_invalid_identity_headers() {
-        let guard = guard(Some(license(1)));
-        for header in [
-            REPLICATION_NODE_ID_HEADER,
-            REPLICATION_STORE_ID_HEADER,
-            REPLICATION_LICENSE_HASH_HEADER,
-        ] {
-            let mut partial = HeaderMap::new();
-            partial.insert(header, HeaderValue::from_static("value"));
-            assert_eq!(
-                guard.validate_headers(&partial).unwrap_err().status,
-                ErrorCode::TooManyRequests
-            );
-        }
-
+    fn empty_node_headers() -> HeaderMap {
         let mut empty = headers(Uuid::new_v4(), "node", "license-fingerprint");
         empty.insert(REPLICATION_NODE_ID_HEADER, HeaderValue::from_static(""));
-        assert_eq!(
-            guard.validate_headers(&empty).unwrap_err().status,
-            ErrorCode::TooManyRequests
-        );
+        empty
+    }
 
+    fn non_utf8_node_headers() -> HeaderMap {
         let mut non_utf8 = headers(Uuid::new_v4(), "node", "license-fingerprint");
         non_utf8.insert(
             REPLICATION_NODE_ID_HEADER,
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
-        assert_eq!(
-            guard.validate_headers(&non_utf8).unwrap_err().status,
-            ErrorCode::TooManyRequests
-        );
+        non_utf8
+    }
 
-        let invalid = headers(Uuid::new_v4(), "node", "null");
+    #[rstest]
+    #[case::unlicensed(guard(None))]
+    #[case::licensed_without_identity(guard(Some(license(1))))]
+    fn bypasses_unlicensed_or_identity_free_requests(#[case] guard: LicenseDeviceGuard) {
+        assert!(guard.check(&HeaderMap::new()).is_ok());
+    }
+
+    #[rstest]
+    #[case::node_only(partial_headers(REPLICATION_NODE_ID_HEADER))]
+    #[case::store_only(partial_headers(REPLICATION_STORE_ID_HEADER))]
+    #[case::license_only(partial_headers(REPLICATION_LICENSE_HASH_HEADER))]
+    #[case::empty_node(empty_node_headers())]
+    #[case::non_utf8_node(non_utf8_node_headers())]
+    fn rejects_invalid_identity_headers(
+        licensed_guard: LicenseDeviceGuard,
+        #[case] headers: HeaderMap,
+    ) {
         assert_eq!(
-            guard.check(&invalid).unwrap_err().status,
-            ErrorCode::TooManyRequests
-        );
-        let invalid = headers(Uuid::new_v4(), "node", "different-fingerprint");
-        assert_eq!(
-            guard.check(&invalid).unwrap_err().status,
+            licensed_guard
+                .validate_headers(&headers)
+                .unwrap_err()
+                .status,
             ErrorCode::TooManyRequests
         );
     }
 
-    #[test]
-    fn admits_matching_identity_and_enforces_distinct_stores() {
-        let guard = guard(Some(license(1)));
+    #[rstest]
+    #[case::null("null")]
+    #[case::different("different-fingerprint")]
+    fn rejects_invalid_license_fingerprints(
+        licensed_guard: LicenseDeviceGuard,
+        #[case] fingerprint: &str,
+    ) {
+        let invalid = headers(Uuid::new_v4(), "node", fingerprint);
+        assert_eq!(
+            licensed_guard.check(&invalid).unwrap_err().status,
+            ErrorCode::TooManyRequests
+        );
+    }
+
+    #[rstest]
+    fn admits_matching_identity_and_enforces_distinct_stores(licensed_guard: LicenseDeviceGuard) {
         let first = Uuid::new_v4();
         let second = Uuid::new_v4();
-        assert!(guard
+        assert!(licensed_guard
             .check(&headers(first, "node-a", "license-fingerprint"))
             .is_ok());
-        assert!(guard
+        assert!(licensed_guard
             .check(&headers(first, "node-b", "license-fingerprint"))
             .is_ok());
         assert_eq!(
-            guard
+            licensed_guard
                 .check(&headers(second, "node-a", "license-fingerprint"))
                 .unwrap_err()
                 .status,
@@ -241,7 +256,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[rstest]
     fn supports_unlimited_devices_and_releases_expired_stores() {
         let unlimited_guard = guard(Some(license(0)));
         assert!(unlimited_guard

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -32,6 +32,7 @@ use crate::core::file_cache::FILE_CACHE;
 use crate::core::sync::{set_rwlock_failure_action, set_rwlock_timeout, AsyncRwLock};
 use crate::ext::ext_repository::create_ext_repository;
 use crate::lock_file::{BoxedLockFile, LockFileBuilder};
+use crate::replication::ReplicationSourceIdentity;
 use crate::storage::bucket::Bucket;
 use crate::storage::usage::UsageCounters;
 use crate::syslog::build_system_event_logger;
@@ -440,6 +441,13 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
             .load_or_create()
             .await?;
         let node_id = NodeId::from_instance_name(&self.cfg.instance_name);
+        let replication_source_identity = ReplicationSourceIdentity::new(
+            node_id.to_string(),
+            store_id.to_string(),
+            self.license
+                .as_ref()
+                .map(|license| license.fingerprint.clone()),
+        );
         // One shared counters instance: the engine increments it at its choke
         // points, the usage aggregator drains it.
         let usage_counters = Arc::new(UsageCounters::default());
@@ -455,8 +463,12 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         let system_events =
             build_system_event_logger(&self.cfg, Arc::clone(&storage), usage_counters).await;
         let replication_engine = Arc::new(AsyncRwLock::new(
-            self.provision_replication_repo(Arc::clone(&storage), system_events.sink())
-                .await?,
+            self.provision_replication_repo(
+                Arc::clone(&storage),
+                system_events.sink(),
+                replication_source_identity,
+            )
+            .await?,
         ));
         // Register the replication notifier so `$system` writes replicate
         // like API writes.

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -507,6 +507,10 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         Ok(Components {
             store_id,
             node_id,
+            license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
+                self.license.clone(),
+                store_id,
+            ),
             storage: Arc::clone(&storage),
             token_repo: AsyncRwLock::new(token_repo.await),
             auth: TokenAuthorization::new(self.cfg.api_token.as_str()),

--- a/reductstore/src/cfg.rs
+++ b/reductstore/src/cfg.rs
@@ -13,6 +13,7 @@ pub mod system_events;
 pub mod zenoh;
 
 use crate::api::components::Components;
+use crate::api::license_device_guard::LicenseDeviceGuard;
 use crate::api::limits::{LimitsBuilder, LimitsConfig};
 use crate::asset::asset_manager::create_asset_manager;
 use crate::auth::token_auth::TokenAuthorization;
@@ -506,11 +507,8 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
 
         Ok(Components {
             store_id,
-            node_id,
-            license_device_guard: crate::api::license_device_guard::LicenseDeviceGuard::new(
-                self.license.clone(),
-                store_id,
-            ),
+            node_id: node_id.clone(),
+            license_device_guard: LicenseDeviceGuard::new(self.license.clone(), store_id, node_id),
             storage: Arc::clone(&storage),
             token_repo: AsyncRwLock::new(token_repo.await),
             auth: TokenAuthorization::new(self.cfg.api_token.as_str()),

--- a/reductstore/src/cfg/provision/replication.rs
+++ b/reductstore/src/cfg/provision/replication.rs
@@ -3,7 +3,9 @@
 
 use crate::cfg::{CfgParser, ExtCfgBounds, ProvisionedReplication};
 use crate::core::env::{Env, GetEnv};
-use crate::replication::{prepend_when_conditions, ManageReplications, ReplicationRepoBuilder};
+use crate::replication::{
+    prepend_when_conditions, ManageReplications, ReplicationRepoBuilder, ReplicationSourceIdentity,
+};
 use crate::storage::engine::StorageEngine;
 use crate::syslog::SystemEventSink;
 use log::{error, info, warn};
@@ -19,9 +21,11 @@ impl<EnvGetter: GetEnv, ExtCfg: ExtCfgBounds> CfgParser<EnvGetter, ExtCfg> {
         &self,
         storage: Arc<StorageEngine>,
         system_event_sink: SystemEventSink,
+        source_identity: ReplicationSourceIdentity,
     ) -> Result<Box<dyn ManageReplications + Send + Sync>, ReductError> {
         let repo = ReplicationRepoBuilder::new(self.cfg.clone())
             .with_system_event_sink(system_event_sink)
+            .with_source_identity(source_identity)
             .build(Arc::clone(&storage))
             .await;
         for (name, replication) in &self.cfg.replications {

--- a/reductstore/src/core/internal_client.rs
+++ b/reductstore/src/core/internal_client.rs
@@ -26,6 +26,7 @@ pub(crate) struct ClientBuildErrorContext<'a> {
 
 pub(crate) struct InternalClientBuilder<'a> {
     api_token: &'a str,
+    default_headers: HeaderMap,
     verify_ssl: bool,
     ca_path: Option<&'a PathBuf>,
     connect_timeout: Duration,
@@ -36,6 +37,7 @@ impl<'a> InternalClientBuilder<'a> {
     pub(crate) fn new(error_context: ClientBuildErrorContext<'a>) -> Self {
         Self {
             api_token: "",
+            default_headers: HeaderMap::new(),
             verify_ssl: true,
             ca_path: None,
             connect_timeout: Duration::from_secs(10),
@@ -45,6 +47,11 @@ impl<'a> InternalClientBuilder<'a> {
 
     pub(crate) fn api_token(mut self, api_token: &'a str) -> Self {
         self.api_token = api_token;
+        self
+    }
+
+    pub(crate) fn default_headers(mut self, default_headers: HeaderMap) -> Self {
+        self.default_headers = default_headers;
         self
     }
 
@@ -64,7 +71,7 @@ impl<'a> InternalClientBuilder<'a> {
     }
 
     pub(crate) fn build(self) -> Result<Client, ReductError> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.default_headers;
         if !self.api_token.is_empty() {
             let mut value = HeaderValue::from_str(&format!("Bearer {}", self.api_token)).unwrap();
             value.set_sensitive(true);

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -17,6 +17,23 @@ mod replication_task;
 mod transaction_filter;
 mod transaction_log;
 
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ReplicationSourceIdentity {
+    pub(crate) node_id: String,
+    pub(crate) store_id: String,
+    pub(crate) license_hash: String,
+}
+
+impl ReplicationSourceIdentity {
+    pub(crate) fn new(node_id: String, store_id: String, license_hash: Option<String>) -> Self {
+        Self {
+            node_id,
+            store_id,
+            license_hash: license_hash.unwrap_or_else(|| "null".to_string()),
+        }
+    }
+}
+
 /// Replication event to be synchronized.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Transaction {

--- a/reductstore/src/replication.rs
+++ b/reductstore/src/replication.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 use async_trait::async_trait;
+use axum::http::HeaderName;
 use reduct_base::error::ReductError;
 use reduct_base::io::RecordMeta;
 use reduct_base::msg::replication_api::{
@@ -16,6 +17,13 @@ mod replication_sender;
 mod replication_task;
 mod transaction_filter;
 mod transaction_log;
+
+pub(crate) const REPLICATION_NODE_ID_HEADER: HeaderName =
+    HeaderName::from_static("x-reduct-node-id");
+pub(crate) const REPLICATION_STORE_ID_HEADER: HeaderName =
+    HeaderName::from_static("x-reduct-store-id");
+pub(crate) const REPLICATION_LICENSE_HASH_HEADER: HeaderName =
+    HeaderName::from_static("x-reduct-license-hash");
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ReplicationSourceIdentity {

--- a/reductstore/src/replication/remote_bucket.rs
+++ b/reductstore/src/replication/remote_bucket.rs
@@ -5,6 +5,7 @@ mod client_wrapper;
 mod states;
 
 use crate::replication::remote_bucket::states::{InitialState, RemoteBucketState};
+use crate::replication::ReplicationSourceIdentity;
 use crate::replication::Transaction;
 use async_trait::async_trait;
 use reduct_base::error::ReductError;
@@ -21,6 +22,7 @@ pub(super) struct RemoteBucketConfig {
     pub(super) verify_ssl: bool,
     pub(super) ca_path: Option<PathBuf>,
     pub(super) compression: ReplicationCompression,
+    pub(super) source_identity: ReplicationSourceIdentity,
 }
 
 pub(super) struct RemoteBucketBuilder {
@@ -64,6 +66,11 @@ impl RemoteBucketBuilder {
 
     pub fn compression(mut self, compression: ReplicationCompression) -> Self {
         self.config.compression = compression;
+        self
+    }
+
+    pub fn source_identity(mut self, source_identity: ReplicationSourceIdentity) -> Self {
+        self.config.source_identity = source_identity;
         self
     }
 

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -5,7 +5,10 @@ use crate::core::internal_client::{
     ClientBuildErrorContext, ClientBuildErrorKind, InternalClientApi, InternalClientBuilder,
 };
 use crate::replication::remote_bucket::{ErrorRecordMap, RemoteBucketConfig};
-use crate::replication::ReplicationSourceIdentity;
+use crate::replication::{
+    ReplicationSourceIdentity, REPLICATION_LICENSE_HASH_HEADER, REPLICATION_NODE_ID_HEADER,
+    REPLICATION_STORE_ID_HEADER,
+};
 use async_compression::tokio::bufread::{GzipEncoder, ZstdEncoder};
 use async_stream::stream;
 use async_trait::async_trait;
@@ -79,9 +82,6 @@ struct ReductClient {
 }
 
 static API_PATH: &str = "api/v1";
-const NODE_ID_HEADER: HeaderName = HeaderName::from_static("x-reduct-node-id");
-const STORE_ID_HEADER: HeaderName = HeaderName::from_static("x-reduct-store-id");
-const LICENSE_HASH_HEADER: HeaderName = HeaderName::from_static("x-reduct-license-hash");
 
 /// The first server version that decompresses request bodies sent with
 /// `Content-Encoding`.
@@ -432,9 +432,12 @@ pub(super) fn create_client(config: &RemoteBucketConfig) -> Result<BoxedClientAp
 fn identity_headers(source_identity: &ReplicationSourceIdentity) -> Result<HeaderMap, ReductError> {
     let mut headers = HeaderMap::new();
     for (name, value) in [
-        (NODE_ID_HEADER, &source_identity.node_id),
-        (STORE_ID_HEADER, &source_identity.store_id),
-        (LICENSE_HASH_HEADER, &source_identity.license_hash),
+        (REPLICATION_NODE_ID_HEADER, &source_identity.node_id),
+        (REPLICATION_STORE_ID_HEADER, &source_identity.store_id),
+        (
+            REPLICATION_LICENSE_HASH_HEADER,
+            &source_identity.license_hash,
+        ),
     ] {
         let value = HeaderValue::from_str(value).map_err(|err| {
             unprocessable_entity!("Invalid replication identity header '{}': {}", name, err)
@@ -579,15 +582,18 @@ pub(super) mod tests {
         assert_eq!(headers.len(), 3);
         for request in headers.iter() {
             assert_eq!(
-                request.get(NODE_ID_HEADER).unwrap().as_bytes(),
+                request.get(REPLICATION_NODE_ID_HEADER).unwrap().as_bytes(),
                 identity.node_id.as_bytes()
             );
             assert_eq!(
-                request.get(STORE_ID_HEADER).unwrap().as_bytes(),
+                request.get(REPLICATION_STORE_ID_HEADER).unwrap().as_bytes(),
                 identity.store_id.as_bytes()
             );
             assert_eq!(
-                request.get(LICENSE_HASH_HEADER).unwrap().as_bytes(),
+                request
+                    .get(REPLICATION_LICENSE_HASH_HEADER)
+                    .unwrap()
+                    .as_bytes(),
                 identity.license_hash.as_bytes()
             );
             assert_eq!(request.get("authorization").unwrap(), "Bearer token");
@@ -622,7 +628,9 @@ pub(super) mod tests {
             .await
             .unwrap();
         assert_eq!(
-            headers.lock().unwrap()[0].get(LICENSE_HASH_HEADER).unwrap(),
+            headers.lock().unwrap()[0]
+                .get(REPLICATION_LICENSE_HASH_HEADER)
+                .unwrap(),
             "null"
         );
     }

--- a/reductstore/src/replication/remote_bucket/client_wrapper.rs
+++ b/reductstore/src/replication/remote_bucket/client_wrapper.rs
@@ -5,6 +5,7 @@ use crate::core::internal_client::{
     ClientBuildErrorContext, ClientBuildErrorKind, InternalClientApi, InternalClientBuilder,
 };
 use crate::replication::remote_bucket::{ErrorRecordMap, RemoteBucketConfig};
+use crate::replication::ReplicationSourceIdentity;
 use async_compression::tokio::bufread::{GzipEncoder, ZstdEncoder};
 use async_stream::stream;
 use async_trait::async_trait;
@@ -78,6 +79,9 @@ struct ReductClient {
 }
 
 static API_PATH: &str = "api/v1";
+const NODE_ID_HEADER: HeaderName = HeaderName::from_static("x-reduct-node-id");
+const STORE_ID_HEADER: HeaderName = HeaderName::from_static("x-reduct-store-id");
+const LICENSE_HASH_HEADER: HeaderName = HeaderName::from_static("x-reduct-license-hash");
 
 /// The first server version that decompresses request bodies sent with
 /// `Content-Encoding`.
@@ -90,7 +94,9 @@ impl ReductClient {
         verify_ssl: bool,
         ca_path: Option<&std::path::PathBuf>,
         compression: ReplicationCompression,
+        source_identity: &ReplicationSourceIdentity,
     ) -> Result<Self, ReductError> {
+        let default_headers = identity_headers(source_identity)?;
         let client = InternalClientBuilder::new(ClientBuildErrorContext {
             ca_read: "Failed to read replication CA certificate",
             ca_parse: "Invalid replication CA certificate",
@@ -98,6 +104,7 @@ impl ReductClient {
             kind: ClientBuildErrorKind::UnprocessableEntity,
         })
         .api_token(api_token)
+        .default_headers(default_headers)
         .verify_ssl(verify_ssl)
         .ca_path(ca_path)
         .connect_timeout(std::time::Duration::from_secs(10))
@@ -418,7 +425,23 @@ pub(super) fn create_client(config: &RemoteBucketConfig) -> Result<BoxedClientAp
         config.verify_ssl,
         config.ca_path.as_ref(),
         config.compression,
+        &config.source_identity,
     )?))
+}
+
+fn identity_headers(source_identity: &ReplicationSourceIdentity) -> Result<HeaderMap, ReductError> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in [
+        (NODE_ID_HEADER, &source_identity.node_id),
+        (STORE_ID_HEADER, &source_identity.store_id),
+        (LICENSE_HASH_HEADER, &source_identity.license_hash),
+    ] {
+        let value = HeaderValue::from_str(value).map_err(|err| {
+            unprocessable_entity!("Invalid replication identity header '{}': {}", name, err)
+        })?;
+        headers.insert(name, value);
+    }
+    Ok(headers)
 }
 
 #[cfg(test)]
@@ -428,6 +451,7 @@ pub(super) mod tests {
     use crate::replication::remote_bucket::RemoteBucketConfig;
     use crate::storage::proto::record::Label;
     use crate::storage::proto::{us_to_ts, Record};
+    use axum::{extract::State, http::StatusCode, routing::any, Router};
     use crossbeam_channel::{Receiver, Sender};
     use futures_util::StreamExt;
     use hyper::http;
@@ -436,6 +460,8 @@ pub(super) mod tests {
     use std::io::{Read, Seek, SeekFrom};
     use std::path::PathBuf;
     use std::pin::pin;
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
 
     #[rstest]
     #[tokio::test]
@@ -498,9 +524,125 @@ pub(super) mod tests {
             true,
             None,
             ReplicationCompression::None,
+            &Default::default(),
         )
         .unwrap();
         assert_eq!(client.server_url, "http://localhost:8080/");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_client_includes_licensed_identity_headers_on_all_replication_requests() {
+        let headers = Arc::new(Mutex::new(Vec::new()));
+        let url = start_header_server(Arc::clone(&headers)).await;
+        let identity = ReplicationSourceIdentity::new(
+            "instance:source:run:123".to_string(),
+            "f2f3931e-faca-4db5-84ed-d23bc1b09bda".to_string(),
+            Some("license-fingerprint".to_string()),
+        );
+        let client = ReductClient::new(
+            &url,
+            "token",
+            true,
+            None,
+            ReplicationCompression::None,
+            &identity,
+        )
+        .unwrap();
+
+        let api_client = client.client_api.client();
+        let bucket = BucketWrapper {
+            server_url: client.server_url.clone(),
+            bucket_name: "bucket".to_string(),
+            client: api_client.clone(),
+            compression: ReplicationCompression::None,
+        };
+
+        api_client
+            .get(format!("{url}api/v1/b/bucket"))
+            .send()
+            .await
+            .unwrap();
+        api_client
+            .post(format!("{url}api/v1/b/bucket"))
+            .send()
+            .await
+            .unwrap();
+        bucket
+            .client
+            .patch(format!("{url}api/v1/b/bucket/entry/batch"))
+            .send()
+            .await
+            .unwrap();
+
+        let headers = headers.lock().unwrap();
+        assert_eq!(headers.len(), 3);
+        for request in headers.iter() {
+            assert_eq!(
+                request.get(NODE_ID_HEADER).unwrap().as_bytes(),
+                identity.node_id.as_bytes()
+            );
+            assert_eq!(
+                request.get(STORE_ID_HEADER).unwrap().as_bytes(),
+                identity.store_id.as_bytes()
+            );
+            assert_eq!(
+                request.get(LICENSE_HASH_HEADER).unwrap().as_bytes(),
+                identity.license_hash.as_bytes()
+            );
+            assert_eq!(request.get("authorization").unwrap(), "Bearer token");
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_client_includes_null_license_hash_when_unlicensed() {
+        let headers = Arc::new(Mutex::new(Vec::new()));
+        let url = start_header_server(Arc::clone(&headers)).await;
+        let identity = ReplicationSourceIdentity::new(
+            "instance:source:run:123".to_string(),
+            "f2f3931e-faca-4db5-84ed-d23bc1b09bda".to_string(),
+            None,
+        );
+        let client = ReductClient::new(
+            &url,
+            "",
+            true,
+            None,
+            ReplicationCompression::None,
+            &identity,
+        )
+        .unwrap();
+
+        client
+            .client_api
+            .client()
+            .get(format!("{url}api/v1/b/bucket"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            headers.lock().unwrap()[0].get(LICENSE_HASH_HEADER).unwrap(),
+            "null"
+        );
+    }
+
+    async fn start_header_server(headers: Arc<Mutex<Vec<HeaderMap>>>) -> String {
+        async fn handler(
+            State(headers): State<Arc<Mutex<Vec<HeaderMap>>>>,
+            request: axum::extract::Request,
+        ) -> StatusCode {
+            headers.lock().unwrap().push(request.headers().clone());
+            StatusCode::OK
+        }
+
+        let app = Router::new().fallback(any(handler)).with_state(headers);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{address}/")
     }
 
     #[rstest]
@@ -511,6 +653,7 @@ pub(super) mod tests {
             true,
             Some(&PathBuf::from("/definitely/missing/ca.pem")),
             ReplicationCompression::None,
+            &Default::default(),
         )
         .err()
         .unwrap();
@@ -538,6 +681,7 @@ pub(super) mod tests {
             verify_ssl: true,
             ca_path: Some(ca_path),
             compression: ReplicationCompression::None,
+            source_identity: Default::default(),
         };
 
         let client = create_client(&config).unwrap();
@@ -561,6 +705,7 @@ pub(super) mod tests {
             true,
             Some(&ca_path),
             ReplicationCompression::None,
+            &Default::default(),
         )
         .err();
 

--- a/reductstore/src/replication/remote_bucket/states/initial_state.rs
+++ b/reductstore/src/replication/remote_bucket/states/initial_state.rs
@@ -98,6 +98,7 @@ mod tests {
             verify_ssl: true,
             ca_path: None,
             compression: Default::default(),
+            source_identity: Default::default(),
         })
         .unwrap();
         assert_eq!(state.last_result(), &Ok(ErrorRecordMap::new()));

--- a/reductstore/src/replication/replication_repository.rs
+++ b/reductstore/src/replication/replication_repository.rs
@@ -6,7 +6,7 @@ mod repo;
 
 use crate::cfg::Cfg;
 use crate::cfg::InstanceRole::Replica;
-use crate::replication::ManageReplications;
+use crate::replication::{ManageReplications, ReplicationSourceIdentity};
 use crate::storage::engine::StorageEngine;
 use crate::syslog::SystemEventSink;
 use read_only::ReadOnlyReplicationRepository;
@@ -16,6 +16,7 @@ use std::sync::Arc;
 pub(crate) struct ReplicationRepoBuilder {
     cfg: Cfg,
     system_event_sink: Option<SystemEventSink>,
+    source_identity: ReplicationSourceIdentity,
 }
 
 type BoxedReplicationRepository = Box<dyn ManageReplications + Send + Sync>;
@@ -25,6 +26,7 @@ impl ReplicationRepoBuilder {
         ReplicationRepoBuilder {
             cfg,
             system_event_sink: None,
+            source_identity: ReplicationSourceIdentity::default(),
         }
     }
 
@@ -33,13 +35,23 @@ impl ReplicationRepoBuilder {
         self
     }
 
+    pub fn with_source_identity(mut self, source_identity: ReplicationSourceIdentity) -> Self {
+        self.source_identity = source_identity;
+        self
+    }
+
     pub async fn build(self, storage: Arc<StorageEngine>) -> BoxedReplicationRepository {
         if self.cfg.role == Replica {
             Box::new(ReadOnlyReplicationRepository::new())
         } else {
             Box::new(
-                ReplicationRepository::load_or_create(storage, self.cfg, self.system_event_sink)
-                    .await,
+                ReplicationRepository::load_or_create(
+                    storage,
+                    self.cfg,
+                    self.system_event_sink,
+                    self.source_identity,
+                )
+                .await,
             )
         }
     }

--- a/reductstore/src/replication/replication_repository/repo.rs
+++ b/reductstore/src/replication/replication_repository/repo.rs
@@ -10,7 +10,9 @@ use crate::replication::proto::{
     ReplicationRepo as ProtoReplicationRepo, ReplicationSettings as ProtoReplicationSettings,
 };
 use crate::replication::replication_task::ReplicationTask;
-use crate::replication::{prepend_when_conditions, ManageReplications, TransactionNotification};
+use crate::replication::{
+    prepend_when_conditions, ManageReplications, ReplicationSourceIdentity, TransactionNotification,
+};
 use crate::storage::engine::StorageEngine;
 use crate::storage::query::condition::Parser;
 use crate::storage::query::filters::WhenFilter;
@@ -255,6 +257,7 @@ pub(crate) struct ReplicationRepository {
     repo_path: PathBuf,
     config: Cfg,
     system_event_sink: Option<SystemEventSink>,
+    source_identity: ReplicationSourceIdentity,
     started: bool,
     notification_tx: UnboundedSender<NotificationCommand>,
     notification_worker: Option<JoinHandle<()>>,
@@ -433,6 +436,7 @@ impl ReplicationRepository {
         storage: Arc<StorageEngine>,
         config: Cfg,
         system_event_sink: Option<SystemEventSink>,
+        source_identity: ReplicationSourceIdentity,
     ) -> Self {
         let repo_path = storage.data_path().join(REPLICATION_REPO_FILE_NAME);
         let replications = Arc::new(AsyncRwLock::new(HashMap::<String, ReplicationTask>::new()));
@@ -471,6 +475,7 @@ impl ReplicationRepository {
             repo_path,
             config,
             system_event_sink,
+            source_identity,
             started: false,
             notification_tx,
             notification_worker: Some(notification_worker),
@@ -621,6 +626,7 @@ impl ReplicationRepository {
             conf,
             Arc::clone(&self.storage),
             self.system_event_sink.clone(),
+            self.source_identity.clone(),
         )?;
         let mut replication = replication;
         if self.started {
@@ -834,16 +840,24 @@ mod tests {
         ) {
             settings.dst_prefix = "robot-1".to_string();
             let storage = storage.await;
-            let mut repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
-                    .await;
+            let mut repo = ReplicationRepository::load_or_create(
+                Arc::clone(&storage),
+                Cfg::default(),
+                None,
+                ReplicationSourceIdentity::default(),
+            )
+            .await;
             repo.create_replication("test", settings.clone())
                 .await
                 .unwrap();
 
-            let repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
-                    .await;
+            let repo = ReplicationRepository::load_or_create(
+                Arc::clone(&storage),
+                Cfg::default(),
+                None,
+                ReplicationSourceIdentity::default(),
+            )
+            .await;
             assert_eq!(repo.replications().await.unwrap().len(), 1);
             assert_eq!(
                 repo.get_replication_settings("test").await.unwrap(),
@@ -1098,9 +1112,13 @@ mod tests {
             assert!(!log_path.exists(), "Should remove transaction log");
 
             // check if replication is removed from file
-            let repo =
-                ReplicationRepository::load_or_create(Arc::clone(&storage), Cfg::default(), None)
-                    .await;
+            let repo = ReplicationRepository::load_or_create(
+                Arc::clone(&storage),
+                Cfg::default(),
+                None,
+                ReplicationSourceIdentity::default(),
+            )
+            .await;
             assert_eq!(
                 repo.replications().await.unwrap().len(),
                 0,
@@ -2066,7 +2084,13 @@ mod tests {
     #[fixture]
     async fn repo(#[future] storage: Arc<StorageEngine>) -> ReplicationRepository {
         let storage = storage.await;
-        ReplicationRepository::load_or_create(storage, Cfg::default(), None).await
+        ReplicationRepository::load_or_create(
+            storage,
+            Cfg::default(),
+            None,
+            ReplicationSourceIdentity::default(),
+        )
+        .await
     }
 
     mod each_s_migration {

--- a/reductstore/src/replication/replication_task.rs
+++ b/reductstore/src/replication/replication_task.rs
@@ -10,6 +10,7 @@ use crate::replication::remote_bucket::{RemoteBucket, RemoteBucketBuilder};
 use crate::replication::replication_sender::{ReplicationSender, SyncState};
 use crate::replication::transaction_filter::TransactionFilter;
 use crate::replication::transaction_log::{TransactionLog, TransactionLogMap, TransactionLogRef};
+use crate::replication::ReplicationSourceIdentity;
 use crate::replication::TransactionNotification;
 use crate::storage::engine::StorageEngine;
 use crate::syslog::aggregate::replication::ReplicationEventAggregator;
@@ -70,6 +71,7 @@ impl ReplicationTask {
         config: Cfg,
         storage: Arc<StorageEngine>,
         system_event_sink: Option<SystemEventSink>,
+        source_identity: ReplicationSourceIdentity,
     ) -> Result<Self, ReductError> {
         let ReplicationSettings {
             dst_bucket: remote_bucket,
@@ -83,7 +85,8 @@ impl ReplicationTask {
             .bucket_name(remote_bucket)
             .verify_ssl(config.replication_conf.verify_ssl)
             .ca_path(config.replication_conf.ca_path.clone())
-            .compression(settings.compression);
+            .compression(settings.compression)
+            .source_identity(source_identity);
 
         if let Some(token) = remote_token {
             remote_bucket_builder = remote_bucket_builder.api_token(token);


### PR DESCRIPTION
Closes #1580

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Add source node, store, and license-fingerprint headers to replication HTTP requests.
- Enforce complete identity headers, matching commercial license fingerprints, and per-store device limits on licensed receivers.
- Track active remote store/node identities in a process-local sliding one-hour registry after request authorization.
- Keep Core receivers and replication requests without identity headers compatible.

### Related issues

https://github.com/reductstore/reductstore/issues/1580

### Does this PR introduce a breaking change?

No. Older replication clients that do not send identity headers remain supported. Licensed receivers reject partial identities, mismatched license fingerprints, and new devices beyond the configured limit with HTTP 429.

### Other information:

Validated with `cargo fmt --all`, `cargo check --workspace`, focused license/middleware tests, and `cargo test --workspace`. The full suite had three unrelated concurrent-test failures: two launcher tests could not bind port 8383, and one storage test timed out acquiring a file-cache lock.
